### PR TITLE
[codex] Support wallpaper interactions and Petdex action states

### DIFF
--- a/app/src/androidTest/java/com/hank/clawlive/WallpaperMoreSettingsUiTest.kt
+++ b/app/src/androidTest/java/com/hank/clawlive/WallpaperMoreSettingsUiTest.kt
@@ -20,6 +20,7 @@ class WallpaperMoreSettingsUiTest {
                 val prefs = LayoutPreferences.getInstance(activity)
                 assertTrue(prefs.wallpaperSpeechBubblesEnabled)
                 assertTrue(prefs.wallpaperPurposefulWalkingEnabled)
+                assertTrue(prefs.wallpaperEntityInteractionsEnabled)
                 assertTrue(prefs.wallpaperBubblePulseEnabled)
                 assertTrue(prefs.wallpaperBubbleOverlayAvoidanceEnabled)
                 assertTrue(prefs.wallpaperStateAuraEnabled)
@@ -38,9 +39,12 @@ class WallpaperMoreSettingsUiTest {
                     }
                 }
                 collect(root)
-                assertTrue("Expected advanced wallpaper switches", switches.size >= 8)
+                assertTrue("Expected advanced wallpaper switches", switches.size >= 9)
                 switches.forEach { assertTrue("Default-on switch should start checked", it.isChecked) }
                 assertTrue("Expected bubble duration slider", sliders.isNotEmpty())
+                val durationSlider = sliders.first()
+                assertEquals(5f, durationSlider.valueFrom, 0.001f)
+                assertEquals(300f, durationSlider.valueTo, 0.001f)
 
                 switches.first().isChecked = false
                 assertFalse(prefs.wallpaperSpeechBubblesEnabled)
@@ -50,8 +54,18 @@ class WallpaperMoreSettingsUiTest {
                 assertFalse(prefs.wallpaperPurposefulWalkingEnabled)
                 prefs.wallpaperPurposefulWalkingEnabled = true
 
-                sliders.first().value = 18f
+                switches[2].isChecked = false
+                assertFalse(prefs.wallpaperEntityInteractionsEnabled)
+                prefs.wallpaperEntityInteractionsEnabled = true
+
+                durationSlider.value = 18f
                 assertEquals(18, prefs.wallpaperBubbleDurationSeconds)
+                durationSlider.value = 300f
+                assertEquals(300, prefs.wallpaperBubbleDurationSeconds)
+                prefs.wallpaperBubbleDurationSeconds = 1
+                assertEquals(5, prefs.wallpaperBubbleDurationSeconds)
+                prefs.wallpaperBubbleDurationSeconds = 999
+                assertEquals(300, prefs.wallpaperBubbleDurationSeconds)
                 prefs.wallpaperBubbleDurationSeconds = LayoutPreferences.WALLPAPER_BUBBLE_DURATION_DEFAULT_SECONDS
             }
         }

--- a/app/src/main/java/com/hank/clawlive/WallpaperMoreSettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/WallpaperMoreSettingsActivity.kt
@@ -72,6 +72,12 @@ class WallpaperMoreSettingsActivity : AppCompatActivity() {
         ) { layoutPrefs.wallpaperPurposefulWalkingEnabled = it }
         addSwitch(
             content,
+            title = getString(R.string.wallpaper_setting_entity_interactions),
+            description = getString(R.string.wallpaper_setting_entity_interactions_desc),
+            checked = layoutPrefs.wallpaperEntityInteractionsEnabled
+        ) { layoutPrefs.wallpaperEntityInteractionsEnabled = it }
+        addSwitch(
+            content,
             title = getString(R.string.wallpaper_setting_bubble_pulse),
             description = getString(R.string.wallpaper_setting_bubble_pulse_desc),
             checked = layoutPrefs.wallpaperBubblePulseEnabled
@@ -170,7 +176,20 @@ class WallpaperMoreSettingsActivity : AppCompatActivity() {
     }
 
     private fun bubbleDurationLabel(seconds: Int): String {
-        return getString(R.string.wallpaper_setting_bubble_duration_value, seconds)
+        val minutes = seconds / 60
+        val remainingSeconds = seconds % 60
+        return when {
+            minutes <= 0 -> getString(R.string.wallpaper_setting_bubble_duration_value, seconds)
+            remainingSeconds == 0 -> getString(
+                R.string.wallpaper_setting_bubble_duration_minutes_value,
+                minutes
+            )
+            else -> getString(
+                R.string.wallpaper_setting_bubble_duration_minutes_seconds_value,
+                minutes,
+                remainingSeconds
+            )
+        }
     }
 
     private fun addSwitch(

--- a/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
@@ -306,6 +306,12 @@ class LayoutPreferences private constructor(context: Context) {
             prefs.edit().putBoolean(KEY_WALLPAPER_PURPOSEFUL_WALKING_ENABLED, value).apply()
         }
 
+    var wallpaperEntityInteractionsEnabled: Boolean
+        get() = prefs.getBoolean(KEY_WALLPAPER_ENTITY_INTERACTIONS_ENABLED, true)
+        set(value) {
+            prefs.edit().putBoolean(KEY_WALLPAPER_ENTITY_INTERACTIONS_ENABLED, value).apply()
+        }
+
     var wallpaperSpeechBubblesEnabled: Boolean
         get() = prefs.getBoolean(KEY_WALLPAPER_SPEECH_BUBBLES_ENABLED, true)
         set(value) {
@@ -530,6 +536,7 @@ class LayoutPreferences private constructor(context: Context) {
         private const val KEY_SERVER_ENTITY_LIMIT = "server_entity_limit"
         private const val KEY_WALLPAPER_WALKING_ENABLED = "wallpaper_walking_enabled"
         private const val KEY_WALLPAPER_PURPOSEFUL_WALKING_ENABLED = "wallpaper_purposeful_walking_enabled"
+        private const val KEY_WALLPAPER_ENTITY_INTERACTIONS_ENABLED = "wallpaper_entity_interactions_enabled"
         private const val KEY_WALLPAPER_SPEECH_BUBBLES_ENABLED = "wallpaper_speech_bubbles_enabled"
         private const val KEY_WALLPAPER_BUBBLE_DURATION_SECONDS = "wallpaper_bubble_duration_seconds"
         private const val KEY_WALLPAPER_BUBBLE_PULSE_ENABLED = "wallpaper_bubble_pulse_enabled"
@@ -555,8 +562,8 @@ class LayoutPreferences private constructor(context: Context) {
         const val RESET_WINDOW_WEEKLY = "weekly"
         const val RESET_WINDOW_5H_WEEKLY = "5h_weekly"
 
-        const val WALLPAPER_BUBBLE_DURATION_MIN_SECONDS = 3
-        const val WALLPAPER_BUBBLE_DURATION_MAX_SECONDS = 30
+        const val WALLPAPER_BUBBLE_DURATION_MIN_SECONDS = 5
+        const val WALLPAPER_BUBBLE_DURATION_MAX_SECONDS = 300
         const val WALLPAPER_BUBBLE_DURATION_DEFAULT_SECONDS = 12
 
         // Display mode constants

--- a/app/src/main/java/com/hank/clawlive/data/local/WallpaperEntitySnapshotCache.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/WallpaperEntitySnapshotCache.kt
@@ -1,8 +1,10 @@
 package com.hank.clawlive.data.local
 
 import android.content.Context
-import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import com.google.gson.reflect.TypeToken
+import com.hank.clawlive.data.model.CharacterState
+import com.hank.clawlive.data.model.CharacterStateJsonAdapter
 import com.hank.clawlive.data.model.CompanionDetail
 import com.hank.clawlive.data.model.EntityStatus
 import timber.log.Timber
@@ -18,7 +20,9 @@ import timber.log.Timber
  */
 class WallpaperEntitySnapshotCache private constructor(context: Context) {
     private val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    private val gson = Gson()
+    private val gson = GsonBuilder()
+        .registerTypeAdapter(CharacterState::class.java, CharacterStateJsonAdapter())
+        .create()
 
     data class Snapshot(
         val entities: List<EntityStatus>,

--- a/app/src/main/java/com/hank/clawlive/data/model/AgentStatus.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/AgentStatus.kt
@@ -1,5 +1,7 @@
 package com.hank.clawlive.data.model
 
+import java.util.Locale
+
 data class AgentStatus(
     val name: String? = null,
     val character: String = "LOBSTER",
@@ -23,10 +25,127 @@ enum class CharacterType {
     LOBSTER
 }
 
-enum class CharacterState {
-    IDLE,       // Default state
-    BUSY,       // Working on something
-    EATING,     // Eating noodles/food
-    SLEEPING,   // Night time or inactive
-    EXCITED     // New task or user interaction
+enum class CharacterState(
+    val serverValue: String,
+    val wallpaperActionKey: String,
+    val pausesAmbientWander: Boolean = false,
+    val canUseAmbientWalkingAnimation: Boolean = false,
+    val busyLike: Boolean = false,
+    val excitedLike: Boolean = false
+) {
+    IDLE(
+        serverValue = "IDLE",
+        wallpaperActionKey = "idle",
+        canUseAmbientWalkingAnimation = true
+    ),
+    BUSY(
+        serverValue = "BUSY",
+        wallpaperActionKey = "running",
+        busyLike = true
+    ),
+    EATING(
+        serverValue = "EATING",
+        wallpaperActionKey = "idle"
+    ),
+    SLEEPING(
+        serverValue = "SLEEPING",
+        wallpaperActionKey = "waiting",
+        pausesAmbientWander = true
+    ),
+    EXCITED(
+        serverValue = "EXCITED",
+        wallpaperActionKey = "jumping",
+        excitedLike = true
+    ),
+    HAPPY(
+        serverValue = "HAPPY",
+        wallpaperActionKey = "waving",
+        excitedLike = true
+    ),
+    WALKING(
+        serverValue = "WALKING",
+        wallpaperActionKey = "running-right",
+        busyLike = true
+    ),
+    RUNNING(
+        serverValue = "running",
+        wallpaperActionKey = "running",
+        busyLike = true
+    ),
+    RUNNING_RIGHT(
+        serverValue = "running-right",
+        wallpaperActionKey = "running-right",
+        busyLike = true
+    ),
+    RUNNING_LEFT(
+        serverValue = "running-left",
+        wallpaperActionKey = "running-left",
+        busyLike = true
+    ),
+    WAVING(
+        serverValue = "waving",
+        wallpaperActionKey = "waving",
+        pausesAmbientWander = true,
+        excitedLike = true
+    ),
+    JUMPING(
+        serverValue = "jumping",
+        wallpaperActionKey = "jumping",
+        pausesAmbientWander = true,
+        excitedLike = true
+    ),
+    FAILED(
+        serverValue = "failed",
+        wallpaperActionKey = "failed",
+        pausesAmbientWander = true
+    ),
+    WAITING(
+        serverValue = "waiting",
+        wallpaperActionKey = "waiting",
+        pausesAmbientWander = true
+    ),
+    REVIEW(
+        serverValue = "review",
+        wallpaperActionKey = "review",
+        pausesAmbientWander = true
+    );
+
+    val usesDirectionalPetdexRow: Boolean
+        get() = this == RUNNING_LEFT || this == RUNNING_RIGHT
+
+    companion object {
+        val petdexActionKeys: Set<String> = setOf(
+            "idle",
+            "running-right",
+            "running-left",
+            "waving",
+            "jumping",
+            "failed",
+            "waiting",
+            "running",
+            "review"
+        )
+
+        fun fromWireValue(raw: String?): CharacterState {
+            val value = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return IDLE
+            return when (value.lowercase(Locale.US).replace('_', '-')) {
+                "idle" -> IDLE
+                "busy" -> BUSY
+                "eating" -> EATING
+                "sleeping", "sleep" -> SLEEPING
+                "excited" -> EXCITED
+                "happy" -> HAPPY
+                "walking", "walk" -> WALKING
+                "running", "run" -> RUNNING
+                "running-right", "run-right" -> RUNNING_RIGHT
+                "running-left", "run-left" -> RUNNING_LEFT
+                "waving", "wave" -> WAVING
+                "jumping", "jump" -> JUMPING
+                "failed", "fail" -> FAILED
+                "waiting", "wait" -> WAITING
+                "review", "reviewing" -> REVIEW
+                else -> IDLE
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/hank/clawlive/data/model/CharacterStateJsonAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/CharacterStateJsonAdapter.kt
@@ -1,0 +1,30 @@
+package com.hank.clawlive.data.model
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import java.lang.reflect.Type
+
+class CharacterStateJsonAdapter : JsonDeserializer<CharacterState>, JsonSerializer<CharacterState> {
+    override fun deserialize(
+        json: JsonElement?,
+        typeOfT: Type?,
+        context: JsonDeserializationContext?
+    ): CharacterState {
+        if (json == null || json.isJsonNull || !json.isJsonPrimitive) {
+            return CharacterState.IDLE
+        }
+        return CharacterState.fromWireValue(json.asString)
+    }
+
+    override fun serialize(
+        src: CharacterState?,
+        typeOfSrc: Type?,
+        context: JsonSerializationContext?
+    ): JsonElement {
+        return JsonPrimitive((src ?: CharacterState.IDLE).serverValue)
+    }
+}

--- a/app/src/main/java/com/hank/clawlive/data/model/CompanionDescriptor.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/CompanionDescriptor.kt
@@ -2,6 +2,7 @@ package com.hank.clawlive.data.model
 
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import java.util.Locale
 
 /**
  * Petdx Companion descriptor — Android-side mirror of the JSON returned by
@@ -67,9 +68,12 @@ data class CompanionDetail(
      * or null if not declared.
      */
     fun stateAsset(state: String): StateAssetHint? {
+        return declaredStateAsset(state) ?: declaredStateAsset("IDLE")
+    }
+
+    private fun declaredStateAsset(state: String): StateAssetHint? {
         val sa = descriptor?.getAsJsonObject("stateAssets") ?: return null
-        val key = if (sa.has(state)) state else "IDLE"
-        val obj = sa.getAsJsonObject(key) ?: return null
+        val obj = sa.getAsJsonObject(state) ?: return null
         return StateAssetHint(
             loop = obj.get("loop")?.asBoolean ?: true,
             fps = obj.get("fps")?.asInt ?: 4,
@@ -80,7 +84,13 @@ data class CompanionDetail(
     }
 
     fun spritesheetAnimation(state: String): SpriteAnimationHint? {
-        val stateHint = stateAsset(state) ?: return null
+        val directAnimation = directSpritesheetAnimation(state)
+        val declaredStateHint = declaredStateAsset(state)
+        if (declaredStateHint == null && directAnimation != null) {
+            return directAnimation
+        }
+
+        val stateHint = declaredStateHint ?: declaredStateAsset("IDLE") ?: return directAnimation
         val animationName = stateHint.animation
         val fallbackRow = defaultSpritesheetRow(state, stateHint)
         if (animationName.isNullOrBlank()) {
@@ -91,20 +101,46 @@ data class CompanionDetail(
             )
         }
 
-        val asset = descriptor?.getAsJsonObject("asset") ?: return null
-        val animations = asset.getAsJsonObject("animations") ?: return null
-        val anim = animations.getAsJsonObject(animationName)
-            ?: animations.getAsJsonObject("idle")
+        val anim = animationObject(animationName)
+            ?: animationObject("idle")
             ?: return null
 
+        return spriteAnimationHint(anim, fallbackRow, stateHint.frames, stateHint.fps)
+    }
+
+    private fun directSpritesheetAnimation(state: String): SpriteAnimationHint? {
+        val anim = animationObject(state) ?: return null
+        val row = anim.get("row")?.asInt ?: 0
+        val frames = anim.get("count")?.asInt ?: 1
+        return spriteAnimationHint(anim, row, frames, 4)
+    }
+
+    private fun animationObject(name: String): JsonObject? {
+        val asset = descriptor?.getAsJsonObject("asset") ?: return null
+        val animations = asset.getAsJsonObject("animations") ?: return null
+        val raw = name.trim()
+        if (raw.isBlank()) return null
+        val normalized = raw.lowercase(Locale.US).replace('_', '-')
+        val element = animations.get(raw)
+            ?: animations.get(normalized)
+            ?: return null
+        return element.takeIf { it.isJsonObject }?.asJsonObject
+    }
+
+    private fun spriteAnimationHint(
+        anim: JsonObject,
+        fallbackRow: Int,
+        fallbackFrames: Int,
+        fallbackFps: Int
+    ): SpriteAnimationHint {
         val row = anim.get("row")?.asInt ?: fallbackRow
         val durations = when {
             anim.has("frames") && anim.get("frames").isJsonArray -> {
                 anim.getAsJsonArray("frames").mapNotNull { it.asInt.takeIf { v -> v > 0 } }
             }
             else -> {
-                val count = anim.get("count")?.asInt ?: stateHint.frames
-                val dur = anim.get("dur")?.asInt ?: (1000 / stateHint.fps.coerceAtLeast(1))
+                val count = anim.get("count")?.asInt ?: fallbackFrames
+                val dur = anim.get("dur")?.asInt ?: (1000 / fallbackFps.coerceAtLeast(1))
                 val last = anim.get("last")?.asInt
                 List(count.coerceAtLeast(1)) { index ->
                     if (last != null && index == count - 1) last.coerceAtLeast(1) else dur.coerceAtLeast(1)

--- a/app/src/main/java/com/hank/clawlive/data/remote/NetworkModule.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/NetworkModule.kt
@@ -6,6 +6,8 @@ import com.google.gson.JsonDeserializer
 import com.google.gson.reflect.TypeToken
 import com.hank.clawlive.BuildConfig
 import com.hank.clawlive.data.model.AgentCardCapability
+import com.hank.clawlive.data.model.CharacterState
+import com.hank.clawlive.data.model.CharacterStateJsonAdapter
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -88,6 +90,7 @@ object NetworkModule {
 
     private val gson = GsonBuilder()
         .registerTypeAdapter(AgentCardCapability::class.java, agentCardCapabilityDeserializer)
+        .registerTypeAdapter(CharacterState::class.java, CharacterStateJsonAdapter())
         .create()
 
     private val retrofit = Retrofit.Builder()

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -33,6 +33,7 @@ class ClawRenderer(
     private val spritesheetDrawer = companionRepository?.let { SpritesheetCompanionDrawer(it) }
     private val usageOverlayRenderer = UsageOverlayRenderer(context, layoutPrefs)
     private val wanderController = WallpaperWanderController()
+    private val interactionController = WallpaperInteractionController()
     private val speechBubbleController = SpeechBubbleController()
     private val renderDiagnostics = WallpaperRenderDiagnostics()
     private val lastBubbleMessageByEntity = mutableMapOf<Int, String>()
@@ -127,6 +128,13 @@ class ClawRenderer(
         style = Paint.Style.STROKE
         isAntiAlias = true
         strokeCap = Paint.Cap.ROUND
+    }
+
+    private val interactionTextPaint = TextPaint().apply {
+        color = Color.WHITE
+        textAlign = Paint.Align.CENTER
+        isAntiAlias = true
+        isFakeBoldText = true
     }
 
     // Animation state
@@ -506,6 +514,14 @@ class ClawRenderer(
         )
         val baseScale = getScaleFactor(entities.size)
         val nowMs = System.currentTimeMillis()
+        val interactionState = interactionController.apply(
+            positions = positions,
+            entities = entities,
+            width = width,
+            height = height,
+            enabled = layoutPrefs.wallpaperEntityInteractionsEnabled,
+            nowMs = nowMs
+        )
         if (layoutPrefs.wallpaperSpeechBubblesEnabled) {
             syncSpeechBubbles(entities, nowMs)
         } else {
@@ -528,14 +544,15 @@ class ClawRenderer(
         }
 
         entities.forEachIndexed { index, entity ->
-            if (index < positions.size) {
-                val (cx, cy) = positions[index]
+            if (index < interactionState.positions.size) {
+                val (cx, cy) = interactionState.positions[index]
                 // Apply per-entity scale multiplier on top of base scale
                 val entityScale = layoutPrefs.getEntityScale(entity.entityId)
                 val finalScale = baseScale * entityScale
                 val motionStateOverride = if (wanderController.isWalking(entity.entityId)) {
                     WallpaperWanderController.WALKING_STATE_ASSET
                 } else null
+                val facingDirection = wanderController.facingDirection(entity.entityId)
                 drawSingleEntityAt(
                     canvas,
                     entity,
@@ -545,9 +562,14 @@ class ClawRenderer(
                     width,
                     motionStateOverride,
                     nowMs,
-                    bubbleAvoidBounds
+                    bubbleAvoidBounds,
+                    facingDirection
                 )
             }
+        }
+
+        interactionState.effects.forEach { effect ->
+            drawInteractionEffect(canvas, effect, baseScale, nowMs)
         }
 
         usageOverlayRenderer.draw(canvas, usageSnapshot)
@@ -609,7 +631,8 @@ class ClawRenderer(
         screenWidth: Float,
         motionStateOverride: String? = null,
         nowMs: Long = System.currentTimeMillis(),
-        bubbleAvoidBounds: RectF? = null
+        bubbleAvoidBounds: RectF? = null,
+        facingDirection: WalkFacingDirection = WalkFacingDirection.RIGHT
     ) {
         // Calculate Animation (Bobbing)
         val time = nowMs - startTime
@@ -658,7 +681,8 @@ class ClawRenderer(
                 motionStateOverride ?: entity.state.toString(),
                 centerX,
                 charY,
-                scale
+                scale,
+                facingDirection
             ) ?: SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED
         } else SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED
         if (attemptedSpritesheet && layoutPrefs.wallpaperAdaptiveEffectsEnabled) {
@@ -670,7 +694,7 @@ class ClawRenderer(
             SpritesheetCompanionDrawer.DrawResult.LOADING -> Unit
             SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED,
             SpritesheetCompanionDrawer.DrawResult.ERROR ->
-                drawLobsterAtPosition(canvas, centerX, charY, entity, scale, companion)
+                drawLobsterAtPosition(canvas, centerX, charY, entity, scale, companion, facingDirection)
         }
 
         val bubblePlacement = if (layoutPrefs.wallpaperSpeechBubblesEnabled) {
@@ -788,6 +812,26 @@ class ClawRenderer(
             shadowPaint
         )
         shadowPaint.alpha = 255
+    }
+
+    private fun drawInteractionEffect(
+        canvas: Canvas,
+        effect: WallpaperInteractionController.InteractionEffect,
+        scale: Float,
+        nowMs: Long
+    ) {
+        if (isAmbient) return
+        val alpha = effect.alpha(nowMs)
+        if (alpha <= 0f) return
+        interactionTextPaint.textSize = (30f * scale * effect.scale(nowMs)).coerceIn(18f, 46f)
+        interactionTextPaint.alpha = (alpha * 210f).toInt().coerceIn(0, 230)
+        interactionTextPaint.color = when (effect.kind) {
+            WallpaperInteractionController.InteractionKind.GREETING -> Color.rgb(96, 165, 250)
+            WallpaperInteractionController.InteractionKind.SPARK -> Color.rgb(250, 204, 21)
+            WallpaperInteractionController.InteractionKind.BUMP -> Color.rgb(45, 212, 191)
+        }
+        canvas.drawText(effect.label, effect.centerX, effect.centerY, interactionTextPaint)
+        interactionTextPaint.alpha = 255
     }
 
     private fun drawStateAura(
@@ -1081,13 +1125,18 @@ class ClawRenderer(
         cy: Float,
         entity: EntityStatus,
         scale: Float,
-        companion: CompanionDetail? = null
+        companion: CompanionDetail? = null,
+        facingDirection: WalkFacingDirection = WalkFacingDirection.RIGHT
     ) {
         // SVG scale (original is 4x, now multiply by entity scale)
         val svgScale = 4f * scale
 
         canvas.save()
-        canvas.translate(cx - (60 * svgScale), cy - (60 * svgScale))
+        canvas.translate(cx, cy)
+        if (facingDirection == WalkFacingDirection.LEFT) {
+            canvas.scale(-1f, 1f)
+        }
+        canvas.translate(-(60 * svgScale), -(60 * svgScale))
         canvas.scale(svgScale, svgScale)
 
         // Colors

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -546,24 +546,33 @@ class ClawRenderer(
         entities.forEachIndexed { index, entity ->
             if (index < interactionState.positions.size) {
                 val (cx, cy) = interactionState.positions[index]
+                val interactionPose = interactionState.posesByEntity[entity.entityId]
+                val drawCy = cy - (interactionPose?.liftPx ?: 0f)
                 // Apply per-entity scale multiplier on top of base scale
                 val entityScale = layoutPrefs.getEntityScale(entity.entityId)
                 val finalScale = baseScale * entityScale
-                val motionStateOverride = if (wanderController.isWalking(entity.entityId)) {
+                val spritesheetState = if (
+                    wanderController.isWalking(entity.entityId) &&
+                    entity.state.canUseAmbientWalkingAnimation
+                ) {
                     WallpaperWanderController.WALKING_STATE_ASSET
-                } else null
-                val facingDirection = wanderController.facingDirection(entity.entityId)
+                } else {
+                    entity.state.wallpaperActionKey
+                }
+                val facingDirection = interactionPose?.facingDirection
+                    ?: wanderController.facingDirection(entity.entityId)
                 drawSingleEntityAt(
                     canvas,
                     entity,
                     cx,
-                    cy,
+                    drawCy,
                     finalScale,
                     width,
-                    motionStateOverride,
+                    spritesheetState,
                     nowMs,
                     bubbleAvoidBounds,
-                    facingDirection
+                    facingDirection,
+                    shouldMirrorSpritesheetForFacing(spritesheetState)
                 )
             }
         }
@@ -619,6 +628,11 @@ class ClawRenderer(
         bubblePulseStartedByEntity.clear()
     }
 
+    private fun shouldMirrorSpritesheetForFacing(spritesheetState: String): Boolean {
+        return spritesheetState != CharacterState.RUNNING_LEFT.wallpaperActionKey &&
+            spritesheetState != CharacterState.RUNNING_RIGHT.wallpaperActionKey
+    }
+
     /**
      * Draw a single entity at the specified position with scale.
      */
@@ -629,17 +643,18 @@ class ClawRenderer(
         centerY: Float,
         scale: Float,
         screenWidth: Float,
-        motionStateOverride: String? = null,
+        spritesheetState: String = entity.state.wallpaperActionKey,
         nowMs: Long = System.currentTimeMillis(),
         bubbleAvoidBounds: RectF? = null,
-        facingDirection: WalkFacingDirection = WalkFacingDirection.RIGHT
+        facingDirection: WalkFacingDirection = WalkFacingDirection.RIGHT,
+        mirrorSpritesheetForFacing: Boolean = true
     ) {
         // Calculate Animation (Bobbing)
         val time = nowMs - startTime
-        val bobOffset = if (entity.state == CharacterState.SLEEPING) {
+        val bobOffset = if (entity.state.pausesAmbientWander) {
             0f
         } else {
-            val speed = if (entity.state == CharacterState.BUSY) 0.01f else 0.003f
+            val speed = if (entity.state.busyLike) 0.01f else 0.003f
             (sin(time * speed) * 30 * scale).toFloat()
         }
 
@@ -678,11 +693,12 @@ class ClawRenderer(
                 canvas,
                 companion,
                 entity.entityId,
-                motionStateOverride ?: entity.state.toString(),
+                spritesheetState,
                 centerX,
                 charY,
                 scale,
-                facingDirection
+                facingDirection,
+                mirrorSpritesheetForFacing
             ) ?: SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED
         } else SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED
         if (attemptedSpritesheet && layoutPrefs.wallpaperAdaptiveEffectsEnabled) {
@@ -844,12 +860,15 @@ class ClawRenderer(
         time: Long
     ) {
         if (isAmbient) return
-        val accent = when (entity.state) {
-            CharacterState.IDLE -> if (wanderController.isWalking(entity.entityId)) Color.rgb(45, 212, 191) else return
-            CharacterState.BUSY -> Color.rgb(59, 130, 246)
-            CharacterState.EATING -> Color.rgb(34, 197, 94)
-            CharacterState.EXCITED -> Color.rgb(245, 158, 11)
-            CharacterState.SLEEPING -> Color.rgb(99, 102, 241)
+        val accent = when {
+            entity.state == CharacterState.IDLE && wanderController.isWalking(entity.entityId) -> Color.rgb(45, 212, 191)
+            entity.state.busyLike -> Color.rgb(59, 130, 246)
+            entity.state == CharacterState.EATING -> Color.rgb(34, 197, 94)
+            entity.state.excitedLike -> Color.rgb(245, 158, 11)
+            entity.state == CharacterState.FAILED -> Color.rgb(248, 113, 113)
+            entity.state == CharacterState.REVIEW -> Color.rgb(168, 85, 247)
+            entity.state.pausesAmbientWander -> Color.rgb(99, 102, 241)
+            else -> return
         }
         val pulse = (sin(time * 0.0045f) * 0.5f + 0.5f).toFloat()
         stateAuraPaint.color = accent
@@ -877,12 +896,14 @@ class ClawRenderer(
         bubblePulsePaint.alpha = 255
     }
 
-    private fun stateAccentColor(state: CharacterState): Int = when (state) {
-        CharacterState.SLEEPING -> Color.rgb(129, 140, 248)
-        CharacterState.EXCITED -> Color.rgb(251, 146, 60)
-        CharacterState.BUSY -> Color.rgb(96, 165, 250)
-        CharacterState.EATING -> Color.rgb(74, 222, 128)
-        CharacterState.IDLE -> Color.rgb(45, 212, 191)
+    private fun stateAccentColor(state: CharacterState): Int = when {
+        state == CharacterState.FAILED -> Color.rgb(248, 113, 113)
+        state == CharacterState.REVIEW -> Color.rgb(168, 85, 247)
+        state.pausesAmbientWander -> Color.rgb(129, 140, 248)
+        state.excitedLike -> Color.rgb(251, 146, 60)
+        state.busyLike -> Color.rgb(96, 165, 250)
+        state == CharacterState.EATING -> Color.rgb(74, 222, 128)
+        else -> Color.rgb(45, 212, 191)
     }
 
     /**
@@ -1073,11 +1094,13 @@ class ClawRenderer(
         }
         path.close()
 
-        val bubblesColor = when (entity.state) {
-            CharacterState.SLEEPING -> Color.argb(230, 50, 50, 80)
-            CharacterState.EXCITED -> Color.argb(230, 255, 100, 50)
-            CharacterState.BUSY -> Color.argb(230, 50, 100, 150)
-            CharacterState.EATING -> Color.argb(230, 80, 150, 50)
+        val bubblesColor = when {
+            entity.state == CharacterState.FAILED -> Color.argb(230, 120, 45, 45)
+            entity.state == CharacterState.REVIEW -> Color.argb(230, 80, 55, 135)
+            entity.state.pausesAmbientWander -> Color.argb(230, 50, 50, 80)
+            entity.state.excitedLike -> Color.argb(230, 255, 100, 50)
+            entity.state.busyLike -> Color.argb(230, 50, 100, 150)
+            entity.state == CharacterState.EATING -> Color.argb(230, 80, 150, 50)
             else -> Color.argb(230, 40, 40, 40)
         }
         bubblePaint.color = bubblesColor
@@ -1103,12 +1126,16 @@ class ClawRenderer(
     /**
      * Get emoji for state.
      */
-    private fun getStateEmoji(state: CharacterState): String = when (state) {
-        CharacterState.IDLE -> "😐"
-        CharacterState.SLEEPING -> "😴"
-        CharacterState.EXCITED -> "🎉"
-        CharacterState.BUSY -> "💼"
-        CharacterState.EATING -> "🍽️"
+    private fun getStateEmoji(state: CharacterState): String = when {
+        state == CharacterState.IDLE -> "😐"
+        state == CharacterState.SLEEPING || state == CharacterState.WAITING -> "😴"
+        state == CharacterState.FAILED -> "⚠️"
+        state == CharacterState.REVIEW -> "🔎"
+        state == CharacterState.WAVING || state == CharacterState.HAPPY -> "👋"
+        state.excitedLike -> "🎉"
+        state.busyLike -> "💼"
+        state == CharacterState.EATING -> "🍽️"
+        else -> "😐"
     }
 
     /**
@@ -1312,7 +1339,7 @@ class ClawRenderer(
             isAntiAlias = true
         }
 
-        val defaultLid = if (entity.state == CharacterState.SLEEPING) 1.0f else 0f
+        val defaultLid = if (entity.state == CharacterState.SLEEPING || entity.state == CharacterState.WAITING) 1.0f else 0f
         val lidFactor = (entity.parts?.get("EYE_LID") as? Double)?.toFloat() ?: defaultLid
         val browAngle = (entity.parts?.get("EYE_ANGLE") as? Double)?.toFloat() ?: 0f
 

--- a/app/src/main/java/com/hank/clawlive/engine/ProceduralCreatureDrawer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ProceduralCreatureDrawer.kt
@@ -4,6 +4,7 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Path
+import com.hank.clawlive.data.model.CharacterState
 import com.hank.clawlive.data.model.CompanionDetail
 import com.hank.clawlive.data.model.EntityStatus
 import kotlin.math.sin
@@ -113,7 +114,7 @@ object ProceduralCreatureDrawer {
     private fun drawCatFace(canvas: Canvas, e: EntityStatus, dark: Int) {
         val eye = fillPaint(Color.parseColor("#1a1a2e"))
         val glow = fillPaint(Color.parseColor("#80ffd9"))
-        val sleeping = e.state.toString() == "SLEEPING"
+        val sleeping = e.state == CharacterState.SLEEPING || e.state == CharacterState.WAITING
 
         if (sleeping) {
             // Closed eyes (curve)
@@ -155,7 +156,7 @@ object ProceduralCreatureDrawer {
     // ---------------------------------------------------------------- Dog
     private fun drawDog(canvas: Canvas, e: EntityStatus, body: Int, dark: Int, t: Long) {
         val tailWag = sin(t * 0.012).toFloat() * 12f
-        val tongue = e.state.toString() == "EXCITED" || e.state.toString() == "EATING"
+        val tongue = e.state.excitedLike || e.state == CharacterState.EATING
 
         val bodyP = fillPaint(body)
         val outline = strokePaint(dark, 2f)
@@ -212,7 +213,7 @@ object ProceduralCreatureDrawer {
 
     private fun drawDogFace(canvas: Canvas, e: EntityStatus, dark: Int, tongue: Boolean) {
         val eye = fillPaint(Color.parseColor("#1a1a2e"))
-        val sleeping = e.state.toString() == "SLEEPING"
+        val sleeping = e.state == CharacterState.SLEEPING || e.state == CharacterState.WAITING
 
         if (sleeping) {
             val p = strokePaint(Color.parseColor("#1a1a2e"), 2f)
@@ -316,7 +317,7 @@ object ProceduralCreatureDrawer {
     }
 
     private fun drawFishFace(canvas: Canvas, e: EntityStatus) {
-        val sleeping = e.state.toString() == "SLEEPING"
+        val sleeping = e.state == CharacterState.SLEEPING || e.state == CharacterState.WAITING
         val white = fillPaint(Color.WHITE)
         val pupil = fillPaint(Color.parseColor("#1a1a2e"))
         val outline = strokePaint(Color.parseColor("#1a1a2e"), 1f)

--- a/app/src/main/java/com/hank/clawlive/engine/SpeechBubbleController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/SpeechBubbleController.kt
@@ -71,7 +71,7 @@ class SpeechBubbleController(
 
     /**
      * Show (or refresh) a bubble for [entityId]. TTL starts from the preferred
-     * user duration, then extends for long text at 0.06s/char and caps at 30s.
+     * user duration, then extends for long text at 0.06s/char and caps at 5m.
      * [ttlMsOverride] remains an exact escape hatch for deterministic tests.
      * A new message resets the TTL (rapid-fire chat, open question O-7).
      * Blank text clears any existing bubble.
@@ -170,9 +170,9 @@ class SpeechBubbleController(
         /** Default preferred TTL for short wallpaper bubbles. */
         const val DEFAULT_TTL_MS = 12_000L
         /** Floor for any message bubble (§5.3). */
-        const val MIN_TTL_MS = 3_000L
+        const val MIN_TTL_MS = 5_000L
         /** Smart cap for long messages, regardless of text length. */
-        const val MAX_TTL_MS = 30_000L
+        const val MAX_TTL_MS = 300_000L
         /** Per-character contribution to TTL (§5.3: 0.06s/char). */
         const val PER_CHAR_MS = 60L
         /** Fade-out ramp window at the end of life. */

--- a/app/src/main/java/com/hank/clawlive/engine/SpritesheetCompanionDrawer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/SpritesheetCompanionDrawer.kt
@@ -52,7 +52,8 @@ class SpritesheetCompanionDrawer(
         currentState: String,
         centerX: Float,
         centerY: Float,
-        scale: Float
+        scale: Float,
+        facingDirection: WalkFacingDirection = WalkFacingDirection.RIGHT
     ): DrawResult {
         val sheetUrl = companion.spritesheetUrl()
         if (sheetUrl.isNullOrBlank()) return DrawResult.UNSUPPORTED
@@ -101,7 +102,12 @@ class SpritesheetCompanionDrawer(
             centerX + renderSize / 2f,
             centerY + renderSize / 2f
         )
+        canvas.save()
+        if (facingDirection == WalkFacingDirection.LEFT) {
+            canvas.scale(-1f, 1f, centerX, centerY)
+        }
         canvas.drawBitmap(sheet, src, dst, paint)
+        canvas.restore()
         return DrawResult.DRAWN
     }
 

--- a/app/src/main/java/com/hank/clawlive/engine/SpritesheetCompanionDrawer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/SpritesheetCompanionDrawer.kt
@@ -53,7 +53,8 @@ class SpritesheetCompanionDrawer(
         centerX: Float,
         centerY: Float,
         scale: Float,
-        facingDirection: WalkFacingDirection = WalkFacingDirection.RIGHT
+        facingDirection: WalkFacingDirection = WalkFacingDirection.RIGHT,
+        mirrorForFacing: Boolean = true
     ): DrawResult {
         val sheetUrl = companion.spritesheetUrl()
         if (sheetUrl.isNullOrBlank()) return DrawResult.UNSUPPORTED
@@ -65,14 +66,15 @@ class SpritesheetCompanionDrawer(
         if (frameW <= 0 || frameH <= 0) return DrawResult.UNSUPPORTED
 
         val supported = companion.supportedStates
-        val effectiveState = if (currentState in supported) currentState else "IDLE"
-        val hint = companion.stateAsset(effectiveState) ?: return DrawResult.UNSUPPORTED
+        val effectiveState = currentState.trim().ifBlank { "IDLE" }
+        val hint = companion.stateAsset(effectiveState)
         val animation = companion.spritesheetAnimation(effectiveState)
+        if (hint == null && animation == null) return DrawResult.UNSUPPORTED
 
         // Row defaults to position in supportedStates if descriptor doesn't pin one.
-        val row = animation?.row ?: if (hint.row > 0) hint.row else supported.indexOf(effectiveState).coerceAtLeast(0)
+        val row = animation?.row ?: if ((hint?.row ?: 0) > 0) hint?.row ?: 0 else supported.indexOf(effectiveState).coerceAtLeast(0)
         val frameDurations = animation?.frameDurationsMs?.takeIf { it.isNotEmpty() }
-            ?: List(hint.frames.coerceAtLeast(1)) { (1000 / hint.fps.coerceAtLeast(1)).coerceAtLeast(1) }
+            ?: List((hint?.frames ?: 1).coerceAtLeast(1)) { (1000 / (hint?.fps ?: 4).coerceAtLeast(1)).coerceAtLeast(1) }
         val frames = frameDurations.size
 
         // Reset frame timing on state change so non-looping animations replay.
@@ -83,7 +85,7 @@ class SpritesheetCompanionDrawer(
         }
 
         val elapsed = now - stateStart
-        val frameIndex = computeFrameIndex(elapsed, frameDurations, hint.loop)
+        val frameIndex = computeFrameIndex(elapsed, frameDurations, hint?.loop ?: true)
 
         val srcX = (frameIndex * frameW).coerceAtMost(sheet.width - frameW).coerceAtLeast(0)
         val srcY = (row * frameH).coerceAtMost(sheet.height - frameH).coerceAtLeast(0)
@@ -103,7 +105,7 @@ class SpritesheetCompanionDrawer(
             centerY + renderSize / 2f
         )
         canvas.save()
-        if (facingDirection == WalkFacingDirection.LEFT) {
+        if (mirrorForFacing && facingDirection == WalkFacingDirection.LEFT) {
             canvas.scale(-1f, 1f, centerX, centerY)
         }
         canvas.drawBitmap(sheet, src, dst, paint)

--- a/app/src/main/java/com/hank/clawlive/engine/WallpaperInteractionController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/WallpaperInteractionController.kt
@@ -1,0 +1,219 @@
+package com.hank.clawlive.engine
+
+import com.hank.clawlive.data.model.CharacterState
+import com.hank.clawlive.data.model.EntityStatus
+import kotlin.math.PI
+import kotlin.math.hypot
+import kotlin.math.min
+import kotlin.math.sin
+
+class WallpaperInteractionController(
+    private val collisionDistancePct: Float = DEFAULT_COLLISION_DISTANCE_PCT,
+    private val cooldownMs: Long = DEFAULT_COOLDOWN_MS,
+    private val effectDurationMs: Long = DEFAULT_EFFECT_DURATION_MS
+) {
+    enum class InteractionKind {
+        GREETING,
+        SPARK,
+        BUMP
+    }
+
+    data class InteractionEffect(
+        val firstEntityId: Int,
+        val secondEntityId: Int,
+        val kind: InteractionKind,
+        val centerX: Float,
+        val centerY: Float,
+        val startedAtMs: Long,
+        val expiresAtMs: Long
+    ) {
+        fun progress(nowMs: Long): Float {
+            val duration = (expiresAtMs - startedAtMs).coerceAtLeast(1L)
+            return ((nowMs - startedAtMs).toFloat() / duration.toFloat()).coerceIn(0f, 1f)
+        }
+
+        fun alpha(nowMs: Long): Float {
+            return sin((progress(nowMs) * PI).toFloat()).coerceIn(0f, 1f)
+        }
+
+        fun scale(nowMs: Long): Float {
+            return 0.8f + 0.35f * alpha(nowMs)
+        }
+
+        val label: String
+            get() = when (kind) {
+                InteractionKind.GREETING -> "hi"
+                InteractionKind.SPARK -> "*"
+                InteractionKind.BUMP -> "!"
+            }
+    }
+
+    data class RenderState(
+        val positions: List<Pair<Float, Float>>,
+        val effects: List<InteractionEffect>
+    )
+
+    private data class PairKey(val first: Int, val second: Int) {
+        companion object {
+            fun of(a: Int, b: Int): PairKey {
+                return if (a <= b) PairKey(a, b) else PairKey(b, a)
+            }
+        }
+    }
+
+    private data class ActiveInteraction(
+        val key: PairKey,
+        val kind: InteractionKind,
+        val unitX: Float,
+        val unitY: Float,
+        val startedAtMs: Long,
+        val expiresAtMs: Long
+    )
+
+    private val active = mutableMapOf<PairKey, ActiveInteraction>()
+    private val lastTriggeredAt = mutableMapOf<PairKey, Long>()
+
+    fun reset() {
+        active.clear()
+        lastTriggeredAt.clear()
+    }
+
+    fun apply(
+        positions: List<Pair<Float, Float>>,
+        entities: List<EntityStatus>,
+        width: Float,
+        height: Float,
+        enabled: Boolean,
+        nowMs: Long
+    ): RenderState {
+        if (!enabled || width <= 0f || height <= 0f || positions.size < 2 || entities.size < 2) {
+            active.clear()
+            return RenderState(positions, emptyList())
+        }
+
+        val entityIds = entities.map { it.entityId }.toSet()
+        val sleepingIds = entities.filter { it.state == CharacterState.SLEEPING }.map { it.entityId }.toSet()
+        active.keys.toList().forEach { key ->
+            val expired = active[key]?.expiresAtMs?.let { nowMs >= it } ?: true
+            val missing = key.first !in entityIds || key.second !in entityIds
+            val sleeping = key.first in sleepingIds || key.second in sleepingIds
+            if (expired || missing || sleeping) active.remove(key)
+        }
+
+        detectCollisions(positions, entities, width, height, nowMs, sleepingIds)
+
+        val indexById = entities.mapIndexed { index, entity -> entity.entityId to index }.toMap()
+        val adjusted = positions.toMutableList()
+        active.values.forEach { interaction ->
+            val firstIndex = indexById[interaction.key.first] ?: return@forEach
+            val secondIndex = indexById[interaction.key.second] ?: return@forEach
+            val progress = interactionProgress(interaction, nowMs)
+            val pulse = sin((progress * PI).toFloat()).coerceIn(0f, 1f)
+            val bouncePx = min(width, height) * BOUNCE_DISTANCE_PCT * pulse
+
+            adjusted[firstIndex] = adjusted[firstIndex].offset(
+                -interaction.unitX * bouncePx,
+                -interaction.unitY * bouncePx,
+                width,
+                height
+            )
+            adjusted[secondIndex] = adjusted[secondIndex].offset(
+                interaction.unitX * bouncePx,
+                interaction.unitY * bouncePx,
+                width,
+                height
+            )
+        }
+
+        val effects = active.values.mapNotNull { interaction ->
+            val firstIndex = indexById[interaction.key.first] ?: return@mapNotNull null
+            val secondIndex = indexById[interaction.key.second] ?: return@mapNotNull null
+            val first = adjusted[firstIndex]
+            val second = adjusted[secondIndex]
+            InteractionEffect(
+                firstEntityId = interaction.key.first,
+                secondEntityId = interaction.key.second,
+                kind = interaction.kind,
+                centerX = (first.first + second.first) / 2f,
+                centerY = (first.second + second.second) / 2f - min(width, height) * EFFECT_FLOAT_PCT,
+                startedAtMs = interaction.startedAtMs,
+                expiresAtMs = interaction.expiresAtMs
+            )
+        }
+
+        return RenderState(adjusted, effects)
+    }
+
+    private fun detectCollisions(
+        positions: List<Pair<Float, Float>>,
+        entities: List<EntityStatus>,
+        width: Float,
+        height: Float,
+        nowMs: Long,
+        sleepingIds: Set<Int>
+    ) {
+        val collisionDistancePx = min(width, height) * collisionDistancePct
+        for (i in 0 until minOf(entities.size, positions.size)) {
+            val first = entities[i]
+            if (first.entityId in sleepingIds) continue
+            for (j in i + 1 until minOf(entities.size, positions.size)) {
+                val second = entities[j]
+                if (second.entityId in sleepingIds) continue
+                val key = PairKey.of(first.entityId, second.entityId)
+                if (active.containsKey(key)) continue
+                val last = lastTriggeredAt[key]
+                if (last != null && nowMs - last < cooldownMs) continue
+
+                val firstPos = positions[i]
+                val secondPos = positions[j]
+                val dx = secondPos.first - firstPos.first
+                val dy = secondPos.second - firstPos.second
+                val distance = hypot(dx, dy)
+                if (distance > collisionDistancePx) continue
+
+                val safeDistance = distance.coerceAtLeast(1f)
+                val unitX = if (distance < 1f) {
+                    if (first.entityId <= second.entityId) 1f else -1f
+                } else {
+                    dx / safeDistance
+                }
+                val unitY = if (distance < 1f) 0f else dy / safeDistance
+                val interaction = ActiveInteraction(
+                    key = key,
+                    kind = kindFor(key, nowMs),
+                    unitX = unitX,
+                    unitY = unitY,
+                    startedAtMs = nowMs,
+                    expiresAtMs = nowMs + effectDurationMs
+                )
+                active[key] = interaction
+                lastTriggeredAt[key] = nowMs
+            }
+        }
+    }
+
+    private fun kindFor(key: PairKey, nowMs: Long): InteractionKind {
+        return when (((key.first * 31) + (key.second * 17) + (nowMs / cooldownMs).toInt()) % 3) {
+            0 -> InteractionKind.GREETING
+            1 -> InteractionKind.SPARK
+            else -> InteractionKind.BUMP
+        }
+    }
+
+    private fun interactionProgress(interaction: ActiveInteraction, nowMs: Long): Float {
+        val duration = (interaction.expiresAtMs - interaction.startedAtMs).coerceAtLeast(1L)
+        return ((nowMs - interaction.startedAtMs).toFloat() / duration.toFloat()).coerceIn(0f, 1f)
+    }
+
+    private fun Pair<Float, Float>.offset(dx: Float, dy: Float, width: Float, height: Float): Pair<Float, Float> {
+        return (first + dx).coerceIn(0f, width) to (second + dy).coerceIn(0f, height)
+    }
+
+    companion object {
+        private const val DEFAULT_COLLISION_DISTANCE_PCT = 0.12f
+        private const val DEFAULT_COOLDOWN_MS = 8_000L
+        private const val DEFAULT_EFFECT_DURATION_MS = 1_200L
+        private const val BOUNCE_DISTANCE_PCT = 0.035f
+        private const val EFFECT_FLOAT_PCT = 0.06f
+    }
+}

--- a/app/src/main/java/com/hank/clawlive/engine/WallpaperInteractionController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/WallpaperInteractionController.kt
@@ -1,6 +1,5 @@
 package com.hank.clawlive.engine
 
-import com.hank.clawlive.data.model.CharacterState
 import com.hank.clawlive.data.model.EntityStatus
 import kotlin.math.PI
 import kotlin.math.hypot
@@ -50,7 +49,13 @@ class WallpaperInteractionController(
 
     data class RenderState(
         val positions: List<Pair<Float, Float>>,
-        val effects: List<InteractionEffect>
+        val effects: List<InteractionEffect>,
+        val posesByEntity: Map<Int, InteractionPose> = emptyMap()
+    )
+
+    data class InteractionPose(
+        val liftPx: Float = 0f,
+        val facingDirection: WalkFacingDirection? = null
     )
 
     private data class PairKey(val first: Int, val second: Int) {
@@ -92,7 +97,7 @@ class WallpaperInteractionController(
         }
 
         val entityIds = entities.map { it.entityId }.toSet()
-        val sleepingIds = entities.filter { it.state == CharacterState.SLEEPING }.map { it.entityId }.toSet()
+        val sleepingIds = entities.filter { it.state.pausesAmbientWander }.map { it.entityId }.toSet()
         active.keys.toList().forEach { key ->
             val expired = active[key]?.expiresAtMs?.let { nowMs >= it } ?: true
             val missing = key.first !in entityIds || key.second !in entityIds
@@ -104,12 +109,14 @@ class WallpaperInteractionController(
 
         val indexById = entities.mapIndexed { index, entity -> entity.entityId to index }.toMap()
         val adjusted = positions.toMutableList()
+        val posesByEntity = mutableMapOf<Int, InteractionPose>()
         active.values.forEach { interaction ->
             val firstIndex = indexById[interaction.key.first] ?: return@forEach
             val secondIndex = indexById[interaction.key.second] ?: return@forEach
             val progress = interactionProgress(interaction, nowMs)
             val pulse = sin((progress * PI).toFloat()).coerceIn(0f, 1f)
             val bouncePx = min(width, height) * BOUNCE_DISTANCE_PCT * pulse
+            val hopPx = min(width, height) * HOP_DISTANCE_PCT * pulse
 
             adjusted[firstIndex] = adjusted[firstIndex].offset(
                 -interaction.unitX * bouncePx,
@@ -122,6 +129,14 @@ class WallpaperInteractionController(
                 interaction.unitY * bouncePx,
                 width,
                 height
+            )
+            val firstFacing = if (interaction.unitX >= 0f) WalkFacingDirection.RIGHT else WalkFacingDirection.LEFT
+            val secondFacing = if (interaction.unitX >= 0f) WalkFacingDirection.LEFT else WalkFacingDirection.RIGHT
+            posesByEntity[interaction.key.first] = posesByEntity[interaction.key.first].merge(
+                InteractionPose(liftPx = hopPx, facingDirection = firstFacing)
+            )
+            posesByEntity[interaction.key.second] = posesByEntity[interaction.key.second].merge(
+                InteractionPose(liftPx = hopPx, facingDirection = secondFacing)
             )
         }
 
@@ -141,7 +156,7 @@ class WallpaperInteractionController(
             )
         }
 
-        return RenderState(adjusted, effects)
+        return RenderState(adjusted, effects, posesByEntity)
     }
 
     private fun detectCollisions(
@@ -209,11 +224,20 @@ class WallpaperInteractionController(
         return (first + dx).coerceIn(0f, width) to (second + dy).coerceIn(0f, height)
     }
 
+    private fun InteractionPose?.merge(other: InteractionPose): InteractionPose {
+        if (this == null) return other
+        return InteractionPose(
+            liftPx = maxOf(liftPx, other.liftPx),
+            facingDirection = other.facingDirection ?: facingDirection
+        )
+    }
+
     companion object {
         private const val DEFAULT_COLLISION_DISTANCE_PCT = 0.12f
         private const val DEFAULT_COOLDOWN_MS = 8_000L
         private const val DEFAULT_EFFECT_DURATION_MS = 1_200L
         private const val BOUNCE_DISTANCE_PCT = 0.035f
+        private const val HOP_DISTANCE_PCT = 0.025f
         private const val EFFECT_FLOAT_PCT = 0.06f
     }
 }

--- a/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
@@ -1,7 +1,6 @@
 package com.hank.clawlive.engine
 
 import android.graphics.PointF
-import com.hank.clawlive.data.model.CharacterState
 import com.hank.clawlive.data.model.EntityStatus
 import kotlin.math.abs
 import kotlin.math.hypot
@@ -148,7 +147,7 @@ class WallpaperWanderController(
         val activeIds = entities.map { it.entityId }.toSet()
         states.keys.toList().forEach { id -> if (id !in activeIds) states.remove(id) }
         val ambientPeers = entities.mapIndexedNotNull { index, entity ->
-            if (entity.state == CharacterState.SLEEPING) return@mapIndexedNotNull null
+            if (entity.state.pausesAmbientWander) return@mapIndexedNotNull null
             val base = basePositions.getOrNull(index) ?: (width / 2f to height / 2f)
             val baseX = (base.first / width).coerceIn(MIN_X_PCT, MAX_X_PCT)
             val baseY = (base.second / height).coerceIn(MIN_Y_PCT, MAX_Y_PCT)
@@ -162,7 +161,7 @@ class WallpaperWanderController(
 
         return entities.mapIndexed { index, entity ->
             val base = basePositions.getOrNull(index) ?: (width / 2f to height / 2f)
-            if (entity.state == CharacterState.SLEEPING) {
+            if (entity.state.pausesAmbientWander) {
                 val state = stateFor(entity.entityId, base, width, height, nowMs)
                 state.motionState = MotionState.SLEEPING
                 state.moving = false
@@ -343,8 +342,8 @@ class WallpaperWanderController(
         val peers = ambientPeers.filter { it.entityId != entity.entityId }
         val step = state.ambientStep++
         val goal = when {
-            peers.isNotEmpty() && entity.state == CharacterState.EXCITED -> AmbientWanderGoal.VISIT_COMPANION
-            entity.state == CharacterState.BUSY -> if (step % 2 == 0) AmbientWanderGoal.PATROL else AmbientWanderGoal.RETURN_HOME
+            peers.isNotEmpty() && entity.state.excitedLike -> AmbientWanderGoal.VISIT_COMPANION
+            entity.state.busyLike -> if (step % 2 == 0) AmbientWanderGoal.PATROL else AmbientWanderGoal.RETURN_HOME
             peers.isNotEmpty() && step % 3 == 0 -> AmbientWanderGoal.VISIT_COMPANION
             step % 3 == 1 -> AmbientWanderGoal.PATROL
             else -> AmbientWanderGoal.RETURN_HOME

--- a/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
@@ -3,6 +3,7 @@ package com.hank.clawlive.engine
 import android.graphics.PointF
 import com.hank.clawlive.data.model.CharacterState
 import com.hank.clawlive.data.model.EntityStatus
+import kotlin.math.abs
 import kotlin.math.hypot
 import kotlin.math.min
 import kotlin.random.Random
@@ -28,6 +29,11 @@ enum class AmbientWanderGoal {
     VISIT_COMPANION,
     PATROL,
     RETURN_HOME
+}
+
+enum class WalkFacingDirection {
+    LEFT,
+    RIGHT
 }
 
 /**
@@ -58,6 +64,7 @@ class WallpaperWanderController(
         var motionState: MotionState,
         var ambientGoal: AmbientWanderGoal,
         var ambientStep: Int,
+        var facingDirection: WalkFacingDirection,
         var onArrive: (() -> Unit)? = null
     )
 
@@ -77,6 +84,10 @@ class WallpaperWanderController(
 
     fun ambientGoal(entityId: Int): AmbientWanderGoal {
         return states[entityId]?.ambientGoal ?: AmbientWanderGoal.RANDOM
+    }
+
+    fun facingDirection(entityId: Int): WalkFacingDirection {
+        return states[entityId]?.facingDirection ?: WalkFacingDirection.RIGHT
     }
 
     override fun position(entityId: Int): PointF {
@@ -245,7 +256,8 @@ class WallpaperWanderController(
                 moving = false,
                 motionState = MotionState.WANDERING,
                 ambientGoal = AmbientWanderGoal.RANDOM,
-                ambientStep = 0
+                ambientStep = 0,
+                facingDirection = WalkFacingDirection.RIGHT
             )
         }
         coerceToSafeBounds(state)
@@ -267,7 +279,8 @@ class WallpaperWanderController(
                 moving = false,
                 motionState = MotionState.STOPPED,
                 ambientGoal = AmbientWanderGoal.RANDOM,
-                ambientStep = 0
+                ambientStep = 0,
+                facingDirection = WalkFacingDirection.RIGHT
             )
         }
     }
@@ -281,6 +294,9 @@ class WallpaperWanderController(
     ): Boolean {
         val dxPx = (state.targetXPct - state.xPct) * width
         val dyPx = (state.targetYPct - state.yPct) * height
+        if (abs(dxPx) > FACING_EPSILON_PX) {
+            state.facingDirection = if (dxPx < 0f) WalkFacingDirection.LEFT else WalkFacingDirection.RIGHT
+        }
         val distancePx = hypot(dxPx, dyPx)
         val stepPx = speedPctPerSecond * min(width, height) * dtSeconds
 
@@ -402,6 +418,7 @@ class WallpaperWanderController(
         const val DEFAULT_WANDER_SPEED_PCT_PER_SECOND = 0.04f
         const val DEFAULT_TARGET_SPEED_PCT_PER_SECOND = 0.12f
         private const val ARRIVAL_EPSILON_PX = 1f
+        private const val FACING_EPSILON_PX = 0.5f
         private const val MAX_IDLE_MS = 3000L
         private const val MIN_RETARGET_MS = 3000L
         private const val MAX_RETARGET_MS = 8000L

--- a/app/src/main/java/com/hank/clawlive/ui/EntityCardAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/EntityCardAdapter.kt
@@ -266,12 +266,14 @@ class EntityCardAdapter(
         }
 
         private fun getStateBadgeColor(state: CharacterState): Int {
-            return when (state) {
-                CharacterState.IDLE -> Color.parseColor("#4CAF50")
-                CharacterState.BUSY -> Color.parseColor("#2196F3")
-                CharacterState.EATING -> Color.parseColor("#FF9800")
-                CharacterState.SLEEPING -> Color.parseColor("#607D8B")
-                CharacterState.EXCITED -> Color.parseColor("#E91E63")
+            return when {
+                state == CharacterState.FAILED -> Color.parseColor("#EF4444")
+                state == CharacterState.REVIEW -> Color.parseColor("#8B5CF6")
+                state.pausesAmbientWander -> Color.parseColor("#607D8B")
+                state.busyLike -> Color.parseColor("#2196F3")
+                state.excitedLike -> Color.parseColor("#E91E63")
+                state == CharacterState.EATING -> Color.parseColor("#FF9800")
+                else -> Color.parseColor("#4CAF50")
             }
         }
     }

--- a/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
@@ -314,7 +314,9 @@ class WallpaperPreviewView @JvmOverloads constructor(
             val (x, y) = interactionState.positions.getOrNull(index)
                 ?: basePositions.getOrNull(index)
                 ?: (width / 2f to height / 2f)
-            lastRenderPositionsByEntity[entity.entityId] = x to y
+            val interactionPose = interactionState.posesByEntity[entity.entityId]
+            val drawY = y - (interactionPose?.liftPx ?: 0f)
+            lastRenderPositionsByEntity[entity.entityId] = x to drawY
             
             // Get per-entity scale
             val entityScale = entityScales[entity.entityId] ?: 1.0f
@@ -347,16 +349,17 @@ class WallpaperPreviewView @JvmOverloads constructor(
                 canvas,
                 entity,
                 x,
-                y,
+                drawY,
                 entityScale,
                 walking = wanderController.isWalking(entity.entityId),
-                facingDirection = wanderController.facingDirection(entity.entityId)
+                facingDirection = interactionPose?.facingDirection
+                    ?: wanderController.facingDirection(entity.entityId)
             )
 
             // Draw entity name label
             labelPaint.textSize = 32f * entityScale.coerceAtLeast(0.7f)
             labelPaint.color = Color.WHITE
-            val labelY = y + indicatorRadius + 40f
+            val labelY = drawY + indicatorRadius + 40f
             val displayName = entity.name ?: "#${entity.entityId}"
             canvas.drawText(displayName, x, labelY, labelPaint)
             
@@ -549,15 +552,21 @@ class WallpaperPreviewView @JvmOverloads constructor(
     ) {
         val companion = companionRepository?.cached(entity.entityId) ?: companionsByEntity[entity.entityId]
         if (companion?.assetType == "spritesheet") {
+            val spritesheetState = if (walking && entity.state.canUseAmbientWalkingAnimation) {
+                WallpaperWanderController.WALKING_STATE_ASSET
+            } else {
+                entity.state.wallpaperActionKey
+            }
             val result = spritesheetDrawer?.draw(
                 canvas,
                 companion,
                 entity.entityId,
-                if (walking) WallpaperWanderController.WALKING_STATE_ASSET else entity.state.toString(),
+                spritesheetState,
                 cx,
                 cy,
                 scale * 1.2f,
-                facingDirection
+                facingDirection,
+                shouldMirrorSpritesheetForFacing(spritesheetState)
             ) ?: SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED
             if (result == SpritesheetCompanionDrawer.DrawResult.DRAWN ||
                 result == SpritesheetCompanionDrawer.DrawResult.LOADING
@@ -872,6 +881,11 @@ class WallpaperPreviewView @JvmOverloads constructor(
             enableCustomLayoutForGesture()
             invalidate()
         }
+    }
+
+    private fun shouldMirrorSpritesheetForFacing(spritesheetState: String): Boolean {
+        return spritesheetState != com.hank.clawlive.data.model.CharacterState.RUNNING_LEFT.wallpaperActionKey &&
+            spritesheetState != com.hank.clawlive.data.model.CharacterState.RUNNING_RIGHT.wallpaperActionKey
     }
 
     private fun finishLockedScale() {

--- a/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
@@ -21,6 +21,8 @@ import com.hank.clawlive.data.model.UsageSnapshotLatest
 import com.hank.clawlive.engine.ProceduralCreatureDrawer
 import com.hank.clawlive.engine.SpritesheetCompanionDrawer
 import com.hank.clawlive.engine.UsageOverlayRenderer
+import com.hank.clawlive.engine.WalkFacingDirection
+import com.hank.clawlive.engine.WallpaperInteractionController
 import com.hank.clawlive.engine.WallpaperWanderController
 import com.hank.clawlive.data.repository.CompanionRepository
 import kotlin.math.ceil
@@ -45,6 +47,7 @@ class WallpaperPreviewView @JvmOverloads constructor(
     private val layoutPrefs = LayoutPreferences.getInstance(context)
     private val usageOverlayRenderer = UsageOverlayRenderer(context, layoutPrefs)
     private val wanderController = WallpaperWanderController()
+    private val interactionController = WallpaperInteractionController()
     private val animationHandler = Handler(Looper.getMainLooper())
     private val animationRunnable = object : Runnable {
         override fun run() {
@@ -127,6 +130,14 @@ class WallpaperPreviewView @JvmOverloads constructor(
         textSize = 40f
         textAlign = Paint.Align.CENTER
         isAntiAlias = true
+    }
+
+    private val interactionTextPaint = Paint().apply {
+        color = Color.WHITE
+        textSize = 30f
+        textAlign = Paint.Align.CENTER
+        isAntiAlias = true
+        isFakeBoldText = true
     }
     
     init {
@@ -289,10 +300,20 @@ class WallpaperPreviewView @JvmOverloads constructor(
             enabled = layoutPrefs.wallpaperWalkingEnabled,
             purposeful = layoutPrefs.wallpaperPurposefulWalkingEnabled
         )
+        val interactionState = interactionController.apply(
+            positions = renderPositions,
+            entities = entities,
+            width = width.toFloat(),
+            height = height.toFloat(),
+            enabled = layoutPrefs.wallpaperEntityInteractionsEnabled,
+            nowMs = System.currentTimeMillis()
+        )
 
         // Draw each entity with per-entity scale
         entities.forEachIndexed { index, entity ->
-            val (x, y) = renderPositions.getOrNull(index) ?: basePositions.getOrNull(index) ?: (width / 2f to height / 2f)
+            val (x, y) = interactionState.positions.getOrNull(index)
+                ?: basePositions.getOrNull(index)
+                ?: (width / 2f to height / 2f)
             lastRenderPositionsByEntity[entity.entityId] = x to y
             
             // Get per-entity scale
@@ -328,7 +349,8 @@ class WallpaperPreviewView @JvmOverloads constructor(
                 x,
                 y,
                 entityScale,
-                walking = wanderController.isWalking(entity.entityId)
+                walking = wanderController.isWalking(entity.entityId),
+                facingDirection = wanderController.facingDirection(entity.entityId)
             )
 
             // Draw entity name label
@@ -344,6 +366,10 @@ class WallpaperPreviewView @JvmOverloads constructor(
                 labelPaint.color = Color.CYAN
                 canvas.drawText("${String.format("%.1f", entityScale)}x", x, labelY + 30f, labelPaint)
             }
+        }
+
+        interactionState.effects.forEach { effect ->
+            drawInteractionEffect(canvas, effect)
         }
 
         usageOverlayRenderer.draw(
@@ -518,7 +544,8 @@ class WallpaperPreviewView @JvmOverloads constructor(
         cx: Float,
         cy: Float,
         scale: Float,
-        walking: Boolean = false
+        walking: Boolean = false,
+        facingDirection: WalkFacingDirection = WalkFacingDirection.RIGHT
     ) {
         val companion = companionRepository?.cached(entity.entityId) ?: companionsByEntity[entity.entityId]
         if (companion?.assetType == "spritesheet") {
@@ -529,7 +556,8 @@ class WallpaperPreviewView @JvmOverloads constructor(
                 if (walking) WallpaperWanderController.WALKING_STATE_ASSET else entity.state.toString(),
                 cx,
                 cy,
-                scale * 1.2f
+                scale * 1.2f,
+                facingDirection
             ) ?: SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED
             if (result == SpritesheetCompanionDrawer.DrawResult.DRAWN ||
                 result == SpritesheetCompanionDrawer.DrawResult.LOADING
@@ -541,7 +569,11 @@ class WallpaperPreviewView @JvmOverloads constructor(
         canvas.save()
 
         val svgScale = 3f * scale
-        canvas.translate(cx - (60 * svgScale), cy - (60 * svgScale))
+        canvas.translate(cx, cy)
+        if (facingDirection == WalkFacingDirection.LEFT) {
+            canvas.scale(-1f, 1f)
+        }
+        canvas.translate(-(60 * svgScale), -(60 * svgScale))
         canvas.scale(svgScale, svgScale)
 
         val bodyColor = parseHexColor(companion?.color) ?: when (entity.entityId) {
@@ -593,6 +625,23 @@ class WallpaperPreviewView @JvmOverloads constructor(
         }
 
         canvas.restore()
+    }
+
+    private fun drawInteractionEffect(
+        canvas: Canvas,
+        effect: WallpaperInteractionController.InteractionEffect
+    ) {
+        val alpha = effect.alpha(System.currentTimeMillis())
+        if (alpha <= 0f) return
+        interactionTextPaint.textSize = (30f * effect.scale(System.currentTimeMillis())).coerceIn(18f, 46f)
+        interactionTextPaint.alpha = (alpha * 210f).toInt().coerceIn(0, 230)
+        interactionTextPaint.color = when (effect.kind) {
+            WallpaperInteractionController.InteractionKind.GREETING -> Color.rgb(96, 165, 250)
+            WallpaperInteractionController.InteractionKind.SPARK -> Color.rgb(250, 204, 21)
+            WallpaperInteractionController.InteractionKind.BUMP -> Color.rgb(45, 212, 191)
+        }
+        canvas.drawText(effect.label, effect.centerX, effect.centerY, interactionTextPaint)
+        interactionTextPaint.alpha = 255
     }
 
     private fun drawUsageOverlayScaleIndicator(canvas: Canvas) {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -908,10 +908,14 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="wallpaper_setting_speech_bubbles">消息气泡</string>
     <string name="wallpaper_setting_speech_bubbles_desc">在伙伴旁显示实体状态与最近消息。</string>
     <string name="wallpaper_setting_bubble_duration">消息气泡停留时间</string>
-    <string name="wallpaper_setting_bubble_duration_desc">调整壁纸气泡存在时间；长消息会自动延长，但最多 30 秒。</string>
+    <string name="wallpaper_setting_bubble_duration_desc">调整壁纸气泡存在时间，可从 5 秒到 5 分钟；长消息会自动延长。</string>
     <string name="wallpaper_setting_bubble_duration_value">%1$d 秒</string>
+    <string name="wallpaper_setting_bubble_duration_minutes_value">%1$d 分钟</string>
+    <string name="wallpaper_setting_bubble_duration_minutes_seconds_value">%1$d 分 %2$d 秒</string>
     <string name="wallpaper_setting_purposeful_walking">有目的的行走</string>
     <string name="wallpaper_setting_purposeful_walking_desc">让待机伙伴会拜访同伴、巡逻、回到自己的活动区。</string>
+    <string name="wallpaper_setting_entity_interactions">实体互动</string>
+    <string name="wallpaper_setting_entity_interactions_desc">伙伴碰到彼此时会有小招呼、弹开等互动反应。</string>
     <string name="wallpaper_setting_bubble_pulse">气泡脉冲</string>
     <string name="wallpaper_setting_bubble_pulse_desc">气泡内容更新时短暂高亮伙伴。</string>
     <string name="wallpaper_setting_bubble_avoidance">智能气泡避让</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -822,10 +822,14 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="wallpaper_setting_speech_bubbles">訊息泡泡</string>
     <string name="wallpaper_setting_speech_bubbles_desc">在夥伴旁顯示實體狀態與最近訊息。</string>
     <string name="wallpaper_setting_bubble_duration">訊息泡泡停留時間</string>
-    <string name="wallpaper_setting_bubble_duration_desc">調整桌布泡泡存在時間；長訊息會自動延長，但最多 30 秒。</string>
+    <string name="wallpaper_setting_bubble_duration_desc">調整桌布泡泡存在時間，可從 5 秒到 5 分鐘；長訊息會自動延長。</string>
     <string name="wallpaper_setting_bubble_duration_value">%1$d 秒</string>
+    <string name="wallpaper_setting_bubble_duration_minutes_value">%1$d 分鐘</string>
+    <string name="wallpaper_setting_bubble_duration_minutes_seconds_value">%1$d 分 %2$d 秒</string>
     <string name="wallpaper_setting_purposeful_walking">有目的的走路</string>
     <string name="wallpaper_setting_purposeful_walking_desc">讓待機夥伴會拜訪同伴、巡邏、回到自己的活動區。</string>
+    <string name="wallpaper_setting_entity_interactions">實體互動</string>
+    <string name="wallpaper_setting_entity_interactions_desc">夥伴碰到彼此時會有小招呼、彈開等互動反應。</string>
     <string name="wallpaper_setting_bubble_pulse">泡泡脈衝</string>
     <string name="wallpaper_setting_bubble_pulse_desc">泡泡內容更新時短暫高亮夥伴。</string>
     <string name="wallpaper_setting_bubble_avoidance">智慧泡泡避讓</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,10 +130,14 @@
     <string name="wallpaper_setting_speech_bubbles">Message bubbles</string>
     <string name="wallpaper_setting_speech_bubbles_desc">Show entity status and recent messages near each companion.</string>
     <string name="wallpaper_setting_bubble_duration">Message bubble duration</string>
-    <string name="wallpaper_setting_bubble_duration_desc">Controls how long wallpaper bubbles stay visible; long messages automatically get more time.</string>
+    <string name="wallpaper_setting_bubble_duration_desc">Controls how long wallpaper bubbles stay visible, from 5 seconds to 5 minutes; long messages automatically get more time.</string>
     <string name="wallpaper_setting_bubble_duration_value">%1$d sec</string>
+    <string name="wallpaper_setting_bubble_duration_minutes_value">%1$d min</string>
+    <string name="wallpaper_setting_bubble_duration_minutes_seconds_value">%1$d min %2$d sec</string>
     <string name="wallpaper_setting_purposeful_walking">Purposeful walking</string>
     <string name="wallpaper_setting_purposeful_walking_desc">Give idle companions goals like visiting peers, patrolling, and returning home.</string>
+    <string name="wallpaper_setting_entity_interactions">Entity interactions</string>
+    <string name="wallpaper_setting_entity_interactions_desc">Let companions react when they bump into each other, with tiny greetings and bounce-away moments.</string>
     <string name="wallpaper_setting_bubble_pulse">Bubble pulse</string>
     <string name="wallpaper_setting_bubble_pulse_desc">Briefly highlight a companion when its bubble changes.</string>
     <string name="wallpaper_setting_bubble_avoidance">Smart bubble avoidance</string>

--- a/app/src/test/java/com/hank/clawlive/CompanionDescriptorAnimationTest.kt
+++ b/app/src/test/java/com/hank/clawlive/CompanionDescriptorAnimationTest.kt
@@ -1,6 +1,9 @@
 package com.hank.clawlive
 
+import com.google.gson.GsonBuilder
 import com.google.gson.JsonParser
+import com.hank.clawlive.data.model.CharacterState
+import com.hank.clawlive.data.model.CharacterStateJsonAdapter
 import com.hank.clawlive.data.model.CompanionDetail
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -74,5 +77,75 @@ class CompanionDescriptorAnimationTest {
         assertEquals(1, animation?.row)
         assertEquals(3, animation?.frameDurationsMs?.size)
         assertEquals(166, animation?.frameDurationsMs?.first())
+    }
+
+    @Test
+    fun nativePetdexActionKeysUseNativeAnimationRowsWithoutStateAssets() {
+        val descriptor = JsonParser.parseString(
+            """
+            {
+              "asset": {
+                "url": "https://example.test/petdex.webp",
+                "frameWidth": 192,
+                "frameHeight": 208,
+                "animations": {
+                  "idle": { "row": 0, "frames": [280, 110, 110, 140, 140, 320] },
+                  "running-right": { "row": 1, "count": 8, "dur": 120, "last": 220 },
+                  "running-left": { "row": 2, "count": 8, "dur": 120, "last": 220 },
+                  "waving": { "row": 3, "count": 4, "dur": 140, "last": 280 },
+                  "jumping": { "row": 4, "count": 5, "dur": 140, "last": 280 },
+                  "failed": { "row": 5, "count": 8, "dur": 140, "last": 240 },
+                  "waiting": { "row": 6, "count": 6, "dur": 150, "last": 260 },
+                  "running": { "row": 7, "count": 6, "dur": 120, "last": 220 },
+                  "review": { "row": 8, "count": 6, "dur": 150, "last": 280 }
+                }
+              },
+              "stateAssets": {
+                "IDLE": { "animation": "idle", "loop": true }
+              }
+            }
+            """.trimIndent()
+        ).asJsonObject
+
+        val companion = CompanionDetail(
+            id = "petdex-native-actions",
+            name = "Petdex Native Actions",
+            assetType = "spritesheet",
+            supportedStates = listOf("IDLE"),
+            descriptor = descriptor
+        )
+
+        val expectedRows = mapOf(
+            "idle" to 0,
+            "running-right" to 1,
+            "running-left" to 2,
+            "waving" to 3,
+            "jumping" to 4,
+            "failed" to 5,
+            "waiting" to 6,
+            "running" to 7,
+            "review" to 8
+        )
+
+        expectedRows.forEach { (action, row) ->
+            assertEquals(action, row, companion.spritesheetAnimation(action)?.row)
+        }
+        assertEquals(2, companion.spritesheetAnimation("RUNNING_LEFT")?.row)
+    }
+
+    @Test
+    fun characterStateJsonAdapterAcceptsPetdexActionKeys() {
+        val gson = GsonBuilder()
+            .registerTypeAdapter(CharacterState::class.java, CharacterStateJsonAdapter())
+            .create()
+
+        assertEquals(CharacterState.RUNNING_LEFT, gson.fromJson("\"running-left\"", CharacterState::class.java))
+        assertEquals(CharacterState.RUNNING_LEFT, gson.fromJson("\"RUNNING_LEFT\"", CharacterState::class.java))
+        assertEquals(CharacterState.WAVING, gson.fromJson("\"wave\"", CharacterState::class.java))
+        assertEquals(CharacterState.REVIEW, gson.fromJson("\"review\"", CharacterState::class.java))
+        assertEquals(CharacterState.IDLE, gson.fromJson("\"not-real\"", CharacterState::class.java))
+        assertEquals("\"running-left\"", gson.toJson(CharacterState.RUNNING_LEFT, CharacterState::class.java))
+        assertTrue(CharacterState.WAVING.pausesAmbientWander)
+        assertEquals("review", CharacterState.REVIEW.wallpaperActionKey)
     }
 }

--- a/app/src/test/java/com/hank/clawlive/SpeechBubbleControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/SpeechBubbleControllerTest.kt
@@ -51,17 +51,17 @@ class SpeechBubbleControllerTest {
     /** T2-1 lifecycle — bubble expires and is gone after its TTL. */
     @Test
     fun bubbleExpiresAfterTimeout() {
-        val controller = SpeechBubbleController(defaultTtlMs = 4_000L)
+        val controller = SpeechBubbleController(defaultTtlMs = 5_000L)
         controller.show(entityId = 3, text = "x", nowMs = 0L)
 
         // Short messages use the preferred/default TTL; still visible just before.
-        assertTrue(controller.isVisible(3, nowMs = 3_999L))
-        assertNotNull(controller.placementFor(3, 0.5f, 0.5f, 0.1f, nowMs = 3_999L))
+        assertTrue(controller.isVisible(3, nowMs = 4_999L))
+        assertNotNull(controller.placementFor(3, 0.5f, 0.5f, 0.1f, nowMs = 4_999L))
 
         // after TTL: gone.
-        assertFalse(controller.isVisible(3, nowMs = 4_001L))
-        assertNull(controller.placementFor(3, 0.5f, 0.5f, 0.1f, nowMs = 4_001L))
-        assertEquals(0, controller.activeCount(nowMs = 4_001L))
+        assertFalse(controller.isVisible(3, nowMs = 5_001L))
+        assertNull(controller.placementFor(3, 0.5f, 0.5f, 0.1f, nowMs = 5_001L))
+        assertEquals(0, controller.activeCount(nowMs = 5_001L))
     }
 
     /** Reduce-motion / disabled-walk: a static (non-walking) entity still anchors. */
@@ -123,24 +123,24 @@ class SpeechBubbleControllerTest {
         assertTrue(controller.isVisible(16, nowMs = 14_999L))
         assertFalse(controller.isVisible(16, nowMs = 15_001L))
 
-        // 600-char message -> would be 36s, capped to the smart 30s max.
-        val long = "a".repeat(600)
+        // 6000-char message -> would be 360s, capped to the smart 5m max.
+        val long = "a".repeat(6000)
         controller.show(entityId = 6, text = long, nowMs = 0L)
-        assertTrue(controller.isVisible(6, nowMs = 29_999L))
-        assertFalse(controller.isVisible(6, nowMs = 30_001L))
+        assertTrue(controller.isVisible(6, nowMs = 299_999L))
+        assertFalse(controller.isVisible(6, nowMs = 300_001L))
     }
 
     /** §5.3 / O-7 — a new message resets the TTL rather than letting the old one expire. */
     @Test
     fun newMessageResetsTtl() {
-        val controller = SpeechBubbleController(defaultTtlMs = 4_000L)
+        val controller = SpeechBubbleController(defaultTtlMs = 5_000L)
         controller.show(entityId = 7, text = "first", nowMs = 0L)
         // refresh near end of life
-        controller.show(entityId = 7, text = "second", nowMs = 3_500L)
+        controller.show(entityId = 7, text = "second", nowMs = 4_500L)
 
-        // original would have expired at 4_000L; refreshed one lives to 7_500L.
-        assertTrue(controller.isVisible(7, nowMs = 7_000L))
-        val placement = controller.placementFor(7, 0.5f, 0.5f, 0.1f, nowMs = 7_000L)!!
+        // original would have expired at 5_000L; refreshed one lives to 9_500L.
+        assertTrue(controller.isVisible(7, nowMs = 9_000L))
+        val placement = controller.placementFor(7, 0.5f, 0.5f, 0.1f, nowMs = 9_000L)!!
         assertEquals("second", placement.text)
     }
 

--- a/app/src/test/java/com/hank/clawlive/WallpaperInteractionControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/WallpaperInteractionControllerTest.kt
@@ -1,0 +1,68 @@
+package com.hank.clawlive
+
+import com.hank.clawlive.data.model.CharacterState
+import com.hank.clawlive.data.model.EntityStatus
+import com.hank.clawlive.engine.WallpaperInteractionController
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WallpaperInteractionControllerTest {
+    @Test
+    fun collisionTriggersEffectAndBounceAway() {
+        val controller = WallpaperInteractionController(
+            collisionDistancePct = 0.2f,
+            cooldownMs = 1_000L,
+            effectDurationMs = 1_000L
+        )
+        val entities = listOf(
+            EntityStatus(entityId = 1, state = CharacterState.IDLE),
+            EntityStatus(entityId = 2, state = CharacterState.IDLE)
+        )
+        val positions = listOf(500f to 500f, 540f to 500f)
+
+        val triggered = controller.apply(
+            positions = positions,
+            entities = entities,
+            width = 1000f,
+            height = 1000f,
+            enabled = true,
+            nowMs = 0L
+        )
+        assertEquals(1, triggered.effects.size)
+
+        val bounced = controller.apply(
+            positions = positions,
+            entities = entities,
+            width = 1000f,
+            height = 1000f,
+            enabled = true,
+            nowMs = 250L
+        )
+        assertEquals(1, bounced.effects.size)
+        assertTrue("first entity should bounce left", bounced.positions[0].first < positions[0].first)
+        assertTrue("second entity should bounce right", bounced.positions[1].first > positions[1].first)
+        assertTrue("effect should be visible mid-pulse", bounced.effects.first().alpha(250L) > 0f)
+    }
+
+    @Test
+    fun disabledOrSleepingEntitiesDoNotInteract() {
+        val controller = WallpaperInteractionController(collisionDistancePct = 0.2f)
+        val positions = listOf(500f to 500f, 540f to 500f)
+        val awake = listOf(
+            EntityStatus(entityId = 1, state = CharacterState.IDLE),
+            EntityStatus(entityId = 2, state = CharacterState.IDLE)
+        )
+        val sleeping = listOf(
+            EntityStatus(entityId = 1, state = CharacterState.IDLE),
+            EntityStatus(entityId = 2, state = CharacterState.SLEEPING)
+        )
+
+        val disabled = controller.apply(positions, awake, 1000f, 1000f, enabled = false, nowMs = 0L)
+        assertEquals(positions, disabled.positions)
+        assertEquals(0, disabled.effects.size)
+
+        val blocked = controller.apply(positions, sleeping, 1000f, 1000f, enabled = true, nowMs = 0L)
+        assertEquals(0, blocked.effects.size)
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
@@ -4,6 +4,7 @@ import com.hank.clawlive.data.model.CharacterState
 import com.hank.clawlive.data.model.EntityStatus
 import com.hank.clawlive.engine.AmbientWanderGoal
 import com.hank.clawlive.engine.MotionState
+import com.hank.clawlive.engine.WalkFacingDirection
 import com.hank.clawlive.engine.WallpaperWanderController
 import kotlin.random.Random
 import org.junit.Assert.assertEquals
@@ -54,6 +55,22 @@ class WallpaperWanderControllerTest {
         controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = false, nowMs = 9000L)
 
         assertEquals(AmbientWanderGoal.RANDOM, controller.ambientGoal(1))
+    }
+
+    @Test
+    fun facingDirectionFollowsHorizontalTargetDirection() {
+        val controller = WallpaperWanderController(random = Random(5))
+        val entity = EntityStatus(entityId = 1, state = CharacterState.IDLE)
+        val base = listOf(500f to 500f)
+
+        controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 0L)
+        controller.setTarget(1, 0.1f, 0.5f)
+        controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 1000L)
+        assertEquals(WalkFacingDirection.LEFT, controller.facingDirection(1))
+
+        controller.setTarget(1, 0.9f, 0.5f)
+        controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 2000L)
+        assertEquals(WalkFacingDirection.RIGHT, controller.facingDirection(1))
     }
 
     @Test

--- a/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
@@ -100,6 +100,20 @@ class WallpaperWanderControllerTest {
     }
 
     @Test
+    fun nonLocomotionPetdexActionsDoNotSlideDuringAmbientWander() {
+        val controller = WallpaperWanderController(random = Random(13))
+        val entity = EntityStatus(entityId = 30, state = CharacterState.REVIEW)
+        val base = listOf(540f to 620f)
+
+        val first = controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 0L)
+        val after = controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 9000L)
+
+        assertEquals(first, after)
+        assertFalse(controller.isWalking(30))
+        assertEquals(MotionState.SLEEPING, controller.motionState(30))
+    }
+
+    @Test
     fun wanderStaysInsideSafeWallpaperBounds() {
         val controller = WallpaperWanderController(random = Random(23))
         val entity = EntityStatus(entityId = 4, state = CharacterState.IDLE)

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -170,7 +170,7 @@ components:
           type: string
         state:
           type: string
-          enum: [IDLE, BUSY, HAPPY, SAD, ANGRY, CONFUSED, SLEEPING]
+          enum: [IDLE, BUSY, EATING, SLEEPING, EXCITED, HAPPY, WALKING, SAD, ANGRY, CONFUSED, idle, running-right, running-left, waving, jumping, failed, waiting, running, review]
         message:
           type: string
         parts:
@@ -1311,7 +1311,7 @@ paths:
                   type: string
                 state:
                   type: string
-                  enum: [IDLE, BUSY, HAPPY, SAD, ANGRY, CONFUSED, SLEEPING]
+                  enum: [IDLE, BUSY, EATING, SLEEPING, EXCITED, HAPPY, WALKING, SAD, ANGRY, CONFUSED, idle, running-right, running-left, waving, jumping, failed, waiting, running, review]
                 message:
                   type: string
                   description: Status text (also used as delivery content when speakTo/broadcast is set)

--- a/backend/petdex-bridge.js
+++ b/backend/petdex-bridge.js
@@ -17,9 +17,11 @@
  *     row 3 waving (4f), row 4 jumping (5f), row 5 failed (8f),
  *     row 6 waiting (6f), row 7 running (6f), row 8 review (6f).
  *
- * Our state mapping (EClaw companion state → Petdex animation row):
+ * Our state mapping (EClaw companion state / native Petdex action → Petdex animation row):
  *   IDLE → 0(idle), BUSY → 7(running), WALKING → 1(running-right),
- *   SLEEPING → 6(waiting), EXCITED → 4(jumping), HAPPY → 3(waving).
+ *   SLEEPING → 6(waiting), EXCITED → 4(jumping), HAPPY → 3(waving),
+ *   plus native Petdex actions idle/running-right/running-left/waving/jumping/
+ *   failed/waiting/running/review.
  */
 
 const MANIFEST_URL = 'https://petdex.crafter.run/api/manifest';
@@ -48,6 +50,15 @@ const STATE_TO_ANIMATION = {
     SLEEPING: 'waiting',
     EXCITED:  'jumping',
     HAPPY:    'waving',
+    idle:     'idle',
+    'running-right': 'running-right',
+    'running-left':  'running-left',
+    waving:   'waving',
+    jumping:  'jumping',
+    failed:   'failed',
+    waiting:  'waiting',
+    running:  'running',
+    review:   'review',
 };
 
 const KIND_TO_CATEGORY = {

--- a/backend/tests/jest/petdex-bridge.test.js
+++ b/backend/tests/jest/petdex-bridge.test.js
@@ -3,6 +3,8 @@
  * The renderer-side frame-index math is exercised in petdx-renderer.test.js.
  */
 
+const fs = require('fs');
+const path = require('path');
 const bridge = require('../../petdex-bridge');
 
 describe('buildDescriptor', () => {
@@ -44,13 +46,32 @@ describe('buildDescriptor', () => {
             kind: 'character',
             spritesheetUrl: 'https://r2/cortana.webp',
         });
-        expect(d.supportedStates).toEqual(['IDLE', 'BUSY', 'WALKING', 'SLEEPING', 'EXCITED', 'HAPPY']);
+        expect(d.supportedStates).toEqual([
+            'IDLE',
+            'BUSY',
+            'WALKING',
+            'SLEEPING',
+            'EXCITED',
+            'HAPPY',
+            'idle',
+            'running-right',
+            'running-left',
+            'waving',
+            'jumping',
+            'failed',
+            'waiting',
+            'running',
+            'review',
+        ]);
         expect(d.stateAssets.IDLE.animation).toBe('idle');
         expect(d.stateAssets.BUSY.animation).toBe('running');
         expect(d.stateAssets.WALKING.animation).toBe('running-right');
         expect(d.stateAssets.SLEEPING.animation).toBe('waiting');
         expect(d.stateAssets.EXCITED.animation).toBe('jumping');
         expect(d.stateAssets.HAPPY.animation).toBe('waving');
+        expect(d.stateAssets['running-left'].animation).toBe('running-left');
+        expect(d.stateAssets.failed.animation).toBe('failed');
+        expect(d.stateAssets.review.animation).toBe('review');
     });
 
     it('attaches Petdex provenance + MIT license', () => {
@@ -128,5 +149,24 @@ describe('syncPetdexCatalog', () => {
         const result = await bridge.syncPetdexCatalog(pool, () => {});
         expect(result.inserted).toBe(0);
         expect(result.total).toBe(0);
+    });
+});
+
+describe('OpenAPI Petdex action state contract', () => {
+    it('documents all native Petdex action keys for entity state', () => {
+        const yaml = fs.readFileSync(path.resolve(__dirname, '../../openapi.yaml'), 'utf8');
+        [
+            'idle',
+            'running-right',
+            'running-left',
+            'waving',
+            'jumping',
+            'failed',
+            'waiting',
+            'running',
+            'review',
+        ].forEach((action) => {
+            expect(yaml).toContain(action);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- Add Android support for the Petdex native 9-action state contract: `idle`, `running-right`, `running-left`, `waving`, `jumping`, `failed`, `waiting`, `running`, `review`.
- Change wallpaper walking from ambient wandering to conscious routing motion: entities stay at their home/default positions unless a speak-to, @all, or broadcast conversation occurs; sender + receivers gather at center with one-entity spacing until the message bubble TTL ends, then return home.
- Move wallpaper speech bubbles to the top render layer so entity sprites cannot cover text windows.
- Add collision reactions where both colliding entities play the same random Petdex action (`waving` / `jumping` / `failed` / `review`) for a configurable 1-20s duration.
- Add 1-20s message bubble TTL slider, default 5s, and apply that TTL to conversation motion lifetime.
- Add wallpaper kanban task visualization: active manual cards render as folder objects near assigned entities, automation cards render on background whiteboards sorted by next run time, status changes trigger review + transition/removal animation, and done/archived cards do not persist after removal animation.
- Add privacy and per-feature wallpaper settings, plus consistent `?` help buttons for wallpaper settings surfaces.
- Add optional messageQueue routing metadata (`routingMode`, `routingEventId`, `broadcastTargetIds`) so Android can group speak-to/broadcast routes reliably.

## Validation
- `ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:testDebugUnitTest --tests com.hank.clawlive.CompanionDescriptorAnimationTest --tests com.hank.clawlive.WallpaperInteractionControllerTest --tests com.hank.clawlive.WallpaperWanderControllerTest --tests com.hank.clawlive.SpeechBubbleControllerTest` ✅
- `NODE_PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules /Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin/jest --runTestsByPath backend/tests/jest/transform-delivery.test.js --testNamePattern "routing metadata" --forceExit` ✅
- `NODE_PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules /Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin/jest --runTestsByPath backend/tests/jest/petdex-bridge.test.js --forceExit` ✅
- `git diff --check -- <changed files>` ✅

## Notes
- `app/google-services.json` remains local/gitignored for Gradle only and is not committed.
- Existing unstaged backend CRLF-only dirty files were left untouched.
- A full `transform-delivery.test.js` run printed all tests PASS once, but Jest kept open handles; rerunning the full file with `--forceExit` hit an existing flaky parse error in an unrelated no-message test. The new routing metadata tests pass cleanly with `--testNamePattern`.
- Emulator/admin-account visual validation is still pending for post-review/merge testing as requested.

## Code review checklist
### Core
- A1. Logic trace: ✅ API state strings deserialize through `CharacterStateJsonAdapter`, map to wallpaper action keys, resolve Petdex animation rows, and fall back to IDLE for unknown input. Conversation motion reads messageQueue routing metadata and bubble expiry before moving entities.
- A2. Test coverage: ✅ Android unit tests cover Petdex action mapping, collision action duration/sync, no-random-wander home behavior, center gathering/spacing, TTL expiry, and bubble expiry lookup. Backend Jest covers Petdex descriptors and messageQueue routing metadata.
- A3. Return shape: ✅ `/api/entities` messageQueue entries gain optional backward-compatible metadata fields only.
- A4. What this does NOT fix: emulator visual/admin-auth validation and production verification remain pending after review/merge.
- A5. Security/privacy: ✅ no secrets or auth paths changed; kanban wallpaper privacy mode defaults OFF and hides task names/schedule details when enabled.

### Extended
- B1. /api/help: ⚠️ NO-OP: no new public help endpoint.
- B2. Related docs: ✅ OpenAPI enum and Petdex bridge inline contract already updated in prior commit on this PR.
- B3. i18n: ✅ new user-facing Android strings added for default, zh-rTW, and zh-rCN.
- B4. Info/promo page: ⚠️ NO-OP: wallpaper action/kanban visualization is not surfaced in marketing/info copy yet.
- B5. Debug endpoint: ⚠️ NO-OP: no production incident/debug endpoint required for this feature work.

Result: review pending; do not merge until CI is green and #2/user review approves.
