### PR TITLE
Revert PR #3645 — ALL-state avatars broke #1/#2/#3 (urgent rollback per Hank-direct)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -7412,13 +7412,7 @@
             // a11y contract. We do this even in ALL/none states so AT users
             // hear the same intent the visible text conveys.
             function ariaLabelFor(state, selectedIds) {
-                if (state === 'all') {
-                    // Card_3f7b9c1a — Hank「為何違反 self improvement」: ALL state now
-                    // renders avatars so the recipient identity is recognizable at
-                    // a glance, not just the word "ALL". The aria-label keeps the
-                    // entity count for AT users so they hear "傳送給 ALL (N entities)".
-                    return allText + ' (' + selectedIds.length + ' entities)';
-                }
+                if (state === 'all') return allText;
                 if (state === 'none') return t('chat_sendto_button_label_multi', { count: 0 }) || '傳送給 0 entities';
                 const names = selectedIds.map(id => {
                     return (typeof getEntityDisplayName === 'function') ? getEntityDisplayName(id) : ('#' + id);
@@ -7429,8 +7423,7 @@
                 return PREFIX_ZH + names.join(', ');
             }
 
-            // No bound entities yet (boot before /api/entities resolves) → keep
-            // "ALL" affordance — pure text, no avatars to render yet.
+            // No bound entities yet (boot before /api/entities resolves) → keep "ALL" affordance.
             if (checks.length === 0) {
                 label.textContent = allText;
                 btn.setAttribute('data-sendto-state', 'all');
@@ -7444,21 +7437,8 @@
                 .filter(n => Number.isFinite(n));
 
             if (checked.length === total) {
-                // ALL state (card_3f7b9c1a — Hank「為何違反 self improvement」):
-                // Pet/Dex sprites stacked + "+N" overflow + "傳送給 ALL" suffix
-                // so the user sees WHO is targeted, not just the word "ALL".
-                // Cap at 4 visible avatars to prevent overflow on wide fleets.
-                const ALL_VISIBLE_CAP = 4;
-                const visibleIds = checkedIds.slice(0, ALL_VISIBLE_CAP);
-                const overflow = checkedIds.length - visibleIds.length;
-                const stack = visibleIds.map(_sendtoBtnAvatarHtml).join('');
-                const overflowChip = overflow > 0
-                    ? '<span class="sendto-btn-more">' + safe('+' + overflow) + '</span>'
-                    : '';
-                label.innerHTML =
-                    '<span class="sendto-btn-avatar-stack sendto-btn-avatar-stack--many">' + stack + '</span>'
-                    + overflowChip
-                    + '<span class="sendto-btn-prefix">' + safe(' ' + allText) + '</span>';
+                // All state — text only, no avatars (14-bot overflow guard).
+                label.textContent = allText;
                 btn.setAttribute('data-sendto-state', 'all');
                 btn.setAttribute('aria-label', ariaLabelFor('all', checkedIds));
             } else if (checked.length === 0) {

--- a/backend/tests/jest/chat-sendto-picker.test.js
+++ b/backend/tests/jest/chat-sendto-picker.test.js
@@ -388,17 +388,10 @@ describe('chat-sendto-picker — behaviour against a hand-rolled DOM stub', () =
         ctx.buttonEl.setAttribute('aria-expanded', 'true');
     }
 
-    test('Test 1 — button starts with "傳送給 ALL" + sprites when every entity is checked', () => {
-        // card_3f7b9c1a — ALL state now renders Pet/Dex avatars (cap 4)
-        // alongside "傳送給 ALL" so the user sees WHO is targeted, not just
-        // the word "ALL". The previous "text-only" contract was an over-
-        // simplification flagged by Hank「為何違反 self improvement」.
+    test('Test 1 — button starts with "傳送給 ALL" when every entity is checked', () => {
         const { api, ctx } = makeSandbox([1, 2, 3], new Set([1, 2, 3]));
         api.refreshSendtoPickerButtonLabel();
-        const html = ctx.labelEl.innerHTML;
-        expect(html).toMatch(/傳送給 ALL/);
-        expect((html.match(/<img/g) || []).length).toBe(3);
-        expect(html).toMatch(/sendto-btn-avatar-stack--many/);
+        expect(ctx.labelEl.textContent).toBe('傳送給 ALL');
         expect(ctx.buttonEl.getAttribute('data-sendto-state')).toBe('all');
     });
 
@@ -617,41 +610,15 @@ describe('chat-sendto-button-avatar — label HTML varies by selection count', (
         return (haystack.match(re) || []).length;
     }
 
-    test('ALL state (<=4 entities) → stacked avatars + "傳送給 ALL" suffix, no overflow chip', () => {
-        // card_3f7b9c1a — Hank「為何違反 self improvement」: the ALL branch
-        // previously short-circuited to plain text with NO avatars. The fix
-        // renders Pet/Dex sprites (capped at 4 visible) so the recipient
-        // identity is recognizable at a glance.
-        const ids = [1, 2, 3];
+    test('ALL state → button HTML has "ALL" text, no avatar <img>', () => {
+        const ids = [1, 2, 3, 4, 5];
         const { api, labelEl, buttonEl } = makeShim(ids, new Set(ids));
         api.refreshSendtoPickerButtonLabel();
-        const html = labelEl.innerHTML;
+        const html = labelEl.innerHTML + labelEl.textContent;
         expect(html).toMatch(/ALL/);
-        // 3 selected → 3 avatar <img>s rendered (cap is 4).
-        expect(countMatches(html, /<img/g)).toBe(3);
-        expect(html).toMatch(/sendto-btn-avatar-stack--many/);
-        // No "+N" overflow because count <= cap.
-        expect(html).not.toMatch(/sendto-btn-more/);
+        expect(html).not.toMatch(/<img/);
+        expect(html).not.toMatch(/sendto-btn-avatar/);
         expect(buttonEl.getAttribute('data-sendto-state')).toBe('all');
-    });
-
-    test('ALL state (>4 entities) → 4 avatars + "+N" overflow chip + "傳送給 ALL"', () => {
-        // 6 bound entities all checked → 4 sprites + "+2" overflow.
-        const ids = [1, 2, 3, 4, 5, 6];
-        const { api, labelEl, buttonEl } = makeShim(ids, new Set(ids));
-        api.refreshSendtoPickerButtonLabel();
-        const html = labelEl.innerHTML;
-        expect(html).toMatch(/ALL/);
-        // Exactly 4 visible avatars (the cap), 2 hidden behind "+2" overflow.
-        expect(countMatches(html, /<img/g)).toBe(4);
-        expect(html).toMatch(/sendto-btn-avatar-stack--many/);
-        expect(html).toMatch(/sendto-btn-more/);
-        expect(html).toMatch(/\+2/);
-        expect(buttonEl.getAttribute('data-sendto-state')).toBe('all');
-        // aria-label includes the entity count for AT users.
-        const ariaLabel = buttonEl.getAttribute('aria-label');
-        expect(ariaLabel).toMatch(/ALL/);
-        expect(ariaLabel).toMatch(/6 entities/);
     });
 
     test('single (1 entity) → button HTML contains exactly 1 avatar + entity name', () => {
@@ -934,17 +901,14 @@ describe('chat-sendto-button-avatar — petdx avatar priority (card_f04e9fe5)', 
             { entityId: 4, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/d/sprite.webp' },
             { entityId: 5, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/e/sprite.webp' },
         ];
-        // 5 selected from 5 → ALL state. After card_3f7b9c1a the ALL branch
-        // renders sprites too (cap 4) + "+1" overflow chip, instead of plain text.
         const { api, labelEl, buttonEl } = makeShim(entities, new Set([1, 2, 3, 4, 5]));
         api.refreshSendtoPickerButtonLabel();
-        const htmlAll = labelEl.innerHTML;
+        const html = labelEl.innerHTML;
+        // 5 selected from 5 → ALL state — no avatars rendered (overflow guard).
+        // Bump the entity universe to force "many" not "all".
         expect(buttonEl.getAttribute('data-sendto-state')).toBe('all');
-        expect((htmlAll.match(/<img class="sendto-petdx-avatar"/g) || []).length).toBe(4);
-        expect(htmlAll).toMatch(/\+1/);
-        expect(htmlAll).toMatch(/sendto-btn-more/);
 
-        // Now run again with an extra unchecked entity so checked.length < total → many state.
+        // Now run again with an extra unchecked entity so checked.length < total.
         const entities2 = entities.concat([{ entityId: 6 }, { entityId: 7 }]);
         const second = makeShim(entities2, new Set([1, 2, 3, 4, 5]));
         second.api.refreshSendtoPickerButtonLabel();
@@ -989,23 +953,16 @@ describe('chat-sendto-button-avatar — petdx avatar priority (card_f04e9fe5)', 
         expect(html).toMatch(/&quot;/);
     });
 
-    test('ALL state — petdx sprites render alongside "傳送給 ALL" text (card_3f7b9c1a)', () => {
-        // card_3f7b9c1a — Hank「為何違反 self improvement」: previously ALL state
-        // suppressed avatars; now Pet/Dex sprites show too (cap 4 visible).
+    test('ALL state unchanged — plain "傳送給 ALL" text, no petdx <img>', () => {
         const entities = [
             { entityId: 1, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/a/sprite.webp' },
             { entityId: 2, petdxAvatarUrl: 'https://eclawbot.com/api/petdx/b/sprite.webp' },
         ];
         const { api, labelEl, buttonEl } = makeShim(entities, new Set([1, 2]));
         api.refreshSendtoPickerButtonLabel();
-        const html = labelEl.innerHTML;
+        const html = labelEl.innerHTML + labelEl.textContent;
         expect(html).toMatch(/ALL/);
-        // Petdx sprites render (both URLs).
-        expect((html.match(/<img class="sendto-petdx-avatar"/g) || []).length).toBe(2);
-        expect(html).toContain('https://eclawbot.com/api/petdx/a/sprite.webp');
-        expect(html).toContain('https://eclawbot.com/api/petdx/b/sprite.webp');
-        // No overflow chip because 2 <= cap (4).
-        expect(html).not.toMatch(/sendto-btn-more/);
+        expect(html).not.toMatch(/sendto-petdx-avatar/);
         expect(buttonEl.getAttribute('data-sendto-state')).toBe('all');
     });
 


### PR DESCRIPTION
## Summary
Reverts merge commit 3f2e8567 (PR #3645).

Hank reported 「你完全把 #1、2、3修壞了」 with screenshot. I shipped #3645 without vision-checking on Hank's owner device (BROADCAST_TEST device showed it OK, but owner device with 6 entities + real petdxAvatarUrl rendered broken).

## Why immediate revert (not patch)
- Owner-account regression visible to Hank now
- Don't iterate on top of breakage
- Restore plain "傳送給 ALL" text label (PR #3637's stable behavior)

## Follow-up
- Vision-check rule strengthened: admin/owner account MUST be in test matrix (memory feedback_ux_merge_needs_vision_check updated 2026-06-21 23:19)
- Re-attempt the ALL-state avatar enhancement on a separate branch ONLY after I can vision-check the owner-device session (currently blocked by Playwright iOS-WebView re-login overriding injected JWT cookie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUDRpzSFMMKwMoVtnxK1dd