### PR TITLE
fix(android): wallpaper black after app-switch — don't destroy engine-lifetime scope/renderer on surface destroy (card_f9b2cc2d)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/engine/EngineLifecycleController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/EngineLifecycleController.kt
@@ -1,0 +1,123 @@
+package com.hank.clawlive.engine
+
+/**
+ * Pure-JVM lifecycle decision logic for [com.hank.clawlive.service.ClawWallpaperService.ClawEngine].
+ *
+ * Bug card_f9b2cc2d: the live wallpaper went ENTIRELY BLACK after a brief
+ * app-switch and only recovered on a full process restart. Root cause: the
+ * Engine treated `onSurfaceDestroyed` as engine teardown — it cancelled the
+ * engine-lifetime `engineScope` (a SupervisorJob), released the renderer and
+ * the companion repository. A surface destroy→recreate cycle is *exactly* what
+ * an app-switch causes, so after one cycle the scope was permanently cancelled:
+ * every `engineScope.launch{}` became a no-op and `draw()` used a released
+ * renderer → black. Only killing the process reconstructed the Engine.
+ *
+ * The correct Android WallpaperService.Engine contract:
+ *   - onSurfaceDestroyed  → PAUSE rendering only (stop the draw loop). The
+ *     surface can come back; engine-lifetime objects must survive.
+ *   - onSurfaceCreated/Changed → resume: restart any poller that is inactive
+ *     and redraw, exactly like onVisibilityChanged(true) already does.
+ *   - onDestroy (Engine)  → the *only* place engine-lifetime resources
+ *     (engineScope, renderer, companionRepository, companion jobs) are torn
+ *     down.
+ *
+ * This controller isolates those decisions so they are unit-testable on the
+ * JVM without an Android emulator. The Engine owns the actual coroutine scope,
+ * renderer and repository; it delegates the *decision* of whether the scope is
+ * still alive (and whether teardown has happened) to this class, and runs the
+ * real side-effects through the supplied [Hooks].
+ *
+ * `engineAlive` is the central invariant the bug fix protects: it must remain
+ * true across any number of surface destroy/create cycles and only flip false
+ * once [onEngineDestroy] runs.
+ */
+class EngineLifecycleController(private val hooks: Hooks) {
+
+    /**
+     * Side-effects the Engine wires into real coroutine / renderer operations.
+     * Kept as a tiny interface so tests can substitute a fake recorder.
+     */
+    interface Hooks {
+        /** Stop the periodic draw loop (handler.removeCallbacks). */
+        fun stopDrawLoop()
+        /** Restart any poller whose job is not currently active, then draw once. */
+        fun restartInactivePollersAndDraw()
+        /** Cancel ALL pollers (status/usage/kanban/companion) — quota gate. */
+        fun cancelAllPollers()
+        /** Real engine-lifetime teardown: cancel scope, release renderer + repo. */
+        fun releaseEngineResources()
+    }
+
+    /** True until [onEngineDestroy]. The bug was this flipping false on surface destroy. */
+    var engineAlive: Boolean = true
+        private set
+
+    /** Mirrors the Engine's `visible` flag; resume only redraws when visible. */
+    var visible: Boolean = false
+        private set
+
+    /** True between a surface being created and destroyed. */
+    var surfacePresent: Boolean = false
+        private set
+
+    /** Engine.onCreate → pollers are started by the Engine; nothing to tear down yet. */
+    fun onEngineCreate() {
+        engineAlive = true
+    }
+
+    /**
+     * Engine.onVisibilityChanged. Resume (restart inactive pollers + draw) when
+     * shown; gate off pollers when hidden to avoid the 429 storm that
+     * card_a7baa3b0b1151099d4523428 fixed. Does NOT touch engine-lifetime state.
+     */
+    fun onVisibilityChanged(visible: Boolean) {
+        this.visible = visible
+        if (visible) {
+            hooks.restartInactivePollersAndDraw()
+        } else {
+            hooks.stopDrawLoop()
+            hooks.cancelAllPollers()
+        }
+    }
+
+    /** Surface (re)created. Resume rendering if visible. Engine-lifetime intact. */
+    fun onSurfaceCreated() {
+        surfacePresent = true
+        if (visible) {
+            hooks.restartInactivePollersAndDraw()
+        }
+    }
+
+    /** Surface geometry changed. Treat like a (re)create for resume purposes. */
+    fun onSurfaceChanged() {
+        surfacePresent = true
+        if (visible) {
+            hooks.restartInactivePollersAndDraw()
+        }
+    }
+
+    /**
+     * Surface destroyed. PAUSE ONLY: stop the draw loop and mark not-visible.
+     * Crucially does NOT cancel the engine scope or release the renderer —
+     * those survive so the next [onSurfaceCreated] can resume. This is the core
+     * card_f9b2cc2d fix.
+     */
+    fun onSurfaceDestroyed() {
+        surfacePresent = false
+        visible = false
+        hooks.stopDrawLoop()
+        // engineAlive stays true. No releaseEngineResources() here.
+    }
+
+    /**
+     * Engine.onDestroy — the real teardown point. Idempotent: a second call is
+     * a no-op so a destroy after a surface-destroy can't double-release.
+     */
+    fun onEngineDestroy() {
+        if (!engineAlive) return
+        engineAlive = false
+        hooks.stopDrawLoop()
+        hooks.cancelAllPollers()
+        hooks.releaseEngineResources()
+    }
+}

--- a/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
+++ b/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
@@ -7,6 +7,7 @@ import android.service.wallpaper.WallpaperService
 import android.view.SurfaceHolder
 import timber.log.Timber
 import com.hank.clawlive.engine.ClawRenderer
+import com.hank.clawlive.engine.EngineLifecycleController
 import com.hank.clawlive.data.model.AgentStatus
 import com.hank.clawlive.data.model.CharacterState
 import com.hank.clawlive.data.model.EntityStatus
@@ -74,10 +75,38 @@ class ClawWallpaperService : WallpaperService() {
 
         private val drawRunnable = Runnable { draw() }
 
+        // Pure-JVM lifecycle state machine (card_f9b2cc2d). Source of truth for
+        // whether engine-lifetime resources are still alive. Surface
+        // destroy→recreate (an app-switch) must NOT tear down engineScope /
+        // renderer / companionRepository — only Engine.onDestroy does.
+        private val lifecycle = EngineLifecycleController(object : EngineLifecycleController.Hooks {
+            override fun stopDrawLoop() {
+                handler.removeCallbacks(drawRunnable)
+            }
+
+            override fun restartInactivePollersAndDraw() {
+                if (statusJob?.isActive != true) observeStatus()
+                if (usageJob?.isActive != true) observeUsage()
+                if (kanbanJob?.isActive != true) observeKanban()
+                draw()
+            }
+
+            override fun cancelAllPollers() {
+                this@ClawEngine.cancelAllPollers()
+            }
+
+            override fun releaseEngineResources() {
+                engineScope.cancel()
+                renderer.release()
+                companionRepository.release()
+            }
+        })
+
         override fun onCreate(surfaceHolder: SurfaceHolder?) {
             super.onCreate(surfaceHolder)
             Timber.d("ClawEngine onCreate")
             setTouchEventsEnabled(true)
+            lifecycle.onEngineCreate()
             observeStatus()
             observeUsage()
             observeKanban()
@@ -183,24 +212,12 @@ class ClawWallpaperService : WallpaperService() {
         override fun onVisibilityChanged(visible: Boolean) {
             this.visible = visible
             Timber.d("onVisibilityChanged: $visible")
-            if (visible) {
-                // Restart pollers if they were cancelled while hidden. Without
-                // this, the wallpaper would only repaint stale state until the
-                // user re-enters the live wallpaper preview. Bug
-                // card_a7baa3b0b1151099d4523428 close-out.
-                if (statusJob?.isActive != true) observeStatus()
-                if (usageJob?.isActive != true) observeUsage()
-                if (kanbanJob?.isActive != true) observeKanban()
-                draw()
-            } else {
-                // Stop hitting /api/status while the wallpaper isn't on
-                // screen (screen off, app covering, dock visible). Without
-                // this gate the service kept polling every 5s indefinitely,
-                // saturating CF rate-limits → 429 storms. The companion
-                // jobs are tied to the same lifecycle.
-                handler.removeCallbacks(drawRunnable)
-                cancelAllPollers()
-            }
+            // Delegate to the lifecycle controller. When shown it restarts any
+            // poller that was cancelled while hidden (card_a7baa3b0b1151099d4523428
+            // close-out) and redraws. When hidden it stops the draw loop and
+            // cancels all pollers — the quota gate that prevents the /api/status
+            // 429 storm. Engine-lifetime resources are untouched either way.
+            lifecycle.onVisibilityChanged(visible)
         }
 
         override fun onTouchEvent(event: android.view.MotionEvent?) {
@@ -243,16 +260,50 @@ class ClawWallpaperService : WallpaperService() {
             super.onTouchEvent(event)
         }
 
+        override fun onSurfaceCreated(holder: SurfaceHolder?) {
+            super.onSurfaceCreated(holder)
+            Timber.d("onSurfaceCreated")
+            // Surface is back (e.g. returning from an app-switch). The framework
+            // has already pointed `surfaceHolder` at the new surface. Resume
+            // rendering if visible — restart any poller that went inactive and
+            // redraw. Engine-lifetime resources were preserved by
+            // onSurfaceDestroyed, so this recovers without a process restart.
+            // (card_f9b2cc2d)
+            lifecycle.onSurfaceCreated()
+        }
+
+        override fun onSurfaceChanged(holder: SurfaceHolder?, format: Int, width: Int, height: Int) {
+            super.onSurfaceChanged(holder, format, width, height)
+            Timber.d("onSurfaceChanged ${width}x$height")
+            // Geometry/format change (rotation, etc.). Treat like a recreate for
+            // resume purposes so the very next frame repaints onto the new
+            // surface. (card_f9b2cc2d)
+            lifecycle.onSurfaceChanged()
+        }
+
         override fun onSurfaceDestroyed(holder: SurfaceHolder?) {
             super.onSurfaceDestroyed(holder)
+            // PAUSE ONLY. card_f9b2cc2d: an app-switch destroys then recreates
+            // the surface. Tearing down engine-lifetime resources here (the old
+            // bug) permanently cancelled engineScope so every later
+            // engineScope.launch{} was a no-op and draw() used a released
+            // renderer → black until a full process restart. We now only stop
+            // the draw loop and mark not-visible; engineScope / renderer /
+            // companionRepository survive for the next onSurfaceCreated. Pollers
+            // already get the quota gate via onVisibilityChanged(false), which
+            // fires before the surface is destroyed.
             visible = false
-            handler.removeCallbacks(drawRunnable)
-            companionJobs.values.forEach { it.cancel() }
-            companionJobs.clear()
-            engineScope.cancel()
-            renderer.release()
-            companionRepository.release()
-            Timber.d("onSurfaceDestroyed")
+            lifecycle.onSurfaceDestroyed()
+            Timber.d("onSurfaceDestroyed (paused, engine-lifetime preserved)")
+        }
+
+        override fun onDestroy() {
+            // The ONE place engine-lifetime resources are torn down. Reached when
+            // the Engine itself is being destroyed (wallpaper deselected /
+            // service stopped), not on a transient surface destroy. (card_f9b2cc2d)
+            lifecycle.onEngineDestroy()
+            Timber.d("ClawEngine onDestroy — engine-lifetime resources released")
+            super.onDestroy()
         }
 
         private var drawCount = 0

--- a/app/src/test/java/com/hank/clawlive/EngineLifecycleControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/EngineLifecycleControllerTest.kt
@@ -1,0 +1,153 @@
+package com.hank.clawlive
+
+import com.hank.clawlive.engine.EngineLifecycleController
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM regression tests for card_f9b2cc2d — live wallpaper goes BLACK after
+ * an app-switch and only recovers on a full process restart.
+ *
+ * The bug was that the Engine released engine-lifetime resources (the
+ * SupervisorJob scope, renderer, companion repository) inside
+ * onSurfaceDestroyed. An app-switch destroys then recreates the surface, so the
+ * scope was permanently cancelled and every subsequent poller launch was a
+ * no-op with a released renderer → black.
+ *
+ * These tests assert on the lifecycle decisions:
+ *  - a surface destroy/recreate cycle keeps the engine "alive" (no teardown)
+ *    and resumes rendering;
+ *  - only Engine.onDestroy performs the real teardown.
+ *
+ * NOTE: this exercises the lifecycle decision logic, not the real Android
+ * Engine. The actual black→recover behaviour is build-gated and must be
+ * confirmed on an emulator/device.
+ */
+class EngineLifecycleControllerTest {
+
+    /** Records which hook side-effects fired, in order. */
+    private class RecordingHooks : EngineLifecycleController.Hooks {
+        var stopDrawLoopCount = 0
+        var restartCount = 0
+        var cancelAllPollersCount = 0
+        var releaseCount = 0
+
+        override fun stopDrawLoop() { stopDrawLoopCount++ }
+        override fun restartInactivePollersAndDraw() { restartCount++ }
+        override fun cancelAllPollers() { cancelAllPollersCount++ }
+        override fun releaseEngineResources() { releaseCount++ }
+    }
+
+    private fun controller(hooks: RecordingHooks = RecordingHooks()) =
+        EngineLifecycleController(hooks) to hooks
+
+    @Test
+    fun surfaceDestroyDoesNotReleaseEngineResources() {
+        val (c, hooks) = controller()
+        c.onEngineCreate()
+        c.onSurfaceCreated()
+        c.onVisibilityChanged(true)
+
+        c.onSurfaceDestroyed()
+
+        // The core fix: a surface destroy must NOT tear down engine-lifetime
+        // resources. The engine stays alive so it can resume.
+        assertTrue("engine must stay alive across a surface destroy", c.engineAlive)
+        assertEquals("no engine-lifetime release on surface destroy", 0, hooks.releaseCount)
+        assertEquals("no poller cancel on surface destroy (visibility gate already did it)",
+            0, hooks.cancelAllPollersCount)
+    }
+
+    @Test
+    fun appSwitchCycleResumesWithoutTeardown() {
+        // Simulate exactly what an app-switch does: visible → hidden,
+        // surface destroyed, then surface recreated and visible again.
+        val (c, hooks) = controller()
+        c.onEngineCreate()
+        c.onSurfaceCreated()
+        c.onVisibilityChanged(true)
+        val restartsAfterShow = hooks.restartCount
+
+        // Leaving the app.
+        c.onVisibilityChanged(false)   // quota gate: cancel pollers
+        c.onSurfaceDestroyed()         // PAUSE only
+
+        assertTrue("engine alive after leaving app", c.engineAlive)
+        assertEquals("released while still alive — regression!", 0, hooks.releaseCount)
+
+        // Returning to the app.
+        c.onSurfaceCreated()
+        c.onVisibilityChanged(true)
+
+        assertTrue("engine still alive after returning", c.engineAlive)
+        assertEquals("must not release across the whole app-switch cycle", 0, hooks.releaseCount)
+        assertTrue("must restart pollers + redraw on resume",
+            hooks.restartCount > restartsAfterShow)
+    }
+
+    @Test
+    fun manyDestroyCreateCyclesKeepEngineAlive() {
+        val (c, hooks) = controller()
+        c.onEngineCreate()
+        c.onVisibilityChanged(true)
+
+        repeat(20) {
+            c.onSurfaceDestroyed()
+            c.onSurfaceCreated()
+        }
+
+        assertTrue("engine survives many surface cycles", c.engineAlive)
+        assertEquals("never released across 20 cycles", 0, hooks.releaseCount)
+    }
+
+    @Test
+    fun engineDestroyPerformsRealTeardownExactlyOnce() {
+        val (c, hooks) = controller()
+        c.onEngineCreate()
+        c.onSurfaceCreated()
+        c.onVisibilityChanged(true)
+        c.onSurfaceDestroyed()
+
+        c.onEngineDestroy()
+
+        assertFalse("engine no longer alive after onDestroy", c.engineAlive)
+        assertEquals("teardown releases engine-lifetime resources once", 1, hooks.releaseCount)
+        assertEquals("teardown cancels pollers", 1, hooks.cancelAllPollersCount)
+
+        // Idempotent: a second destroy must not double-release.
+        c.onEngineDestroy()
+        assertEquals("onDestroy is idempotent — no double release", 1, hooks.releaseCount)
+    }
+
+    @Test
+    fun hiddenVisibilityGatesPollersButKeepsEngineAlive() {
+        // The 429-storm quota gate (card_a7baa3b0b1151099d4523428) must remain:
+        // hiding cancels pollers, but never tears down the engine.
+        val (c, hooks) = controller()
+        c.onEngineCreate()
+        c.onVisibilityChanged(true)
+
+        c.onVisibilityChanged(false)
+
+        assertEquals("hiding cancels pollers (quota gate preserved)", 1, hooks.cancelAllPollersCount)
+        assertEquals("hiding stops the draw loop", 1, hooks.stopDrawLoopCount)
+        assertTrue("hiding never tears down the engine", c.engineAlive)
+        assertEquals("hiding never releases engine resources", 0, hooks.releaseCount)
+    }
+
+    @Test
+    fun surfaceCreatedWhileHiddenDoesNotRedraw() {
+        // If the surface comes back while not visible, we should not start
+        // drawing/polling yet — onVisibilityChanged(true) drives that.
+        val (c, hooks) = controller()
+        c.onEngineCreate()
+
+        c.onSurfaceCreated() // visible is still false
+
+        assertEquals("no resume while hidden", 0, hooks.restartCount)
+        assertTrue(c.surfacePresent)
+        assertTrue(c.engineAlive)
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -20,6 +20,7 @@ import org.junit.runners.Suite
     MessageRequestFormatTest::class,
     ChatEchoSuppressionTest::class,
     WallpaperWanderControllerTest::class,
+    EngineLifecycleControllerTest::class,
     CompanionDescriptorAnimationTest::class,
     NotificationPreferenceCatalogTest::class,
     SettingsManifestResolverTest::class,


### PR DESCRIPTION
## Bug (P0, Hank-direct, card_f9b2cc2d)
Android live wallpaper goes **entirely BLACK** when the user briefly switches to the home screen / another app and returns. It only recovers after fully killing and reopening the app.

## Root cause
`ClawWallpaperService.ClawEngine.onSurfaceDestroyed()` tore down **engine-lifetime** resources:
- `engineScope.cancel()` (a `SupervisorJob`)
- `renderer.release()`
- `companionRepository.release()`
- companion jobs cancel/clear

An app-switch destroys then **recreates** the surface. After one destroy→recreate cycle:
- `engineScope` is permanently cancelled → every later `engineScope.launch{}` (`observeStatus`/`observeUsage`/`observeKanban`/companion pollers) is a **no-op**, and
- `draw()` runs against a **released** renderer → black.

There was no `onSurfaceCreated` override to rebuild, and the objects are `val` (unassignable), so only a full process restart reconstructed the Engine. This matches the symptom precisely.

## Fix — correct `WallpaperService.Engine` lifecycle
1. **`onSurfaceDestroyed()` now PAUSES only**: stop the draw loop (`handler.removeCallbacks`), set `visible = false`. It no longer cancels the scope or releases renderer/repo.
2. **New Engine `onDestroy()`** is the single teardown point: cancel all pollers, `engineScope.cancel()`, `renderer.release()`, `companionRepository.release()`, then `super.onDestroy()`. Idempotent.
3. **New `onSurfaceCreated()` / `onSurfaceChanged()`** resume rendering when `visible` — restart any inactive poller and `draw()`, mirroring the existing `onVisibilityChanged(true)` `if (xJob?.isActive != true) observeX()` + `draw()` pattern. The framework re-points the built-in `surfaceHolder` before `onSurfaceCreated`, so `draw()`'s `holder.lockCanvas()` is valid on resume.
4. **Polling/rate-limit behavior unchanged**: the `onVisibilityChanged(false) → cancelAllPollers` quota gate (card_a7baa3b0b1151099d4523428, the 429-storm fix) is preserved exactly.

## Unit-testable seam
Lifecycle decision logic is extracted into a pure-JVM `EngineLifecycleController` (in `com.hank.clawlive.engine`, same pattern as the existing controllers). The Engine owns the real coroutine scope / renderer / repository and wires the actual side-effects through `EngineLifecycleController.Hooks`. This makes the lifecycle invariant testable on the JVM without an emulator.

New `EngineLifecycleControllerTest` (6 tests) asserts:
- a surface destroy does **not** release engine resources (`engineAlive` stays true),
- a full app-switch cycle (hidden → surface destroyed → surface recreated → visible) resumes with **zero** releases and restarts pollers + redraws,
- 20 destroy/create cycles keep the engine alive,
- `onEngineDestroy` performs the real teardown exactly once (idempotent),
- the hidden-visibility quota gate still cancels pollers without teardown.

## Files changed
- `app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt` — lifecycle fix + new overrides, delegates decisions to the controller.
- `app/src/main/java/com/hank/clawlive/engine/EngineLifecycleController.kt` — new pure-JVM lifecycle state machine.
- `app/src/test/java/com/hank/clawlive/EngineLifecycleControllerTest.kt` — new regression tests.
- `app/src/test/java/com/hank/clawlive/UnitTestSuite.kt` — register the new test class.

## What was verified
- `./gradlew :app:testDebugUnitTest` compiles all changed Kotlin and runs **green: 184 tests, 0 failures, 0 errors** (the 6 new lifecycle tests included).
- Static review against the diagnosed root cause and the documented WallpaperService.Engine contract.

## ⚠️ BUILD-GATED — remaining unverified
This environment has **no Android emulator/device**, so the actual on-device **black → recover after app-switch** behaviour could **not** be exercised end-to-end. No emulator/device run was performed and none is claimed. Please build & smoke-test in the morning:
1. Set the wallpaper, switch to home/another app, return → wallpaper must repaint (not black) without killing the app.
2. Rotate the device (exercises `onSurfaceChanged`) → repaints.
3. Confirm no `/api/status` 429 storm while backgrounded (visibility quota gate intact).
4. Deselect the wallpaper → confirm `onDestroy` teardown logs and resources released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)