### PR TITLE
fix(chat): routing-chip detail modal renders "undefined" (card_816c435e)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -8898,9 +8898,99 @@
             renderRoutingChipDetailBody(bodyEl, payload, kind, detail || null);
         }
 
+        // card_816c435e: shared label resolver used by every render site in the
+        // routing-detail modal. Coalesces sum/name/id/publicCode → never lets
+        // `undefined`/`null`/`'?'`/empty/literal-"undefined" string reach the
+        // DOM. Mirrors the chip-path priority chain so the modal label matches
+        // what the chip itself shows (chip uses orgChartCommanderId as the
+        // last-resort floor too).
+        //
+        //   opts.which       'from' | 'to'  (controls neutral fallback label)
+        //   opts.isUser      bool — to-side self-reply (toUser) → "User" label
+        //   opts.tt          (k, fb) => string  (i18n resolver)
+        //
+        // Returns: { label, code, lv, avatar, initials } — caller composes HTML.
+        function resolveEntityLabel(sum, fallbackId, fallbackName, fallbackCode, opts) {
+            const tt = (opts && opts.tt) || ((k, fb) => fb);
+            const which = (opts && opts.which) || 'to';
+
+            // Reject the literal string 'undefined'/'null'/'?' too — backends
+            // (and prior buggy frontends) have been observed stringifying a
+            // JS undefined into the wire payload, and a trimmed '?' is the
+            // exact bug card_29eed229 chased out of the chip path.
+            const isBadName = (v) => {
+                if (v == null) return true;
+                const s = String(v).trim();
+                if (s === '' || s === 'undefined' || s === 'null' || s === '?' || s === '？') return true;
+                return false;
+            };
+
+            const sumName = (sum && !isBadName(sum.name)) ? sum.name
+                : (sum && !isBadName(sum.character)) ? sum.character : null;
+            const safeFallbackName = !isBadName(fallbackName) ? fallbackName : null;
+
+            // to-side self-reply → "User" wins over a missing entity name.
+            if (opts && opts.isUser) {
+                const userLabel = tt('chat_routing_to_user', 'User');
+                return {
+                    label: userLabel,
+                    code: '',
+                    lv: '',
+                    initials: String(userLabel).slice(0, 2),
+                    avatar: (sum && sum.avatar) || null,
+                };
+            }
+
+            // Floor: org-chart commander id (chip-path floor — chat-html cache).
+            const commanderFloor = (typeof orgChartCommanderId !== 'undefined'
+                && orgChartCommanderId != null
+                && (fallbackId == null || Number(orgChartCommanderId) !== Number(fallbackId)))
+                ? ('#' + orgChartCommanderId) : null;
+
+            // Neutral last resort: a sender-side label distinct from the
+            // generic "Unspecified" so we never paint the same word on BOTH
+            // pills (the original symptom card_e53b0908 was hunting).
+            const neutral = which === 'from'
+                ? tt('chat_routing_sender', 'Sender')
+                : tt('chat_routing_supervisor', '主管');
+
+            const label = sumName
+                || safeFallbackName
+                || (fallbackId != null && Number.isFinite(Number(fallbackId)) ? '#' + fallbackId : null)
+                || (!isBadName(fallbackCode) ? '#' + fallbackCode : null)
+                || commanderFloor
+                || neutral;
+
+            const code = (sum && !isBadName(sum.publicCode)) ? '#' + sum.publicCode
+                : (!sum && !isBadName(fallbackCode) ? '#' + fallbackCode : '');
+            const lv = (sum && sum.level != null) ? `LV${sum.level}` : '';
+            const initials = String(label).slice(0, 2);
+            return { label, code, lv, initials, avatar: (sum && sum.avatar) || null };
+        }
+
+        // card_816c435e: normalize a routing payload BEFORE any label render —
+        // coerce undefined/null/'undefined' name fields once so every render
+        // site can rely on a known shape. Returns a SHALLOW COPY (mutation-safe).
+        function normalizeRoutingPayload(payload) {
+            const p = Object.assign({}, payload || {});
+            const isBad = (v) => v == null || (typeof v === 'string' && (v.trim() === '' || v.trim() === 'undefined' || v.trim() === 'null'));
+            if (isBad(p.from_name)) p.from_name = null;
+            if (isBad(p.to_name)) p.to_name = null;
+            if (isBad(p.from_public_code)) p.from_public_code = null;
+            if (isBad(p.to_public_code)) p.to_public_code = null;
+            // Coerce entity ids: keep null if not finite-numeric.
+            if (p.from_entity_id != null && !Number.isFinite(Number(p.from_entity_id))) p.from_entity_id = null;
+            if (p.to_entity_id != null && !Number.isFinite(Number(p.to_entity_id))) p.to_entity_id = null;
+            return p;
+        }
+
         function renderRoutingChipDetailBody(bodyEl, payload, kind, detail) {
             const tt = (k, fb) => (typeof i18n !== 'undefined' && i18n.t && i18n.t(k)) || fb;
             const esc = (v) => escapeHtml(v == null ? '' : String(v));
+
+            // card_816c435e: coerce undefined/null/'undefined' fields ONCE up
+            // front so every render site below works off a known-clean shape.
+            payload = normalizeRoutingPayload(payload);
 
             // Build entity lookup map from server response (preferred) so the
             // tree can label nodes; falls back to local boundEntities.
@@ -8910,36 +9000,17 @@
             const fromSum = (detail && detail.fromEntity) || (payload.from_entity_id != null ? summariesById.get(payload.from_entity_id) : null);
             const toSum = (detail && detail.toEntity) || (payload.to_entity_id != null ? summariesById.get(payload.to_entity_id) : null);
 
-            // card_e53b0908: a chat row ALWAYS knows its sender (entity_id), so
-            // the from-pill must never degrade to 「Unspecified」/undefined. Build
-            // the from-side fallback chain from the payload's sender floor
-            // (id / name / publicCode), only landing on a neutral label as the
-            // last resort — and a sender-specific one ("Sender") so we never
-            // emit the same generic "Unspecified" on BOTH sides.
-            const renderPill = (which, sum, fallbackId, fallbackName, fallbackCode) => {
-                // card_ecda7243: never fall through to a bare '?'. When neither a
-                // summary nor an explicit name/id resolve, show a clearly-labeled
-                // state instead of a naked question mark or a literal "undefined".
-                // Guard: a `undefined`/null fallbackName must NOT be stringified
-                // into the template — coalesce through the whole chain first.
-                const safeFallbackName = (fallbackName != null && String(fallbackName).trim() !== '' && String(fallbackName) !== 'undefined')
-                    ? fallbackName : null;
-                const neutral = which === 'from'
-                    ? tt('chat_routing_sender', 'Sender')
-                    : tt('chat_routing_unspecified', 'Unspecified');
-                const label = (sum && (sum.name || sum.character))
-                    || safeFallbackName
-                    || (fallbackId != null ? '#' + fallbackId : null)
-                    || (fallbackCode ? '#' + fallbackCode : null)
-                    || neutral;
-                const code = sum && sum.publicCode ? '#' + sum.publicCode
-                    : (!sum && fallbackCode ? '#' + fallbackCode : '');
-                const lv = sum && sum.level != null ? `LV${sum.level}` : '';
-                const initials = String(label).slice(0, 2);
-                const avatar = sum && sum.avatar
-                    ? `<img class="rd-avatar" src="${esc(sum.avatar)}" alt="" onerror="this.outerHTML='<span class=\\'rd-avatar-fb\\'>${esc(initials)}</span>'">`
-                    : `<span class="rd-avatar-fb">${esc(initials)}</span>`;
-                return `<span class="rd-entity-pill rd-pill-${which}">${avatar}<span>${esc(label)}</span>${code ? `<span style="opacity:0.55;font-size:11px;">${esc(code)}</span>` : ''}${lv ? `<span class="rd-lv">${esc(lv)}</span>` : ''}</span>`;
+            // card_e53b0908 + card_816c435e: a chat row ALWAYS knows its sender
+            // (entity_id), so the from-pill must never degrade to
+            // 「Unspecified」/undefined. resolveEntityLabel coalesces the whole
+            // chain (sum → fallbackName → fallbackId → fallbackCode →
+            // orgChartCommanderId → neutral) so no '?'/'undefined' can leak.
+            const renderPill = (which, sum, fallbackId, fallbackName, fallbackCode, isUser) => {
+                const r = resolveEntityLabel(sum, fallbackId, fallbackName, fallbackCode, { which, isUser, tt });
+                const avatar = r.avatar
+                    ? `<img class="rd-avatar" src="${esc(r.avatar)}" alt="" onerror="this.outerHTML='<span class=\\'rd-avatar-fb\\'>${esc(r.initials)}</span>'">`
+                    : `<span class="rd-avatar-fb">${esc(r.initials)}</span>`;
+                return `<span class="rd-entity-pill rd-pill-${which}">${avatar}<span>${esc(r.label)}</span>${r.code ? `<span style="opacity:0.55;font-size:11px;">${esc(r.code)}</span>` : ''}${r.lv ? `<span class="rd-lv">${esc(r.lv)}</span>` : ''}</span>`;
             };
 
             const modeLabel = payload.mode === 'broadcast'
@@ -8971,11 +9042,14 @@
             let html = '<div class="rd-section">';
             html += `<div class="rd-section-title">${esc(tt('chat_routing_detail_section_route', 'This message route'))}</div>`;
             html += '<div class="rd-route-line">';
-            html += renderPill('from', fromSum, payload.from_entity_id, payload.from_name, payload.from_public_code);
+            html += renderPill('from', fromSum, payload.from_entity_id, payload.from_name, payload.from_public_code, false);
             html += '<span class="rd-arrow">→</span>';
-            // card_ecda7243: a self-reply to the device owner targets USER (to_is_user),
-            // not an entity — show the localized "User" label instead of a bare '?'.
-            html += renderPill('to', toSum, payload.to_entity_id, payload.to_is_user ? tt('chat_routing_to_user', 'User') : payload.to_name, payload.to_public_code);
+            // card_ecda7243 + card_816c435e: a self-reply to the device owner
+            // targets USER (to_is_user) — pass through the isUser flag so the
+            // shared resolver returns the localized "User" label; never let
+            // payload.to_name (which may be `undefined` on legacy rows) reach
+            // the DOM.
+            html += renderPill('to', toSum, payload.to_entity_id, payload.to_name, payload.to_public_code, !!payload.to_is_user);
             if (modeLabel) html += `<span class="rd-mode-pill">${esc(modeLabel)}</span>`;
             html += `<span class="rd-status-pill rd-status-${esc(statusKey)}">${esc(statusLabel)}</span>`;
             html += '</div>';
@@ -9004,6 +9078,8 @@
             html += '</div>';
 
             // Section 4: smart hierarchy chain (superior + peers)
+            // card_816c435e: every label uses resolveEntityLabel so a missing
+            // summary.name / entityId cannot stringify into '#undefined'.
             if (detail && detail.chain) {
                 const c = detail.chain;
                 html += '<div class="rd-section">';
@@ -9011,15 +9087,15 @@
                 if (c.superior) {
                     const sname = c.superior.kind === 'USER'
                         ? tt('chat_routing_superior_user', 'USER (device owner)')
-                        : (c.superior.summary && (c.superior.summary.name || c.superior.summary.character)) || ('#' + c.superior.entityId);
+                        : resolveEntityLabel(c.superior.summary, c.superior.entityId, null, null, { which: 'to', tt }).label;
                     html += `<div>${esc(tt('chat_routing_chain_superior', 'Superior'))}: ${esc(sname)}</div>`;
                 }
                 if (Array.isArray(c.subordinates) && c.subordinates.length > 0) {
-                    const subNames = c.subordinates.map(s => (s.summary && (s.summary.name || s.summary.character)) || ('#' + s.entityId)).join(', ');
+                    const subNames = c.subordinates.map(s => resolveEntityLabel(s.summary, s.entityId, null, null, { which: 'to', tt }).label).join(', ');
                     html += `<div>${esc(tt('chat_routing_chain_subordinates', 'Subordinates'))}: ${esc(subNames)}</div>`;
                 }
                 if (Array.isArray(c.peers) && c.peers.length > 0) {
-                    const peerNames = c.peers.map(p => (p.summary && (p.summary.name || p.summary.character)) || ('#' + p.entityId)).join(', ');
+                    const peerNames = c.peers.map(p => resolveEntityLabel(p.summary, p.entityId, null, null, { which: 'to', tt }).label).join(', ');
                     html += `<div>${esc(tt('chat_routing_chain_peers', 'Peers'))}: ${esc(peerNames)}</div>`;
                 }
                 html += '</div>';
@@ -9036,10 +9112,14 @@
         function renderOrgTreeHtml(hierarchy, summariesById, currentToId, currentFromId, esc) {
             // Defensive: hierarchy could be malformed. Walk only known keys.
             if (!hierarchy || typeof hierarchy !== 'object') return '';
+            const tt = (k, fb) => (typeof i18n !== 'undefined' && i18n.t && i18n.t(k)) || fb;
+            // card_816c435e: route every label through the shared resolver so a
+            // missing summary AND a missing/non-finite id can't paint
+            // '#undefined' into the tree. resolveEntityLabel returns the
+            // commander/supervisor floor as a last resort.
             const labelFor = (id) => {
                 const s = summariesById.get(id);
-                if (!s) return '#' + id;
-                return (s.name || s.character || ('#' + id));
+                return resolveEntityLabel(s, id, null, null, { which: 'to', tt }).label;
             };
             const roleFor = (id) => {
                 const s = summariesById.get(id);

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650456,6 +650456,8 @@ const TRANSLATIONS = {
         "cron_skip_5h_label": "Skip if 5h usage > X%",
         "cron_skip_7d_label": "Skip if 7d usage > Y%",
         "cron_skip_help_text": "Slider range 50–99. When the assigned entity's current usage exceeds the threshold, this cron tick is skipped to protect the high-load entity; the next scheduled tick auto-retries.",
+
+        "chat_routing_supervisor": "Supervisor",
 },
 
 
@@ -1235348,6 +1235350,8 @@ const TRANSLATIONS = {
         "cron_skip_5h_label": "5小時用量超過 X% 跳過",
         "cron_skip_7d_label": "週用量超過 Y% 跳過",
         "cron_skip_help_text": "拉桿範圍 50–99。當指派智能體目前用量超過門檻時，這次 cron 觸發會跳過以保護高負載智能體；下個排程觸發會自動重試。",
+
+        "chat_routing_supervisor": "主管",
 },
 
 
@@ -1849554,6 +1849558,8 @@ const TRANSLATIONS = {
         "usage_warning_5h_help": "当剩余 5 小时配额 ≤ 此值时触发。默认 15% — 约在耗尽前 45 分钟。如需更早警告可调高；设为 0 可在不关闭开关的情况下禁用 5 小时轴。",
         "usage_warning_7d_label": "7天每周阈值（剩余量 ≤ 此值时警告）",
         "usage_warning_7d_help": "当剩余 7 天每周配额 ≤ 此值时触发。默认 5% — 约在耗尽前 8 小时。设为 0 可在不关闭开关的情况下禁用 7 天轴。",
+
+        "chat_routing_supervisor": "主管",
 },
 
 

--- a/backend/tests/jest/routing-chip-detail.test.js
+++ b/backend/tests/jest/routing-chip-detail.test.js
@@ -276,20 +276,32 @@ describe('sender-floor resolution (chat.html) — never Unspecified/undefined on
     });
 
     test('renderPill guards against a literal "undefined" fallbackName', () => {
-        expect(detailFn).toMatch(/String\(fallbackName\)\s*!==\s*'undefined'/);
-        expect(detailFn).toMatch(/safeFallbackName/);
+        // card_816c435e: guard moved into the shared resolveEntityLabel helper
+        // (lives above renderRoutingChipDetailBody). Both 'undefined' and the
+        // '?' / '？' sentinels are rejected via the isBadName predicate.
+        const resolverStart = chatSrc.indexOf('function resolveEntityLabel(');
+        expect(resolverStart).toBeGreaterThan(-1);
+        const resolver = chatSrc.slice(resolverStart, resolverStart + 4000);
+        expect(resolver).toMatch(/s\s*===\s*'undefined'/);
+        expect(resolver).toMatch(/isBadName/);
     });
 
     test('from-pill uses a sender-specific neutral label, not the shared Unspecified', () => {
         // The from-side must land on chat_routing_sender, never chat_routing_unspecified.
-        expect(detailFn).toMatch(/which\s*===\s*'from'/);
-        expect(detailFn).toMatch(/chat_routing_sender/);
+        // card_816c435e: neutral selection moved into resolveEntityLabel.
+        const resolverStart = chatSrc.indexOf('function resolveEntityLabel(');
+        const resolver = chatSrc.slice(resolverStart, resolverStart + 4000);
+        expect(resolver).toMatch(/which\s*===\s*'from'/);
+        expect(resolver).toMatch(/chat_routing_sender/);
     });
 
     test('renderPill accepts a publicCode fallback and both call sites pass it', () => {
-        expect(detailFn).toMatch(/renderPill\s*=\s*\(which,\s*sum,\s*fallbackId,\s*fallbackName,\s*fallbackCode\)/);
-        expect(detailFn).toMatch(/renderPill\('from',\s*fromSum,\s*payload\.from_entity_id,\s*payload\.from_name,\s*payload\.from_public_code\)/);
-        expect(detailFn).toMatch(/renderPill\('to',\s*toSum,[\s\S]*?payload\.to_public_code\)/);
+        // card_816c435e: renderPill grew an `isUser` 6th arg so the to_is_user
+        // flag flows through the shared resolver instead of being inlined as a
+        // tt('chat_routing_to_user',...) label at the call site.
+        expect(detailFn).toMatch(/renderPill\s*=\s*\(which,\s*sum,\s*fallbackId,\s*fallbackName,\s*fallbackCode,\s*isUser\)/);
+        expect(detailFn).toMatch(/renderPill\('from',\s*fromSum,\s*payload\.from_entity_id,\s*payload\.from_name,\s*payload\.from_public_code,\s*false\)/);
+        expect(detailFn).toMatch(/renderPill\('to',\s*toSum,[\s\S]*?payload\.to_public_code,\s*!!payload\.to_is_user\)/);
     });
 
     test('chat_routing_sender key ships in EN + ZH (>=3 locales)', () => {

--- a/backend/tests/jest/routing-chip-modal-fallback.test.js
+++ b/backend/tests/jest/routing-chip-modal-fallback.test.js
@@ -141,7 +141,11 @@ describe('chat.html surface — resolveEntityLabel + normalizeRoutingPayload exi
 });
 
 describe('i18n — chat_routing_supervisor ships in EN + ZH (>=3 locales)', () => {
-    test('chat_routing_supervisor key occurs at least 3 times (en + zh-TW + zh-CN)', () => {
+    test('chat_routing_supervisor key occurs at least 3 times (en + zh + zh-CN)', () => {
+        // zh holds Traditional (zh-TW falls back through it), zh-CN holds
+        // Simplified, en is the source of meaning. zh-TW is intentionally
+        // slim (<100 keys per i18n-fallback-chain.test.js) and inherits
+        // 主管 via the zh fallback path.
         const occurrences = (i18nSrc.match(/"chat_routing_supervisor"\s*:/g) || []).length;
         expect(occurrences).toBeGreaterThanOrEqual(3);
     });
@@ -150,8 +154,7 @@ describe('i18n — chat_routing_supervisor ships in EN + ZH (>=3 locales)', () =
         expect(i18nSrc).toMatch(/"chat_routing_supervisor"\s*:\s*"Supervisor"/);
     });
 
-    test('zh-TW value is "主管"', () => {
-        // Just check the localized string is present near the key in some form.
+    test('Chinese value is "主管" (covers zh + zh-CN)', () => {
         expect(i18nSrc).toMatch(/"chat_routing_supervisor"\s*:\s*"主管"/);
     });
 });

--- a/backend/tests/jest/routing-chip-modal-fallback.test.js
+++ b/backend/tests/jest/routing-chip-modal-fallback.test.js
@@ -1,0 +1,364 @@
+/**
+ * card_816c435e759649fea9186694 — routing-chip detail modal must NEVER render
+ * the literal string "undefined" in any pill/label.
+ *
+ * Repro: Hank screenshot shows the modal's "to / 目標" field reading "undefined"
+ * instead of the supervisor (org-chart commander) name. Prior cards
+ * (e53b0908 / 1f8 / ecda7243 / 29eed229) hardened the CHIP path
+ * (renderRoutingChip) — this card hardens the MODAL path
+ * (openRoutingChipDetail → renderRoutingChipDetailBody) by adding a
+ * normalizeRoutingPayload() pre-pass + a shared resolveEntityLabel() helper
+ * that every label render site routes through.
+ *
+ * What this test locks:
+ *   1. resolveEntityLabel + normalizeRoutingPayload exist in chat.html.
+ *   2. The label resolver coalesces sum → fallbackName → fallbackId →
+ *      fallbackCode → orgChartCommanderId → neutral, in that order, and
+ *      treats undefined / null / '' / 'undefined' / 'null' / '?' / '？'
+ *      as bad-name sentinels (none reach the DOM).
+ *   3. The modal's chain section (superior/subordinates/peers) and the
+ *      org-tree renderer both use resolveEntityLabel — no naked
+ *      `'#' + entityId` (which renders '#undefined' when id is undefined).
+ *   4. renderPill calls pass the to_is_user FLAG through (not the resolved
+ *      label inline) so the resolver controls all "User" / "Supervisor"
+ *      fallback decisions in one place.
+ *   5. i18n key chat_routing_supervisor ships in EN + ZH (>=3 locales).
+ *   6. The resolver, exercised against canned payloads, never emits the
+ *      string "undefined" in any output label.
+ *
+ * Test approach: chat.html has no module export, so we extract the two
+ * helper-function source blocks (resolveEntityLabel + normalizeRoutingPayload)
+ * with regex slicing and eval them inside a closure that supplies the
+ * `orgChartCommanderId` cache + a stub i18n.t — mirrors the pattern used in
+ * routing-self-reply-card-ecda7243.test.js. No jsdom required.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const chatHtmlPath = path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html');
+const chatHtml = fs.readFileSync(chatHtmlPath, 'utf8');
+const i18nPath = path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js');
+const i18nSrc = fs.readFileSync(i18nPath, 'utf8');
+
+// ── Extract the two helpers as runnable source ─────────────────────────────
+function extractFn(src, signature, endMarker) {
+    const start = src.indexOf(signature);
+    if (start < 0) throw new Error(`signature not found: ${signature}`);
+    const end = src.indexOf(endMarker, start);
+    if (end < 0) throw new Error(`endMarker not found after signature: ${endMarker}`);
+    return src.slice(start, end);
+}
+
+const resolverSrc = extractFn(
+    chatHtml,
+    'function resolveEntityLabel(',
+    '\n        }\n\n        // card_816c435e: normalize'
+) + '\n        }';
+const normalizerSrc = extractFn(
+    chatHtml,
+    'function normalizeRoutingPayload(',
+    '\n        }\n\n        function renderRoutingChipDetailBody'
+) + '\n        }';
+
+// Stand up the helpers in a closure with `orgChartCommanderId` reachable.
+function makeHelpers(commanderId) {
+    // eslint-disable-next-line no-eval
+    const factory = eval(
+        `(function (orgChartCommanderId) {
+            ${resolverSrc}
+            ${normalizerSrc}
+            return { resolveEntityLabel, normalizeRoutingPayload };
+        })`
+    );
+    return factory(commanderId);
+}
+
+// Stub tt — return a known shape so we can assert on the label.
+const ttStub = (k, fb) => {
+    const dict = {
+        chat_routing_to_user: 'User',
+        chat_routing_supervisor: '主管',
+        chat_routing_sender: 'Sender',
+        chat_routing_unspecified: 'Unspecified',
+    };
+    return dict[k] || fb;
+};
+
+// ── Helpers also referenced indirectly: getEntityDisplayName mock (the resolver
+// does NOT call it directly today — kept for forward-compat if a future patch
+// wires the entity name map through). Provided here for documentation.
+const ENTITY_NAMES = { 1: 'Mac_F', 2: 'LOBSTER', 3: 'Mac_E' };
+function getEntityDisplayName(id) { return ENTITY_NAMES[id] || null; }
+
+describe('chat.html surface — resolveEntityLabel + normalizeRoutingPayload exist', () => {
+    test('resolveEntityLabel is defined and reachable from the modal renderer', () => {
+        expect(chatHtml).toMatch(/function\s+resolveEntityLabel\s*\(\s*sum,\s*fallbackId,\s*fallbackName,\s*fallbackCode,\s*opts\s*\)/);
+    });
+
+    test('normalizeRoutingPayload is defined and called at top of renderRoutingChipDetailBody', () => {
+        expect(chatHtml).toMatch(/function\s+normalizeRoutingPayload\s*\(\s*payload\s*\)/);
+        // Called inside renderRoutingChipDetailBody before any render site.
+        const bodyStart = chatHtml.indexOf('function renderRoutingChipDetailBody(bodyEl, payload');
+        expect(bodyStart).toBeGreaterThan(-1);
+        const body = chatHtml.slice(bodyStart, bodyStart + 2000);
+        expect(body).toMatch(/payload\s*=\s*normalizeRoutingPayload\(payload\)/);
+    });
+
+    test('renderPill passes isUser flag through (label not inlined at call site)', () => {
+        const bodyStart = chatHtml.indexOf('function renderRoutingChipDetailBody(bodyEl, payload');
+        const body = chatHtml.slice(bodyStart, bodyStart + 9000);
+        // The to-side call must pass the boolean flag, not a tt(...) label.
+        expect(body).toMatch(/renderPill\('to',\s*toSum,\s*payload\.to_entity_id,\s*payload\.to_name,\s*payload\.to_public_code,\s*!!payload\.to_is_user\)/);
+        // And the from-side must explicitly opt out of isUser.
+        expect(body).toMatch(/renderPill\('from',\s*fromSum,\s*payload\.from_entity_id,\s*payload\.from_name,\s*payload\.from_public_code,\s*false\)/);
+    });
+
+    test('chain section (superior/subordinates/peers) routes through resolveEntityLabel', () => {
+        const bodyStart = chatHtml.indexOf('function renderRoutingChipDetailBody(bodyEl, payload');
+        const body = chatHtml.slice(bodyStart, bodyStart + 9000);
+        // No raw `'#' + c.superior.entityId` / `'#' + s.entityId` / `'#' + p.entityId`
+        // — those would render '#undefined' when entityId is absent.
+        expect(body).not.toMatch(/\(\s*'#'\s*\+\s*c\.superior\.entityId\s*\)/);
+        expect(body).not.toMatch(/\(\s*'#'\s*\+\s*s\.entityId\s*\)/);
+        expect(body).not.toMatch(/\(\s*'#'\s*\+\s*p\.entityId\s*\)/);
+        // Positive: resolveEntityLabel(...) appears in the chain block.
+        const chainStart = body.indexOf('Section 4');
+        expect(chainStart).toBeGreaterThan(-1);
+        const chainBody = body.slice(chainStart);
+        expect(chainBody).toMatch(/resolveEntityLabel\(/);
+    });
+
+    test('renderOrgTreeHtml labelFor uses resolveEntityLabel (no naked #id)', () => {
+        const treeStart = chatHtml.indexOf('function renderOrgTreeHtml(hierarchy');
+        expect(treeStart).toBeGreaterThan(-1);
+        const body = chatHtml.slice(treeStart, treeStart + 3000);
+        // Old shape (banned): `if (!s) return '#' + id;` followed by `s.name || s.character || ('#' + id)`.
+        expect(body).not.toMatch(/if\s*\(!s\)\s*return\s*'#'\s*\+\s*id;/);
+        expect(body).toMatch(/resolveEntityLabel\(/);
+    });
+});
+
+describe('i18n — chat_routing_supervisor ships in EN + ZH (>=3 locales)', () => {
+    test('chat_routing_supervisor key occurs at least 3 times (en + zh-TW + zh-CN)', () => {
+        const occurrences = (i18nSrc.match(/"chat_routing_supervisor"\s*:/g) || []).length;
+        expect(occurrences).toBeGreaterThanOrEqual(3);
+    });
+
+    test('EN value is "Supervisor"', () => {
+        expect(i18nSrc).toMatch(/"chat_routing_supervisor"\s*:\s*"Supervisor"/);
+    });
+
+    test('zh-TW value is "主管"', () => {
+        // Just check the localized string is present near the key in some form.
+        expect(i18nSrc).toMatch(/"chat_routing_supervisor"\s*:\s*"主管"/);
+    });
+});
+
+describe('resolveEntityLabel — behaviour (extracted into a closure)', () => {
+    // ── Test 1: payload has undefined to_name but valid to_entity_id ──
+    test('Test 1: undefined to_name + valid to_entity_id → label falls back to #id, no "undefined"', () => {
+        const { resolveEntityLabel } = makeHelpers(null);
+        // Simulate the modal sum lookup miss (no detail.entities row for id 2).
+        const r = resolveEntityLabel(null, 2, undefined, null, { which: 'to', tt: ttStub });
+        expect(r.label).toBe('#2');
+        expect(r.label).not.toContain('undefined');
+    });
+
+    test('Test 1b: when summary carries a real name, the label is the name (not #id)', () => {
+        const { resolveEntityLabel } = makeHelpers(null);
+        const sum = { name: 'LOBSTER', publicCode: '3xa3h4', level: 2 };
+        const r = resolveEntityLabel(sum, 2, undefined, null, { which: 'to', tt: ttStub });
+        expect(r.label).toBe('LOBSTER');
+        expect(r.code).toBe('#3xa3h4');
+        expect(r.lv).toBe('LV2');
+    });
+
+    // ── Test 2: all fields blank (legacy null routing_meta) → supervisor floor ──
+    test('Test 2: all fields blank/null → falls back to supervisor i18n label, NEVER "undefined"', () => {
+        const { resolveEntityLabel } = makeHelpers(null);
+        const r = resolveEntityLabel(null, null, undefined, null, { which: 'to', tt: ttStub });
+        // No commanderId either, so we land on the neutral i18n label.
+        expect(r.label).toBe('主管');
+        expect(r.label).not.toContain('undefined');
+    });
+
+    test('Test 2b: blank fields BUT commander cached → commander floor wins over neutral', () => {
+        const { resolveEntityLabel } = makeHelpers(7);
+        const r = resolveEntityLabel(null, null, undefined, null, { which: 'to', tt: ttStub });
+        expect(r.label).toBe('#7');
+        expect(r.label).not.toContain('undefined');
+    });
+
+    // ── Test 3: to_is_user → localized "User" label ──
+    test('Test 3: to_is_user=true with undefined to_name → "User" via i18n, never "undefined"', () => {
+        const { resolveEntityLabel } = makeHelpers(null);
+        const r = resolveEntityLabel(null, null, undefined, null, { which: 'to', isUser: true, tt: ttStub });
+        expect(r.label).toBe('User');
+        expect(r.label).not.toContain('undefined');
+    });
+
+    test('Test 3b: to_is_user=true STILL wins even when a sum.name is present', () => {
+        const { resolveEntityLabel } = makeHelpers(null);
+        const sum = { name: 'should-be-ignored' };
+        const r = resolveEntityLabel(sum, 9, 'also-ignored', null, { which: 'to', isUser: true, tt: ttStub });
+        expect(r.label).toBe('User');
+    });
+
+    // ── Test 4: all fields valid → no fallback applied ──
+    test('Test 4: all fields valid → label = sum.name, code from sum.publicCode, no fallback', () => {
+        const { resolveEntityLabel } = makeHelpers(99);
+        const sum = { name: 'Mac_F', publicCode: 'tbwb9e', level: 5, avatar: 'https://x/y.png' };
+        const r = resolveEntityLabel(sum, 1, 'irrelevant-fallback', 'irrelevant-code', { which: 'to', tt: ttStub });
+        expect(r.label).toBe('Mac_F');
+        expect(r.code).toBe('#tbwb9e');
+        expect(r.lv).toBe('LV5');
+        expect(r.avatar).toBe('https://x/y.png');
+    });
+
+    // ── Bad-name sentinel coverage ──
+    test('literal "undefined" string in sum.name is treated as bad → next chain step wins', () => {
+        const { resolveEntityLabel } = makeHelpers(null);
+        const sum = { name: 'undefined' };
+        const r = resolveEntityLabel(sum, 2, 'GoodFallback', null, { which: 'to', tt: ttStub });
+        expect(r.label).toBe('GoodFallback');
+    });
+
+    test('literal "?" / "？" in fallbackName is rejected', () => {
+        const { resolveEntityLabel } = makeHelpers(null);
+        expect(resolveEntityLabel(null, 5, '?', null, { which: 'to', tt: ttStub }).label).toBe('#5');
+        expect(resolveEntityLabel(null, 5, '？', null, { which: 'to', tt: ttStub }).label).toBe('#5');
+    });
+
+    test('from-side neutral is "Sender" (not "Unspecified"/"Supervisor")', () => {
+        const { resolveEntityLabel } = makeHelpers(null);
+        const r = resolveEntityLabel(null, null, undefined, null, { which: 'from', tt: ttStub });
+        expect(r.label).toBe('Sender');
+    });
+
+    test('fallbackId of NaN / non-finite is rejected (no "#NaN" leak)', () => {
+        const { resolveEntityLabel } = makeHelpers(null);
+        const r = resolveEntityLabel(null, 'not-a-number', null, null, { which: 'to', tt: ttStub });
+        expect(r.label).toBe('主管');
+        expect(r.label).not.toContain('NaN');
+    });
+});
+
+describe('normalizeRoutingPayload — coerce undefined name fields to null up-front', () => {
+    test('undefined / "undefined" / "" → null', () => {
+        const { normalizeRoutingPayload } = makeHelpers(null);
+        const p = normalizeRoutingPayload({
+            to_name: undefined,
+            from_name: 'undefined',
+            to_public_code: '',
+            from_public_code: '   ',
+        });
+        expect(p.to_name).toBeNull();
+        expect(p.from_name).toBeNull();
+        expect(p.to_public_code).toBeNull();
+        expect(p.from_public_code).toBeNull();
+    });
+
+    test('valid string names survive untouched', () => {
+        const { normalizeRoutingPayload } = makeHelpers(null);
+        const p = normalizeRoutingPayload({
+            from_name: 'Mac_F',
+            to_name: 'LOBSTER',
+            from_entity_id: 1,
+            to_entity_id: 2,
+        });
+        expect(p.from_name).toBe('Mac_F');
+        expect(p.to_name).toBe('LOBSTER');
+        expect(p.from_entity_id).toBe(1);
+        expect(p.to_entity_id).toBe(2);
+    });
+
+    test('non-finite entity ids → null', () => {
+        const { normalizeRoutingPayload } = makeHelpers(null);
+        const p = normalizeRoutingPayload({
+            from_entity_id: 'not-numeric',
+            to_entity_id: NaN,
+        });
+        expect(p.from_entity_id).toBeNull();
+        expect(p.to_entity_id).toBeNull();
+    });
+
+    test('returns a shallow copy (does not mutate input)', () => {
+        const { normalizeRoutingPayload } = makeHelpers(null);
+        const orig = { to_name: undefined };
+        const out = normalizeRoutingPayload(orig);
+        expect(orig.to_name).toBeUndefined();
+        expect(out.to_name).toBeNull();
+        expect(out).not.toBe(orig);
+    });
+
+    test('null input does not throw', () => {
+        const { normalizeRoutingPayload } = makeHelpers(null);
+        expect(() => normalizeRoutingPayload(null)).not.toThrow();
+        expect(() => normalizeRoutingPayload(undefined)).not.toThrow();
+    });
+});
+
+describe('end-to-end smoke: every modal label-render path is undefined-proof', () => {
+    // Compose normalize + resolve to mimic what the modal does for each pill.
+    function renderLabel(payload, which, opts) {
+        const { normalizeRoutingPayload, resolveEntityLabel } = makeHelpers(opts.commanderId || null);
+        const p = normalizeRoutingPayload(payload);
+        const sum = (which === 'to') ? null : null; // no server detail
+        const id = (which === 'to') ? p.to_entity_id : p.from_entity_id;
+        const nm = (which === 'to') ? p.to_name : p.from_name;
+        const code = (which === 'to') ? p.to_public_code : p.from_public_code;
+        const isUser = (which === 'to') && !!p.to_is_user;
+        return resolveEntityLabel(sum, id, nm, code, { which, isUser, tt: ttStub }).label;
+    }
+
+    test('REPRO: legacy row payload (to_name=undefined, ids null) → "主管" not "undefined"', () => {
+        const label = renderLabel(
+            { to_name: undefined, to_entity_id: null, to_is_user: false, from_name: null, from_entity_id: null },
+            'to',
+            { commanderId: null }
+        );
+        expect(label).toBe('主管');
+    });
+
+    test('REPRO with commander cached: → "#<commanderId>" not "undefined"', () => {
+        const label = renderLabel(
+            { to_name: undefined, to_entity_id: null, to_is_user: false },
+            'to',
+            { commanderId: 9 }
+        );
+        expect(label).toBe('#9');
+    });
+
+    test('to_is_user=true with undefined to_name → "User" not "undefined"', () => {
+        const label = renderLabel({ to_is_user: true, to_name: undefined }, 'to', { commanderId: null });
+        expect(label).toBe('User');
+    });
+
+    test('from-side with undefined from_name + valid from_entity_id → "#id"', () => {
+        const label = renderLabel(
+            { from_name: undefined, from_entity_id: 1, to_name: 'LOBSTER', to_entity_id: 2 },
+            'from',
+            { commanderId: null }
+        );
+        expect(label).toBe('#1');
+    });
+
+    test('no path produces the literal string "undefined" for any of the 6 canned payloads', () => {
+        const cases = [
+            { to_name: undefined, to_entity_id: 2, from_name: 'Mac_F', from_entity_id: 1 },
+            { to_name: undefined, to_entity_id: null, to_is_user: false, from_entity_id: null, from_name: null },
+            { to_is_user: true, to_name: undefined },
+            { to_name: 'LOBSTER', to_entity_id: 2, from_name: 'Mac_F', from_entity_id: 1 },
+            { to_name: 'undefined', to_entity_id: 2 }, // literal-string sentinel
+            { to_name: '?', to_entity_id: 2 },         // '?' sentinel
+        ];
+        for (const c of cases) {
+            const tlabel = renderLabel(c, 'to', { commanderId: null });
+            const flabel = renderLabel(c, 'from', { commanderId: null });
+            expect(tlabel).not.toContain('undefined');
+            expect(flabel).not.toContain('undefined');
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- **Bug** (Hank screenshot): clicking a routing chip on the chat page opens the 路由詳情 modal with the `to / 目標` field showing literal `"undefined"` instead of the supervisor (org-chart commander) name.
- **Card**: `card_816c435e759649fea9186694`
- **Repro path**: legacy null `routing_meta` row → `openRoutingChipDetail` → `renderRoutingChipDetailBody` → `renderPill` (or the chain section / org-tree label) → JS `undefined` stringified into the DOM at one of several inject sites.

## Why prior fixes missed this

Cards `e53b0908` / `1f8` / `ecda7243` / `29eed229` hardened the CHIP path (`renderRoutingChip`). The MODAL path had its own renderer (`renderRoutingChipDetailBody`) with overlapping but incomplete guards:

| Site | Old behavior | New behavior |
|------|-------------|--------------|
| `renderPill` | `safeFallbackName` chain rejected `undefined` but `sum.name === 'undefined'` (literal string) slipped through | Routed through `resolveEntityLabel`; `isBadName` predicate rejects `''`/`'undefined'`/`'null'`/`'?'`/`'？'` for sum AND fallback |
| Chain section (superior/subordinates/peers) | `'#' + c.superior.entityId` → `'#undefined'` when id absent | Routed through `resolveEntityLabel` |
| `renderOrgTreeHtml.labelFor` | `'#' + id` → `'#undefined'` | Routed through `resolveEntityLabel` |
| `renderPill` to-side | `to_is_user ? tt('chat_routing_to_user') : payload.to_name` inlined at call site (split decision) | Flag (`!!payload.to_is_user`) passed through to resolver — one decision point |

## Fix

1. **`resolveEntityLabel(sum, fallbackId, fallbackName, fallbackCode, opts)`** — shared helper, single source of truth for any entity-label decision in the modal. Coalesces `sum → fallbackName → fallbackId → fallbackCode → orgChartCommanderId → neutral i18n label`. Rejects non-finite ids so no `#NaN` / `#undefined` can leak.
2. **`normalizeRoutingPayload(payload)`** — called once at the top of `renderRoutingChipDetailBody`. Coerces undefined/'undefined'/empty name fields and non-finite entity ids to `null` so every downstream render site works off a known-clean shape.
3. **Render-site refactors**: `renderPill`, chain section, `renderOrgTreeHtml.labelFor` all delegate to `resolveEntityLabel`.
4. **i18n key `chat_routing_supervisor`** added via the AST tool (`backend/scripts/i18n-insert-locale-keys.js`, per project policy — never regex insertion, see PR #3253 revert post-mortem):
   - `en` → `"Supervisor"`
   - `zh` (Traditional) → `"主管"`
   - `zh-CN` (Simplified) → `"主管"`
   - `zh-TW` slim-override layer intentionally NOT touched (would push it from 99 → 100 keys and break `i18n-fallback-chain.test.js`'s `<100` cap); zh-TW inherits via the zh fallback chain.
   - **Remaining 13 locales (ja / ko / th / vi / id / fr / es / de / pt / ms / hi / ar / etc.)** to be fanned out in a separate i18n card per CLAUDE.md (owners #3 / #4 / #5).

## Files touched

- `backend/public/portal/chat.html` — `+158 / −39` (helper + refactors)
- `backend/public/shared/i18n.js` — `+6` (AST inserts in en / zh / zh-CN)
- `backend/tests/jest/routing-chip-modal-fallback.test.js` — `+364` (new, 29 tests)
- `backend/tests/jest/routing-chip-detail.test.js` — `+26 / −7` (update 3 sender-floor tests to point at the relocated guards + new `isUser` 6th arg)

## Test plan

- [x] `npm test -- --testPathPattern routing-chip-modal-fallback` — **29 / 29 passing**
- [x] `npm test -- --testPathPattern routing` (all routing suites) — **162 / 162 passing**
- [x] `npm test -- --testPathPattern chat` — **289 / 289 passing**
- [x] `npm test -- --testPathPattern i18n` — **42 / 42 passing**
- [x] Full backend Jest — **5035 passing, 0 failed, 17 skipped**
- [x] ESLint — 0 errors (6 pre-existing warnings unrelated)
- [ ] **Post-deploy manual prod verification** — click a routing chip with a legacy null `routing_meta` row on the chat page; modal `to / 目標` field should now show `主管` / `#<commanderId>` / a real entity name, NEVER `undefined`. Playwright isn't configured locally; will need a Hank screenshot from prod once `main` deploys.

## Hard constraints respected

- `renderRoutingChip` untouched (already heavily tested).
- `routing_meta` backend schema untouched.
- All existing guards preserved; only added new ones.
- LF line endings preserved (matches chat.html convention).
- i18n inserts via AST tool only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUDRpzSFMMKwMoVtnxK1dd