### PR TITLE
fix(chat): sendto button uses petdxAvatarUrl (real Pet/Dex sprite) over emoji fallback (card_f04e9fe5)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2088,6 +2088,21 @@
             display: inline-block;
             vertical-align: middle;
         }
+        /* Direct Pet/Dex companion sprite path (card_f04e9fe5). When
+           /api/entities ships a petdxAvatarUrl we bypass the emoji ladder
+           inside getAvatarForEntity (which would otherwise let an explicit
+           non-default avatar emoji like 🐻 win over the real sprite) and
+           render the image directly. Sizing matches the generic <img> rule
+           above; object-fit:cover guarantees the spritesheet first frame
+           fills the circle even when the sheet is wider than tall. */
+        .sendto-btn-avatar > .sendto-petdx-avatar {
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            object-fit: cover;
+            display: inline-block;
+            vertical-align: middle;
+        }
         .sendto-btn-name {
             overflow: hidden;
             text-overflow: ellipsis;
@@ -7321,15 +7336,48 @@
             return Array.from(document.querySelectorAll('.target-entity-check input[type="checkbox"]'));
         }
 
-        // Render a tiny avatar element for the picker-button summary. The
-        // existing renderAvatarHtml is reused so emoji / image URL / petdx
-        // sprite all keep their already-tested rendering paths. Falls back
-        // to the 🦞 emoji when getAvatarForEntity returns nothing (matches
-        // the global default at chat.html:3867 + entity-utils.js).
+        // Render a tiny avatar element for the picker-button summary.
+        //
+        // Priority chain (card_f04e9fe5 — Hank「#1 2 3 還是沒有同步夥伴外觀」):
+        //   1. boundEntities[*].petdxAvatarUrl → direct <img class="sendto-petdx-avatar">.
+        //      This shortcut exists because /api/entities returns the OWNER's
+        //      selected Pet/Dex companion sprite URL for every bound entity,
+        //      but `_entityAvatarMap` will let a NON-default explicit emoji
+        //      (e.g. 🐻/🐱/🐶) win over the petdx URL inside getAvatarForEntity
+        //      (entity-utils.js §0.4 — only 🦞/🐷 are treated as "default"
+        //      and dropped; any other explicit emoji shadows the petdx URL).
+        //      The sendto button summary needs to surface the REAL companion
+        //      sprite so users can recognize who they're targeting at a glance.
+        //   2. Fall back to getAvatarForEntity + renderAvatarHtml — preserves
+        //      every already-tested path (live descriptor canvas, vault URL,
+        //      character emoji, legacy default 🦞).
         function _sendtoBtnAvatarHtml(entityId) {
             const name = (typeof getEntityDisplayName === 'function')
                 ? getEntityDisplayName(entityId)
                 : ('Entity #' + entityId);
+            const safeName = (typeof escapeHtml === 'function') ? escapeHtml(name) : name;
+
+            // Step 1: petdxAvatarUrl from boundEntities — wins over explicit
+            // emoji avatars so the sendto button shows the real companion.
+            let petdxUrl = null;
+            if (typeof boundEntities !== 'undefined' && Array.isArray(boundEntities)) {
+                const eidNum = Number(entityId);
+                const match = boundEntities.find(e => Number(e && e.entityId) === eidNum);
+                if (match && typeof match.petdxAvatarUrl === 'string' && match.petdxAvatarUrl) {
+                    petdxUrl = match.petdxAvatarUrl;
+                }
+            }
+            if (petdxUrl) {
+                const safeUrl = (typeof escapeHtml === 'function') ? escapeHtml(petdxUrl) : petdxUrl;
+                // 20px circular img — inherits .sendto-btn-avatar wrapper sizing
+                // for stacked layout (-8px overlap is owned by the wrapper).
+                const img = '<img class="sendto-petdx-avatar" src="' + safeUrl
+                    + '" alt="' + safeName + '" loading="lazy">';
+                return '<span class="sendto-btn-avatar" role="img" aria-label="' + safeName
+                    + '" title="' + safeName + '">' + img + '</span>';
+            }
+
+            // Step 2: existing fallback chain (emoji / live descriptor / vault URL).
             const raw = (typeof getAvatarForEntity === 'function')
                 ? getAvatarForEntity(entityId)
                 : '';
@@ -7342,7 +7390,6 @@
             // span carries title for hover-readability AT; renderAvatarHtml
             // also emits alt="avatar" inside <img>, which we replace by
             // injecting the entity name via aria-label on the wrapper.
-            const safeName = (typeof escapeHtml === 'function') ? escapeHtml(name) : name;
             return '<span class="sendto-btn-avatar" role="img" aria-label="' + safeName
                 + '" title="' + safeName + '">' + inner + '</span>';
         }

--- a/backend/tests/jest/chat-sendto-picker.test.js
+++ b/backend/tests/jest/chat-sendto-picker.test.js
@@ -719,3 +719,289 @@ describe('chat-sendto-button-avatar — label HTML varies by selection count', (
         expect(chatHtml).not.toMatch(/class="current-target[^"]*"/);
     });
 });
+
+// =====================================================================
+// petdx avatar priority on the sendto picker button (card_f04e9fe5).
+//
+// /api/entities returns a `petdxAvatarUrl` for every bound entity — the
+// owner's currently selected Pet/Dex companion sprite. Before this fix
+// the button rendered the static `entity.avatar` emoji (🐻/🐱/🐶) because
+// _entityAvatarMap's §0.4 invariant only filters 🦞/🐷 as "default" —
+// any other explicit avatar emoji shadows the petdx URL inside
+// getAvatarForEntity. The fix short-circuits that path inside
+// _sendtoBtnAvatarHtml so the real companion sprite wins on the button.
+// =====================================================================
+describe('chat-sendto-button-avatar — petdx avatar priority (card_f04e9fe5)', () => {
+    function extractFunction(name) {
+        const re = new RegExp(`function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`, 'g');
+        const m = re.exec(chatHtml);
+        if (!m) throw new Error(`function ${name} not found`);
+        let depth = 1;
+        let i = m.index + m[0].length;
+        while (i < chatHtml.length && depth > 0) {
+            const ch = chatHtml[i];
+            if (ch === '{') depth++;
+            else if (ch === '}') depth--;
+            i++;
+        }
+        return chatHtml.slice(m.index, i);
+    }
+
+    function makeLabelEl() {
+        return {
+            _text: '',
+            _html: '',
+            set textContent(v) { this._text = String(v); this._html = ''; },
+            get textContent() { return this._text || this._html; },
+            set innerHTML(v) { this._html = String(v); this._text = ''; },
+            get innerHTML() { return this._html; },
+        };
+    }
+
+    function makeButtonEl() {
+        return {
+            __attrs: { 'aria-expanded': 'false' },
+            setAttribute(k, v) { this.__attrs[k] = v; },
+            getAttribute(k) { return this.__attrs[k]; },
+        };
+    }
+
+    // entities: array of { entityId, petdxAvatarUrl?, avatar? }
+    // checkedIds: Set<number> of the entity IDs whose underlying checkbox is on.
+    function makeShim(entities, checkedIds, opts = {}) {
+        const underlyings = entities.map(e => ({
+            type: 'checkbox',
+            checked: checkedIds.has(e.entityId),
+            dataset: { entity: String(e.entityId) },
+        }));
+        const labelEl = makeLabelEl();
+        const buttonEl = makeButtonEl();
+        const document = {
+            getElementById(id) {
+                if (id === 'sendtoPickerBtn') return buttonEl;
+                if (id === 'sendtoPickerBtnLabel') return labelEl;
+                return null;
+            },
+            querySelectorAll(sel) {
+                if (sel === '.target-entity-check input[type="checkbox"]') return underlyings;
+                return [];
+            },
+        };
+        const nameByEid = opts.names || {};
+        // Simulate the production behavior: getAvatarForEntity returns the
+        // explicit entity.avatar (emoji) when present — exactly the bug
+        // condition the petdx priority is meant to bypass.
+        const avatarByEid = {};
+        entities.forEach(e => { if (e.avatar) avatarByEid[e.entityId] = e.avatar; });
+        const sandbox = {
+            document,
+            // boundEntities is the load-bearing input for the new priority chain.
+            boundEntities: entities,
+            i18n: {
+                t(k, params) {
+                    const tpls = {
+                        chat_sendto_button_label_all: '傳送給 ALL',
+                        chat_sendto_button_label_single: '傳送給 {target}',
+                        chat_sendto_button_label_multi: '傳送給 {count} entities',
+                        chat_sendto_button_label_many_more: '+{count} 位',
+                    };
+                    let s = tpls[k] || k;
+                    if (params) {
+                        Object.keys(params).forEach(p => {
+                            s = s.replace(new RegExp('\\{' + p + '\\}', 'g'), params[p]);
+                        });
+                    }
+                    return s;
+                },
+            },
+            getAvatarForEntity: (id) => avatarByEid[id] || '\u{1F99E}',
+            getEntityDisplayName: (id) => nameByEid[id] || ('Entity#' + id),
+            // Stand-in renderAvatarHtml: emits an <img> with src=avatar when
+            // avatar looks like a URL, else a <span class="entity-avatar-emoji">.
+            // Used ONLY by the FALLBACK path (the petdx priority short-circuits
+            // before reaching it), so it lets us tell the two paths apart in
+            // assertions by checking for `class="sendto-petdx-avatar"`.
+            renderAvatarHtml: (a, size, eid) => {
+                if (typeof a === 'string' && /^https?:\/\//.test(a)) {
+                    return '<img class="entity-avatar-img" data-entity-id="' + eid
+                        + '" src="' + a + '" alt="avatar">';
+                }
+                return '<span class="entity-avatar-emoji" data-entity-id="' + eid + '">'
+                    + (a || '\u{1F99E}') + '</span>';
+            },
+            escapeHtml: (s) => String(s).replace(/[&<>"']/g, c => ({
+                '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+            })[c]),
+        };
+        const body =
+            extractFunction('getSendtoUnderlyingChecks') + '\n' +
+            extractFunction('_sendtoBtnAvatarHtml') + '\n' +
+            extractFunction('refreshSendtoPickerButtonLabel') + '\n';
+        const fn = new Function(
+            'document', 'i18n', 'boundEntities',
+            'getAvatarForEntity', 'getEntityDisplayName', 'renderAvatarHtml', 'escapeHtml',
+            `${body}\nreturn { refreshSendtoPickerButtonLabel, _sendtoBtnAvatarHtml };`
+        );
+        const api = fn(
+            sandbox.document, sandbox.i18n, sandbox.boundEntities,
+            sandbox.getAvatarForEntity, sandbox.getEntityDisplayName,
+            sandbox.renderAvatarHtml, sandbox.escapeHtml,
+        );
+        return { api, labelEl, buttonEl };
+    }
+
+    test('single → petdxAvatarUrl wins over explicit emoji avatar (real sprite renders)', () => {
+        // Entity #1 has BOTH a non-default emoji (🐻) and a petdx sprite URL.
+        // Before the fix the button rendered 🐻 (because _entityAvatarMap
+        // §0.4 only filters 🦞/🐷). After the fix the sprite URL wins.
+        const url = 'https://eclawbot.com/api/petdx/zoro/sprite.webp';
+        const entities = [
+            { entityId: 1, avatar: '\u{1F43B}', petdxAvatarUrl: url },
+            { entityId: 2, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/luffy/sprite.webp' },
+            { entityId: 3 },
+        ];
+        const { api, labelEl } = makeShim(entities, new Set([1]), {
+            names: { 1: 'Mac_F' },
+        });
+        api.refreshSendtoPickerButtonLabel();
+        const html = labelEl.innerHTML;
+        // The petdx <img> renders with the dedicated class and the exact URL.
+        expect(html).toMatch(/<img class="sendto-petdx-avatar"/);
+        expect(html).toContain(url);
+        // The 🐻 fallback emoji must NOT appear.
+        expect(html).not.toMatch(/\u{1F43B}/u);
+        // Name + wrapper still present (existing contract).
+        expect(html).toMatch(/sendto-btn-name/);
+        expect(html).toMatch(/Mac_F/);
+    });
+
+    test('single → entity with petdxAvatarUrl=null but avatar="🐱" → button shows 🐱', () => {
+        // Fallback path: missing petdx URL → use existing emoji renderer.
+        const entities = [
+            { entityId: 7, avatar: '\u{1F431}', petdxAvatarUrl: null },
+            { entityId: 8 },
+        ];
+        const { api, labelEl } = makeShim(entities, new Set([7]), {
+            names: { 7: 'Cat_Bot' },
+        });
+        api.refreshSendtoPickerButtonLabel();
+        const html = labelEl.innerHTML;
+        // Petdx class must NOT appear (no URL to render).
+        expect(html).not.toMatch(/sendto-petdx-avatar/);
+        // The 🐱 emoji renders via the legacy renderAvatarHtml emoji branch.
+        expect(html).toMatch(/\u{1F431}/u);
+        expect(html).toMatch(/sendto-btn-name/);
+    });
+
+    test('many (5 entities all with petdx) → 2 sprite <img>s + "+3 more" pill', () => {
+        const entities = [
+            { entityId: 1, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/a/sprite.webp' },
+            { entityId: 2, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/b/sprite.webp' },
+            { entityId: 3, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/c/sprite.webp' },
+            { entityId: 4, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/d/sprite.webp' },
+            { entityId: 5, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/e/sprite.webp' },
+        ];
+        const { api, labelEl, buttonEl } = makeShim(entities, new Set([1, 2, 3, 4, 5]));
+        api.refreshSendtoPickerButtonLabel();
+        const html = labelEl.innerHTML;
+        // 5 selected from 5 → ALL state — no avatars rendered (overflow guard).
+        // Bump the entity universe to force "many" not "all".
+        expect(buttonEl.getAttribute('data-sendto-state')).toBe('all');
+
+        // Now run again with an extra unchecked entity so checked.length < total.
+        const entities2 = entities.concat([{ entityId: 6 }, { entityId: 7 }]);
+        const second = makeShim(entities2, new Set([1, 2, 3, 4, 5]));
+        second.api.refreshSendtoPickerButtonLabel();
+        const html2 = second.labelEl.innerHTML;
+        // many state: only the first 2 selected avatars render + the overflow pill.
+        expect((html2.match(/<img class="sendto-petdx-avatar"/g) || []).length).toBe(2);
+        expect(html2).toMatch(/\+3/);
+        expect(html2).toMatch(/sendto-btn-more/);
+        expect(second.buttonEl.getAttribute('data-sendto-state')).toBe('many');
+    });
+
+    test('img alt attribute = entity displayName (a11y for screen readers)', () => {
+        const entities = [
+            { entityId: 9, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/zoro/sprite.webp' },
+            { entityId: 10 },
+        ];
+        const { api, labelEl } = makeShim(entities, new Set([9]), {
+            names: { 9: 'Mac_F' },
+        });
+        api.refreshSendtoPickerButtonLabel();
+        const html = labelEl.innerHTML;
+        // alt attribute carries the displayName, not generic "avatar".
+        expect(html).toMatch(/<img class="sendto-petdx-avatar"[^>]*alt="Mac_F"/);
+    });
+
+    test('petdxAvatarUrl is escaped (XSS prevention)', () => {
+        // A hostile URL must be escaped before interpolation. boundEntities is
+        // server-supplied today but the helper should still escapeHtml the URL
+        // so a future malicious source can't inject markup.
+        const evil = 'https://x.test/"><script>alert(1)</script>';
+        const entities = [
+            { entityId: 1, petdxAvatarUrl: evil },
+            { entityId: 2 },
+        ];
+        const { api, labelEl } = makeShim(entities, new Set([1]), {
+            names: { 1: 'A' },
+        });
+        api.refreshSendtoPickerButtonLabel();
+        const html = labelEl.innerHTML;
+        // Raw <script> must NOT appear; the quote must be HTML-escaped.
+        expect(html).not.toMatch(/<script>/);
+        expect(html).toMatch(/&quot;/);
+    });
+
+    test('ALL state unchanged — plain "傳送給 ALL" text, no petdx <img>', () => {
+        const entities = [
+            { entityId: 1, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/a/sprite.webp' },
+            { entityId: 2, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/b/sprite.webp' },
+        ];
+        const { api, labelEl, buttonEl } = makeShim(entities, new Set([1, 2]));
+        api.refreshSendtoPickerButtonLabel();
+        const html = labelEl.innerHTML + labelEl.textContent;
+        expect(html).toMatch(/ALL/);
+        expect(html).not.toMatch(/sendto-petdx-avatar/);
+        expect(buttonEl.getAttribute('data-sendto-state')).toBe('all');
+    });
+
+    test('entity without petdxAvatarUrl AND default avatar → falls back to renderAvatarHtml emoji', () => {
+        // Pure fallback: no petdx URL, no explicit emoji avatar → the legacy
+        // path runs and emits the default 🦞 emoji via renderAvatarHtml.
+        const entities = [
+            { entityId: 11 },
+            { entityId: 12 },
+        ];
+        const { api, labelEl } = makeShim(entities, new Set([11]), {
+            names: { 11: 'Default_Bot' },
+        });
+        api.refreshSendtoPickerButtonLabel();
+        const html = labelEl.innerHTML;
+        expect(html).not.toMatch(/sendto-petdx-avatar/);
+        // The default 🦞 lobster from getAvatarForEntity fallback.
+        expect(html).toMatch(/\u{1F99E}/u);
+    });
+});
+
+// =====================================================================
+// CSS contract — .sendto-petdx-avatar must size as a 20px circle so it
+// matches the existing .sendto-btn-avatar wrapper geometry and the
+// stacked overlap rule (-8px sibling margin) keeps working.
+// =====================================================================
+describe('chat-sendto-button-avatar — .sendto-petdx-avatar CSS (card_f04e9fe5)', () => {
+    test('CSS rule for .sendto-petdx-avatar exists with 20px circular sizing', () => {
+        // The rule lives under .sendto-btn-avatar > .sendto-petdx-avatar so
+        // it only applies inside the picker-button wrapper, never bleeding
+        // into other surfaces (chat bubble, etc.).
+        expect(chatHtml).toMatch(/\.sendto-btn-avatar\s*>\s*\.sendto-petdx-avatar/);
+        // Extract just that block so the size assertions stay scoped.
+        const m = chatHtml.match(/\.sendto-btn-avatar\s*>\s*\.sendto-petdx-avatar\s*\{[\s\S]*?\}/);
+        expect(m).not.toBeNull();
+        const block = m[0];
+        expect(block).toMatch(/width:\s*20px/);
+        expect(block).toMatch(/height:\s*20px/);
+        expect(block).toMatch(/border-radius:\s*50%/);
+        expect(block).toMatch(/object-fit:\s*cover/);
+    });
+});


### PR DESCRIPTION
## Summary

Hank reported: > 「#1 2 3 還是沒有同步夥伴外觀」

PR #3637 added avatars to the sendto picker button via `getAvatarForEntity`, which reads from `_entityAvatarMap`. Per `entity-utils.js` §0.4 the map only filters 🦞/🐷 as "default" — any other explicit avatar emoji (🐻/🐱/🐶) shadows the petdx sprite URL further down the priority chain. So entities whose owners had set a non-default emoji avatar kept rendering the emoji even though `/api/entities` ships their real Pet/Dex companion sprite.

**Fix**: short-circuit `petdxAvatarUrl` from `boundEntities` ahead of the existing fallback chain inside `_sendtoBtnAvatarHtml`. URL is `escapeHtml`'d before interpolation. Adds a `.sendto-petdx-avatar` `<img>` class with explicit 20px circular sizing + `object-fit:cover` so the spritesheet first frame fills the circle, sharing the existing `-8px` sibling overlap for stacked layout.

## Before / After (from /api/entities)

| entity   | petdxAvatarUrl                          | entity.avatar | Before | After             |
|----------|-----------------------------------------|---------------|--------|-------------------|
| #1 Mac_F | `…/api/petdx/zoro/sprite.webp`          | 🐻            | 🐻     | Zoro sprite img   |
| #2 LOBSTER | `…/api/petdx/*/sprite.webp`           | 🦞            | 🦞     | real sprite img   |
| #3 Mac_E | `…/api/petdx/*/sprite.webp`             | 🐱            | 🐱     | real sprite img   |
| entity w/o petdx | (null)                          | 🐶            | 🐶     | 🐶 (unchanged)    |

## Files touched

- `backend/public/portal/chat.html` — `_sendtoBtnAvatarHtml()` priority chain + `.sendto-petdx-avatar` CSS
- `backend/tests/jest/chat-sendto-picker.test.js` — 2 new describe blocks (petdx priority + CSS contract)

## Hard constraints honored

- No regression to PR #3637 / PR #3632 — existing 41 assertions still green
- No change to `boundEntities` data shape or `/api/entities` fetch
- No other surface touched (chat-message avatar, smart-filter button — separate follow-up)
- `escapeHtml` applied to URL (XSS prevention; covered by test)
- CRLF / line conventions matched (LF, 4-space indent)

## Test plan

- [x] `npx jest --testPathPatterns chat-sendto-picker --forceExit` — 50/50 pass
- [x] Existing assertions (ALL / single / few / many / aria-label / fallback emoji) still green
- [x] New petdx priority tests: petdx URL wins over explicit emoji avatar
- [x] New CSS contract test: `.sendto-petdx-avatar` selector + 20px circular sizing
- [ ] Post-deploy prod URL screenshot at https://eclawbot.com/portal/chat.html — verify Mac_F sprite renders on the sendto picker button (desktop + mobile)
- [ ] Verify ALL state still shows plain "傳送給 ALL" text
- [ ] Verify entity without `petdxAvatarUrl` still shows its emoji avatar

Card: card_f04e9fe5cb500714d4dc083f

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUDRpzSFMMKwMoVtnxK1dd