### PR TITLE
feat(portal): keep session on transport disconnect + reconnect overlay (card_93d56b5d Hank-direct)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3590,6 +3590,7 @@
     </div>
 
     <script src="shared/api.js"></script>
+    <script src="shared/reconnect-overlay.js" defer></script>
     <!-- SmartRouter: split-mode "在看板中開啟" must route into the existing kanban
          pane, not window.open a 2nd pane / redirect chat (card_2d5fbe88). -->
     <script src="/shared-core/route-registry.js"></script>

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -2574,6 +2574,7 @@
     <script src="https://js.tappaysdk.com/sdk/tpdirect/v5.17.0" async></script>
 
     <script src="shared/api.js"></script>
+    <script src="shared/reconnect-overlay.js" defer></script>
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
     <script src="/shared-core/route-registry.js"></script>

--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -424,6 +424,7 @@
         </select>
     </div>
     <script src="shared/api.js"></script>
+    <script src="shared/reconnect-overlay.js" defer></script>
     <!-- IMPORTANT: Check path for i18n.js relative to portal/index.html. it is in ../shared/i18n.js since index.html is in portal/ -->
     <script src="../shared/i18n.js"></script>
     <script src="../shared/transition-overlay.js"></script>

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1742,6 +1742,7 @@
 
     <!-- Shared scripts -->
     <script src="shared/api.js"></script>
+    <script src="shared/reconnect-overlay.js" defer></script>
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
     <script src="/shared-core/route-registry.js"></script>

--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -15,7 +15,23 @@ async function apiCall(method, path, body = null, opts = {}) {
     }
 
     const url = path.startsWith('http') ? path : `${API_BASE}${path}`;
-    const response = await fetch(url, options);
+    let response;
+    try {
+        response = await fetch(url, options);
+    } catch (fetchErr) {
+        // Transport-level failure (offline, DNS, server unreachable) — NOT auth.
+        // Tag the error so callers (auth.js, reconnect-overlay.js) can distinguish
+        // transport-disconnect from session-expired and avoid redirecting to login.
+        const netErr = new Error(fetchErr && fetchErr.message || 'Network unavailable');
+        netErr.networkError = true;
+        netErr.cause = fetchErr;
+        try {
+            if (typeof window !== 'undefined' && window.__reconnectOverlay && typeof window.__reconnectOverlay.show === 'function') {
+                window.__reconnectOverlay.show();
+            }
+        } catch (_) { /* overlay optional */ }
+        throw netErr;
+    }
 
     // Guard against non-JSON responses (e.g. HTML error pages)
     const contentType = response.headers.get('content-type') || '';

--- a/backend/public/portal/shared/auth.js
+++ b/backend/public/portal/shared/auth.js
@@ -177,6 +177,19 @@ async function checkAuth() {
             console.error('[Auth] iOS WebView device-login failed:', iosErr);
         }
 
+        // Distinguish transport-level disconnect from auth-level failure.
+        // api.js tags fetch-throw with `networkError:true`; do NOT force logout
+        // on transport blips — show the reconnect overlay and keep session state.
+        if (e && (e.networkError || e.name === 'TypeError'
+            || (typeof navigator !== 'undefined' && navigator.onLine === false))) {
+            console.warn('[Auth] checkAuth transport failure (network) — keeping session, showing reconnect overlay:', e.message || e);
+            try {
+                if (window.__reconnectOverlay && typeof window.__reconnectOverlay.show === 'function') {
+                    window.__reconnectOverlay.show();
+                }
+            } catch (_) { /* overlay optional */ }
+            return null;
+        }
         console.error('[Auth] checkAuth failed, redirecting to login:', e.message || e);
         window.location.href = 'index.html';
         return null;

--- a/backend/public/portal/shared/reconnect-overlay.js
+++ b/backend/public/portal/shared/reconnect-overlay.js
@@ -1,0 +1,83 @@
+(function () {
+    'use strict';
+    if (window.__reconnectOverlay) return;
+
+    const STYLE_ID = '__reconnect-overlay-style';
+    const BANNER_ID = '__reconnect-overlay-banner';
+
+    function ensureStyle() {
+        if (document.getElementById(STYLE_ID)) return;
+        const s = document.createElement('style');
+        s.id = STYLE_ID;
+        s.textContent =
+            '#' + BANNER_ID + '{position:fixed;top:0;left:0;right:0;z-index:99999;' +
+            'background:rgba(220,38,38,0.95);color:#fff;text-align:center;' +
+            'padding:10px 16px;font-size:14px;font-weight:600;' +
+            'box-shadow:0 2px 6px rgba(0,0,0,0.2);transition:transform 0.18s ease;' +
+            'transform:translateY(-100%);}' +
+            '#' + BANNER_ID + '.visible{transform:translateY(0);}' +
+            '#' + BANNER_ID + ' .spinner{display:inline-block;width:12px;height:12px;' +
+            'border:2px solid rgba(255,255,255,0.4);border-top-color:#fff;' +
+            'border-radius:50%;animation:rcSpin 0.8s linear infinite;' +
+            'vertical-align:middle;margin-right:8px;}' +
+            '@keyframes rcSpin{to{transform:rotate(360deg);}}';
+        document.head.appendChild(s);
+    }
+
+    function ensureBanner() {
+        let el = document.getElementById(BANNER_ID);
+        if (el) return el;
+        ensureStyle();
+        el = document.createElement('div');
+        el.id = BANNER_ID;
+        el.setAttribute('role', 'status');
+        el.setAttribute('aria-live', 'polite');
+        const t = (k, fb) => (window.i18n && window.i18n.t) ? window.i18n.t(k, fb) : fb;
+        el.innerHTML = '<span class="spinner" aria-hidden="true"></span>' +
+            '<span>' + t('reconnect_overlay_text', '網路連線中斷，正在重新連線…') + '</span>';
+        el.title = t('reconnect_overlay_help',
+            '網路連線中斷，正在自動重連。Session 仍有效，不需重新登入。');
+        document.body.appendChild(el);
+        return el;
+    }
+
+    let visible = false;
+    let probeTimer = null;
+    let probeDelay = 5000;
+
+    function show() {
+        const el = ensureBanner();
+        if (!visible) {
+            visible = true;
+            requestAnimationFrame(() => el.classList.add('visible'));
+            scheduleProbe();
+        }
+    }
+
+    function hide() {
+        const el = document.getElementById(BANNER_ID);
+        if (el) el.classList.remove('visible');
+        visible = false;
+        probeDelay = 5000;
+        if (probeTimer) { clearTimeout(probeTimer); probeTimer = null; }
+    }
+
+    async function probe() {
+        try {
+            const r = await fetch('/api/version', { credentials: 'include', cache: 'no-store' });
+            if (r && r.ok) { hide(); return; }
+        } catch (_) { /* still offline */ }
+        probeDelay = Math.min(30000, Math.round(probeDelay * 1.5));
+        scheduleProbe();
+    }
+
+    function scheduleProbe() {
+        if (probeTimer) clearTimeout(probeTimer);
+        probeTimer = setTimeout(probe, probeDelay);
+    }
+
+    window.addEventListener('online', () => { if (visible) probe(); });
+    window.addEventListener('offline', () => { show(); });
+
+    window.__reconnectOverlay = { show, hide, isVisible: () => visible };
+})();


### PR DESCRIPTION
## Summary
- Distinguish transport disconnect from session-expired in portal auth flow — stop forcing login when network blips
- New shared/reconnect-overlay.js: top-of-page banner + auto-poll + auto-resume
- api.js wraps fetch() to tag networkError; auth.js checkAuth catches it and shows overlay instead of redirecting
- Wired into dashboard/chat/settings/index portal pages

Card: card_93d56b5d0978b50845d96557 (Hank-direct from web_chat, P0)

## Test plan
- [ ] Jest unit tests pass (no new tests; UI behavior change)
- [ ] Portal Smoke CI confirms pages load with no console errors
- [ ] i18n syntax check passes (no new i18n keys in this PR; uses fallback strings)
- [ ] After deploy: visit /portal/dashboard.html → DevTools Network tab → Offline → red banner "網路連線中斷，正在重新連線…" appears, NO redirect to login
- [ ] Restore Online → banner disappears within ~5-10s, session intact, no re-login needed
- [ ] Force real 401 (e.g., wait for session expiry or delete cookie) → still redirects correctly

## Out of scope (filed as child cards)
- Android WebView (card_93d56b5d child) — Hank-gated build
- iOS WKWebView (card_93d56b5d child) — Hank-gated build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUDRpzSFMMKwMoVtnxK1dd