### PR TITLE
feat(cron): skip dispatch when entity usage exceeds threshold (card_c2635849)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -85,6 +85,149 @@ try {
 const SCHEDULE_LATE_FIRE_GRACE_MS = 5 * 60 * 1000;
 const SCHEDULE_STALE_EPSILON_MS = 1000;
 
+// Per-card usage-threshold cron skip (card_c2635849, parent card_ad507345).
+// Recurring schedules can skip child-card dispatch when ANY assigned entity's
+// rolling 5h / 7d usage% strictly exceeds the configured cap. Defaults match
+// the standard "quota almost full" markers on the dashboard widget so cards
+// created before this column gain a sensible guard automatically.
+const SCHEDULE_USAGE_THRESHOLD_MIN = 50;
+const SCHEDULE_USAGE_THRESHOLD_MAX = 99;
+const DEFAULT_SKIP_5H_PCT = 85;
+const DEFAULT_SKIP_7D_PCT = 95;
+
+function clampUsageThreshold(value, fallback) {
+    if (value === undefined || value === null || value === '') return fallback;
+    const n = Number(value);
+    if (!Number.isFinite(n)) return fallback;
+    const i = Math.trunc(n);
+    if (i < SCHEDULE_USAGE_THRESHOLD_MIN || i > SCHEDULE_USAGE_THRESHOLD_MAX) return fallback;
+    return i;
+}
+
+function isValidUsageThreshold(value) {
+    // Returns true iff value is a JS number integer in [50, 99]. Used at the
+    // API write boundary so bad input rejects HTTP 400 rather than silently
+    // clamping. Strings (even numeric-looking ones like "85"), booleans,
+    // decimals, NaN, Infinity all reject — clients must send actual integers
+    // so a typo in JSON isn't normalized to a working request.
+    if (typeof value !== 'number') return false;
+    if (!Number.isFinite(value)) return false;
+    if (!Number.isInteger(value)) return false;
+    return value >= SCHEDULE_USAGE_THRESHOLD_MIN && value <= SCHEDULE_USAGE_THRESHOLD_MAX;
+}
+
+/**
+ * Pull the highest "currently used%" signal out of a usage_snapshots row for
+ * one engine + window. The Claude statusLine hook writes the nested shape
+ * `live.rate_limits.{five_hour,seven_day}.used_percentage`, but earlier
+ * callers also produced flat `live.five_hour_pct` (see usage-api.js
+ * `pickClaudeLivePct`). Codex daemon writes the flat shape under
+ * `rate_limits.{five_hour_pct, seven_day_pct}`. Returns null if no signal
+ * is present (caller treats null as 0% to preserve dispatch).
+ */
+function readClaudeLivePct(claudeJson, key) {
+    const live = (claudeJson && claudeJson.live) || null;
+    if (!live) return null;
+    const flatKey = key + '_pct';
+    if (typeof live[flatKey] === 'number') return live[flatKey];
+    const nested = live.rate_limits && live.rate_limits[key];
+    if (nested && typeof nested.used_percentage === 'number') return nested.used_percentage;
+    return null;
+}
+
+function readCodexLivePct(codexJson, key) {
+    const rl = (codexJson && codexJson.rate_limits) || null;
+    if (!rl) return null;
+    const flatKey = key + '_pct';
+    if (typeof rl[flatKey] === 'number') return rl[flatKey];
+    return null;
+}
+
+/**
+ * Look up the latest usage snapshot for a (deviceId, entityId) pair and
+ * extract the 5h / 7d usage% across both Claude + Codex engines. Returns
+ * { five: number|null, seven: number|null } where each is the MAX of the
+ * two engines' current %, or null if nothing is recorded for that window.
+ *
+ * The query prefers the entity-scoped row (entity_id = $2) when present,
+ * but falls back to the device-scoped row (entity_id IS NULL) because the
+ * mac-daemon historically pushed unscoped rows before per-entity routing
+ * landed. This keeps the guard working on legacy devices without forcing
+ * a daemon upgrade.
+ */
+async function getEntityUsagePct(deviceId, entityId) {
+    if (!deviceId) return { five: null, seven: null };
+    try {
+        const eid = Number(entityId);
+        const useEid = Number.isFinite(eid);
+        const sql = useEid
+            ? `SELECT claude_json, codex_json
+                 FROM usage_snapshots
+                 WHERE device_id = $1 AND (entity_id = $2 OR entity_id IS NULL)
+                 ORDER BY (entity_id = $2) DESC, captured_at DESC
+                 LIMIT 1`
+            : `SELECT claude_json, codex_json
+                 FROM usage_snapshots
+                 WHERE device_id = $1
+                 ORDER BY captured_at DESC
+                 LIMIT 1`;
+        const params = useEid ? [deviceId, eid] : [deviceId];
+        const r = await pool.query(sql, params);
+        if (!r.rows.length) return { five: null, seven: null };
+        const row = r.rows[0];
+        const claudeJson = row.claude_json || null;
+        const codexJson = row.codex_json || null;
+        const claude5 = readClaudeLivePct(claudeJson, 'five_hour');
+        const codex5 = readCodexLivePct(codexJson, 'five_hour');
+        const claude7 = readClaudeLivePct(claudeJson, 'seven_day');
+        const codex7 = readCodexLivePct(codexJson, 'seven_day');
+        // Take the worst-case (max) across engines so a saturated Claude
+        // session still trips the guard even when Codex is idle.
+        const maxOrNull = (a, b) => {
+            if (a == null && b == null) return null;
+            if (a == null) return b;
+            if (b == null) return a;
+            return a > b ? a : b;
+        };
+        return { five: maxOrNull(claude5, codex5), seven: maxOrNull(claude7, codex7) };
+    } catch (err) {
+        // Don't block dispatch on infra failures — preserve current behavior
+        // (Mac daemon down, table missing on staging, etc.).
+        console.warn('[Kanban] getEntityUsagePct failed:', err.message);
+        return { five: null, seven: null };
+    }
+}
+
+/**
+ * Decide whether a recurring schedule fire should be skipped due to any
+ * assigned entity exceeding the per-card usage threshold. Returns
+ *   { skip: boolean, reason?: string, entityId?: number, window?: '5h'|'7d',
+ *     pct?: number, limit?: number }
+ * where `skip=true` carries the first offending entity for log/comment text.
+ *
+ * Null usage% is treated as 0% (do NOT skip) so the guard never blocks a
+ * card whose entity simply doesn't have a daemon push yet — preserves the
+ * pre-card_c2635849 dispatch behavior.
+ */
+async function evaluateUsageSkipDecision(card, bots, usageLookup) {
+    const limit5 = clampUsageThreshold(card.schedule_skip_if_5h_pct_over, DEFAULT_SKIP_5H_PCT);
+    const limit7 = clampUsageThreshold(card.schedule_skip_if_7d_pct_over, DEFAULT_SKIP_7D_PCT);
+    const ids = Array.isArray(bots) ? bots : [];
+    // Injectable usage lookup so tests can avoid hitting the real DB; in prod
+    // calls into the entity-scoped usage_snapshots query.
+    const lookup = typeof usageLookup === 'function' ? usageLookup : getEntityUsagePct;
+    for (const botId of ids) {
+        const usage = await lookup(card.device_id, botId);
+        if (usage && usage.five != null && usage.five > limit5) {
+            return { skip: true, entityId: botId, window: '5h', pct: usage.five, limit: limit5 };
+        }
+        if (usage && usage.seven != null && usage.seven > limit7) {
+            return { skip: true, entityId: botId, window: '7d', pct: usage.seven, limit: limit7 };
+        }
+    }
+    return { skip: false };
+}
+
 function asValidDate(value) {
     const date = value instanceof Date ? value : new Date(value);
     return Number.isNaN(date.getTime()) ? null : date;
@@ -794,6 +937,9 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             timezone: row.schedule_timezone || 'Asia/Taipei',
             lastRunAt: row.schedule_last_run_at ? new Date(row.schedule_last_run_at).getTime() : null,
             nextRunAt: row.schedule_next_run_at ? new Date(row.schedule_next_run_at).getTime() : null,
+            // card_c2635849: per-card usage-quota cron skip thresholds.
+            skipIf5hUsagePctOver: clampUsageThreshold(row.schedule_skip_if_5h_pct_over, DEFAULT_SKIP_5H_PCT),
+            skipIf7dUsagePctOver: clampUsageThreshold(row.schedule_skip_if_7d_pct_over, DEFAULT_SKIP_7D_PCT),
         } : null;
 
         // Automation fields
@@ -915,6 +1061,12 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         // Inline automation + schedule support
         const wantAutomation = !!isAutomation;
         let schedEnabled = false, schedType = null, schedCron = null, schedRunAt = null, schedTz = 'Asia/Taipei', schedNextRunAt = null;
+        // card_c2635849 per-card usage-skip thresholds. Default to column-level
+        // defaults so cards filed without explicit thresholds still gain the
+        // standard 85/95 guard. Validated here so bad input rejects 400 instead
+        // of silently clamping (matches the PUT /schedule write boundary).
+        let schedSkip5h = DEFAULT_SKIP_5H_PCT;
+        let schedSkip7d = DEFAULT_SKIP_7D_PCT;
 
         if (schedule && typeof schedule === 'object') {
             schedType = (schedule.type === 'once' || schedule.type === 'recurring') ? schedule.type : null;
@@ -941,6 +1093,26 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 if (!schedNextRunAt) {
                     return res.status(400).json({ success: false, error: 'Invalid cron expression' });
                 }
+            }
+
+            // Optional per-card usage-skip thresholds (50–99 inclusive).
+            if (schedule.skipIf5hUsagePctOver !== undefined) {
+                if (!isValidUsageThreshold(schedule.skipIf5hUsagePctOver)) {
+                    return res.status(400).json({
+                        success: false,
+                        error: 'schedule.skipIf5hUsagePctOver must be an integer in [50, 99]'
+                    });
+                }
+                schedSkip5h = Number(schedule.skipIf5hUsagePctOver);
+            }
+            if (schedule.skipIf7dUsagePctOver !== undefined) {
+                if (!isValidUsageThreshold(schedule.skipIf7dUsagePctOver)) {
+                    return res.status(400).json({
+                        success: false,
+                        error: 'schedule.skipIf7dUsagePctOver must be an integer in [50, 99]'
+                    });
+                }
+                schedSkip7d = Number(schedule.skipIf7dUsagePctOver);
             }
         }
 
@@ -1005,14 +1177,17 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             const result = await pool.query(
                 `INSERT INTO kanban_cards (id, device_id, title, description, priority, status, assigned_bots, created_by, reviewer_entity_id, status_changed_at,
                     is_automation, schedule_enabled, schedule_type, schedule_cron, schedule_run_at, schedule_timezone, schedule_next_run_at, requires_screenshot_review,
-                    chat_anchor_message_id, chat_anchor_coord, dispatch_mode)
+                    chat_anchor_message_id, chat_anchor_coord, dispatch_mode,
+                    schedule_skip_if_5h_pct_over, schedule_skip_if_7d_pct_over)
                  VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, NOW(),
                     $10, $11, $12, $13, $14, $15, $16, $17,
-                    $18, $19::jsonb, $20)
+                    $18, $19::jsonb, $20,
+                    $21, $22)
                  RETURNING *`,
                 [newCardId(), deviceId, title.trim(), finalDescription, cardPriority, cardStatus, JSON.stringify(bots), createdBy, reviewer,
                     finalAutomation, schedEnabled, schedType, schedCron, schedRunAt, schedTz, schedNextRunAt, finalRequiresScreenshot,
-                    anchorMsgId, anchorCoord ? JSON.stringify(anchorCoord) : null, finalDispatchMode]
+                    anchorMsgId, anchorCoord ? JSON.stringify(anchorCoord) : null, finalDispatchMode,
+                    schedSkip5h, schedSkip7d]
             );
 
             const card = serializeCard(result.rows[0]);
@@ -2825,7 +3000,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
     router.put('/card/:id/schedule', async (req, res) => {
         if (!authenticate(req, res)) return;
         const _p = { ...req.query, ...req.body }; console.log('[Kanban] PUT /card/:id/schedule called', { deviceId: _p.deviceId, entityId: _p.entityId, cardId: req.params?.id });
-        const { deviceId, enabled, type, cronExpression, runAt, timezone } = req.body;
+        const { deviceId, enabled, type, cronExpression, runAt, timezone, skipIf5hUsagePctOver, skipIf7dUsagePctOver } = req.body;
         const cardId = req.params.id;
 
         try {
@@ -2868,6 +3043,31 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 }
             }
 
+            // card_c2635849: per-card usage-quota thresholds. Validate at the
+            // write boundary so bad input rejects HTTP 400 instead of silently
+            // clamping. Omitted fields keep the existing column value (NULL →
+            // falls back to default at fire time via clampUsageThreshold).
+            let newSkip5h = existing.rows[0].schedule_skip_if_5h_pct_over;
+            let newSkip7d = existing.rows[0].schedule_skip_if_7d_pct_over;
+            if (skipIf5hUsagePctOver !== undefined) {
+                if (!isValidUsageThreshold(skipIf5hUsagePctOver)) {
+                    return res.status(400).json({
+                        success: false,
+                        error: 'skipIf5hUsagePctOver must be an integer in [50, 99]'
+                    });
+                }
+                newSkip5h = Number(skipIf5hUsagePctOver);
+            }
+            if (skipIf7dUsagePctOver !== undefined) {
+                if (!isValidUsageThreshold(skipIf7dUsagePctOver)) {
+                    return res.status(400).json({
+                        success: false,
+                        error: 'skipIf7dUsagePctOver must be an integer in [50, 99]'
+                    });
+                }
+                newSkip7d = Number(skipIf7dUsagePctOver);
+            }
+
             // recurring schedule → auto-promote to automation card
             const autoPromote = schedEnabled && schedType === 'recurring';
 
@@ -2879,9 +3079,11 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     schedule_run_at = $4,
                     schedule_timezone = $5,
                     schedule_next_run_at = $6,
+                    schedule_skip_if_5h_pct_over = $7,
+                    schedule_skip_if_7d_pct_over = $8,
                     ${autoPromote ? 'is_automation = TRUE,' : ''}
                     updated_at = NOW()
-                 WHERE id = $7 AND device_id = $8
+                 WHERE id = $9 AND device_id = $10
                  RETURNING *`,
                 [
                     schedEnabled,
@@ -2890,6 +3092,8 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     schedType === 'once' ? nextRunAt : null,
                     tz,
                     nextRunAt,
+                    newSkip5h,
+                    newSkip7d,
                     cardId,
                     deviceId
                 ]
@@ -3644,6 +3848,28 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                         }
                     }
 
+                    // card_c2635849 (parent card_ad507345): per-card usage-quota
+                    // guard. If ANY assigned entity's rolling 5h / 7d usage% is
+                    // above the per-card threshold, skip child dispatch this
+                    // tick. We advance schedule_next_run_at to the next cron
+                    // slot (so the row doesn't fire-spin every poll loop —
+                    // the scheduler scans WHERE next_run_at <= NOW()) but do
+                    // NOT bump schedule_last_run_at — the audit trail should
+                    // show the last *successful* dispatch, not the skip.
+                    const usageBots = card.assigned_bots || [];
+                    const usageDecision = await evaluateUsageSkipDecision(card, usageBots);
+                    if (usageDecision.skip) {
+                        const nextRun = computeNextRun(card.schedule_cron, card.schedule_timezone);
+                        await pool.query(
+                            `UPDATE kanban_cards SET schedule_next_run_at = $1, updated_at = NOW() WHERE id = $2`,
+                            [nextRun, card.id]
+                        );
+                        await addSystemComment(card.id, card.device_id,
+                            `⏭️ 排程觸發跳過 — Entity #${usageDecision.entityId} ${usageDecision.window} 用量 ${usageDecision.pct}% > ${usageDecision.limit}%（下次嘗試: ${nextRun ? nextRun.toISOString() : '未知'}）`);
+                        console.log(`[CronSkip] card_${card.id} entity_${usageDecision.entityId} usage_${usageDecision.window}=${usageDecision.pct}% > ${usageDecision.limit}% — child dispatch skipped`);
+                        continue;
+                    }
+
                     // Check idle dispatch mode before creating child card
                     const dispatchMode = card.dispatch_mode || 'immediate';
                     if (dispatchMode === 'idle_only') {
@@ -4290,4 +4516,14 @@ module.exports._private = {
     computeCronPreviousRun,
     getRecurringScheduleFireDecision,
     SCHEDULE_LATE_FIRE_GRACE_MS,
+    // card_c2635849 cron usage-threshold skip
+    isValidUsageThreshold,
+    clampUsageThreshold,
+    readClaudeLivePct,
+    readCodexLivePct,
+    evaluateUsageSkipDecision,
+    SCHEDULE_USAGE_THRESHOLD_MIN,
+    SCHEDULE_USAGE_THRESHOLD_MAX,
+    DEFAULT_SKIP_5H_PCT,
+    DEFAULT_SKIP_7D_PCT,
 };

--- a/backend/kanban_schema.sql
+++ b/backend/kanban_schema.sql
@@ -38,6 +38,13 @@ ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS schedule_timezone VARCHAR(64) 
 ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS schedule_last_run_at TIMESTAMPTZ DEFAULT NULL;
 ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS schedule_next_run_at TIMESTAMPTZ DEFAULT NULL;
 
+-- Per-card usage-quota guard for recurring cron schedules (card_c2635849,
+-- parent card_ad507345). When a scheduled card fires, the scheduler skips
+-- child-card dispatch if ANY assigned entity's rolling 5h or 7d usage%
+-- strictly exceeds these thresholds. Range [50, 99]; defaults 85 / 95.
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS schedule_skip_if_5h_pct_over SMALLINT DEFAULT 85;
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS schedule_skip_if_7d_pct_over SMALLINT DEFAULT 95;
+
 CREATE INDEX IF NOT EXISTS idx_kanban_cards_schedule ON kanban_cards(schedule_enabled, schedule_next_run_at)
     WHERE schedule_enabled = true;
 

--- a/backend/migrations/20260621_kanban_card_schedule_usage_threshold.down.sql
+++ b/backend/migrations/20260621_kanban_card_schedule_usage_threshold.down.sql
@@ -1,0 +1,5 @@
+-- Reverse of 20260621_kanban_card_schedule_usage_threshold.up.sql
+
+ALTER TABLE kanban_cards
+    DROP COLUMN IF EXISTS schedule_skip_if_5h_pct_over,
+    DROP COLUMN IF EXISTS schedule_skip_if_7d_pct_over;

--- a/backend/migrations/20260621_kanban_card_schedule_usage_threshold.up.sql
+++ b/backend/migrations/20260621_kanban_card_schedule_usage_threshold.up.sql
@@ -1,0 +1,29 @@
+-- Migration: 20260621_kanban_card_schedule_usage_threshold
+-- card_c26358498ecee64638b9ca9c (parent card_ad507345ce19fc5f51c2d814)
+--
+-- Per-card usage-quota guard for recurring cron schedules. When a scheduled
+-- automation card fires, the scheduler can now skip dispatching the child
+-- card if any assigned entity's current usage% (Claude/Codex 5h or 7d window)
+-- exceeds the per-card threshold. This avoids burning quota on a busy
+-- subagent or starving the user during peak load.
+--
+-- Defaults: 5h>85%, 7d>95% (the standard "quota almost full" markers).
+-- Range: [50, 99]. Editable per-card via PUT /api/mission/card/:id/schedule.
+-- When usage data is unavailable for the entity, treat as 0% (do NOT skip)
+-- — preserves the existing dispatch behavior on cards predating this column.
+
+ALTER TABLE kanban_cards
+    ADD COLUMN IF NOT EXISTS schedule_skip_if_5h_pct_over SMALLINT DEFAULT 85,
+    ADD COLUMN IF NOT EXISTS schedule_skip_if_7d_pct_over SMALLINT DEFAULT 95;
+
+COMMENT ON COLUMN kanban_cards.schedule_skip_if_5h_pct_over IS
+    'Recurring-schedule guard: skip child-card dispatch when ANY assigned '
+    'entity''s rolling 5-hour usage% strictly exceeds this value. Range '
+    '[50, 99]. Default 85. NULL or out-of-range falls back to 85 at fire '
+    'time. Wired from PUT /api/mission/card/:id/schedule.';
+
+COMMENT ON COLUMN kanban_cards.schedule_skip_if_7d_pct_over IS
+    'Recurring-schedule guard: skip child-card dispatch when ANY assigned '
+    'entity''s rolling 7-day usage% strictly exceeds this value. Range '
+    '[50, 99]. Default 95. NULL or out-of-range falls back to 95 at fire '
+    'time. Wired from PUT /api/mission/card/:id/schedule.';

--- a/backend/tests/jest/kanban-card.test.js
+++ b/backend/tests/jest/kanban-card.test.js
@@ -52,6 +52,53 @@ const put = (path) => request(app).put(path);
 
 const AUTH = { deviceId: 'test-dev', deviceSecret: 'test-secret' };
 
+/**
+ * Given an INSERT SQL string + column name, return the 0-based index into
+ * the params array. The column list and VALUES placeholder list can drift
+ * (some columns use NOW() / DEFAULT and don't consume a $N slot), so we
+ * count $N references in VALUES rather than naively zipping the lists.
+ * Adding columns at the end (like card_c2635849's schedule_skip_* pair)
+ * does not shift earlier assertions.
+ */
+function columnParamIndex(sql, columnName) {
+    // Extract balanced parenthesis groups — the VALUES clause may contain
+    // nested parens (NOW(), $7::jsonb, etc.) so a lazy regex on `)` matches
+    // too early. Walk the string tracking depth.
+    function takeBalanced(src, startIdx) {
+        let depth = 0;
+        let start = -1;
+        for (let i = startIdx; i < src.length; i++) {
+            if (src[i] === '(') {
+                if (depth === 0) start = i + 1;
+                depth++;
+            } else if (src[i] === ')') {
+                depth--;
+                if (depth === 0) return { body: src.slice(start, i), end: i };
+            }
+        }
+        return null;
+    }
+    const colKeyword = sql.indexOf('INSERT INTO kanban_cards');
+    if (colKeyword < 0) return -1;
+    const colGroup = takeBalanced(sql, colKeyword);
+    if (!colGroup) return -1;
+    const valKeyword = sql.indexOf('VALUES', colGroup.end);
+    if (valKeyword < 0) return -1;
+    const valGroup = takeBalanced(sql, valKeyword);
+    if (!valGroup) return -1;
+    const cols = colGroup.body.split(',').map(s => s.trim());
+    const values = valGroup.body.split(',').map(s => s.trim());
+    if (cols.length !== values.length) return -1;
+    for (let i = 0; i < cols.length; i++) {
+        if (cols[i] === columnName) {
+            const m = values[i].match(/^\$(\d+)/);
+            if (!m) return -1;  // column uses NOW()/DEFAULT, no param
+            return parseInt(m[1], 10) - 1;
+        }
+    }
+    return -1;
+}
+
 // ════════════════════════════════════════════════════════════════
 // POST /card — Create card requires assignedBots
 // ════════════════════════════════════════════════════════════════
@@ -120,9 +167,15 @@ describe('POST /card — assignedBots validation', () => {
         expect(res.status).not.toBe(400);
         const insertCall = mockQuery.mock.calls.find(c => /INSERT INTO kanban_cards/.test(c[0]));
         expect(insertCall).toBeTruthy();
-        // chat_anchor_message_id is the 3rd-from-last INSERT param (… anchor, coord, dispatch_mode).
+        // chat_anchor_message_id index: build a (column → $N) map from the
+        // SQL, then convert $N to a params array index. This is robust to
+        // adding new columns / SQL-literal placeholders like NOW() that
+        // don't consume a param slot.
+        const sql = insertCall[0];
         const params = insertCall[1];
-        expect(params[params.length - 3]).toBe(null);
+        const idx = columnParamIndex(sql, 'chat_anchor_message_id');
+        expect(idx).toBeGreaterThanOrEqual(0);
+        expect(params[idx]).toBe(null);
     });
 
     it('allows bot-filed card (entityId > 0) without chatAnchorMessageId', async () => {
@@ -255,10 +308,17 @@ describe('POST /card — assignedBots validation', () => {
         });
         expect(res.status).not.toBe(400);
         const insertCall = mockQuery.mock.calls.find(c => /INSERT INTO kanban_cards/.test(c[0]));
+        const sql = insertCall[0];
         const params = insertCall[1];
-        // The coord param immediately precedes dispatch_mode; null when invalid.
-        expect(params[params.length - 2]).toBe(null);
-        expect(params[params.length - 1]).toBe('immediate');
+        // Map column→$N→params index so adding columns (e.g.
+        // schedule_skip_if_*_pct_over) or NOW()-literal columns don't shift
+        // these assertions.
+        const coordIdx = columnParamIndex(sql, 'chat_anchor_coord');
+        const dispatchIdx = columnParamIndex(sql, 'dispatch_mode');
+        expect(coordIdx).toBeGreaterThanOrEqual(0);
+        expect(dispatchIdx).toBeGreaterThanOrEqual(0);
+        expect(params[coordIdx]).toBe(null);
+        expect(params[dispatchIdx]).toBe('immediate');
     });
 });
 

--- a/backend/tests/jest/kanban-cron-usage-threshold.test.js
+++ b/backend/tests/jest/kanban-cron-usage-threshold.test.js
@@ -1,0 +1,364 @@
+'use strict';
+
+/**
+ * Per-card usage-threshold cron skip (card_c2635849, parent card_ad507345).
+ *
+ * Covers:
+ *   1. PUT /card/:id/schedule validation accepts integers 50–99 and rejects
+ *      out-of-range / non-integer / non-numeric input.
+ *   2. POST /card accepts schedule.skipIf{5h,7d}UsagePctOver with the same
+ *      validation surface.
+ *   3. evaluateUsageSkipDecision returns skip=true when ANY assigned entity
+ *      crosses the 5h or 7d threshold and skip=false otherwise.
+ *   4. Null usage% (no daemon push for that entity) is treated as 0% so the
+ *      guard never blocks dispatch on missing data — preserves existing
+ *      behavior for cards predating this column.
+ *   5. Static code-shape: the cron fire path advances schedule_next_run_at
+ *      on skip but does NOT bump schedule_last_run_at, so the audit trail
+ *      reflects last successful dispatch.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { _private } = require('../../kanban');
+
+const {
+    isValidUsageThreshold,
+    clampUsageThreshold,
+    readClaudeLivePct,
+    readCodexLivePct,
+    evaluateUsageSkipDecision,
+    SCHEDULE_USAGE_THRESHOLD_MIN,
+    SCHEDULE_USAGE_THRESHOLD_MAX,
+    DEFAULT_SKIP_5H_PCT,
+    DEFAULT_SKIP_7D_PCT,
+} = _private;
+
+describe('isValidUsageThreshold — write-boundary validator', () => {
+    test('accepts canonical boundary values 50, 85, 99', () => {
+        expect(isValidUsageThreshold(50)).toBe(true);
+        expect(isValidUsageThreshold(85)).toBe(true);
+        expect(isValidUsageThreshold(99)).toBe(true);
+    });
+
+    test('accepts arbitrary integer mid-range values', () => {
+        expect(isValidUsageThreshold(65)).toBe(true);
+        expect(isValidUsageThreshold(72)).toBe(true);
+        expect(isValidUsageThreshold(95)).toBe(true);
+    });
+
+    test('rejects boundary-adjacent invalid values 49 and 100', () => {
+        expect(isValidUsageThreshold(49)).toBe(false);
+        expect(isValidUsageThreshold(100)).toBe(false);
+    });
+
+    test('rejects negative numbers and extreme out-of-range values', () => {
+        expect(isValidUsageThreshold(-1)).toBe(false);
+        expect(isValidUsageThreshold(0)).toBe(false);
+        expect(isValidUsageThreshold(1000)).toBe(false);
+    });
+
+    test('rejects non-integer numerics (decimals)', () => {
+        expect(isValidUsageThreshold(85.5)).toBe(false);
+        expect(isValidUsageThreshold(50.0001)).toBe(false);
+    });
+
+    test('rejects strings (even numeric-looking ones)', () => {
+        expect(isValidUsageThreshold('85')).toBe(false);
+        expect(isValidUsageThreshold('abc')).toBe(false);
+        expect(isValidUsageThreshold('')).toBe(false);
+    });
+
+    test('rejects null, undefined, booleans, objects, arrays', () => {
+        expect(isValidUsageThreshold(null)).toBe(false);
+        expect(isValidUsageThreshold(undefined)).toBe(false);
+        expect(isValidUsageThreshold(true)).toBe(false);
+        expect(isValidUsageThreshold(false)).toBe(false);
+        expect(isValidUsageThreshold({})).toBe(false);
+        expect(isValidUsageThreshold([])).toBe(false);
+        expect(isValidUsageThreshold(NaN)).toBe(false);
+        expect(isValidUsageThreshold(Infinity)).toBe(false);
+    });
+
+    test('boundary constants match the documented [50, 99] range', () => {
+        expect(SCHEDULE_USAGE_THRESHOLD_MIN).toBe(50);
+        expect(SCHEDULE_USAGE_THRESHOLD_MAX).toBe(99);
+    });
+});
+
+describe('clampUsageThreshold — read-side normalizer', () => {
+    test('returns valid in-range integer unchanged', () => {
+        expect(clampUsageThreshold(50, 85)).toBe(50);
+        expect(clampUsageThreshold(72, 85)).toBe(72);
+        expect(clampUsageThreshold(99, 85)).toBe(99);
+    });
+
+    test('falls back to default for null/undefined/empty string', () => {
+        expect(clampUsageThreshold(null, 85)).toBe(85);
+        expect(clampUsageThreshold(undefined, 85)).toBe(85);
+        expect(clampUsageThreshold('', 85)).toBe(85);
+    });
+
+    test('falls back to default for out-of-range values', () => {
+        expect(clampUsageThreshold(0, 85)).toBe(85);
+        expect(clampUsageThreshold(49, 85)).toBe(85);
+        expect(clampUsageThreshold(100, 85)).toBe(85);
+        expect(clampUsageThreshold(-50, 85)).toBe(85);
+    });
+
+    test('truncates decimals to integer when in-range', () => {
+        // Legacy rows could carry decimals; truncate rather than reject so
+        // the guard still functions instead of permanently falling back.
+        expect(clampUsageThreshold(85.7, 50)).toBe(85);
+        expect(clampUsageThreshold(72.4, 50)).toBe(72);
+    });
+
+    test('defaults match documented column defaults', () => {
+        expect(DEFAULT_SKIP_5H_PCT).toBe(85);
+        expect(DEFAULT_SKIP_7D_PCT).toBe(95);
+    });
+});
+
+describe('readClaudeLivePct / readCodexLivePct — usage-snapshot shape adapters', () => {
+    test('reads Claude nested rate_limits shape', () => {
+        const claudeJson = {
+            live: {
+                rate_limits: {
+                    five_hour: { used_percentage: 87.4 },
+                    seven_day: { used_percentage: 42.1 },
+                },
+            },
+        };
+        expect(readClaudeLivePct(claudeJson, 'five_hour')).toBe(87.4);
+        expect(readClaudeLivePct(claudeJson, 'seven_day')).toBe(42.1);
+    });
+
+    test('reads Claude flat *_pct fallback shape', () => {
+        const claudeJson = { live: { five_hour_pct: 90, seven_day_pct: 30 } };
+        expect(readClaudeLivePct(claudeJson, 'five_hour')).toBe(90);
+        expect(readClaudeLivePct(claudeJson, 'seven_day')).toBe(30);
+    });
+
+    test('returns null when Claude live block missing or empty', () => {
+        expect(readClaudeLivePct(null, 'five_hour')).toBeNull();
+        expect(readClaudeLivePct({}, 'five_hour')).toBeNull();
+        expect(readClaudeLivePct({ live: {} }, 'five_hour')).toBeNull();
+        expect(readClaudeLivePct({ live: { rate_limits: {} } }, 'five_hour')).toBeNull();
+    });
+
+    test('reads Codex flat rate_limits *_pct shape', () => {
+        const codexJson = { rate_limits: { five_hour_pct: 55, seven_day_pct: 88 } };
+        expect(readCodexLivePct(codexJson, 'five_hour')).toBe(55);
+        expect(readCodexLivePct(codexJson, 'seven_day')).toBe(88);
+    });
+
+    test('returns null when Codex rate_limits missing', () => {
+        expect(readCodexLivePct(null, 'five_hour')).toBeNull();
+        expect(readCodexLivePct({}, 'five_hour')).toBeNull();
+        expect(readCodexLivePct({ rate_limits: {} }, 'five_hour')).toBeNull();
+    });
+});
+
+describe('evaluateUsageSkipDecision — per-card dispatch guard', () => {
+    const mkCard = (overrides = {}) => ({
+        id: 'card_test',
+        device_id: 'dev1',
+        schedule_skip_if_5h_pct_over: null,  // → falls back to default 85
+        schedule_skip_if_7d_pct_over: null,  // → falls back to default 95
+        ...overrides,
+    });
+
+    test('SKIPS when entity 5h usage strictly exceeds threshold', async () => {
+        const lookup = jest.fn().mockResolvedValue({ five: 87, seven: 40 });
+        const decision = await evaluateUsageSkipDecision(mkCard(), [2], lookup);
+        expect(decision.skip).toBe(true);
+        expect(decision.entityId).toBe(2);
+        expect(decision.window).toBe('5h');
+        expect(decision.pct).toBe(87);
+        expect(decision.limit).toBe(85);
+    });
+
+    test('SKIPS when entity 7d usage strictly exceeds threshold', async () => {
+        const lookup = jest.fn().mockResolvedValue({ five: 40, seven: 96 });
+        const decision = await evaluateUsageSkipDecision(mkCard(), [5], lookup);
+        expect(decision.skip).toBe(true);
+        expect(decision.entityId).toBe(5);
+        expect(decision.window).toBe('7d');
+        expect(decision.pct).toBe(96);
+        expect(decision.limit).toBe(95);
+    });
+
+    test('PROCEEDS (skip=false) when 5h usage exactly equals threshold (strict >)', async () => {
+        // Threshold is "strictly over" — equal is not over.
+        const lookup = jest.fn().mockResolvedValue({ five: 85, seven: 95 });
+        const decision = await evaluateUsageSkipDecision(mkCard(), [2], lookup);
+        expect(decision.skip).toBe(false);
+    });
+
+    test('PROCEEDS when usage under threshold', async () => {
+        const lookup = jest.fn().mockResolvedValue({ five: 30, seven: 50 });
+        const decision = await evaluateUsageSkipDecision(mkCard(), [2], lookup);
+        expect(decision.skip).toBe(false);
+    });
+
+    test('PROCEEDS when usage data unavailable (null) — treated as 0%', async () => {
+        // Per spec: "If usage data unavailable for the entity, treat as 0%
+        // (do NOT skip — preserve current behavior)."
+        const lookup = jest.fn().mockResolvedValue({ five: null, seven: null });
+        const decision = await evaluateUsageSkipDecision(mkCard(), [2], lookup);
+        expect(decision.skip).toBe(false);
+    });
+
+    test('PROCEEDS when usage lookup returns null/undefined entirely', async () => {
+        const lookup = jest.fn().mockResolvedValue(null);
+        const decision = await evaluateUsageSkipDecision(mkCard(), [2], lookup);
+        expect(decision.skip).toBe(false);
+    });
+
+    test('honors per-card custom 5h threshold (60%)', async () => {
+        const lookup = jest.fn().mockResolvedValue({ five: 65, seven: 40 });
+        const card = mkCard({ schedule_skip_if_5h_pct_over: 60 });
+        const decision = await evaluateUsageSkipDecision(card, [2], lookup);
+        expect(decision.skip).toBe(true);
+        expect(decision.limit).toBe(60);
+    });
+
+    test('honors per-card custom 7d threshold (70%)', async () => {
+        const lookup = jest.fn().mockResolvedValue({ five: 10, seven: 75 });
+        const card = mkCard({ schedule_skip_if_7d_pct_over: 70 });
+        const decision = await evaluateUsageSkipDecision(card, [3], lookup);
+        expect(decision.skip).toBe(true);
+        expect(decision.window).toBe('7d');
+        expect(decision.limit).toBe(70);
+    });
+
+    test('SKIPS on FIRST offending entity in multi-entity assignment', async () => {
+        // First bot is over threshold → skip; we don't need to check the rest.
+        const lookup = jest.fn()
+            .mockResolvedValueOnce({ five: 90, seven: 40 })  // entity 2 — over
+            .mockResolvedValueOnce({ five: 10, seven: 10 }); // entity 3 — fine
+        const decision = await evaluateUsageSkipDecision(mkCard(), [2, 3], lookup);
+        expect(decision.skip).toBe(true);
+        expect(decision.entityId).toBe(2);
+        expect(lookup).toHaveBeenCalledTimes(1);  // short-circuit
+    });
+
+    test('SKIPS when SECOND of two entities is over threshold', async () => {
+        const lookup = jest.fn()
+            .mockResolvedValueOnce({ five: 30, seven: 40 })  // entity 2 — fine
+            .mockResolvedValueOnce({ five: 88, seven: 40 }); // entity 3 — over
+        const decision = await evaluateUsageSkipDecision(mkCard(), [2, 3], lookup);
+        expect(decision.skip).toBe(true);
+        expect(decision.entityId).toBe(3);
+    });
+
+    test('PROCEEDS when bots array empty (no assigned entities to check)', async () => {
+        const lookup = jest.fn();
+        const decision = await evaluateUsageSkipDecision(mkCard(), [], lookup);
+        expect(decision.skip).toBe(false);
+        expect(lookup).not.toHaveBeenCalled();
+    });
+
+    test('out-of-range stored threshold falls back to default 85/95 at fire time', async () => {
+        // Defense-in-depth: if a corrupt row stores 200 or 0, the dispatch
+        // path must not silently disable the guard. clampUsageThreshold
+        // returns the default, so a 90% entity still trips the 85% guard.
+        const card = mkCard({ schedule_skip_if_5h_pct_over: 200 });
+        const lookup = jest.fn().mockResolvedValue({ five: 90, seven: 10 });
+        const decision = await evaluateUsageSkipDecision(card, [2], lookup);
+        expect(decision.skip).toBe(true);
+        expect(decision.limit).toBe(85);  // not 200
+    });
+});
+
+describe('cron fire path — source-shape invariants (card_c2635849)', () => {
+    const kanbanSrc = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'kanban.js'),
+        'utf8'
+    );
+
+    test('usage-skip check runs inside the recurring + is_automation branch', () => {
+        const branchStart = kanbanSrc.indexOf("schedType === 'recurring' && card.is_automation");
+        // Anchor on the in-fn call site (await form), not the export entry
+        // — the export list also mentions evaluateUsageSkipDecision but
+        // that's after every router handler.
+        const usageIdx = kanbanSrc.indexOf('await evaluateUsageSkipDecision');
+        // The cron-path idle gate is the only one whose log line says
+        // "checking entity idle status (dispatch_mode=idle_only)" — anchor
+        // on that to avoid colliding with the POST /card validator.
+        const idlePathIdx = kanbanSrc.indexOf('checking entity idle status (dispatch_mode=idle_only)');
+        expect(branchStart).toBeGreaterThan(-1);
+        expect(idlePathIdx).toBeGreaterThan(branchStart);
+        expect(usageIdx).toBeGreaterThan(branchStart);
+        // Usage gate runs before the idle-dispatch path so quota saturation
+        // trumps idle gating (both can defer dispatch but for different reasons).
+        expect(usageIdx).toBeLessThan(idlePathIdx);
+    });
+
+    test('on usage skip, advances schedule_next_run_at but does NOT bump schedule_last_run_at', () => {
+        // Grab the block from the [CronSkip] log line backward to the if (usageDecision.skip).
+        const block = kanbanSrc.match(
+            /if \(usageDecision\.skip\) \{[\s\S]*?\[CronSkip\][\s\S]*?continue;\s*\}/
+        );
+        expect(block).not.toBeNull();
+        // Must update schedule_next_run_at so the row doesn't fire-spin on every poll.
+        expect(block[0]).toMatch(/SET schedule_next_run_at = \$1/);
+        // Must NOT bump schedule_last_run_at — preserves last-successful-dispatch audit.
+        expect(block[0]).not.toMatch(/schedule_last_run_at = NOW\(\)/);
+    });
+
+    test('skip log line names entity + window + pct + limit (operator-friendly)', () => {
+        // [CronSkip] card_X entity_Y usage_5h=87% > 85% — child dispatch skipped
+        expect(kanbanSrc).toMatch(
+            /\[CronSkip\] card_\$\{card\.id\} entity_\$\{usageDecision\.entityId\} usage_\$\{usageDecision\.window\}=\$\{usageDecision\.pct\}% > \$\{usageDecision\.limit\}%/
+        );
+    });
+
+    test('serializeCard surfaces skipIf{5h,7d}UsagePctOver on schedule object', () => {
+        expect(kanbanSrc).toMatch(/skipIf5hUsagePctOver: clampUsageThreshold\(row\.schedule_skip_if_5h_pct_over, DEFAULT_SKIP_5H_PCT\)/);
+        expect(kanbanSrc).toMatch(/skipIf7dUsagePctOver: clampUsageThreshold\(row\.schedule_skip_if_7d_pct_over, DEFAULT_SKIP_7D_PCT\)/);
+    });
+
+    test('PUT /card/:id/schedule validates skipIf5h/7d via isValidUsageThreshold', () => {
+        // The handler must call isValidUsageThreshold for both fields, and
+        // return HTTP 400 with a [50, 99] error message when invalid.
+        expect(kanbanSrc).toMatch(/skipIf5hUsagePctOver !== undefined[\s\S]{0,400}isValidUsageThreshold\(skipIf5hUsagePctOver\)/);
+        expect(kanbanSrc).toMatch(/skipIf7dUsagePctOver !== undefined[\s\S]{0,400}isValidUsageThreshold\(skipIf7dUsagePctOver\)/);
+        expect(kanbanSrc).toMatch(/skipIf5hUsagePctOver must be an integer in \[50, 99\]/);
+        expect(kanbanSrc).toMatch(/skipIf7dUsagePctOver must be an integer in \[50, 99\]/);
+    });
+
+    test('POST /card validates the same threshold fields under schedule', () => {
+        expect(kanbanSrc).toMatch(/schedule\.skipIf5hUsagePctOver !== undefined[\s\S]{0,400}isValidUsageThreshold\(schedule\.skipIf5hUsagePctOver\)/);
+        expect(kanbanSrc).toMatch(/schedule\.skipIf7dUsagePctOver !== undefined[\s\S]{0,400}isValidUsageThreshold\(schedule\.skipIf7dUsagePctOver\)/);
+    });
+});
+
+describe('migration + schema mirror', () => {
+    test('up.sql adds both schedule_skip_if_*_pct_over columns', () => {
+        const sql = fs.readFileSync(
+            path.join(__dirname, '..', '..', 'migrations', '20260621_kanban_card_schedule_usage_threshold.up.sql'),
+            'utf8'
+        );
+        expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS schedule_skip_if_5h_pct_over SMALLINT DEFAULT 85/);
+        expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS schedule_skip_if_7d_pct_over SMALLINT DEFAULT 95/);
+    });
+
+    test('down.sql drops both columns (reversibility)', () => {
+        const sql = fs.readFileSync(
+            path.join(__dirname, '..', '..', 'migrations', '20260621_kanban_card_schedule_usage_threshold.down.sql'),
+            'utf8'
+        );
+        expect(sql).toMatch(/DROP COLUMN IF EXISTS schedule_skip_if_5h_pct_over/);
+        expect(sql).toMatch(/DROP COLUMN IF EXISTS schedule_skip_if_7d_pct_over/);
+    });
+
+    test('kanban_schema.sql mirrors the migration columns (boot-time bootstrap)', () => {
+        const sql = fs.readFileSync(
+            path.join(__dirname, '..', '..', 'kanban_schema.sql'),
+            'utf8'
+        );
+        expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS schedule_skip_if_5h_pct_over SMALLINT DEFAULT 85/);
+        expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS schedule_skip_if_7d_pct_over SMALLINT DEFAULT 95/);
+    });
+});


### PR DESCRIPTION
## Summary

Implements the BACKEND side of the per-card usage-threshold cron skip spec
(parent **card_ad507345ce19fc5f51c2d814**, Backend child **card_c26358498ecee64638b9ca9c**).

When a cron-scheduled automation card fires, the scheduler now checks each
assigned entity's rolling 5h/7d usage% (Claude statusLine + Codex rate_limits,
read from `usage_snapshots`). If any assigned entity strictly exceeds the
per-card threshold, child-card dispatch is skipped this tick — preventing
quota burn on a busy subagent or starving the user during peak load.

## What changed

- **Schema** (`backend/migrations/20260621_kanban_card_schedule_usage_threshold.{up,down}.sql` + `backend/kanban_schema.sql` mirror): adds `schedule_skip_if_5h_pct_over` (SMALLINT, default 85) and `schedule_skip_if_7d_pct_over` (SMALLINT, default 95) to `kanban_cards`.
- **API validation** (`PUT /api/mission/card/:id/schedule` + `POST /api/mission/card`): accepts `skipIf5hUsagePctOver` / `skipIf7dUsagePctOver` (under `schedule` for POST) — must be JS-number integer in `[50, 99]`, otherwise HTTP 400. Strings, decimals, booleans all reject.
- **Cron fire path** (`backend/kanban.js` `checkScheduleTriggers`): in the recurring + `is_automation` branch, runs `evaluateUsageSkipDecision` BEFORE the existing idle-dispatch path. On skip:
  - Logs `[CronSkip] card_X entity_Y usage_5h=87% > 85% — child dispatch skipped`
  - Posts a Chinese system comment naming the entity / window / usage / limit / next attempt time
  - **Advances `schedule_next_run_at`** to the next cron slot (otherwise the row fire-spins every poll loop — the scheduler scans `WHERE next_run_at <= NOW()`)
  - **Does NOT bump `schedule_last_run_at`** — keeps the audit trail pointing at the last *successful* dispatch
  - `continue`s the loop without creating a child card
- **Graceful degradation**: when usage data is unavailable for the entity (no daemon push, DB infra error, `usage_snapshots` empty), the helper returns `null` and the guard treats it as 0% → PROCEEDS with dispatch. Preserves pre-card_c2635849 behavior on devices without the Mac daemon.
- **`serializeCard`** surfaces the new thresholds on the `schedule` object so the upcoming UI editor can read them.

## Tests

- New `backend/tests/jest/kanban-cron-usage-threshold.test.js` — **39 tests**:
  - Validator boundary: accepts 50/85/99, rejects 49/100, decimals, strings, booleans, null, NaN
  - `clampUsageThreshold` read-side normalizer + truncation behavior
  - Claude nested + flat shape extraction; Codex flat shape
  - `evaluateUsageSkipDecision`: SKIP on 5h or 7d over; PROCEED on equal-to-threshold (strict `>`), under threshold, null usage, empty bots array; honors per-card custom thresholds; short-circuits on first offending entity; defends against out-of-range stored values
  - Source-shape invariants: usage check runs inside recurring+automation branch and before idle-dispatch path; skip block does not bump `schedule_last_run_at`; log line format; serializeCard exposure; both POST/PUT validate via `isValidUsageThreshold`
  - Migration up/down + schema-mirror invariants
- Fixed 2 pre-existing tests in `kanban-card.test.js` that asserted INSERT params via tail-offset (`params.length - 2`). My added columns shifted the offsets; replaced with a `columnParamIndex(sql, columnName)` helper that maps column → `$N` → params index, so future column additions don't break those assertions.
- Full backend Jest suite: **355 suites / 4993 tests passing** (17 pre-existing `skip`s).

## Out of scope

- Frontend editor UI for the threshold fields — separate UI child card under the same parent.
- i18n strings — backend-only PR.

## Test plan

- [x] New unit tests pass (39/39)
- [x] Existing kanban-card tests pass (40/40) after the offset-fix
- [x] Full backend Jest pass (4993 passing)
- [x] Lint clean on changed files (1 pre-existing warning unrelated)
- [ ] CI green on Backend workflow
- [ ] Reviewer (LOBSTER #2) admin-merge after review

Refs:
- Parent: `card_ad507345ce19fc5f51c2d814`
- Backend child: `card_c26358498ecee64638b9ca9c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUDRpzSFMMKwMoVtnxK1dd