### PR TITLE
feat(webpush): global autoEnable on dashboard/index/chat (card_cfb844d0)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -9854,6 +9854,7 @@
             closeFileEditor();
         });
     </script>
+    <script src="/shared/webpush-auto.js" defer></script>
     </main>
 </body>
 

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -6428,6 +6428,7 @@
         }
     })();
     </script>
+    <script src="/shared/webpush-auto.js" defer></script>
     </main>
 </body>
 

--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -809,6 +809,7 @@
         // Load OAuth config on page load
         loadOAuthConfig();
     </script>
+    <script src="/shared/webpush-auto.js" defer></script>
     </main>
 </body>
 

--- a/backend/public/shared/webpush-auto.js
+++ b/backend/public/shared/webpush-auto.js
@@ -1,0 +1,53 @@
+(function () {
+    'use strict';
+    if (window.__webpushAutoLoaded) return;
+    window.__webpushAutoLoaded = true;
+
+    function urlBase64ToUint8Array(base64String) {
+        const padding = '='.repeat((4 - base64String.length % 4) % 4);
+        const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+        const rawData = atob(base64);
+        const out = new Uint8Array(rawData.length);
+        for (let i = 0; i < rawData.length; i++) out[i] = rawData.charCodeAt(i);
+        return out;
+    }
+
+    async function autoEnableWebPush() {
+        try {
+            if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+            if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+            const reg = await navigator.serviceWorker.register('/sw.js');
+            const existing = await reg.pushManager.getSubscription();
+            if (existing) return;
+            const vapidRes = await fetch('/api/push/vapid-public-key', { credentials: 'include' })
+                .then(r => r.ok ? r.json() : null)
+                .catch(() => null);
+            if (!vapidRes || !vapidRes.publicKey) return;
+            const sub = await reg.pushManager.subscribe({
+                userVisibleOnly: true,
+                applicationServerKey: urlBase64ToUint8Array(vapidRes.publicKey)
+            });
+            await fetch('/api/push/subscribe', {
+                method: 'POST',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ subscription: sub.toJSON() })
+            });
+        } catch (e) {
+            if (typeof console !== 'undefined') console.debug('[webpush] auto-enable skipped:', e && e.message);
+        }
+    }
+
+    window.autoEnableWebPush = autoEnableWebPush;
+
+    function tryFire() {
+        if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+            autoEnableWebPush();
+        }
+    }
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', tryFire);
+    } else {
+        tryFire();
+    }
+})();


### PR DESCRIPTION
## Summary
- Extract autoEnableWebPush into shared/webpush-auto.js (self-contained IIFE, fetch-based, double-load guarded)
- Wire into portal/{dashboard,index,chat}.html so any logged-in user with Notification.permission='granted' silently auto-subscribes on first authenticated page load
- Settings.html unchanged (keeps inline copy to avoid double-fire race during page init)

Card: card_cfb844d0fb3e247e7f6aadf6 (follow-up to PR #3594 / card_b3bb2bce)

## Test plan
- [ ] Jest unit tests pass (no new tests; mostly frontend wiring)
- [ ] Portal Smoke CI confirms dashboard/index/chat load without console errors
- [ ] i18n syntax check passes (no string changes)
- [ ] After deploy: visit /portal/dashboard.html from a browser with prior-granted notification permission and no existing subscription → push_subscriptions row appears for the new endpoint within seconds (Railway log filter «sub-store: success»)
- [ ] Repeat from /portal/chat.html and /portal/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUDRpzSFMMKwMoVtnxK1dd