### PR TITLE
chore(release): Android v1.0.96 (versionCode 104)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 103
-        versionName = "1.0.95"
+        versionCode = 104
+        versionName = "1.0.96"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Summary
- Bump Android `versionCode` 103→104 and `versionName` 1.0.95→1.0.96
- Captures all Android-affecting merges since v1.0.95

## Android changes since v1.0.95
- #3617 wallpaper conversation + kanban motion
- #3620 polish wallpaper kanban visuals
- #3627 wallpaper v2 assets (Caveat font + whiteboard + layout settings)
- #3630 reconnect-overlay native (WebViewClient)
- #3635 wallpaper task orbit + board text fitting
- #3636 wallpaper whiteboard text layout
- #3638 wallpaper folder pile depth (Hank-flagged for this release)

## Test plan
- [x] Android Lint CI
- [x] Assemble release CI
- [ ] Bundle release AAB → Play internal + production tracks (post-merge)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UUDRpzSFMMKwMoVtnxK1dd