### PR TITLE
feat(chat): sendto picker — button + multi-select sheet matching smart-filter UX (card_91d5c93b)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1989,6 +1989,203 @@
             color: #fff;
         }
 
+        /* ── Sendto picker (card_91d5c93b) — matches .sys-chip / .filter-chip
+           tactile style and opens a scrollable multi-select sheet / popover. */
+        .sendto-picker-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            min-height: 34px;
+        }
+        .sendto-picker-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 4px 12px;
+            border-radius: 16px;
+            font-size: 12px;
+            line-height: 1.4;
+            cursor: pointer;
+            background: var(--card);
+            border: 1px solid var(--card-border);
+            color: var(--text-secondary);
+            white-space: nowrap;
+            user-select: none;
+            transition: all 0.15s;
+            max-width: 100%;
+        }
+        .sendto-picker-btn:hover {
+            border-color: var(--primary);
+            color: var(--text-primary);
+        }
+        .sendto-picker-btn[aria-expanded="true"] {
+            background: var(--primary);
+            border-color: var(--primary);
+            color: var(--text);
+        }
+        .sendto-picker-btn-label {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            max-width: 240px;
+        }
+        .sendto-picker-btn-caret {
+            font-size: 10px;
+            opacity: 0.7;
+            flex-shrink: 0;
+        }
+        .sendto-picker-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(0,0,0,0.32);
+            z-index: 1200;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .sendto-picker-overlay[hidden] {
+            display: none !important;
+        }
+        .sendto-picker-dialog {
+            background: var(--card);
+            color: var(--text);
+            border: 1px solid var(--card-border);
+            border-radius: 12px;
+            width: min(420px, calc(100% - 32px));
+            max-height: 60vh;
+            display: flex;
+            flex-direction: column;
+            box-shadow: 0 12px 36px rgba(0,0,0,0.32);
+            overflow: hidden;
+        }
+        .sendto-picker-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 12px 16px;
+            border-bottom: 1px solid var(--card-border);
+            flex-shrink: 0;
+        }
+        .sendto-picker-title {
+            font-size: 15px;
+            font-weight: 600;
+            margin: 0;
+            color: var(--text);
+        }
+        .sendto-picker-close {
+            background: transparent;
+            border: none;
+            color: var(--text-muted);
+            font-size: 16px;
+            cursor: pointer;
+            padding: 4px 8px;
+            border-radius: 6px;
+            line-height: 1;
+        }
+        .sendto-picker-close:hover {
+            background: var(--input-bg);
+            color: var(--text);
+        }
+        .sendto-picker-selectall {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 16px;
+            border-bottom: 1px solid var(--card-border);
+            font-size: 13px;
+            color: var(--text-secondary);
+            cursor: pointer;
+            user-select: none;
+            flex-shrink: 0;
+        }
+        .sendto-picker-selectall input[type="checkbox"] {
+            accent-color: var(--primary);
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+        }
+        .sendto-picker-list {
+            flex: 1 1 auto;
+            overflow-y: auto;
+            padding: 4px 0;
+        }
+        .sendto-picker-row-item {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 10px 16px;
+            cursor: pointer;
+            user-select: none;
+            font-size: 14px;
+            color: var(--text);
+            border-bottom: 1px solid transparent;
+        }
+        .sendto-picker-row-item:hover {
+            background: var(--input-bg);
+        }
+        .sendto-picker-row-avatar {
+            flex-shrink: 0;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .sendto-picker-row-meta {
+            flex: 1 1 auto;
+            min-width: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }
+        .sendto-picker-row-name {
+            font-weight: 500;
+            color: var(--text);
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .sendto-picker-row-sub {
+            font-size: 11px;
+            color: var(--text-muted);
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+        .sendto-picker-row-item input[type="checkbox"] {
+            accent-color: var(--primary);
+            width: 16px;
+            height: 16px;
+            flex-shrink: 0;
+            cursor: pointer;
+        }
+        .sendto-picker-empty {
+            padding: 24px 16px;
+            text-align: center;
+            color: var(--text-muted);
+            font-size: 13px;
+        }
+        .sendto-picker-footer {
+            display: flex;
+            justify-content: flex-end;
+            gap: 8px;
+            padding: 12px 16px;
+            border-top: 1px solid var(--card-border);
+            background: var(--input-bg);
+            flex-shrink: 0;
+        }
+        /* Bottom-sheet on touch devices (mobile + tablet). */
+        @media (pointer: coarse) {
+            .sendto-picker-overlay {
+                align-items: flex-end;
+            }
+            .sendto-picker-dialog {
+                width: 100%;
+                max-width: 100%;
+                max-height: 70vh;
+                border-radius: 16px 16px 0 0;
+                border-bottom: none;
+            }
+        }
+
         /* ── Reduced Motion ── */
         @media (prefers-reduced-motion: reduce) {
             .scroll-nav { transition: none; }
@@ -3331,15 +3528,57 @@
                 </button>
             </div>
 
-            <!-- Target Bar (checkboxes) -->
+            <!-- Target Bar — sendto picker button + hidden checkbox source-of-truth
+                 (card_91d5c93ba31bda385881ad59 — match smart-filter button UX).
+                 The .target-bar-row hosts the *underlying* checkboxes used by
+                 downstream code (sendMessage, applyAutoToggleReceivers,
+                 persistTargetSelection). The picker button + overlay below are
+                 the visible UI; the overlay just reads/writes those inputs. -->
             <div class="target-bar" id="targetBar">
                 <div class="target-bar-overflow" id="targetBarOverflow"></div>
-                <div class="target-bar-row" id="targetBarRow">
+                <div class="target-bar-row" id="targetBarRow" hidden aria-hidden="true">
                     <span class="target-label" data-i18n="chat_send_to">Send to:</span>
                     <label class="target-check" id="targetAll" style="display:none;">
                         <input type="checkbox" checked onchange="toggleTargetAll(this)" aria-label="Send to all">
                         <span data-i18n="chat_filter_all">All</span>
                     </label>
+                </div>
+                <div class="sendto-picker-row" id="sendtoPickerRow">
+                    <button type="button"
+                            class="sendto-picker-btn"
+                            id="sendtoPickerBtn"
+                            aria-haspopup="listbox"
+                            aria-expanded="false"
+                            aria-controls="sendtoPickerDialog"
+                            data-i18n-title="chat_sendto_picker_title"
+                            title="Select recipients"
+                            onclick="openSendtoPicker()"><span class="sendto-picker-btn-label" id="sendtoPickerBtnLabel" data-i18n="chat_sendto_button_label_all">傳送給 ALL</span><span class="sendto-picker-btn-caret" aria-hidden="true">▾</span></button>
+                </div>
+                <!-- Picker overlay: dropdown on desktop, bottom-sheet on touch.
+                     Hidden by default; openSendtoPicker() unhides + populates. -->
+                <div class="sendto-picker-overlay"
+                     id="sendtoPickerOverlay"
+                     hidden
+                     onclick="if(event.target===this)cancelSendtoPicker()">
+                    <div class="sendto-picker-dialog"
+                         id="sendtoPickerDialog"
+                         role="dialog"
+                         aria-modal="true"
+                         aria-labelledby="sendtoPickerTitle">
+                        <div class="sendto-picker-header">
+                            <h3 class="sendto-picker-title" id="sendtoPickerTitle" data-i18n="chat_sendto_picker_title">Select recipients</h3>
+                            <button type="button" class="sendto-picker-close" onclick="cancelSendtoPicker()" aria-label="Close" data-i18n-title="chat_sendto_picker_cancel" title="Cancel">&#x2715;</button>
+                        </div>
+                        <label class="sendto-picker-selectall">
+                            <input type="checkbox" id="sendtoPickerSelectAll" onchange="toggleSendtoPickerSelectAll(this)">
+                            <span data-i18n="chat_sendto_picker_select_all">Select all</span>
+                        </label>
+                        <div class="sendto-picker-list" id="sendtoPickerList" role="listbox" aria-multiselectable="true"></div>
+                        <div class="sendto-picker-footer">
+                            <button type="button" class="btn btn-outline btn-sm" onclick="cancelSendtoPicker()" data-i18n="chat_sendto_picker_cancel">Cancel</button>
+                            <button type="button" class="btn btn-primary btn-sm" onclick="confirmSendtoPicker()" data-i18n="chat_sendto_picker_confirm">Confirm</button>
+                        </div>
+                    </div>
                 </div>
             </div>
 
@@ -4867,7 +5106,12 @@
         function updateTargetAll(opts) {
             const allCb = document.querySelector('#targetAll input');
             const entityCbs = document.querySelectorAll('.target-entity-check input[type="checkbox"]');
-            if (entityCbs.length === 0) return;
+            if (entityCbs.length === 0) {
+                // Even with no checks present yet (boot race), keep the
+                // picker button label in a sane state.
+                if (typeof refreshSendtoPickerButtonLabel === 'function') refreshSendtoPickerButtonLabel();
+                return;
+            }
             const allChecked = Array.from(entityCbs).every(cb => cb.checked);
             allCb.checked = allChecked;
             // Manual uncheck revokes that receiver's auto-select hint — keep
@@ -4883,6 +5127,8 @@
                 });
             }
             persistTargetSelection();
+            // Keep the visible "傳送給 …" button label in sync (card_91d5c93b).
+            if (typeof refreshSendtoPickerButtonLabel === 'function') refreshSendtoPickerButtonLabel();
         }
 
         // Persist current target selection to localStorage. Called on every toggle
@@ -6988,6 +7234,207 @@
         function clearAllReceiverHints() {
             document.querySelectorAll('.target-entity-check .receiver-hint-auto').forEach(b => b.remove());
             autoToggledReceiverEntities.clear();
+        }
+
+        // ── Sendto picker (card_91d5c93ba31bda385881ad59) ──
+        // The visible UI for choosing recipients. The underlying source-of-
+        // truth checkboxes live in #targetBarRow (hidden); this picker reads
+        // their state to render its summary label and the dialog rows, and
+        // writes back to them on Confirm. This preserves every downstream
+        // contract: sendMessage() / persistTargetSelection() / getSelectedTargets()
+        // / applyAutoToggleReceivers() (card_3462... exclusive auto-select).
+        //
+        // Cancel + click-outside discard changes; Confirm applies them. The
+        // overlay is a <dialog>-shaped div (role="dialog" + aria-modal) and
+        // each row is a <label>-as-row so clicking anywhere on the row toggles
+        // the embedded checkbox.
+
+        function getSendtoUnderlyingChecks() {
+            return Array.from(document.querySelectorAll('.target-entity-check input[type="checkbox"]'));
+        }
+
+        function refreshSendtoPickerButtonLabel() {
+            const btn = document.getElementById('sendtoPickerBtn');
+            const label = document.getElementById('sendtoPickerBtnLabel');
+            if (!btn || !label) return;
+            const checks = getSendtoUnderlyingChecks();
+            // No bound entities yet (boot before /api/entities resolves) → keep "ALL" affordance.
+            if (checks.length === 0) {
+                label.textContent = (i18n && i18n.t) ? i18n.t('chat_sendto_button_label_all') : '傳送給 ALL';
+                btn.setAttribute('data-sendto-state', 'all');
+                return;
+            }
+            const checked = checks.filter(cb => cb.checked);
+            const total = checks.length;
+            if (checked.length === total) {
+                label.textContent = (i18n && i18n.t) ? i18n.t('chat_sendto_button_label_all') : '傳送給 ALL';
+                btn.setAttribute('data-sendto-state', 'all');
+            } else if (checked.length === 1) {
+                const eid = Number(checked[0].dataset.entity);
+                const target = '#' + eid;
+                label.textContent = (i18n && i18n.t)
+                    ? i18n.t('chat_sendto_button_label_single', { target })
+                    : ('傳送給 ' + target);
+                btn.setAttribute('data-sendto-state', 'single');
+            } else if (checked.length === 0) {
+                // Zero recipients is a real (unsendable) state — show count
+                // so users understand why the send button errors.
+                label.textContent = (i18n && i18n.t)
+                    ? i18n.t('chat_sendto_button_label_multi', { count: 0 })
+                    : '傳送給 0 entities';
+                btn.setAttribute('data-sendto-state', 'none');
+            } else {
+                label.textContent = (i18n && i18n.t)
+                    ? i18n.t('chat_sendto_button_label_multi', { count: checked.length })
+                    : ('傳送給 ' + checked.length + ' entities');
+                btn.setAttribute('data-sendto-state', 'multi');
+            }
+        }
+
+        function openSendtoPicker() {
+            const overlay = document.getElementById('sendtoPickerOverlay');
+            const list = document.getElementById('sendtoPickerList');
+            const btn = document.getElementById('sendtoPickerBtn');
+            const selectAll = document.getElementById('sendtoPickerSelectAll');
+            if (!overlay || !list) return;
+
+            // Snapshot current selection (so Cancel can restore).
+            const snapshot = {};
+            getSendtoUnderlyingChecks().forEach(cb => {
+                snapshot[String(cb.dataset.entity)] = !!cb.checked;
+            });
+            overlay.dataset.snapshot = JSON.stringify(snapshot);
+
+            // Render rows from the live boundEntities list (so the picker
+            // reflects whatever `loadBoundEntities` last resolved). We fall
+            // back to the in-DOM underlying checkboxes if boundEntities is
+            // empty for some reason (defensive).
+            list.innerHTML = '';
+            const entitiesToRender = (Array.isArray(boundEntities) && boundEntities.length > 0)
+                ? boundEntities
+                : getSendtoUnderlyingChecks().map(cb => ({ entityId: Number(cb.dataset.entity) }));
+
+            if (entitiesToRender.length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'sendto-picker-empty';
+                empty.textContent = (i18n && i18n.t) ? i18n.t('chat_loading_entities') : 'Loading…';
+                list.appendChild(empty);
+            } else {
+                entitiesToRender.forEach(e => {
+                    const eid = Number(e.entityId);
+                    if (!Number.isFinite(eid)) return;
+                    const underlying = document.querySelector('.target-entity-check input[type="checkbox"][data-entity="' + eid + '"]');
+                    const isChecked = !!(underlying && underlying.checked);
+                    const avatar = (typeof getAvatarForEntity === 'function') ? getAvatarForEntity(eid) : '';
+                    const name = (typeof getEntityDisplayName === 'function') ? getEntityDisplayName(eid) : ('#' + eid);
+                    const pubCode = (e && e.publicCode) ? String(e.publicCode) : '';
+                    const avatarHtml = (typeof renderAvatarHtml === 'function') ? renderAvatarHtml(avatar, 28) : '';
+
+                    const row = document.createElement('label');
+                    row.className = 'sendto-picker-row-item';
+                    row.dataset.entityId = String(eid);
+                    row.innerHTML = `
+                        <span class="sendto-picker-row-avatar">${avatarHtml}</span>
+                        <span class="sendto-picker-row-meta">
+                            <span class="sendto-picker-row-name">${escapeHtml(name)}</span>
+                            <span class="sendto-picker-row-sub">
+                                <span>#${eid}</span>
+                                ${pubCode ? `<span>${escapeHtml(pubCode)}</span>` : ''}
+                            </span>
+                        </span>
+                        <input type="checkbox" data-picker-entity="${eid}" ${isChecked ? 'checked' : ''} onchange="onSendtoPickerRowChange()" aria-label="${escapeHtml(name)}">
+                    `;
+                    list.appendChild(row);
+                });
+            }
+
+            // Reflect select-all state from current row checkboxes.
+            syncSendtoPickerSelectAllState();
+
+            overlay.hidden = false;
+            if (btn) btn.setAttribute('aria-expanded', 'true');
+            // Focus the dialog for AT, after the next paint.
+            requestAnimationFrame(() => {
+                const dlg = document.getElementById('sendtoPickerDialog');
+                if (dlg && typeof dlg.focus === 'function') {
+                    dlg.setAttribute('tabindex', '-1');
+                    dlg.focus();
+                }
+            });
+            document.addEventListener('keydown', sendtoPickerKeydown);
+        }
+
+        function sendtoPickerKeydown(ev) {
+            if (ev.key === 'Escape') {
+                ev.preventDefault();
+                cancelSendtoPicker();
+            }
+        }
+
+        function closeSendtoPickerOverlay() {
+            const overlay = document.getElementById('sendtoPickerOverlay');
+            const btn = document.getElementById('sendtoPickerBtn');
+            if (overlay) overlay.hidden = true;
+            if (btn) btn.setAttribute('aria-expanded', 'false');
+            document.removeEventListener('keydown', sendtoPickerKeydown);
+        }
+
+        function cancelSendtoPicker() {
+            // No state change — just close. Underlying checkboxes were never
+            // touched (the dialog only edits its own row inputs); we discard
+            // the snapshot.
+            const overlay = document.getElementById('sendtoPickerOverlay');
+            if (overlay) delete overlay.dataset.snapshot;
+            closeSendtoPickerOverlay();
+        }
+
+        function confirmSendtoPicker() {
+            // Apply dialog row state → underlying entity checkboxes, then
+            // route through the existing updateTargetAll/persistTargetSelection
+            // pipeline so downstream code sees the same transition it would
+            // from a direct checkbox click.
+            const rows = document.querySelectorAll('#sendtoPickerList input[data-picker-entity]');
+            rows.forEach(rowCb => {
+                const eid = rowCb.dataset.pickerEntity;
+                const underlying = document.querySelector('.target-entity-check input[type="checkbox"][data-entity="' + eid + '"]');
+                if (!underlying) return;
+                if (underlying.checked !== rowCb.checked) {
+                    underlying.checked = rowCb.checked;
+                    // Manual change revokes the auto-receiver hint for that
+                    // entity (same semantics as toggling the inline checkbox).
+                    if (!rowCb.checked && typeof clearReceiverHintForEntity === 'function') {
+                        clearReceiverHintForEntity(Number(eid));
+                    }
+                }
+            });
+            if (typeof persistTargetSelection === 'function') persistTargetSelection();
+            if (typeof updateTargetAll === 'function') updateTargetAll();
+            refreshSendtoPickerButtonLabel();
+            closeSendtoPickerOverlay();
+        }
+
+        function toggleSendtoPickerSelectAll(checkbox) {
+            const rows = document.querySelectorAll('#sendtoPickerList input[data-picker-entity]');
+            rows.forEach(cb => { cb.checked = !!checkbox.checked; });
+        }
+
+        function onSendtoPickerRowChange() {
+            syncSendtoPickerSelectAllState();
+        }
+
+        function syncSendtoPickerSelectAllState() {
+            const rows = Array.from(document.querySelectorAll('#sendtoPickerList input[data-picker-entity]'));
+            const selectAll = document.getElementById('sendtoPickerSelectAll');
+            if (!selectAll || rows.length === 0) {
+                if (selectAll) {
+                    selectAll.checked = false;
+                    selectAll.indeterminate = false;
+                }
+                return;
+            }
+            const checkedCount = rows.filter(cb => cb.checked).length;
+            selectAll.checked = checkedCount === rows.length;
+            selectAll.indeterminate = checkedCount > 0 && checkedCount < rows.length;
         }
 
         function fileMsgText(index, file, text) {

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650458,6 +650458,14 @@ const TRANSLATIONS = {
         "cron_skip_help_text": "Slider range 50–99. When the assigned entity's current usage exceeds the threshold, this cron tick is skipped to protect the high-load entity; the next scheduled tick auto-retries.",
 
         "chat_routing_supervisor": "Supervisor",
+
+        "chat_sendto_button_label_all": "Send to ALL",
+        "chat_sendto_button_label_single": "Send to {target}",
+        "chat_sendto_button_label_multi": "Send to {count} entities",
+        "chat_sendto_picker_title": "Select recipients",
+        "chat_sendto_picker_select_all": "Select all",
+        "chat_sendto_picker_confirm": "Confirm",
+        "chat_sendto_picker_cancel": "Cancel",
 },
 
 
@@ -1235352,6 +1235360,14 @@ const TRANSLATIONS = {
         "cron_skip_help_text": "拉桿範圍 50–99。當指派智能體目前用量超過門檻時，這次 cron 觸發會跳過以保護高負載智能體；下個排程觸發會自動重試。",
 
         "chat_routing_supervisor": "主管",
+
+        "chat_sendto_button_label_all": "傳送給 ALL",
+        "chat_sendto_button_label_single": "傳送給 {target}",
+        "chat_sendto_button_label_multi": "傳送給 {count} entities",
+        "chat_sendto_picker_title": "選擇傳送對象",
+        "chat_sendto_picker_select_all": "全選",
+        "chat_sendto_picker_confirm": "確認",
+        "chat_sendto_picker_cancel": "取消",
 },
 
 

--- a/backend/tests/jest/chat-sendto-picker.test.js
+++ b/backend/tests/jest/chat-sendto-picker.test.js
@@ -1,0 +1,472 @@
+/**
+ * chat-sendto-picker — UI polish that swaps the inline recipient checkbox
+ * row for a button styled like the smart-filter button. Clicking it opens
+ * a scrollable multi-select sheet (bottom-sheet on touch, dropdown on
+ * desktop) with checkmarks; Confirm writes the choices back to the
+ * underlying `.target-entity-check input[type="checkbox"]` source-of-truth
+ * so every downstream consumer (sendMessage, applyAutoToggleReceivers,
+ * persistTargetSelection) keeps working without modification.
+ *
+ * Card: card_91d5c93ba31bda385881ad59.
+ *
+ * jest.config.js uses testEnvironment:'node' with no jsdom. We mirror the
+ * pattern from chat-quote-smart-receiver.test.js: lock the surface with
+ * regex contracts and exercise the label / confirm / cancel logic by
+ * extracting the function bodies and running them inside a tiny document
+ * shim.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const chatHtml = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html'),
+    'utf8'
+);
+
+describe('chat-sendto-picker — chat.html static surface', () => {
+    test('picker button exists with smart-filter-mirroring aria + classes', () => {
+        // The button must declare itself as a listbox opener and own the
+        // overlay it controls so assistive tech can announce the relationship.
+        expect(chatHtml).toMatch(/id="sendtoPickerBtn"/);
+        expect(chatHtml).toMatch(/class="sendto-picker-btn"/);
+        expect(chatHtml).toMatch(/aria-haspopup="listbox"/);
+        expect(chatHtml).toMatch(/aria-expanded="false"/);
+        expect(chatHtml).toMatch(/aria-controls="sendtoPickerDialog"/);
+    });
+
+    test('picker overlay declares role="dialog" + aria-modal="true"', () => {
+        // role=dialog + aria-modal=true so screen readers treat the overlay
+        // as a modal; matches the destructive-confirm a11y contract.
+        expect(chatHtml).toMatch(/id="sendtoPickerDialog"/);
+        expect(chatHtml).toMatch(/role="dialog"/);
+        expect(chatHtml).toMatch(/aria-modal="true"/);
+        // The list itself is a listbox so AT can announce items.
+        expect(chatHtml).toMatch(/role="listbox"/);
+        expect(chatHtml).toMatch(/aria-multiselectable="true"/);
+    });
+
+    test('click-outside-overlay triggers cancelSendtoPicker (same as Cancel)', () => {
+        // Overlay click handler — clicking on the overlay backdrop (event.target
+        // === overlay element itself, not the dialog) cancels. This is the
+        // load-bearing contract for "click outside = cancel without saving".
+        expect(chatHtml).toMatch(/onclick="if\(event\.target===this\)cancelSendtoPicker\(\)"/);
+    });
+
+    test('Select all toggle + Confirm + Cancel buttons present', () => {
+        expect(chatHtml).toMatch(/id="sendtoPickerSelectAll"/);
+        expect(chatHtml).toMatch(/onchange="toggleSendtoPickerSelectAll\(this\)"/);
+        expect(chatHtml).toMatch(/onclick="confirmSendtoPicker\(\)"/);
+        // Cancel reachable from header X + footer button.
+        const cancelCalls = chatHtml.match(/onclick="cancelSendtoPicker\(\)"/g) || [];
+        expect(cancelCalls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('underlying #targetBarRow checkbox source-of-truth is preserved (hidden, not removed)', () => {
+        // Downstream code (sendMessage / persistTargetSelection /
+        // applyAutoToggleReceivers / getSelectedTargets) reads the underlying
+        // .target-entity-check inputs. Removing them would break every
+        // consumer; we hide them and let the picker overlay edit them.
+        expect(chatHtml).toMatch(/id="targetBarRow"[^>]*hidden/);
+        expect(chatHtml).toMatch(/aria-hidden="true"/);
+        // The query downstream code uses must still be findable in source.
+        expect(chatHtml).toMatch(/\.target-entity-check input\[type="checkbox"\]/);
+    });
+
+    test('updateTargetAll now refreshes the picker button label', () => {
+        // The visible button summary must track underlying state, otherwise
+        // a quote-auto-select or manual toggle leaves the button stale.
+        const fnMatch = chatHtml.match(/function\s+updateTargetAll\s*\(\s*opts\s*\)\s*\{[\s\S]*?\n        \}/);
+        expect(fnMatch).not.toBeNull();
+        expect(fnMatch[0]).toMatch(/refreshSendtoPickerButtonLabel/);
+    });
+
+    test('confirmSendtoPicker routes through persistTargetSelection + updateTargetAll', () => {
+        // The picker must NOT bypass the existing persistence pipeline,
+        // otherwise localStorage drifts from DOM and a refresh restores the
+        // wrong recipients.
+        const fnMatch = chatHtml.match(/function\s+confirmSendtoPicker\s*\(\s*\)\s*\{[\s\S]*?\n        \}/);
+        expect(fnMatch).not.toBeNull();
+        const body = fnMatch[0];
+        expect(body).toMatch(/persistTargetSelection\(\)/);
+        expect(body).toMatch(/updateTargetAll\(\)/);
+        // It must also clear the auto-receiver hint when the user un-checks
+        // an entity that was previously auto-toggled (card_3462... contract).
+        expect(body).toMatch(/clearReceiverHintForEntity/);
+    });
+
+    test('three i18n keys for the button label exist', () => {
+        // The summary label is one of three strings — ALL, single (one
+        // {target}), or multi ({count} entities). The picker chooses based
+        // on how many entities are checked.
+        expect(chatHtml).toMatch(/chat_sendto_button_label_all/);
+        expect(chatHtml).toMatch(/chat_sendto_button_label_single/);
+        expect(chatHtml).toMatch(/chat_sendto_button_label_multi/);
+    });
+
+    test('overlay uses bottom-sheet on @media (pointer:coarse)', () => {
+        // Mobile bottom-sheet contract: docked to the bottom, max-height
+        // 70vh so the chat input is still reachable above. Desktop hover
+        // devices keep the centered dialog (60vh).
+        expect(chatHtml).toMatch(/@media\s*\(\s*pointer:\s*coarse\s*\)/);
+        expect(chatHtml).toMatch(/max-height:\s*70vh/);
+        expect(chatHtml).toMatch(/max-height:\s*60vh/);
+    });
+});
+
+describe('chat-sendto-picker — i18n parity (en + zh)', () => {
+    const i18nJs = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js'),
+        'utf8'
+    );
+    // Locate locale blocks by their opener (matches the pattern other
+    // tests use — bare-identifier `en: {` / `zh: {` at column 4).
+    const LOCALE_RE = /^(\s*)(en|zh|zh-TW|ja|ko|th|vi|id|fr|es|de|pt|ms|hi|ar):\s*\{\s*$/gm;
+    const openers = [];
+    let m;
+    while ((m = LOCALE_RE.exec(i18nJs)) !== null) {
+        openers.push({ name: m[2], start: m.index });
+    }
+    openers.sort((a, b) => a.start - b.start);
+    const blocks = {};
+    openers.forEach((entry, i) => {
+        const end = i + 1 < openers.length ? openers[i + 1].start : i18nJs.length;
+        blocks[entry.name] = i18nJs.slice(entry.start, end);
+    });
+
+    const EXPECT = {
+        en: {
+            chat_sendto_button_label_all: 'Send to ALL',
+            chat_sendto_button_label_single: 'Send to {target}',
+            chat_sendto_button_label_multi: 'Send to {count} entities',
+            chat_sendto_picker_title: 'Select recipients',
+            chat_sendto_picker_select_all: 'Select all',
+            chat_sendto_picker_confirm: 'Confirm',
+            chat_sendto_picker_cancel: 'Cancel',
+        },
+        zh: {
+            chat_sendto_button_label_all: '傳送給 ALL',
+            chat_sendto_button_label_single: '傳送給 {target}',
+            chat_sendto_button_label_multi: '傳送給 {count} entities',
+            chat_sendto_picker_title: '選擇傳送對象',
+            chat_sendto_picker_select_all: '全選',
+            chat_sendto_picker_confirm: '確認',
+            chat_sendto_picker_cancel: '取消',
+        },
+    };
+
+    Object.entries(EXPECT).forEach(([locale, kv]) => {
+        Object.entries(kv).forEach(([key, val]) => {
+            test(`${locale} → ${key}`, () => {
+                const block = blocks[locale];
+                expect(block).toBeDefined();
+                const re = new RegExp(
+                    '"' + key + '"\\s*:\\s*"' + val.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '"'
+                );
+                expect(block).toMatch(re);
+            });
+        });
+    });
+});
+
+describe('chat-sendto-picker — behaviour against a hand-rolled DOM stub', () => {
+    // Minimal DOM shim that mirrors only what the picker functions touch:
+    //   - underlying .target-entity-check input checkboxes (hidden row)
+    //   - dialog row checkboxes ([data-picker-entity])
+    //   - the button label span (id="sendtoPickerBtnLabel")
+    //   - the overlay container + dialog (for hidden/aria-expanded toggles)
+    //   - getEntityDisplayName / getAvatarForEntity / renderAvatarHtml /
+    //     escapeHtml / boundEntities (consulted while rendering rows)
+
+    function extractFunction(name) {
+        const re = new RegExp(`function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`, 'g');
+        const m = re.exec(chatHtml);
+        if (!m) throw new Error(`function ${name} not found`);
+        let depth = 1;
+        let i = m.index + m[0].length;
+        while (i < chatHtml.length && depth > 0) {
+            const ch = chatHtml[i];
+            if (ch === '{') depth++;
+            else if (ch === '}') depth--;
+            i++;
+        }
+        return chatHtml.slice(m.index, i);
+    }
+
+    function makeDoc(entityIds, initiallyChecked) {
+        // Hidden source-of-truth checkboxes.
+        const underlyings = entityIds.map(eid => ({
+            type: 'checkbox',
+            checked: initiallyChecked.has(eid),
+            dataset: { entity: String(eid) },
+            __role: 'underlying',
+        }));
+        // Dialog row checkboxes — created at openSendtoPicker time. Start
+        // empty so a "picker not open" state still works.
+        const dialogRows = [];
+        // Visible elements: button label span + button + overlay + select-all + dialog list.
+        const labelEl = { textContent: '' };
+        const buttonEl = {
+            __attrs: { 'aria-expanded': 'false' },
+            setAttribute(k, v) { this.__attrs[k] = v; },
+            getAttribute(k) { return this.__attrs[k]; },
+        };
+        const overlayEl = {
+            hidden: true,
+            dataset: {},
+        };
+        const dialogEl = {
+            setAttribute() {},
+            focus() {},
+        };
+        const selectAllEl = {
+            type: 'checkbox',
+            checked: false,
+            indeterminate: false,
+        };
+        const listEl = {
+            innerHTML: '',
+            __children: [],
+            appendChild(node) {
+                this.__children.push(node);
+                if (node && node.__type === 'pickerRow' && node.__input) {
+                    dialogRows.push(node.__input);
+                }
+            },
+        };
+
+        const elementById = {
+            sendtoPickerBtn: buttonEl,
+            sendtoPickerBtnLabel: labelEl,
+            sendtoPickerOverlay: overlayEl,
+            sendtoPickerDialog: dialogEl,
+            sendtoPickerSelectAll: selectAllEl,
+            sendtoPickerList: listEl,
+        };
+
+        const document = {
+            getElementById(id) { return elementById[id] || null; },
+            querySelector(sel) {
+                // Underlying by data-entity="N".
+                const m = sel.match(/\.target-entity-check input\[type="checkbox"\]\[data-entity="(\d+)"\]/);
+                if (m) return underlyings.find(u => u.dataset.entity === m[1]) || null;
+                return null;
+            },
+            querySelectorAll(sel) {
+                if (sel === '.target-entity-check input[type="checkbox"]') return underlyings;
+                if (sel === '#sendtoPickerList input[data-picker-entity]') return dialogRows;
+                return [];
+            },
+            createElement(tag) {
+                const el = {
+                    tagName: tag.toUpperCase(),
+                    className: '',
+                    dataset: {},
+                    innerHTML: '',
+                };
+                return el;
+            },
+            addEventListener() {},
+            removeEventListener() {},
+        };
+
+        return { document, underlyings, dialogRows, labelEl, buttonEl, overlayEl, selectAllEl, listEl };
+    }
+
+    function makeSandbox(entityIds, initiallyChecked, opts = {}) {
+        const ctx = makeDoc(entityIds, initiallyChecked);
+        const sandbox = {
+            document: ctx.document,
+            i18n: {
+                t(k, params) {
+                    const tpls = {
+                        chat_sendto_button_label_all: '傳送給 ALL',
+                        chat_sendto_button_label_single: '傳送給 {target}',
+                        chat_sendto_button_label_multi: '傳送給 {count} entities',
+                        chat_loading_entities: 'Loading…',
+                    };
+                    let s = tpls[k] || k;
+                    if (params) {
+                        Object.keys(params).forEach(p => {
+                            s = s.replace(new RegExp('\\{' + p + '\\}', 'g'), params[p]);
+                        });
+                    }
+                    return s;
+                },
+            },
+            boundEntities: entityIds.map(eid => ({
+                entityId: eid,
+                publicCode: 'pc' + eid,
+            })),
+            persistTargetSelection: () => { sandbox._persisted = (sandbox._persisted || 0) + 1; },
+            clearReceiverHintForEntity: () => { sandbox._hintClears = (sandbox._hintClears || 0) + 1; },
+            updateTargetAll: function () { /* picker-confirm calls this; no-op for the test */ },
+            requestAnimationFrame: (fn) => fn(),
+            getAvatarForEntity: () => '\u{1F99E}',
+            getEntityDisplayName: (id) => 'Entity#' + id,
+            renderAvatarHtml: () => '<i></i>',
+            escapeHtml: (s) => String(s).replace(/[&<>"']/g, c => ({
+                '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+            })[c]),
+        };
+
+        const body =
+            extractFunction('getSendtoUnderlyingChecks') + '\n' +
+            extractFunction('refreshSendtoPickerButtonLabel') + '\n' +
+            extractFunction('openSendtoPicker') + '\n' +
+            extractFunction('cancelSendtoPicker') + '\n' +
+            extractFunction('closeSendtoPickerOverlay') + '\n' +
+            extractFunction('confirmSendtoPicker') + '\n' +
+            extractFunction('toggleSendtoPickerSelectAll') + '\n' +
+            extractFunction('onSendtoPickerRowChange') + '\n' +
+            extractFunction('syncSendtoPickerSelectAllState') + '\n' +
+            extractFunction('sendtoPickerKeydown') + '\n';
+
+        const fn = new Function(
+            'document', 'i18n', 'boundEntities',
+            'persistTargetSelection', 'updateTargetAll', 'clearReceiverHintForEntity',
+            'requestAnimationFrame',
+            'getAvatarForEntity', 'getEntityDisplayName', 'renderAvatarHtml', 'escapeHtml',
+            `${body}\nreturn {
+                getSendtoUnderlyingChecks,
+                refreshSendtoPickerButtonLabel,
+                openSendtoPicker,
+                cancelSendtoPicker,
+                closeSendtoPickerOverlay,
+                confirmSendtoPicker,
+                toggleSendtoPickerSelectAll,
+                syncSendtoPickerSelectAllState,
+            };`
+        );
+        const api = fn(
+            sandbox.document, sandbox.i18n, sandbox.boundEntities,
+            sandbox.persistTargetSelection, sandbox.updateTargetAll, sandbox.clearReceiverHintForEntity,
+            sandbox.requestAnimationFrame,
+            sandbox.getAvatarForEntity, sandbox.getEntityDisplayName, sandbox.renderAvatarHtml, sandbox.escapeHtml,
+        );
+        return { sandbox, api, ctx };
+    }
+
+    // Helper: simulate openSendtoPicker by populating dialog rows manually
+    // (the live openSendtoPicker uses .innerHTML which our shim doesn't parse,
+    // so we instead push checkbox stubs into ctx.dialogRows).
+    function simulateOpen(ctx, initiallyCheckedSet) {
+        // Mirror what openSendtoPicker would produce: one row checkbox per
+        // boundEntity, pre-checked from the underlying state.
+        ctx.dialogRows.length = 0;
+        ctx.underlyings.forEach(u => {
+            ctx.dialogRows.push({
+                type: 'checkbox',
+                checked: !!initiallyCheckedSet.has(Number(u.dataset.entity)),
+                dataset: { pickerEntity: u.dataset.entity },
+            });
+        });
+        // Also stash snapshot like the real fn would.
+        const snapshot = {};
+        ctx.underlyings.forEach(u => { snapshot[u.dataset.entity] = !!u.checked; });
+        ctx.overlayEl.dataset.snapshot = JSON.stringify(snapshot);
+        ctx.overlayEl.hidden = false;
+        ctx.buttonEl.setAttribute('aria-expanded', 'true');
+    }
+
+    test('Test 1 — button starts with "傳送給 ALL" when every entity is checked', () => {
+        const { api, ctx } = makeSandbox([1, 2, 3], new Set([1, 2, 3]));
+        api.refreshSendtoPickerButtonLabel();
+        expect(ctx.labelEl.textContent).toBe('傳送給 ALL');
+        expect(ctx.buttonEl.getAttribute('data-sendto-state')).toBe('all');
+    });
+
+    test('Test 2 — openSendtoPicker shows the overlay (hidden=false) and flips aria-expanded', () => {
+        const { api, ctx } = makeSandbox([1, 2, 3], new Set([1, 2, 3]));
+        // openSendtoPicker uses innerHTML which the shim doesn't render, but
+        // it still toggles overlay.hidden + button aria-expanded which is the
+        // load-bearing visibility contract for role="dialog".
+        api.openSendtoPicker();
+        expect(ctx.overlayEl.hidden).toBe(false);
+        expect(ctx.buttonEl.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    test('Test 3 — confirm with 2 of 3 entities → label becomes multi ("傳送給 2 entities")', () => {
+        const { api, ctx } = makeSandbox([1, 2, 3], new Set([1, 2, 3]));
+        simulateOpen(ctx, new Set([1, 2, 3]));
+        // User unchecks #3 inside the dialog.
+        ctx.dialogRows.find(r => r.dataset.pickerEntity === '3').checked = false;
+        api.confirmSendtoPicker();
+        // Underlying state flushed to the source-of-truth checkboxes.
+        expect(ctx.underlyings.find(u => u.dataset.entity === '1').checked).toBe(true);
+        expect(ctx.underlyings.find(u => u.dataset.entity === '2').checked).toBe(true);
+        expect(ctx.underlyings.find(u => u.dataset.entity === '3').checked).toBe(false);
+        // Visible label reflects the multi-recipient summary.
+        expect(ctx.labelEl.textContent).toBe('傳送給 2 entities');
+        expect(ctx.buttonEl.getAttribute('data-sendto-state')).toBe('multi');
+        // Overlay closes on Confirm.
+        expect(ctx.overlayEl.hidden).toBe(true);
+        expect(ctx.buttonEl.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    test('Test 4 — uncheck all but one → label becomes single ("傳送給 #1")', () => {
+        const { api, ctx } = makeSandbox([1, 2, 3], new Set([1, 2, 3]));
+        simulateOpen(ctx, new Set([1, 2, 3]));
+        ctx.dialogRows.find(r => r.dataset.pickerEntity === '2').checked = false;
+        ctx.dialogRows.find(r => r.dataset.pickerEntity === '3').checked = false;
+        api.confirmSendtoPicker();
+        expect(ctx.underlyings.find(u => u.dataset.entity === '1').checked).toBe(true);
+        expect(ctx.underlyings.find(u => u.dataset.entity === '2').checked).toBe(false);
+        expect(ctx.underlyings.find(u => u.dataset.entity === '3').checked).toBe(false);
+        expect(ctx.labelEl.textContent).toBe('傳送給 #1');
+        expect(ctx.buttonEl.getAttribute('data-sendto-state')).toBe('single');
+    });
+
+    test('Test 5 — cancel does NOT modify underlying state', () => {
+        const { api, ctx } = makeSandbox([1, 2, 3], new Set([1, 2, 3]));
+        simulateOpen(ctx, new Set([1, 2, 3]));
+        // User toggles every dialog row off, but then hits Cancel.
+        ctx.dialogRows.forEach(r => { r.checked = false; });
+        api.cancelSendtoPicker();
+        // Underlying still all true.
+        expect(ctx.underlyings.every(u => u.checked === true)).toBe(true);
+        expect(ctx.overlayEl.hidden).toBe(true);
+        expect(ctx.buttonEl.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    test('Test 6 — click-outside closes overlay without saving (same as Cancel)', () => {
+        // The HTML inline handler is `if(event.target===this)cancelSendtoPicker()`,
+        // so a backdrop click routes through cancelSendtoPicker. We assert
+        // that behavior by invoking cancelSendtoPicker directly after a
+        // dialog-row mutation and confirming no state change leaks out.
+        const { api, ctx } = makeSandbox([1, 2, 3], new Set([1, 2, 3]));
+        simulateOpen(ctx, new Set([1, 2, 3]));
+        ctx.dialogRows.find(r => r.dataset.pickerEntity === '1').checked = false;
+        // Simulate the backdrop click → cancelSendtoPicker.
+        api.cancelSendtoPicker();
+        expect(ctx.underlyings.find(u => u.dataset.entity === '1').checked).toBe(true);
+        expect(ctx.overlayEl.hidden).toBe(true);
+    });
+
+    test('select-all toggle flips every dialog row + reflects in state sync', () => {
+        const { api, ctx } = makeSandbox([1, 2, 3], new Set([1]));
+        simulateOpen(ctx, new Set([1]));
+        // Programmatically check the select-all box + call its handler.
+        ctx.selectAllEl.checked = true;
+        api.toggleSendtoPickerSelectAll(ctx.selectAllEl);
+        expect(ctx.dialogRows.every(r => r.checked)).toBe(true);
+        // Sync helper detects "all checked" → indeterminate cleared.
+        api.syncSendtoPickerSelectAllState();
+        expect(ctx.selectAllEl.checked).toBe(true);
+        expect(ctx.selectAllEl.indeterminate).toBe(false);
+
+        // Partial uncheck → indeterminate true.
+        ctx.dialogRows[1].checked = false;
+        api.syncSendtoPickerSelectAllState();
+        expect(ctx.selectAllEl.indeterminate).toBe(true);
+        expect(ctx.selectAllEl.checked).toBe(false);
+    });
+
+    test('zero entities checked → label shows "傳送給 0 entities" (sendable-state-honest)', () => {
+        const { api, ctx } = makeSandbox([1, 2], new Set());
+        api.refreshSendtoPickerButtonLabel();
+        expect(ctx.labelEl.textContent).toBe('傳送給 0 entities');
+        expect(ctx.buttonEl.getAttribute('data-sendto-state')).toBe('none');
+    });
+});


### PR DESCRIPTION
## Summary
Replaces the inline `傳送給:` checkbox row at the bottom of the chat page with a single button styled like the existing 智慧過濾 / smart-filter chip (`.sys-chip` / `.filter-chip`). Clicking the button opens a scrollable multi-select sheet — bottom-sheet on `@media (pointer:coarse)`, centered dropdown on desktop — with Select-all, per-row checkboxes (avatar + name + #id + publicCode), Confirm, Cancel, click-outside-to-cancel, Escape-to-cancel.

Card: `card_91d5c93ba31bda385881ad59`.

## Design
The underlying `.target-entity-check input[type="checkbox"]` elements remain the **source of truth** — they're now hidden inside `#targetBarRow` (`hidden aria-hidden="true"`) but every downstream consumer keeps reading from them with zero edits:

- `sendMessage()` / `getSelectedTargets()`
- `persistTargetSelection()`
- `applyAutoToggleReceivers()` — `card_3462117951fa588df9ff8a95` exclusive auto-select for quote-reply still wipes + re-checks the underlying boxes; the new picker button label refreshes through `updateTargetAll()`
- `renderTargetBar()`'s in-DOM-snapshot logic preserving in-progress toggles between renders

So no `/api/transform` payload change, no `sendMessage` path change, no route resolution semantics change — only the picker UI.

**Button label states** (i18n params via `{target}` / `{count}`):
- `all`     → `傳送給 ALL` / `Send to ALL`
- `single`  → `傳送給 #1` / `Send to #1`
- `multi`   → `傳送給 3 entities` / `Send to 3 entities`
- `zero`    → `傳送給 0 entities` / `Send to 0 entities` (honest unsendable state)

**Accessibility:**
- Button: `aria-haspopup="listbox"`, `aria-expanded` toggled, `aria-controls="sendtoPickerDialog"`
- Overlay: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`
- List: `role="listbox"`, `aria-multiselectable="true"`
- Each row is a `<label>` wrapping its checkbox so click-anywhere toggles
- `Escape` cancels; click on backdrop cancels (`event.target === overlay`)

## i18n
Added to `backend/public/shared/i18n.js` via the AST tool `backend/scripts/i18n-insert-locale-keys.js` (no brace-walker regex; PR #3253 lesson).

7 keys × **en + zh** only this PR:
- `chat_sendto_button_label_all`
- `chat_sendto_button_label_single` (param `{target}`)
- `chat_sendto_button_label_multi` (param `{count}`)
- `chat_sendto_picker_title`
- `chat_sendto_picker_select_all`
- `chat_sendto_picker_confirm`
- `chat_sendto_picker_cancel`

**Follow-up (other 13 locales):** `zh-TW` / `ja` / `ko` / `th` / `vi` / `id` / `fr` / `es` / `de` / `pt` / `ms` / `hi` / `ar` to be filled in by #3 Mac_E / #4 Eclaw_Office per the standard i18n fanout. Missing-key fallback chain (configured locale → `zh` → `en`) renders cleanly until then.

## Tests
`backend/tests/jest/chat-sendto-picker.test.js` — **31 cases**, mirrors the `chat-quote-smart-receiver.test.js` pattern (static surface contracts + sandboxed function-body execution against a hand-rolled DOM stub; `testEnvironment:'node'` so no JSDOM dep).

Local results:

| suite | pass | total |
|---|---|---|
| `--testPathPattern chat-sendto-picker` | 31 | 31 |
| `--testPathPattern chat` | 320 | 320 |
| `--testPathPattern "i18n\|portal"` | 144 | 144 |
| full Jest run | 5054 | 5054 (1 unrelated flake on first run, clean on retry) |

The 6 hard-spec cases all pass:
1. Button starts with `傳送給 ALL` when every entity checked
2. Click button → overlay visible (role="dialog")
3. Uncheck one of three, confirm → `傳送給 2 entities`
4. Uncheck all but one → `傳送給 #1`
5. Cancel does not modify underlying state
6. Click-outside closes overlay without saving

Plus: select-all + indeterminate state sync, zero-recipients honest label, ARIA contract locked, click-outside handler locked, hidden source-of-truth locked, `updateTargetAll` ↔ picker label wiring locked, `confirmSendtoPicker` → `persistTargetSelection` + `updateTargetAll` wiring locked, bottom-sheet `@media (pointer:coarse)` locked, both i18n locales × 7 keys locked.

## Test plan
- [ ] Jest green (CI)
- [ ] ESLint green (CI — `public/**` is in eslint ignore; my new test is in `tests/**` also ignored)
- [ ] i18n key parity CI green
- [ ] Critical portal pages smoke green
- [ ] Required PR CI gate green
- [ ] After deploy: prod URL screenshot, desktop 1280×800 — picker button styled like sys-chip, click opens centered dropdown
- [ ] After deploy: prod URL screenshot, mobile 390×844 — bottom-sheet anchored bottom, scroll inside, dismiss on backdrop tap
- [ ] After deploy: live quote-reply on chat (`card_3462`...): exclusive auto-select still routes only to quoted sender, picker label flips to `傳送給 #N`
- [ ] After deploy: select-all → all 5+ entities checked, confirm, send a test message — only this UI changed, routing identical to pre-PR

## Globe-user
Works for any entity count from 1 to ~100 (rows scroll inside 60vh/70vh). All labels are string templates with i18n parameters so every locale gets a correct interpolation; non-translated locales fall through to `zh` → `en` (existing i18n.js chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUDRpzSFMMKwMoVtnxK1dd