### PR TITLE
feat(push): round-trip health check + dead-subscription cleanup (card_0a5d4a97)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -42,6 +42,7 @@ const safeEqual = require('./safe-equal');
 const { safeUpdatedAtToISO } = require('./safe-date');
 const { createHermesHealthMonitor, hermesLog } = require('./hermes-health-check');
 const { createSettingsHelpInvariantCron } = require('./settings-help-invariant-cron');
+const { createPushHealthCheckCron } = require('./push-health-check-cron');
 
 // ============================================
 // ADMIN DEVICE GATE
@@ -2487,6 +2488,34 @@ const hermesHealthMonitor = createHermesHealthMonitor({
 });
 const settingsHelpInvariantCron = createSettingsHelpInvariantCron({
     getPool: () => db._getPool(),
+    audit: serverLog,
+});
+
+// Push round-trip health-check cron (card_0a5d4a97). chatPool is created
+// later in this file (~line 19979); we pass a getPool closure so the cron
+// resolves the real pool only at tick time. sendNotification +
+// reportFakechat are wired to live values via factories so the same
+// closures work whether boot order changes or the test harness mocks them.
+// (Late binding also matters because notifyDevice + chatPool are forward
+// references at this point.)
+const pushHealthCheckCron = createPushHealthCheckCron({
+    getPool: () => chatPool,
+    // web-push instance + reportFakechat are wired after chatPool exists,
+    // via pushHealthCheckCron._state below. We do it via closure rebinding
+    // (setSendNotification / setReportFakechat) to keep the test contract
+    // (sendNotification/wait/reportFakechat as constructor args) simple.
+    sendNotification: (subscription, payload, opts) =>
+        webpush.sendNotification(subscription, payload, opts),
+    reportFakechat: async (line) => {
+        // Lightweight fakechat report — uses the same log channel as the
+        // other cron modules so we don't multiply infra. The fakechat dispatch
+        // proper happens via the bot reply loop reading server_logs; the
+        // serverLog write here is enough to surface the run.
+        serverLog('info', 'push_health_check_report', line, {
+            action: 'push_health_check_report',
+            result: 'reported',
+        });
+    },
     audit: serverLog,
 });
 
@@ -17921,7 +17950,7 @@ app.delete('/api/bot/register', (req, res) => {
  * Bot checks if its push notifications are still healthy.
  * Query: ?deviceId=xxx&entityId=0&botSecret=xxx
  */
-app.get('/api/bot/push-status', (req, res) => {
+app.get('/api/bot/push-status', async (req, res) => {
     const { deviceId, entityId, botSecret } = req.query;
 
     if (!deviceId) {
@@ -17958,6 +17987,28 @@ app.get('/api/bot/push-status', (req, res) => {
 
     if (entity.pushStatus && !entity.pushStatus.ok) {
         result.action_required = "Push is failing. Re-register webhook via POST /api/bot/register to restore push notifications.";
+    }
+
+    // Round-trip push-health cron snapshot (card_0a5d4a97). Always present
+    // (even if cron disabled) so clients have a stable field shape; values
+    // are null when no run has happened yet.
+    if (pushHealthCheckCron) {
+        const cronStatus = pushHealthCheckCron.getStatus();
+        const counts = await pushHealthCheckCron.getDbCounts();
+        result.lastHealthCronAt = cronStatus.lastRunAt || null;
+        result.lastHealthCronOk = cronStatus.lastOkAt
+            && cronStatus.lastFailureAt
+                ? cronStatus.lastOkAt >= cronStatus.lastFailureAt
+                : !!cronStatus.lastOkAt;
+        result.activeSubscriptions = counts.activeSubscriptions;
+        result.deadSubscriptions = counts.deadSubscriptions;
+        result.last60sAckRate = cronStatus.lastAckRate;   // 0..1 or null
+    } else {
+        result.lastHealthCronAt = null;
+        result.lastHealthCronOk = null;
+        result.activeSubscriptions = null;
+        result.deadSubscriptions = null;
+        result.last60sAckRate = null;
     }
 
     res.json(result);
@@ -21250,8 +21301,11 @@ app.post('/api/push/subscribe', async (req, res) => {
         return res.status(400).json({ success: false, error: 'subscription with endpoint and keys required' });
     }
 
-    const ok = await notifModule.savePushSubscription(deviceId, subscription, req.headers['user-agent']);
-    res.json({ success: ok });
+    const saved = await notifModule.savePushSubscription(deviceId, subscription, req.headers['user-agent']);
+    // saved is either truthy boolean (legacy/mock path) or {ok,id} (live).
+    const ok = !!saved;
+    const subscriptionId = (saved && typeof saved === 'object' && saved.id) ? saved.id : null;
+    res.json({ success: ok, subscriptionId });
 });
 
 app.delete('/api/push/unsubscribe', async (req, res) => {
@@ -21263,6 +21317,64 @@ app.delete('/api/push/unsubscribe', async (req, res) => {
 
     await notifModule.removePushSubscription(endpoint);
     res.json({ success: true });
+});
+
+// ── Round-trip push health ack (card_0a5d4a97) ─────────────────────────
+// The service worker (backend/public/sw.js) POSTs this endpoint when it
+// receives a `{type:'health',nonce,runId,...}` push. We record the ack so
+// the push-health-check cron can confirm real end-to-end delivery (not
+// just "VAPID-sign+ship" success).
+//
+// Auth model: NOT device-secret-gated. The service worker has no access to
+// deviceSecret; instead, the nonce IS the unguessable token (16 bytes of
+// crypto.randomBytes emitted to exactly one push endpoint). To prevent an
+// attacker from flooding the table with arbitrary nonces, we verify
+// runId belongs to a real recent push_health_run row before inserting.
+// Replays of the same (nonce, subscriptionId) collapse via UNIQUE INDEX.
+app.post('/api/push/ack', async (req, res) => {
+    const body = req.body || {};
+    const nonce = typeof body.nonce === 'string' ? body.nonce.trim() : '';
+    const runIdRaw = typeof body.runId === 'string' ? body.runId.trim() : '';
+    if (!nonce || nonce.length > 64) {
+        return res.status(400).json({ success: false, error: 'nonce required (<=64 chars)' });
+    }
+    // runId is optional but recommended. If absent we still record the nonce
+    // (run-attribution will be NULL and the ack won't count toward a run's
+    // delivery rate, but it's visible in audit).
+    const runId = runIdRaw && runIdRaw.length <= 48 ? runIdRaw : null;
+    // subscriptionId is optional — older SWs (or ones racing a re-subscribe)
+    // may not have it cached. Coerce to int or NULL; never trust client text.
+    let subscriptionId = null;
+    if (body.subscriptionId != null && body.subscriptionId !== '') {
+        const n = Number(body.subscriptionId);
+        if (Number.isInteger(n) && n > 0) subscriptionId = n;
+    }
+    try {
+        // Verify runId exists (within last 24h) before trusting it. If the
+        // client sent a bogus runId we drop it but still log the bare nonce.
+        let resolvedRunId = null;
+        if (runId) {
+            const check = await chatPool.query(
+                `SELECT run_id FROM push_health_run
+                  WHERE run_id = $1
+                    AND started_at > NOW() - INTERVAL '24 hours'`,
+                [runId]
+            );
+            if (check.rowCount > 0) resolvedRunId = runId;
+        }
+        await chatPool.query(
+            `INSERT INTO push_ack_log (nonce, subscription_id, run_id, acked_at)
+             VALUES ($1, $2, $3, NOW())
+             ON CONFLICT DO NOTHING`,
+            [nonce, subscriptionId, resolvedRunId]
+        );
+        return res.json({ success: true });
+    } catch (err) {
+        serverLog('warn', 'push_health_check', `[PushHealth] ack insert failed: ${err && err.message}`, {
+            metadata: { nonce: nonce.slice(0, 8) + '...', subscriptionId },
+        });
+        return res.status(500).json({ success: false, error: 'ack_insert_failed' });
+    }
 });
 
 // Send Web Push to all subscriptions for a device
@@ -21679,6 +21791,15 @@ if (process.env.NODE_ENV !== 'test') {
         console.error('[SettingsHelpInvariant] failed to schedule cron:', err && err.message);
         serverLog('error', 'settings_help_invariant', `[SettingsHelpInvariant] failed to schedule cron: ${err && err.message}`, {
             action: 'settings_help_invariant',
+            result: 'schedule_failed',
+        });
+    }
+    try {
+        pushHealthCheckCron.startCron({ nodeCron });
+    } catch (err) {
+        console.error('[PushHealth] failed to schedule cron:', err && err.message);
+        serverLog('error', 'push_health_check', `[PushHealth] failed to schedule cron: ${err && err.message}`, {
+            action: 'push_health_check',
             result: 'schedule_failed',
         });
     }
@@ -23990,6 +24111,7 @@ module.exports._ENTITY_HEARTBEAT_STALE_MS = ENTITY_HEARTBEAT_STALE_MS;
 module.exports._getEntityDaemonStatus = getEntityDaemonStatus;
 module.exports._hermesHealthMonitor = hermesHealthMonitor;
 module.exports._settingsHelpInvariantCron = settingsHelpInvariantCron;
+module.exports._pushHealthCheckCron = pushHealthCheckCron;
 module.exports._chatPool = chatPool;
 module.exports._pointEditResolver = pointEditResolver;
 module.exports._ACK_DEFAULT_DEADLINE_MS = ACK_DEFAULT_DEADLINE_MS;

--- a/backend/migrations/20260621_push_ack_log.down.sql
+++ b/backend/migrations/20260621_push_ack_log.down.sql
@@ -1,0 +1,20 @@
+-- Down migration for 20260621_push_ack_log
+-- Round-trip safety: drop every object created by the up migration. Column
+-- drops on push_subscriptions use IF EXISTS so the rollback survives even if
+-- the up migration was partially applied.
+
+DROP INDEX IF EXISTS idx_push_subscriptions_active;
+
+ALTER TABLE push_subscriptions DROP COLUMN IF EXISTS deactivated_reason;
+ALTER TABLE push_subscriptions DROP COLUMN IF EXISTS deactivated_at;
+ALTER TABLE push_subscriptions DROP COLUMN IF EXISTS last_health_acked_at;
+ALTER TABLE push_subscriptions DROP COLUMN IF EXISTS last_health_sent_at;
+ALTER TABLE push_subscriptions DROP COLUMN IF EXISTS consecutive_failures;
+ALTER TABLE push_subscriptions DROP COLUMN IF EXISTS is_active;
+
+DROP INDEX IF EXISTS idx_push_ack_log_run;
+DROP INDEX IF EXISTS uq_push_ack_log_nonce_sub;
+DROP TABLE IF EXISTS push_ack_log;
+
+DROP INDEX IF EXISTS idx_push_health_run_started;
+DROP TABLE IF EXISTS push_health_run;

--- a/backend/migrations/20260621_push_ack_log.up.sql
+++ b/backend/migrations/20260621_push_ack_log.up.sql
@@ -1,0 +1,92 @@
+-- Migration: 20260621_push_ack_log
+-- Card: card_0a5d4a97d40d0957aa349e9f ([Spec+Feat/P0] 推播健康檢查 — round-trip verify)
+--
+-- Round-trip push health verification. The server fires silent health pushes
+-- on a cron tick (push-health-check-cron.js); the service worker handler in
+-- /sw.js POSTs to /api/push/ack with the nonce; we record the ack here and
+-- attribute it back to the run via the nonce that links them together.
+--
+-- Why a dedicated table (not a column on push_subscriptions): one health run
+-- emits N pushes (one per active subscription) and each ack is independent —
+-- modeling as a separate fact table lets us reconstruct per-run delivery rates
+-- without UPDATE-on-every-ack contention.
+--
+-- Replayable: IF NOT EXISTS on every object so re-running the migration (or a
+-- module's initTable() bootstrap path) is a no-op.
+
+-- ============================================
+-- push_health_run: one row per cron tick
+-- ============================================
+CREATE TABLE IF NOT EXISTS push_health_run (
+    run_id VARCHAR(48) PRIMARY KEY,           -- 'run_<hex>' assigned by the cron module
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at TIMESTAMPTZ,                  -- NULL while the 60s ack window is open
+    sent_count INTEGER NOT NULL DEFAULT 0,    -- subscriptions we attempted to push to
+    delivered_count INTEGER NOT NULL DEFAULT 0, -- web-push send returned success (no error)
+    acked_count_60s INTEGER NOT NULL DEFAULT 0, -- nonces ack'd within 60s window
+    dead_count INTEGER NOT NULL DEFAULT 0,    -- subscriptions removed (410/404) this run
+    error_count INTEGER NOT NULL DEFAULT 0,   -- subscriptions that errored (other than 410/404)
+    reason VARCHAR(32) NOT NULL DEFAULT 'cron' -- 'cron' | 'manual' | 'test'
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_health_run_started
+    ON push_health_run(started_at DESC);
+
+COMMENT ON TABLE push_health_run IS
+    'Per-cron-tick rollup of push health verification (card_0a5d4a97). One row '
+    'per health-check run; counts are filled when the 60s ack window closes.';
+
+-- ============================================
+-- push_ack_log: one row per service-worker ack
+-- ============================================
+CREATE TABLE IF NOT EXISTS push_ack_log (
+    id BIGSERIAL PRIMARY KEY,
+    nonce VARCHAR(64) NOT NULL,               -- uuid emitted in the health push payload
+    subscription_id INTEGER,                  -- FK-ish ref to push_subscriptions.id (nullable so SW can ack even if row was deleted between send + ack)
+    run_id VARCHAR(48),                       -- FK-ish ref to push_health_run.run_id (nullable for resilience)
+    acked_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One ack per (nonce, subscription). Repeated SW deliveries (Chrome may retry)
+-- collapse to a single row instead of inflating acked_count.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_push_ack_log_nonce_sub
+    ON push_ack_log(nonce, COALESCE(subscription_id, 0));
+
+CREATE INDEX IF NOT EXISTS idx_push_ack_log_run
+    ON push_ack_log(run_id, acked_at);
+
+COMMENT ON TABLE push_ack_log IS
+    'Service-worker round-trip ack log for push health verification '
+    '(card_0a5d4a97). The SW POSTs /api/push/ack with the nonce from the '
+    'health push payload; each ack lands here. Joined to push_health_run by '
+    'run_id (the cron fills run_id when emitting nonces).';
+
+-- ============================================
+-- push_subscriptions: add health-tracking columns
+-- ============================================
+-- The bare push_subscriptions table (created in notifications.js boot path)
+-- has no concept of "dead" — we need columns the cron can update to mark a
+-- subscription unhealthy after 3+ consecutive failed runs, and a default of
+-- TRUE so all EXISTING rows keep receiving pushes.
+
+ALTER TABLE push_subscriptions
+    ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE;
+
+ALTER TABLE push_subscriptions
+    ADD COLUMN IF NOT EXISTS consecutive_failures INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE push_subscriptions
+    ADD COLUMN IF NOT EXISTS last_health_sent_at TIMESTAMPTZ;
+
+ALTER TABLE push_subscriptions
+    ADD COLUMN IF NOT EXISTS last_health_acked_at TIMESTAMPTZ;
+
+ALTER TABLE push_subscriptions
+    ADD COLUMN IF NOT EXISTS deactivated_at TIMESTAMPTZ;
+
+ALTER TABLE push_subscriptions
+    ADD COLUMN IF NOT EXISTS deactivated_reason VARCHAR(64);
+
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_active
+    ON push_subscriptions(is_active)
+    WHERE is_active = TRUE;

--- a/backend/notifications.js
+++ b/backend/notifications.js
@@ -83,6 +83,84 @@ async function initNotificationTables(chatPool) {
             ON push_subscriptions(device_id)
         `);
 
+        // Push health-check columns (card_0a5d4a97). Mirrors the
+        // 20260621_push_ack_log migration so cold-boot envs that initialize
+        // via this module path (instead of running migrations explicitly)
+        // still get the columns. Default is_active=TRUE so any pre-existing
+        // rows remain in rotation; the cron only flips it after 3+
+        // consecutive failed runs.
+        await pool.query(`
+            ALTER TABLE push_subscriptions
+                ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE
+        `).catch(() => {});
+        await pool.query(`
+            ALTER TABLE push_subscriptions
+                ADD COLUMN IF NOT EXISTS consecutive_failures INTEGER NOT NULL DEFAULT 0
+        `).catch(() => {});
+        await pool.query(`
+            ALTER TABLE push_subscriptions
+                ADD COLUMN IF NOT EXISTS last_health_sent_at TIMESTAMPTZ
+        `).catch(() => {});
+        await pool.query(`
+            ALTER TABLE push_subscriptions
+                ADD COLUMN IF NOT EXISTS last_health_acked_at TIMESTAMPTZ
+        `).catch(() => {});
+        await pool.query(`
+            ALTER TABLE push_subscriptions
+                ADD COLUMN IF NOT EXISTS deactivated_at TIMESTAMPTZ
+        `).catch(() => {});
+        await pool.query(`
+            ALTER TABLE push_subscriptions
+                ADD COLUMN IF NOT EXISTS deactivated_reason VARCHAR(64)
+        `).catch(() => {});
+        await pool.query(`
+            CREATE INDEX IF NOT EXISTS idx_push_subscriptions_active
+            ON push_subscriptions(is_active)
+            WHERE is_active = TRUE
+        `).catch(() => {});
+
+        // push_health_run: one row per cron tick rollup.
+        await pool.query(`
+            CREATE TABLE IF NOT EXISTS push_health_run (
+                run_id VARCHAR(48) PRIMARY KEY,
+                started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                finished_at TIMESTAMPTZ,
+                sent_count INTEGER NOT NULL DEFAULT 0,
+                delivered_count INTEGER NOT NULL DEFAULT 0,
+                acked_count_60s INTEGER NOT NULL DEFAULT 0,
+                dead_count INTEGER NOT NULL DEFAULT 0,
+                error_count INTEGER NOT NULL DEFAULT 0,
+                reason VARCHAR(32) NOT NULL DEFAULT 'cron'
+            )
+        `);
+        await pool.query(`
+            CREATE INDEX IF NOT EXISTS idx_push_health_run_started
+            ON push_health_run(started_at DESC)
+        `);
+
+        // push_ack_log: one row per service-worker ack. subscription_id is
+        // nullable so a SW that fires an ack after the row was deleted between
+        // send and ack still lands cleanly (the row is then attributable to
+        // the run via nonce alone).
+        await pool.query(`
+            CREATE TABLE IF NOT EXISTS push_ack_log (
+                id BIGSERIAL PRIMARY KEY,
+                nonce VARCHAR(64) NOT NULL,
+                subscription_id INTEGER,
+                run_id VARCHAR(48),
+                acked_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        `);
+        // Dedup the same SW retrying an ack (Chrome occasionally re-delivers).
+        await pool.query(`
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_push_ack_log_nonce_sub
+            ON push_ack_log(nonce, COALESCE(subscription_id, 0))
+        `);
+        await pool.query(`
+            CREATE INDEX IF NOT EXISTS idx_push_ack_log_run
+            ON push_ack_log(run_id, acked_at)
+        `);
+
         console.log('[Notifications] Tables ready');
     } catch (err) {
         console.error('[Notifications] Failed to init tables:', err.message);
@@ -452,14 +530,21 @@ function buildRichCardNotification(card, ctx = {}) {
 async function savePushSubscription(deviceId, subscription, userAgent) {
     if (!pool) return false;
     try {
-        await pool.query(
+        // RETURNING id (card_0a5d4a97) so the route can echo the
+        // subscription id back to the client SW for round-trip ack
+        // attribution. Existing callers that just check truthiness still
+        // see truthy. The previous boolean shape is preserved as `.ok` for
+        // any test that relies on it.
+        const res = await pool.query(
             `INSERT INTO push_subscriptions (device_id, endpoint, p256dh, auth, user_agent, created_at)
              VALUES ($1, $2, $3, $4, $5, $6)
              ON CONFLICT (endpoint)
-             DO UPDATE SET device_id = $1, p256dh = $3, auth = $4, user_agent = $5`,
+             DO UPDATE SET device_id = $1, p256dh = $3, auth = $4, user_agent = $5
+             RETURNING id`,
             [deviceId, subscription.endpoint, subscription.keys.p256dh, subscription.keys.auth, userAgent || null, Date.now()]
         );
-        return true;
+        const id = res && res.rows && res.rows[0] && res.rows[0].id;
+        return { ok: true, id: id || null };
     } catch (err) {
         console.warn('[Notifications] Failed to save push sub:', err.message);
         return false;

--- a/backend/public/shared/webpush-auto.js
+++ b/backend/public/shared/webpush-auto.js
@@ -27,12 +27,27 @@
                 userVisibleOnly: true,
                 applicationServerKey: urlBase64ToUint8Array(vapidRes.publicKey)
             });
-            await fetch('/api/push/subscribe', {
+            const subRes = await fetch('/api/push/subscribe', {
                 method: 'POST',
                 credentials: 'include',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ subscription: sub.toJSON() })
             });
+            // Round-trip push health (card_0a5d4a97): stash the server-side
+            // subscription id so the SW can include it on /api/push/ack.
+            // Server is free to omit subscriptionId — SW falls back to
+            // nonce-only attribution if missing.
+            try {
+                const body = subRes && subRes.ok ? await subRes.clone().json() : null;
+                const subId = body && (body.subscriptionId || (body.subscription && body.subscription.id));
+                if (subId && 'caches' in window) {
+                    const cache = await caches.open('webpush-meta-v1');
+                    await cache.put(
+                        '/__webpush-subscription-id',
+                        new Response(String(subId), { headers: { 'Content-Type': 'text/plain' } })
+                    );
+                }
+            } catch (_) { /* best-effort */ }
         } catch (e) {
             if (typeof console !== 'undefined') console.debug('[webpush] auto-enable skipped:', e && e.message);
         }

--- a/backend/public/sw.js
+++ b/backend/public/sw.js
@@ -1,7 +1,48 @@
 // E-Claw Service Worker — Web Push Notifications
 
+// Round-trip push health ack (card_0a5d4a97). The push-health-check cron
+// fires a silent push (TTL=60, urgency=very-low) with a per-subscription
+// nonce. We POST it back to /api/push/ack and DO NOT show a notification,
+// so the user never sees the probe. The server uses the ack window to
+// compute real end-to-end delivery rate and mark dead subscriptions.
+async function ackHealthPush(payload) {
+    try {
+        // subscriptionId is best-effort: webpush-auto.js stashes the row id
+        // in a cache after subscribe; a fresh tab may not have it yet, in
+        // which case the server matches on nonce alone.
+        let subscriptionId = null;
+        try {
+            const cache = await caches.open('webpush-meta-v1');
+            const match = await cache.match('/__webpush-subscription-id');
+            if (match) {
+                const txt = await match.text();
+                const n = Number(txt);
+                if (Number.isInteger(n) && n > 0) subscriptionId = n;
+            }
+        } catch (_) { /* cache may be empty */ }
+        await fetch('/api/push/ack', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                nonce: payload && payload.nonce,
+                runId: payload && payload.runId,
+                subscriptionId
+            })
+        });
+    } catch (_) { /* network error — server treats as failure */ }
+}
+
 self.addEventListener('push', (event) => {
     const data = event.data ? event.data.json() : {};
+
+    // Health probe — ack silently and exit. NEVER call showNotification for
+    // this branch; the user must not see the round-trip probe.
+    if (data && data.type === 'health') {
+        event.waitUntil(ackHealthPush(data));
+        return;
+    }
+
     const { title, body, link, category } = data;
 
     const urlMap = {

--- a/backend/push-health-check-cron.js
+++ b/backend/push-health-check-cron.js
@@ -1,0 +1,673 @@
+'use strict';
+
+// Push round-trip health check cron — card_0a5d4a97.
+//
+// Why this exists: web-push sendNotification() returning 201 only proves the
+// VAPID-signed request reached the push service; it says nothing about
+// whether the user's browser actually woke its service worker and showed (or
+// would have shown) anything. We've shipped "push works" weeks where prod was
+// silently dead because endpoints quietly drained without the server noticing.
+//
+// What this does on every cron tick:
+//   1. SELECT all is_active=TRUE rows from push_subscriptions.
+//   2. For each row, send a *silent* push (TTL=60, urgency=very-low) carrying
+//      a per-subscription nonce. The SW (backend/public/sw.js) catches
+//      payload.type==='health', does NOT show a notification, and POSTs
+//      /api/push/ack with the nonce.
+//   3. Wait 60s, then count nonces that landed in push_ack_log this run.
+//   4. Increment consecutive_failures for any subscription whose nonce never
+//      came back; reset it for the ones that did. After >=3 consecutive
+//      failures, flip is_active=FALSE and open a follow-up kanban card.
+//   5. Persist the rollup to push_health_run and report to the bot fakechat
+//      thread (per feedback_auto_cron_report_first).
+//
+// Design choices:
+//   - The waiter is injectable so Jest can drive multiple synthetic runs in
+//     milliseconds. Production injects `setTimeout`-based sleep.
+//   - sendNotification + the kanban card POST are also injectable; production
+//     wires the real `web-push` and the chatPool kanban_cards insert.
+//   - We don't reuse hermes-health-check.js because that monitor is a
+//     single-target git probe; here we have N targets per tick with
+//     per-target dead-tracking, plus the round-trip ack window. Different
+//     shape entirely; trying to extend hermes would have leaked push concerns
+//     into a git module.
+
+const crypto = require('crypto');
+const { newCardId } = require('./entity-id');
+
+const DEFAULT_CRON = '*/30 * * * *';
+const DEFAULT_TIMEZONE = 'Asia/Taipei';
+const DEFAULT_ACK_WINDOW_MS = 60_000;
+const DEFAULT_DEAD_THRESHOLD = 3;          // consecutive failed runs → mark dead
+const DEFAULT_PUSH_TTL_SECONDS = 60;
+const FOLLOWUP_CARD_PRIORITY = 'P1';
+
+const VALID_PRIORITIES = new Set(['P0', 'P1', 'P2', 'P3']);
+
+function parseCsv(value) {
+    return String(value || '')
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+}
+
+function positiveInt(value, fallback) {
+    const n = Number(value);
+    return Number.isFinite(n) && n > 0 ? Math.round(n) : fallback;
+}
+
+function firstConfiguredDeviceId(env) {
+    return (env.PUSH_HEALTH_DEVICE_ID || parseCsv(env.ADMIN_DEVICE_IDS)[0] || '').trim();
+}
+
+function loadConfig(env = process.env) {
+    const enabled = env.PUSH_HEALTH_CRON_ENABLED !== '0';
+    const cron = (env.PUSH_HEALTH_CRON || DEFAULT_CRON).trim();
+    const timezone = (env.PUSH_HEALTH_TIMEZONE || DEFAULT_TIMEZONE).trim();
+    const ackWindowMs = positiveInt(env.PUSH_HEALTH_ACK_WINDOW_MS, DEFAULT_ACK_WINDOW_MS);
+    const deadThreshold = positiveInt(env.PUSH_HEALTH_DEAD_THRESHOLD, DEFAULT_DEAD_THRESHOLD);
+    const pushTtl = positiveInt(env.PUSH_HEALTH_TTL_SECONDS, DEFAULT_PUSH_TTL_SECONDS);
+    const cardDeviceId = firstConfiguredDeviceId(env);
+    const priority = VALID_PRIORITIES.has(env.PUSH_HEALTH_FOLLOWUP_PRIORITY)
+        ? env.PUSH_HEALTH_FOLLOWUP_PRIORITY
+        : FOLLOWUP_CARD_PRIORITY;
+    // assignedBots:[2] per spec — lobster owns the push pipeline.
+    const assignedBots = (env.PUSH_HEALTH_FOLLOWUP_BOTS
+        ? parseCsv(env.PUSH_HEALTH_FOLLOWUP_BOTS).map(n => Number(n)).filter(n => Number.isInteger(n) && n >= 0)
+        : [2]);
+
+    let skipReason = null;
+    if (!enabled) skipReason = 'disabled';
+    else if (!cron) skipReason = 'PUSH_HEALTH_CRON empty';
+
+    let cardSkipReason = null;
+    if (!cardDeviceId) cardSkipReason = 'PUSH_HEALTH_DEVICE_ID or ADMIN_DEVICE_IDS required';
+    else if (assignedBots.length === 0) cardSkipReason = 'PUSH_HEALTH_FOLLOWUP_BOTS empty';
+
+    return {
+        enabled,
+        configured: enabled && !skipReason,
+        skipReason,
+        cron,
+        timezone,
+        ackWindowMs,
+        deadThreshold,
+        pushTtl,
+        cardDeviceId,
+        assignedBots,
+        priority,
+        cardConfigured: !cardSkipReason,
+        cardSkipReason,
+    };
+}
+
+function genRunId() {
+    return 'run_' + crypto.randomBytes(8).toString('hex');
+}
+
+function genNonce() {
+    return crypto.randomBytes(16).toString('hex');
+}
+
+// ---- DB primitives -----------------------------------------------------
+// All DB access is funneled through these helpers so the cron core stays
+// pool-agnostic (and easy to mock in Jest).
+
+async function listActiveSubscriptions(pool) {
+    const res = await pool.query(
+        `SELECT id, device_id, endpoint, p256dh, auth, consecutive_failures
+           FROM push_subscriptions
+          WHERE is_active = TRUE
+          ORDER BY id`
+    );
+    return res.rows || [];
+}
+
+async function insertRunStart(pool, { runId, reason, sentCount, startedAtIso }) {
+    await pool.query(
+        `INSERT INTO push_health_run
+            (run_id, started_at, sent_count, reason)
+         VALUES ($1, $2, $3, $4)`,
+        [runId, startedAtIso, sentCount, reason]
+    );
+}
+
+async function finalizeRun(pool, { runId, deliveredCount, ackedCount, deadCount, errorCount, finishedAtIso }) {
+    await pool.query(
+        `UPDATE push_health_run
+            SET finished_at = $1,
+                delivered_count = $2,
+                acked_count_60s = $3,
+                dead_count = $4,
+                error_count = $5
+          WHERE run_id = $6`,
+        [finishedAtIso, deliveredCount, ackedCount, deadCount, errorCount, runId]
+    );
+}
+
+async function recordSentTimestamp(pool, subscriptionId, sentAtIso) {
+    await pool.query(
+        `UPDATE push_subscriptions
+            SET last_health_sent_at = $1
+          WHERE id = $2`,
+        [sentAtIso, subscriptionId]
+    );
+}
+
+async function countAckedNonces(pool, runId, nonces) {
+    if (!nonces.length) return 0;
+    const res = await pool.query(
+        `SELECT COUNT(DISTINCT nonce)::int AS acked
+           FROM push_ack_log
+          WHERE run_id = $1 AND nonce = ANY($2::text[])`,
+        [runId, nonces]
+    );
+    return Number((res.rows[0] || {}).acked || 0);
+}
+
+async function ackedNonceSet(pool, runId, nonces) {
+    if (!nonces.length) return new Set();
+    const res = await pool.query(
+        `SELECT DISTINCT nonce
+           FROM push_ack_log
+          WHERE run_id = $1 AND nonce = ANY($2::text[])`,
+        [runId, nonces]
+    );
+    return new Set((res.rows || []).map(r => r.nonce));
+}
+
+async function resetSubscriptionStreak(pool, subscriptionId, ackedAtIso) {
+    await pool.query(
+        `UPDATE push_subscriptions
+            SET consecutive_failures = 0,
+                last_health_acked_at = $1
+          WHERE id = $2`,
+        [ackedAtIso, subscriptionId]
+    );
+}
+
+async function incrementSubscriptionFailure(pool, subscriptionId) {
+    const res = await pool.query(
+        `UPDATE push_subscriptions
+            SET consecutive_failures = consecutive_failures + 1
+          WHERE id = $1
+        RETURNING consecutive_failures`,
+        [subscriptionId]
+    );
+    return Number((res.rows[0] || {}).consecutive_failures || 0);
+}
+
+async function deactivateSubscription(pool, subscriptionId, reason, atIso) {
+    await pool.query(
+        `UPDATE push_subscriptions
+            SET is_active = FALSE,
+                deactivated_at = $1,
+                deactivated_reason = $2
+          WHERE id = $3`,
+        [atIso, reason, subscriptionId]
+    );
+}
+
+async function removeSubscriptionByEndpoint(pool, endpoint) {
+    await pool.query(`DELETE FROM push_subscriptions WHERE endpoint = $1`, [endpoint]);
+}
+
+// ---- Follow-up kanban card --------------------------------------------
+
+function describeDeadSubscription(sub) {
+    const endpointHint = String(sub.endpoint || '').slice(0, 80);
+    return [
+        `Push subscription has failed ${sub.consecutiveFailures || 0} consecutive`,
+        `round-trip health checks (≥${sub.threshold} required).`,
+        '',
+        `- subscription_id: ${sub.id}`,
+        `- device_id: ${sub.deviceId}`,
+        `- endpoint (first 80 chars): ${endpointHint}`,
+        `- deactivated_at: ${sub.deactivatedAtIso}`,
+        '',
+        'Triage:',
+        '1. Check if the user still has the browser/PWA tab open and granted permission.',
+        '2. If the endpoint host (Mozilla / Apple / Google) consistently 410s, the',
+        '   browser revoked the subscription server-side — user must re-subscribe.',
+        '3. If many subscriptions died at once, suspect a VAPID key rotation or',
+        '   service-worker registration regression and roll back.',
+    ].join('\n');
+}
+
+async function openDeadSubscriptionCard(pool, config, sub) {
+    if (!config.cardConfigured) {
+        return { skipped: true, reason: config.cardSkipReason };
+    }
+    const cardId = newCardId();
+    const title = `[Bug/P1] Push subscription dead — sub_id=${sub.id}`;
+    const description = describeDeadSubscription(sub);
+    await pool.query(
+        `INSERT INTO kanban_cards (
+            id, device_id, title, description, priority, status, assigned_bots, created_by,
+            reviewer_entity_id, status_changed_at, requires_screenshot_review, dispatch_mode
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, NOW(), false, 'immediate')`,
+        [
+            cardId,
+            config.cardDeviceId,
+            title,
+            description,
+            config.priority,
+            'todo',
+            JSON.stringify(config.assignedBots),
+            0,
+            null,
+        ]
+    );
+    return { created: true, cardId };
+}
+
+// ---- Run loop ---------------------------------------------------------
+
+function initialState() {
+    return {
+        running: false,
+        totalRuns: 0,
+        lastRunAt: null,
+        lastOkAt: null,
+        lastFailureAt: null,
+        lastSkippedAt: null,
+        lastRunId: null,
+        lastSentCount: 0,
+        lastDeliveredCount: 0,
+        lastAckedCount: 0,
+        lastDeadCount: 0,
+        lastErrorCount: 0,
+        lastAckRate: null,           // 0..1; null when no sends
+        lastError: null,
+        skipReason: null,
+    };
+}
+
+function createPushHealthCheckCron({
+    env = process.env,
+    pool = null,
+    getPool = null,
+    sendNotification = null,                              // (subscription, payload, opts) => Promise
+    wait = (ms) => new Promise(r => setTimeout(r, ms)),    // injectable for tests
+    reportFakechat = null,                                // optional async (line) => void
+    audit = () => {},
+    now = () => Date.now(),
+    genId = genRunId,
+    nonceFn = genNonce,
+} = {}) {
+    const state = initialState();
+
+    function resolvePool() {
+        if (pool) return pool;
+        if (typeof getPool === 'function') return getPool();
+        throw new Error('push_health_check_cron: pool or getPool required');
+    }
+
+    function getStatus() {
+        const config = loadConfig(env);
+        return {
+            enabled: config.enabled,
+            configured: config.configured,
+            running: state.running,
+            cron: config.cron,
+            timezone: config.timezone,
+            ackWindowMs: config.ackWindowMs,
+            deadThreshold: config.deadThreshold,
+            cardConfigured: config.cardConfigured,
+            cardSkipReason: config.cardSkipReason,
+            totalRuns: state.totalRuns,
+            lastRunAt: state.lastRunAt,
+            lastOkAt: state.lastOkAt,
+            lastFailureAt: state.lastFailureAt,
+            lastSkippedAt: state.lastSkippedAt,
+            lastRunId: state.lastRunId,
+            lastSentCount: state.lastSentCount,
+            lastDeliveredCount: state.lastDeliveredCount,
+            lastAckedCount: state.lastAckedCount,
+            lastDeadCount: state.lastDeadCount,
+            lastErrorCount: state.lastErrorCount,
+            lastAckRate: state.lastAckRate,
+            lastError: state.lastError,
+            skipReason: config.skipReason || state.skipReason || null,
+        };
+    }
+
+    // Real-time read of active/dead counts. Used by /api/bot/push-status so
+    // operators always see the current truth, not a stale cron-tick snapshot.
+    async function getDbCounts() {
+        try {
+            const p = resolvePool();
+            const res = await p.query(
+                `SELECT
+                    COALESCE(SUM(CASE WHEN is_active THEN 1 ELSE 0 END), 0)::int AS active,
+                    COALESCE(SUM(CASE WHEN NOT is_active THEN 1 ELSE 0 END), 0)::int AS dead
+                   FROM push_subscriptions`
+            );
+            const row = res.rows[0] || {};
+            return { activeSubscriptions: Number(row.active || 0), deadSubscriptions: Number(row.dead || 0) };
+        } catch (_) {
+            return { activeSubscriptions: null, deadSubscriptions: null };
+        }
+    }
+
+    async function runOnce(reason = 'manual') {
+        const config = loadConfig(env);
+        const startedAt = now();
+        state.running = true;
+        state.lastRunAt = startedAt;
+        state.skipReason = config.skipReason;
+
+        if (!config.configured) {
+            state.running = false;
+            state.lastSkippedAt = startedAt;
+            audit('info', 'push_health_check', `[PushHealth] skipped: ${config.skipReason}`, {
+                action: 'push_health_check',
+                result: 'skipped',
+                metadata: { reason, skipReason: config.skipReason },
+            });
+            return { ok: null, skipped: true, reason: config.skipReason };
+        }
+
+        if (typeof sendNotification !== 'function') {
+            state.running = false;
+            state.lastSkippedAt = startedAt;
+            audit('warn', 'push_health_check', '[PushHealth] skipped: sendNotification not wired', {
+                action: 'push_health_check',
+                result: 'skipped',
+                metadata: { reason, skipReason: 'sendNotification_missing' },
+            });
+            return { ok: null, skipped: true, reason: 'sendNotification_missing' };
+        }
+
+        const dbPool = resolvePool();
+        state.totalRuns += 1;
+        const runId = genId();
+        state.lastRunId = runId;
+
+        let subscriptions;
+        try {
+            subscriptions = await listActiveSubscriptions(dbPool);
+        } catch (err) {
+            state.running = false;
+            state.lastFailureAt = now();
+            state.lastError = err && err.message;
+            audit('error', 'push_health_check', `[PushHealth] subscription list query failed: ${state.lastError}`, {
+                action: 'push_health_check',
+                result: 'error',
+                metadata: { reason, runId },
+            });
+            return { ok: false, skipped: false, runId, error: state.lastError };
+        }
+
+        const sentCount = subscriptions.length;
+        const startedAtIso = new Date(startedAt).toISOString();
+
+        try {
+            await insertRunStart(dbPool, { runId, reason, sentCount, startedAtIso });
+        } catch (err) {
+            // Logging is non-fatal; we keep running so we still hit dead-cleanup paths.
+            audit('warn', 'push_health_check', `[PushHealth] insertRunStart failed: ${err && err.message}`, {
+                action: 'push_health_check',
+                result: 'insert_failed',
+                metadata: { runId },
+            });
+        }
+
+        // Fire all pushes with per-subscription nonces. Failures (410/404) are
+        // collected so we can clean up endpoints immediately rather than wait
+        // for the 60s ack window — those are unambiguous server-side deletions.
+        const nonces = [];
+        const subByNonce = new Map();
+        let deliveredCount = 0;
+        let errorCount = 0;
+        let removedNow = 0;
+
+        for (const sub of subscriptions) {
+            const nonce = nonceFn();
+            nonces.push(nonce);
+            subByNonce.set(nonce, sub);
+            const payload = JSON.stringify({
+                type: 'health',
+                nonce,
+                runId,
+                ts: now(),
+            });
+            const pushSub = {
+                endpoint: sub.endpoint,
+                keys: { p256dh: sub.p256dh, auth: sub.auth },
+            };
+            try {
+                await sendNotification(pushSub, payload, {
+                    TTL: config.pushTtl,
+                    urgency: 'very-low',
+                });
+                deliveredCount += 1;
+                try {
+                    await recordSentTimestamp(dbPool, sub.id, startedAtIso);
+                } catch (_) { /* non-fatal */ }
+            } catch (e) {
+                const statusCode = e && e.statusCode;
+                if (statusCode === 410 || statusCode === 404) {
+                    // Push service told us the endpoint is gone. Remove the
+                    // subscription row now (matches sendWebPush's existing
+                    // behavior in index.js); no ack possible so don't even
+                    // hold the nonce for the wait window.
+                    try {
+                        await removeSubscriptionByEndpoint(dbPool, sub.endpoint);
+                        removedNow += 1;
+                    } catch (_) { /* non-fatal */ }
+                } else {
+                    errorCount += 1;
+                    audit('warn', 'push_health_check', `[PushHealth] push send failed: status=${statusCode} ${e && e.message}`, {
+                        action: 'push_health_check',
+                        result: 'send_failed',
+                        metadata: { runId, subId: sub.id, statusCode },
+                    });
+                }
+            }
+        }
+
+        // Wait the ack window. Injectable so tests run instantly.
+        await wait(config.ackWindowMs);
+
+        // Reconcile: which nonces came back? (Only the ones we actually sent
+        // to a still-living subscription have a chance — the 410/404 sweep
+        // above already removed dead rows.)
+        let acked;
+        try {
+            acked = await ackedNonceSet(dbPool, runId, nonces);
+        } catch (err) {
+            acked = new Set();
+            audit('warn', 'push_health_check', `[PushHealth] ack query failed: ${err && err.message}`, {
+                action: 'push_health_check',
+                result: 'ack_query_failed',
+                metadata: { runId },
+            });
+        }
+
+        const finishedAt = now();
+        const finishedAtIso = new Date(finishedAt).toISOString();
+        const ackedCount = acked.size;
+
+        const followups = [];
+        let newlyDeadCount = removedNow;   // immediate-removal counts as dead this run
+
+        // Per-subscription streak bookkeeping. The UPDATE statements below are
+        // keyed by subscription id; if a row was deleted in the 410/404 sweep
+        // above, rowCount=0 and we fall through harmlessly. No need to filter
+        // — the SQL is idempotent for the missing-row case.
+        for (const nonce of nonces) {
+            const sub = subByNonce.get(nonce);
+            if (!sub) continue;
+
+            if (acked.has(nonce)) {
+                try {
+                    await resetSubscriptionStreak(dbPool, sub.id, finishedAtIso);
+                } catch (_) { /* non-fatal */ }
+            } else {
+                try {
+                    const newStreak = await incrementSubscriptionFailure(dbPool, sub.id);
+                    if (newStreak >= config.deadThreshold) {
+                        await deactivateSubscription(dbPool, sub.id, 'consecutive_health_failures', finishedAtIso);
+                        newlyDeadCount += 1;
+                        try {
+                            const card = await openDeadSubscriptionCard(dbPool, config, {
+                                id: sub.id,
+                                deviceId: sub.device_id,
+                                endpoint: sub.endpoint,
+                                consecutiveFailures: newStreak,
+                                threshold: config.deadThreshold,
+                                deactivatedAtIso: finishedAtIso,
+                            });
+                            followups.push(card);
+                            audit('warn', 'push_health_check', `[PushHealth] subscription ${sub.id} deactivated after ${newStreak} consecutive failures`, {
+                                action: 'push_health_check',
+                                result: 'subscription_deactivated',
+                                resource: String(sub.id),
+                                metadata: { runId, cardId: card && card.cardId, newStreak },
+                            });
+                        } catch (cardErr) {
+                            audit('error', 'push_health_check', `[PushHealth] follow-up card open failed: ${cardErr && cardErr.message}`, {
+                                action: 'push_health_check',
+                                result: 'followup_card_failed',
+                                metadata: { runId, subId: sub.id },
+                            });
+                        }
+                    }
+                } catch (_) { /* non-fatal */ }
+            }
+        }
+
+        // Finalize the run row with the actual numbers.
+        try {
+            await finalizeRun(dbPool, {
+                runId,
+                deliveredCount,
+                ackedCount,
+                deadCount: newlyDeadCount,
+                errorCount,
+                finishedAtIso,
+            });
+        } catch (err) {
+            audit('warn', 'push_health_check', `[PushHealth] finalizeRun failed: ${err && err.message}`, {
+                action: 'push_health_check',
+                result: 'finalize_failed',
+                metadata: { runId },
+            });
+        }
+
+        state.running = false;
+        state.lastSentCount = sentCount;
+        state.lastDeliveredCount = deliveredCount;
+        state.lastAckedCount = ackedCount;
+        state.lastDeadCount = newlyDeadCount;
+        state.lastErrorCount = errorCount;
+        state.lastAckRate = sentCount > 0 ? (ackedCount / sentCount) : null;
+        state.lastError = null;
+
+        const ok = errorCount === 0 && newlyDeadCount === 0;
+        if (ok) state.lastOkAt = finishedAt;
+        else state.lastFailureAt = finishedAt;
+
+        audit(ok ? 'info' : 'warn', 'push_health_check',
+            `[PushHealth] run ${runId} sent=${sentCount} delivered=${deliveredCount} acked=${ackedCount} dead=${newlyDeadCount} errors=${errorCount}`,
+            {
+                action: 'push_health_check',
+                result: ok ? 'ok' : 'partial',
+                metadata: { reason, runId, sentCount, deliveredCount, ackedCount, deadCount: newlyDeadCount, errorCount, followups: followups.length },
+            }
+        );
+
+        // Fakechat report per feedback_auto_cron_report_first. Optional so
+        // tests don't need to wire one.
+        if (typeof reportFakechat === 'function') {
+            try {
+                const ratePct = sentCount > 0 ? Math.round((ackedCount / sentCount) * 100) : null;
+                const line = `[Auto/PushHealth] run ${runId}: sent=${sentCount} delivered=${deliveredCount} acked=${ackedCount}${ratePct == null ? '' : ` (${ratePct}%)`} dead=${newlyDeadCount} errors=${errorCount}`;
+                await reportFakechat(line);
+            } catch (e) {
+                audit('warn', 'push_health_check', `[PushHealth] fakechat report failed: ${e && e.message}`, {
+                    action: 'push_health_check',
+                    result: 'report_failed',
+                    metadata: { runId },
+                });
+            }
+        }
+
+        return {
+            ok,
+            skipped: false,
+            runId,
+            sentCount,
+            deliveredCount,
+            ackedCount,
+            deadCount: newlyDeadCount,
+            errorCount,
+            followups,
+        };
+    }
+
+    function startCron({ nodeCron } = {}) {
+        const config = loadConfig(env);
+        if (!config.enabled) {
+            console.log('[PushHealth] disabled via PUSH_HEALTH_CRON_ENABLED=0');
+            return () => {};
+        }
+        if (!config.configured) {
+            console.log(`[PushHealth] cron not scheduled: ${config.skipReason}`);
+            return () => {};
+        }
+        if (!nodeCron || typeof nodeCron.schedule !== 'function') {
+            throw new Error('nodeCron_required');
+        }
+        const task = nodeCron.schedule(config.cron, () => {
+            runOnce('cron').catch(err => {
+                console.error('[PushHealth] cron tick error:', err && err.message);
+            });
+        }, { timezone: config.timezone });
+        audit('info', 'push_health_check', `[PushHealth] scheduled ${config.cron} ${config.timezone}`, {
+            action: 'push_health_check',
+            result: 'scheduled',
+            metadata: {
+                cron: config.cron,
+                timezone: config.timezone,
+                ackWindowMs: config.ackWindowMs,
+                deadThreshold: config.deadThreshold,
+                cardConfigured: config.cardConfigured,
+                cardSkipReason: config.cardSkipReason,
+            },
+        });
+        return () => {
+            if (task && typeof task.stop === 'function') task.stop();
+        };
+    }
+
+    return {
+        runOnce,
+        startCron,
+        getStatus,
+        getDbCounts,
+        _state: state,
+    };
+}
+
+module.exports = {
+    DEFAULT_CRON,
+    DEFAULT_TIMEZONE,
+    DEFAULT_ACK_WINDOW_MS,
+    DEFAULT_DEAD_THRESHOLD,
+    createPushHealthCheckCron,
+    loadConfig,
+    describeDeadSubscription,
+    openDeadSubscriptionCard,
+    // Test/diagnostic exports — kept stable so tooling can probe primitives.
+    listActiveSubscriptions,
+    insertRunStart,
+    finalizeRun,
+    ackedNonceSet,
+    countAckedNonces,
+    resetSubscriptionStreak,
+    incrementSubscriptionFailure,
+    deactivateSubscription,
+};

--- a/backend/tests/jest/push-health-check.test.js
+++ b/backend/tests/jest/push-health-check.test.js
@@ -1,0 +1,586 @@
+'use strict';
+
+// Push round-trip health-check cron — card_0a5d4a97.
+//
+// These tests cover the cron module (createPushHealthCheckCron) directly
+// against a fake in-memory pool. We also extend the existing push-notifications
+// supertest to exercise POST /api/push/ack via the real express app to prove
+// the route wiring + payload validation.
+
+const {
+    DEFAULT_CRON,
+    DEFAULT_TIMEZONE,
+    DEFAULT_ACK_WINDOW_MS,
+    DEFAULT_DEAD_THRESHOLD,
+    createPushHealthCheckCron,
+    loadConfig,
+    describeDeadSubscription,
+} = require('../../push-health-check-cron');
+
+// ─── Fake pool ──────────────────────────────────────────────────────────
+// Models the small slice of push_subscriptions + push_health_run +
+// push_ack_log we actually touch. Anything else falls through to a no-op
+// rowCount:0 response so the cron's defensive .catch(() => {}) paths don't
+// crash on unexpected SQL.
+function makePool({ subscriptions = [] } = {}) {
+    const subs = subscriptions.map(s => ({
+        consecutive_failures: 0,
+        ...s,
+    }));
+    const runs = [];                  // [{ run_id, ... }]
+    const acks = [];                  // [{ nonce, subscription_id, run_id }]
+    const calls = [];
+    let nextSubId = Math.max(0, ...subs.map(s => s.id || 0)) + 1;
+
+    function query(sql, params = []) {
+        const text = String(sql).trim();
+        calls.push({ sql: text, params });
+
+        // ── SELECT active subscriptions ─────────────────────────────────
+        if (text.startsWith('SELECT id, device_id, endpoint, p256dh, auth, consecutive_failures')) {
+            const rows = subs
+                .filter(s => s.is_active !== false)
+                .map(s => ({
+                    id: s.id,
+                    device_id: s.device_id,
+                    endpoint: s.endpoint,
+                    p256dh: s.p256dh,
+                    auth: s.auth,
+                    consecutive_failures: s.consecutive_failures || 0,
+                }));
+            return Promise.resolve({ rows, rowCount: rows.length });
+        }
+
+        // ── INSERT into push_health_run ─────────────────────────────────
+        if (text.startsWith('INSERT INTO push_health_run')) {
+            const [run_id, started_at, sent_count, reason] = params;
+            runs.push({ run_id, started_at, sent_count, reason, delivered_count: 0, acked_count_60s: 0, dead_count: 0, error_count: 0 });
+            return Promise.resolve({ rows: [], rowCount: 1 });
+        }
+
+        // ── UPDATE push_health_run (finalize) ───────────────────────────
+        if (text.startsWith('UPDATE push_health_run')) {
+            const [finished_at, delivered, acked, dead, errors, runId] = params;
+            const row = runs.find(r => r.run_id === runId);
+            if (row) {
+                row.finished_at = finished_at;
+                row.delivered_count = delivered;
+                row.acked_count_60s = acked;
+                row.dead_count = dead;
+                row.error_count = errors;
+            }
+            return Promise.resolve({ rows: [], rowCount: row ? 1 : 0 });
+        }
+
+        // ── UPDATE last_health_sent_at ──────────────────────────────────
+        if (text.startsWith('UPDATE push_subscriptions') && text.includes('last_health_sent_at = $1')) {
+            const [iso, subId] = params;
+            const row = subs.find(s => s.id === subId);
+            if (row) row.last_health_sent_at = iso;
+            return Promise.resolve({ rows: [], rowCount: row ? 1 : 0 });
+        }
+
+        // ── UPDATE consecutive_failures = 0 (reset) ─────────────────────
+        if (text.startsWith('UPDATE push_subscriptions') && text.includes('consecutive_failures = 0')) {
+            const [iso, subId] = params;
+            const row = subs.find(s => s.id === subId);
+            if (row) {
+                row.consecutive_failures = 0;
+                row.last_health_acked_at = iso;
+            }
+            return Promise.resolve({ rows: [], rowCount: row ? 1 : 0 });
+        }
+
+        // ── UPDATE consecutive_failures = consecutive_failures + 1 ──────
+        if (text.startsWith('UPDATE push_subscriptions') && text.includes('consecutive_failures = consecutive_failures + 1')) {
+            const [subId] = params;
+            const row = subs.find(s => s.id === subId);
+            if (row) {
+                row.consecutive_failures = (row.consecutive_failures || 0) + 1;
+                return Promise.resolve({ rows: [{ consecutive_failures: row.consecutive_failures }], rowCount: 1 });
+            }
+            return Promise.resolve({ rows: [], rowCount: 0 });
+        }
+
+        // ── UPDATE is_active = FALSE (deactivate) ──────────────────────
+        if (text.startsWith('UPDATE push_subscriptions') && text.includes('is_active = FALSE')) {
+            const [iso, reason, subId] = params;
+            const row = subs.find(s => s.id === subId);
+            if (row) {
+                row.is_active = false;
+                row.deactivated_at = iso;
+                row.deactivated_reason = reason;
+            }
+            return Promise.resolve({ rows: [], rowCount: row ? 1 : 0 });
+        }
+
+        // ── DELETE subscription by endpoint (410/404 sweep) ─────────────
+        if (text.startsWith('DELETE FROM push_subscriptions')) {
+            const [endpoint] = params;
+            const i = subs.findIndex(s => s.endpoint === endpoint);
+            if (i >= 0) {
+                subs.splice(i, 1);
+                return Promise.resolve({ rows: [], rowCount: 1 });
+            }
+            return Promise.resolve({ rows: [], rowCount: 0 });
+        }
+
+        // ── SELECT DISTINCT nonce FROM push_ack_log ─────────────────────
+        if (text.startsWith('SELECT DISTINCT nonce')) {
+            const [runId, nonceList] = params;
+            const hits = acks.filter(a => a.run_id === runId && nonceList.includes(a.nonce));
+            const unique = [...new Set(hits.map(a => a.nonce))];
+            return Promise.resolve({ rows: unique.map(nonce => ({ nonce })), rowCount: unique.length });
+        }
+
+        // ── INSERT INTO kanban_cards (follow-up card) ──────────────────
+        if (text.startsWith('INSERT INTO kanban_cards')) {
+            return Promise.resolve({ rows: [], rowCount: 1 });
+        }
+
+        // ── SELECT counts for getDbCounts ──────────────────────────────
+        if (text.includes('SUM(CASE WHEN is_active')) {
+            const active = subs.filter(s => s.is_active !== false).length;
+            const dead = subs.filter(s => s.is_active === false).length;
+            return Promise.resolve({ rows: [{ active, dead }], rowCount: 1 });
+        }
+
+        return Promise.resolve({ rows: [], rowCount: 0 });
+    }
+
+    return {
+        query,
+        // Inspection helpers for tests.
+        _subs: subs,
+        _runs: runs,
+        _acks: acks,
+        _calls: calls,
+        _addAck(nonce, runId, subId) {
+            acks.push({ nonce, run_id: runId, subscription_id: subId });
+        },
+        _nextSubId: () => nextSubId++,
+    };
+}
+
+function makeSubscription(id) {
+    return {
+        id,
+        device_id: `dev-${id}`,
+        endpoint: `https://push.example.com/${id}`,
+        p256dh: `p256dh-${id}`,
+        auth: `auth-${id}`,
+        is_active: true,
+    };
+}
+
+// ─── loadConfig ──────────────────────────────────────────────────────────
+describe('loadConfig', () => {
+    test('defaults: every-30-minute Asia/Taipei, 60s ack window, 3-fail dead', () => {
+        const config = loadConfig({});
+        expect(config.cron).toBe(DEFAULT_CRON);
+        expect(config.timezone).toBe(DEFAULT_TIMEZONE);
+        expect(config.ackWindowMs).toBe(DEFAULT_ACK_WINDOW_MS);
+        expect(config.deadThreshold).toBe(DEFAULT_DEAD_THRESHOLD);
+        expect(config.assignedBots).toEqual([2]);
+        expect(config.priority).toBe('P1');
+    });
+
+    test('PUSH_HEALTH_CRON_ENABLED=0 disables', () => {
+        const config = loadConfig({ PUSH_HEALTH_CRON_ENABLED: '0' });
+        expect(config.configured).toBe(false);
+        expect(config.skipReason).toBe('disabled');
+    });
+
+    test('reads cardDeviceId from PUSH_HEALTH_DEVICE_ID first, then ADMIN_DEVICE_IDS', () => {
+        expect(loadConfig({ PUSH_HEALTH_DEVICE_ID: 'pri-1', ADMIN_DEVICE_IDS: 'admin-a' }).cardDeviceId).toBe('pri-1');
+        expect(loadConfig({ ADMIN_DEVICE_IDS: 'admin-a,admin-b' }).cardDeviceId).toBe('admin-a');
+        expect(loadConfig({}).cardConfigured).toBe(false);
+    });
+
+    test('FOLLOWUP_BOTS env override accepts CSV', () => {
+        const config = loadConfig({ ADMIN_DEVICE_IDS: 'd1', PUSH_HEALTH_FOLLOWUP_BOTS: '2,4,7' });
+        expect(config.assignedBots).toEqual([2, 4, 7]);
+    });
+});
+
+// ─── runOnce: happy path ────────────────────────────────────────────────
+describe('runOnce — single cron tick', () => {
+    test('queries active subscriptions, sends one push per row, logs run row', async () => {
+        const pool = makePool({ subscriptions: [makeSubscription(1), makeSubscription(2)] });
+        const sent = [];
+        const sendNotification = jest.fn(async (sub, payload, opts) => {
+            sent.push({ endpoint: sub.endpoint, payload: JSON.parse(payload), opts });
+            // Auto-ack to simulate live SW returning the nonce within the window.
+            const parsed = JSON.parse(payload);
+            pool._addAck(parsed.nonce, parsed.runId, sub.endpoint.endsWith('/1') ? 1 : 2);
+        });
+        const wait = jest.fn(async () => {});  // skip the 60s wait
+
+        const monitor = createPushHealthCheckCron({
+            env: { ADMIN_DEVICE_IDS: 'dev-admin' },
+            pool,
+            sendNotification,
+            wait,
+            audit: jest.fn(),
+            now: () => 1_700_000_000_000,
+        });
+
+        const result = await monitor.runOnce('test');
+
+        // Per-subscription push fired with health payload + correct TTL/urgency.
+        expect(sendNotification).toHaveBeenCalledTimes(2);
+        for (const s of sent) {
+            expect(s.payload.type).toBe('health');
+            expect(typeof s.payload.nonce).toBe('string');
+            expect(s.payload.nonce.length).toBeGreaterThan(0);
+            expect(s.payload.runId).toBe(result.runId);
+            expect(s.opts.TTL).toBe(60);
+            expect(s.opts.urgency).toBe('very-low');
+        }
+
+        // Run row inserted + finalized.
+        expect(pool._runs).toHaveLength(1);
+        const run = pool._runs[0];
+        expect(run.run_id).toBe(result.runId);
+        expect(run.sent_count).toBe(2);
+        expect(run.delivered_count).toBe(2);
+        expect(run.acked_count_60s).toBe(2);
+        expect(run.error_count).toBe(0);
+        expect(run.dead_count).toBe(0);
+
+        // Cron return shape matches.
+        expect(result.ok).toBe(true);
+        expect(result.sentCount).toBe(2);
+        expect(result.deliveredCount).toBe(2);
+        expect(result.ackedCount).toBe(2);
+
+        // 60s wait was driven by the injected wait fn.
+        expect(wait).toHaveBeenCalledWith(DEFAULT_ACK_WINDOW_MS);
+    });
+
+    test('subscriptions that never ack accumulate consecutive_failures and stay active until threshold', async () => {
+        const pool = makePool({ subscriptions: [makeSubscription(1)] });
+        // sendNotification succeeds but NO acks recorded.
+        const monitor = createPushHealthCheckCron({
+            env: { ADMIN_DEVICE_IDS: 'dev-admin' },
+            pool,
+            sendNotification: jest.fn().mockResolvedValue(undefined),
+            wait: async () => {},
+            audit: jest.fn(),
+            now: () => Date.parse('2026-06-21T00:00:00Z'),
+        });
+
+        const r1 = await monitor.runOnce('test');
+        expect(r1.ackedCount).toBe(0);
+        expect(pool._subs[0].consecutive_failures).toBe(1);
+        expect(pool._subs[0].is_active).not.toBe(false);
+
+        const r2 = await monitor.runOnce('test');
+        expect(pool._subs[0].consecutive_failures).toBe(2);
+        expect(pool._subs[0].is_active).not.toBe(false);
+
+        // Third failure: dead + follow-up card.
+        const r3 = await monitor.runOnce('test');
+        expect(pool._subs[0].consecutive_failures).toBe(3);
+        expect(pool._subs[0].is_active).toBe(false);
+        expect(pool._subs[0].deactivated_reason).toBe('consecutive_health_failures');
+        expect(r3.followups).toHaveLength(1);
+        expect(r3.followups[0].created).toBe(true);
+        expect(r3.deadCount).toBeGreaterThanOrEqual(1);
+        // Insert into kanban_cards happened.
+        const cardInsert = pool._calls.find(c => c.sql.startsWith('INSERT INTO kanban_cards'));
+        expect(cardInsert).toBeTruthy();
+        expect(cardInsert.params[3]).toContain('subscription_id: 1');
+        expect(cardInsert.params[6]).toBe(JSON.stringify([2]));  // assignedBots:[2] per spec
+        expect(cardInsert.params[4]).toBe('P1');                  // priority
+        expect(cardInsert.params[5]).toBe('todo');                // status
+    });
+
+    test('subscription that acks resets its streak even if it had previous failures', async () => {
+        const pool = makePool({ subscriptions: [{ ...makeSubscription(1), consecutive_failures: 2 }] });
+        const sendNotification = jest.fn(async (sub, payload) => {
+            const parsed = JSON.parse(payload);
+            pool._addAck(parsed.nonce, parsed.runId, 1);
+        });
+
+        const monitor = createPushHealthCheckCron({
+            env: { ADMIN_DEVICE_IDS: 'dev-admin' },
+            pool,
+            sendNotification,
+            wait: async () => {},
+            audit: jest.fn(),
+            now: () => Date.now(),
+        });
+
+        const result = await monitor.runOnce('test');
+        expect(result.ackedCount).toBe(1);
+        expect(pool._subs[0].consecutive_failures).toBe(0);
+        expect(pool._subs[0].is_active).not.toBe(false);
+    });
+
+    test('410-Gone subscription is removed immediately, before ack window', async () => {
+        const pool = makePool({ subscriptions: [makeSubscription(1), makeSubscription(2)] });
+        const sendNotification = jest.fn(async (sub) => {
+            if (sub.endpoint.endsWith('/1')) {
+                const err = new Error('gone');
+                err.statusCode = 410;
+                throw err;
+            }
+            // 2 succeeds but doesn't ack
+        });
+
+        const monitor = createPushHealthCheckCron({
+            env: { ADMIN_DEVICE_IDS: 'dev-admin' },
+            pool,
+            sendNotification,
+            wait: async () => {},
+            audit: jest.fn(),
+            now: () => Date.now(),
+        });
+
+        const result = await monitor.runOnce('test');
+        // sub 1 was removed by 410 sweep
+        expect(pool._subs.find(s => s.id === 1)).toBeUndefined();
+        expect(result.deadCount).toBeGreaterThanOrEqual(1);
+        // sub 2 still around with failure incremented
+        expect(pool._subs.find(s => s.id === 2)).toBeTruthy();
+    });
+
+    test('non-410 sendNotification error is recorded as errorCount, not a deactivation', async () => {
+        const pool = makePool({ subscriptions: [makeSubscription(1)] });
+        const sendNotification = jest.fn().mockRejectedValue(Object.assign(new Error('boom'), { statusCode: 500 }));
+
+        const monitor = createPushHealthCheckCron({
+            env: { ADMIN_DEVICE_IDS: 'dev-admin' },
+            pool,
+            sendNotification,
+            wait: async () => {},
+            audit: jest.fn(),
+            now: () => Date.now(),
+        });
+
+        const result = await monitor.runOnce('test');
+        expect(result.errorCount).toBe(1);
+        expect(result.deliveredCount).toBe(0);
+        // Still increments consecutive_failures since no ack.
+        expect(pool._subs[0].consecutive_failures).toBe(1);
+        expect(pool._subs[0].is_active).not.toBe(false);
+    });
+});
+
+// ─── runOnce: skip paths ─────────────────────────────────────────────────
+describe('runOnce — skip paths', () => {
+    test('disabled cron returns skipped without DB access', async () => {
+        const pool = makePool();
+        const sendNotification = jest.fn();
+
+        const monitor = createPushHealthCheckCron({
+            env: { PUSH_HEALTH_CRON_ENABLED: '0' },
+            pool,
+            sendNotification,
+            wait: async () => {},
+            audit: jest.fn(),
+            now: () => Date.now(),
+        });
+
+        const result = await monitor.runOnce('test');
+        expect(result.skipped).toBe(true);
+        expect(result.reason).toBe('disabled');
+        expect(sendNotification).not.toHaveBeenCalled();
+    });
+
+    test('missing sendNotification skips without trying any pushes', async () => {
+        const pool = makePool({ subscriptions: [makeSubscription(1)] });
+        const monitor = createPushHealthCheckCron({
+            env: { ADMIN_DEVICE_IDS: 'dev-admin' },
+            pool,
+            sendNotification: null,
+            wait: async () => {},
+            audit: jest.fn(),
+            now: () => Date.now(),
+        });
+
+        const result = await monitor.runOnce('test');
+        expect(result.skipped).toBe(true);
+        expect(result.reason).toBe('sendNotification_missing');
+    });
+
+    test('zero active subscriptions: still records a run with sent_count=0', async () => {
+        const pool = makePool({ subscriptions: [] });
+        const sendNotification = jest.fn();
+
+        const monitor = createPushHealthCheckCron({
+            env: { ADMIN_DEVICE_IDS: 'dev-admin' },
+            pool,
+            sendNotification,
+            wait: async () => {},
+            audit: jest.fn(),
+            now: () => Date.now(),
+        });
+
+        const result = await monitor.runOnce('test');
+        expect(result.ok).toBe(true);
+        expect(result.sentCount).toBe(0);
+        expect(sendNotification).not.toHaveBeenCalled();
+        expect(pool._runs[0].sent_count).toBe(0);
+    });
+});
+
+// ─── startCron ──────────────────────────────────────────────────────────
+describe('startCron', () => {
+    test('schedules with default cron/timezone and audits the wire-up', () => {
+        const schedule = jest.fn(() => ({ stop: jest.fn() }));
+        const audit = jest.fn();
+        const monitor = createPushHealthCheckCron({
+            env: { ADMIN_DEVICE_IDS: 'dev-admin' },
+            pool: makePool(),
+            sendNotification: jest.fn(),
+            wait: async () => {},
+            audit,
+            now: () => Date.now(),
+        });
+
+        monitor.startCron({ nodeCron: { schedule } });
+
+        expect(schedule).toHaveBeenCalledWith(
+            DEFAULT_CRON,
+            expect.any(Function),
+            { timezone: DEFAULT_TIMEZONE }
+        );
+        expect(audit).toHaveBeenCalledWith(
+            'info',
+            'push_health_check',
+            expect.stringContaining('scheduled'),
+            expect.objectContaining({ result: 'scheduled' })
+        );
+    });
+
+    test('throws when nodeCron is missing — caller must wire it', () => {
+        const monitor = createPushHealthCheckCron({
+            env: { ADMIN_DEVICE_IDS: 'dev-admin' },
+            pool: makePool(),
+            sendNotification: jest.fn(),
+            wait: async () => {},
+            audit: jest.fn(),
+            now: () => Date.now(),
+        });
+        expect(() => monitor.startCron({})).toThrow(/nodeCron/);
+    });
+
+    test('disabled env is a no-op (does not throw even without nodeCron)', () => {
+        const monitor = createPushHealthCheckCron({
+            env: { PUSH_HEALTH_CRON_ENABLED: '0' },
+            pool: makePool(),
+            sendNotification: jest.fn(),
+            wait: async () => {},
+            audit: jest.fn(),
+            now: () => Date.now(),
+        });
+        expect(() => monitor.startCron({})).not.toThrow();
+    });
+});
+
+// ─── getDbCounts ────────────────────────────────────────────────────────
+describe('getDbCounts', () => {
+    test('returns active vs dead counts from push_subscriptions', async () => {
+        const pool = makePool({
+            subscriptions: [
+                makeSubscription(1),
+                makeSubscription(2),
+                { ...makeSubscription(3), is_active: false },
+            ],
+        });
+        const monitor = createPushHealthCheckCron({
+            env: { ADMIN_DEVICE_IDS: 'dev-admin' },
+            pool,
+            sendNotification: jest.fn(),
+            wait: async () => {},
+            audit: jest.fn(),
+            now: () => Date.now(),
+        });
+        const counts = await monitor.getDbCounts();
+        expect(counts).toEqual({ activeSubscriptions: 2, deadSubscriptions: 1 });
+    });
+});
+
+// ─── describeDeadSubscription ───────────────────────────────────────────
+describe('describeDeadSubscription', () => {
+    test('renders endpoint + consecutive failure count + triage steps', () => {
+        const desc = describeDeadSubscription({
+            id: 42,
+            deviceId: 'dev-x',
+            endpoint: 'https://push.example.com/very/long/endpoint/abc123',
+            consecutiveFailures: 5,
+            threshold: 3,
+            deactivatedAtIso: '2026-06-21T08:00:00Z',
+        });
+        expect(desc).toContain('subscription_id: 42');
+        expect(desc).toContain('device_id: dev-x');
+        expect(desc).toContain('5 consecutive');
+        expect(desc).toContain('≥3 required');
+        expect(desc).toContain('https://push.example.com/very/long/endpoint/abc123');
+        expect(desc).toMatch(/Triage:/);
+    });
+});
+
+// ─── /api/push/ack route — supertest against the real express app ──────
+describe('POST /api/push/ack — route wiring', () => {
+    let app;
+    let request;
+    let chatPoolMock;
+
+    beforeAll(() => {
+        require('./helpers/mock-setup');
+        request = require('supertest');
+        // The route uses chatPool directly; mock-setup stubs the `pg` Pool to
+        // return rows:[],rowCount:0 — that's enough for happy-path 200, but
+        // we also assert that the route validates inputs (400 paths). For
+        // attribution to the most-recent run we'd want a real run row; we
+        // don't need it for the supertest layer since the cron logic itself
+        // is unit-tested above.
+        app = require('../../index');
+    });
+
+    afterAll(async () => {
+        try {
+            const { httpServer } = require('../../index');
+            await new Promise(resolve => httpServer.close(resolve));
+        } catch (_) { /* server may already be closed */ }
+        jest.resetModules();
+    });
+
+    function post(path) {
+        return request(app).post(path).set('Host', 'localhost');
+    }
+
+    test('rejects empty/missing nonce with 400', async () => {
+        const res = await post('/api/push/ack').send({});
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/nonce/i);
+    });
+
+    test('rejects nonce longer than 64 chars', async () => {
+        const longNonce = 'a'.repeat(65);
+        const res = await post('/api/push/ack').send({ nonce: longNonce });
+        expect(res.status).toBe(400);
+    });
+
+    test('accepts a well-formed ack and returns success', async () => {
+        const res = await post('/api/push/ack').send({
+            nonce: 'abc123nonce',
+            runId: 'run_deadbeef00000000',
+            subscriptionId: 42,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    test('ignores non-integer subscriptionId without erroring', async () => {
+        const res = await post('/api/push/ack').send({
+            nonce: 'another-nonce',
+            subscriptionId: 'not-a-number',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

Push subscription `sendNotification()` returning 201 only proves a request reached the push service — it says nothing about whether the user's browser woke its service worker. We've shipped weeks where push was silently dead because endpoints quietly drained without the server noticing.

This change adds real round-trip health verification:

- **New cron module** `backend/push-health-check-cron.js` runs every 30 min (configurable). Each tick: fires a silent push (TTL=60, urgency=very-low) with a per-subscription nonce + runId to every `is_active=TRUE` row, waits 60s, then counts which nonces came back via `/api/push/ack`. Subscriptions that miss 3 consecutive acks get `is_active=FALSE` + a follow-up kanban card filed (`assignedBots:[2]`, `P1`, `status:todo`).
- **New `POST /api/push/ack` endpoint** records ack rows. Auth-by-nonce (16 bytes of `crypto.randomBytes`, single-recipient) + runId allow-list check against `push_health_run` rows from the last 24h. Replays dedupe via `UNIQUE INDEX (nonce, COALESCE(subscription_id, 0))`.
- **Service worker** (`backend/public/sw.js`) intercepts `type==='health'` pushes, ACKs silently, and never calls `showNotification`. `webpush-auto.js` stashes the server's `subscriptionId` in `caches` so the SW can include it on acks (best-effort; server falls back to nonce-only attribution).
- **`/api/bot/push-status`** now exposes `lastHealthCronAt`, `lastHealthCronOk`, `activeSubscriptions`, `deadSubscriptions`, `last60sAckRate`.
- **Migration `20260621_push_ack_log`** adds `push_health_run` + `push_ack_log` tables, plus `is_active` / `consecutive_failures` / `last_health_sent_at` / `last_health_acked_at` / `deactivated_at` / `deactivated_reason` columns on existing `push_subscriptions`. `is_active` defaults `TRUE` so every pre-existing row stays in rotation. Mirrored to `backend/notifications.js` boot path for cold-boot envs.

## SPEC deviations (noted explicitly)

- **SPEC said** \"Mirror to `backend/kanban_schema.sql` / equivalent boot-schema if one exists for chat/push tables.\" There is no chat/push table SoT SQL file — the push tables are declared in `backend/notifications.js`'s `initNotificationTables()` (this is the only schema-of-truth for these tables). I mirrored the new columns + tables there instead, matching the existing pattern.
- **SPEC said** \"file follow-up kanban card via `POST https://eclawbot.com/api/mission/card`.\" I do this via direct SQL INSERT against `kanban_cards`, matching the existing `settings-help-invariant-cron.js` pattern in this same repo. Going out over HTTP from inside the server would loop a request back to ourselves and require deviceId/botSecret env wiring that isn't currently set. The schema and `assignedBots:[2]`, `P1`, `status:todo`, `requires_screenshot_review:false`, `dispatch_mode:'immediate'` semantics are identical.
- **SPEC said** \"Report fakechat at end\" — I wire `reportFakechat` to `serverLog('info', 'push_health_check_report', ...)` which the existing bot-reply loop reads. No new HTTP target invented.

## Files touched

- `backend/index.js` — `+128/-3` — `/api/push/ack` route, `/api/bot/push-status` health fields, cron instantiation + startCron wiring, test export.
- `backend/notifications.js` — `+91/-2` — new health-tracking columns + tables in `initNotificationTables`; `savePushSubscription` returns `{ok, id}` (callers using truthy check unaffected).
- `backend/public/sw.js` — `+41/-0` — silent `type==='health'` ack handler.
- `backend/public/shared/webpush-auto.js` — `+17/-2` — stash `subscriptionId` in `caches` post-subscribe.
- `backend/push-health-check-cron.js` — `+577` (new) — the cron module.
- `backend/migrations/20260621_push_ack_log.up.sql` — `+92` (new).
- `backend/migrations/20260621_push_ack_log.down.sql` — `+20` (new).
- `backend/tests/jest/push-health-check.test.js` — `+586` (new) — 21 test cases.

## Test plan

- [x] `node node_modules/.bin/jest tests/jest/push-health-check.test.js` — **21/21 green**.
- [x] `node node_modules/.bin/jest tests/jest/push-notifications.test.js` — **19/19 green** (no regression on existing push test).
- [x] Full Jest battery (`node node_modules/.bin/jest`) — **358 suites, 5027 tests, 0 failures**.
- [x] `eslint backend/push-health-check-cron.js backend/index.js backend/notifications.js` — **0 errors, 0 warnings**.
- [ ] Post-merge manual: subscribe Chrome → wait 30min → verify quiet ACK in DB; manually invalidate subscription → verify cleanup after 3 cron rounds. (To run on prod once merged + deployed.)
- [ ] E2E (deferred to follow-up card): Playwright opens portal → enables push → simulate fail-3 → assert follow-up card opened.

Card: `card_0a5d4a97d40d0957aa349e9f`