### PR TITLE
feat(ios): settings screen consumes /api/settings-manifest (Stage 2 iOS, card_411b8098)

### DIFF
--- a/ios-app/app/(tabs)/settings.tsx
+++ b/ios-app/app/(tabs)/settings.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { View, ScrollView, StyleSheet } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { View, ScrollView, StyleSheet, Modal } from 'react-native';
 import {
   Text,
   List,
@@ -13,13 +13,20 @@ import {
   useTheme,
   Snackbar,
   ActivityIndicator,
+  IconButton,
+  Appbar,
 } from 'react-native-paper';
+import { WebView } from 'react-native-webview';
 import { useTranslation } from 'react-i18next';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import i18next from 'i18next';
 import { useAuthStore } from '../../store/authStore';
-import { authApi } from '../../services/api';
+import { authApi, settingsManifestApi } from '../../services/api';
+import {
+  planDynamicRows,
+  type DynamicSettingsRow,
+} from '../../services/settingsManifest';
 import { Alert, Linking } from 'react-native';
 import { SUPPORTED_LANGUAGES } from '../../i18n';
 import Constants from 'expo-constants';
@@ -42,6 +49,46 @@ export default function SettingsScreen() {
   const [notifBroadcast, setNotifBroadcast] = useState(true);
 
   const appVersion = Constants.expoConfig?.version ?? '1.0.0';
+
+  // ── Settings auto-sync (manifest Stage 2) ──────────────────────────────────
+  // Mirrors Android SettingsActivity.loadSettingsManifest(): fetch
+  // GET /api/settings-manifest at launch and surface any settings feature this
+  // binary does NOT render natively — opening its web fallback in a WebView. A
+  // native feature gated out by the running app version shows a "?" gated-help row.
+  // Graceful degradation: any failure leaves the static screen exactly as-is.
+  const [manifestRows, setManifestRows] = useState<DynamicSettingsRow[]>([]);
+  const [webView, setWebView] = useState<DynamicSettingsRow | null>(null);
+  const [helpRow, setHelpRow] = useState<DynamicSettingsRow | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        // Spec §4 / Stage-2: send the REAL installed version so the backend's
+        // minAppVersion gate is correct. Constants.expoConfig.version is the
+        // app.json version pinned at build time.
+        const res = await settingsManifestApi.get(appVersion, 'ios');
+        const data = res.data;
+        if (cancelled) return;
+        if (!data?.success || !data.manifest) {
+          // non-success / missing manifest — keep static screen
+          return;
+        }
+        const rows = planDynamicRows(data.manifest, appVersion);
+        if (!cancelled) setManifestRows(rows);
+      } catch {
+        // offline / 5xx / parse — keep static settings screen, never crash/blank
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [appVersion]);
+
+  const openWebFallback = (row: DynamicSettingsRow) => {
+    setHelpRow(null);
+    setWebView(row);
+  };
 
   // Mirrors Android SettingsActivity.showBindEmailDialog() — this is
   // account REGISTRATION (bind device to new email), not login.
@@ -276,6 +323,43 @@ export default function SettingsScreen() {
 
         <Divider />
 
+        {/* Auto-synced settings (manifest Stage 2) — features this app version
+            doesn't render natively; opens the web fallback in a WebView. Renders
+            nothing when the manifest is empty / fetch failed (graceful degrade). */}
+        {manifestRows.length > 0 && (
+          <>
+            <List.Section title={t('settings.more_section_title', 'More settings')}>
+              {manifestRows.map((row) => (
+                <List.Item
+                  key={row.key}
+                  title={row.name}
+                  description={
+                    row.gated
+                      ? t('settings.feature_gated_badge', 'Update app for native screen')
+                      : undefined
+                  }
+                  left={(props) => (
+                    <List.Icon
+                      {...props}
+                      icon={row.gated ? 'alert-circle-outline' : 'open-in-new'}
+                    />
+                  )}
+                  right={(props) => (
+                    <IconButton
+                      {...props}
+                      icon="help-circle-outline"
+                      accessibilityLabel={t('settings.feature_help_title', 'About this setting')}
+                      onPress={() => setHelpRow(row)}
+                    />
+                  )}
+                  onPress={() => openWebFallback(row)}
+                />
+              ))}
+            </List.Section>
+            <Divider />
+          </>
+        )}
+
         {/* Account Actions */}
         <View style={styles.bottomActions}>
           <Button
@@ -381,6 +465,64 @@ export default function SettingsScreen() {
         </Dialog>
       </Portal>
 
+      {/* Manifest feature "?" help — what / needs / next step (spec §4) */}
+      <Portal>
+        <Dialog visible={!!helpRow} onDismiss={() => setHelpRow(null)}>
+          <Dialog.Title>
+            {t('settings.feature_help_title', 'About this setting')}
+          </Dialog.Title>
+          <Dialog.Content>
+            <Text variant="bodyMedium">
+              {helpRow?.gated
+                ? t(
+                    'settings.feature_gated_help',
+                    "This setting has a native screen in a newer app version. Update the app to get it here, or open it on the web now."
+                  )
+                : t(
+                    'settings.feature_web_help',
+                    "This setting opens in a web view because the native screen isn't in this app version yet. You can use it on the web now."
+                  )}
+            </Text>
+          </Dialog.Content>
+          <Dialog.Actions>
+            <Button onPress={() => setHelpRow(null)}>
+              {t('common.cancel', 'Cancel')}
+            </Button>
+            <Button
+              mode="contained"
+              onPress={() => helpRow && openWebFallback(helpRow)}
+            >
+              {t('settings.open_on_web', 'Open on web')}
+            </Button>
+          </Dialog.Actions>
+        </Dialog>
+      </Portal>
+
+      {/* Web fallback WebView — opens the manifest feature's portal page */}
+      <Modal
+        visible={!!webView}
+        animationType="slide"
+        onRequestClose={() => setWebView(null)}
+      >
+        <SafeAreaView style={{ flex: 1, backgroundColor: theme.colors.background }} edges={['top', 'bottom']}>
+          <Appbar.Header>
+            <Appbar.BackAction onPress={() => setWebView(null)} />
+            <Appbar.Content title={webView?.name ?? ''} />
+          </Appbar.Header>
+          {webView && (
+            <WebView
+              source={{ uri: webView.webFallback }}
+              startInLoadingState
+              renderLoading={() => (
+                <View style={styles.webLoading}>
+                  <ActivityIndicator />
+                </View>
+              )}
+            />
+          )}
+        </SafeAreaView>
+      </Modal>
+
       <Snackbar visible={!!snack} onDismiss={() => setSnack('')} duration={2000}>
         {snack}
       </Snackbar>
@@ -400,5 +542,10 @@ const styles = StyleSheet.create({
   },
   deleteBtn: {
     width: '100%',
+  },
+  webLoading: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });

--- a/ios-app/i18n/en.json
+++ b/ios-app/i18n/en.json
@@ -259,7 +259,13 @@
     "file_manager": "Files",
     "card_holder": "Card Holder",
     "intro_guide": "Tutorial & Intro",
-    "intro_guide_desc": "Watch the 75s demo + Quick Start walkthrough"
+    "intro_guide_desc": "Watch the 75s demo + Quick Start walkthrough",
+    "more_section_title": "More settings",
+    "feature_help_title": "About this setting",
+    "feature_gated_badge": "Update app for native screen",
+    "feature_gated_help": "This setting has a native screen in a newer app version. Update the app to get it here, or open it on the web now.",
+    "feature_web_help": "This setting opens in a web view because the native screen isn't in this app version yet. You can use it on the web now.",
+    "open_on_web": "Open on web"
   },
   "entity": {
     "rename": "Rename Entity",

--- a/ios-app/i18n/zh-CN.json
+++ b/ios-app/i18n/zh-CN.json
@@ -259,7 +259,13 @@
     "file_manager": "文件",
     "card_holder": "名片夹",
     "intro_guide": "教学与简介",
-    "intro_guide_desc": "观看 75 秒简介影片与快速上手导览"
+    "intro_guide_desc": "观看 75 秒简介影片与快速上手导览",
+    "more_section_title": "更多设置",
+    "feature_help_title": "关于此设置",
+    "feature_gated_badge": "更新 App 以使用原生界面",
+    "feature_gated_help": "此设置在较新版本的 App 中有原生界面。请更新 App 以在此使用，或先在网页版打开。",
+    "feature_web_help": "此设置会在网页视图中打开，因为这个 App 版本尚未内建原生界面。你现在可以在网页版使用。",
+    "open_on_web": "在网页打开"
   },
   "entity": {
     "rename": "重命名实体",

--- a/ios-app/i18n/zh-TW.json
+++ b/ios-app/i18n/zh-TW.json
@@ -259,7 +259,13 @@
     "file_manager": "檔案",
     "card_holder": "名片夾",
     "intro_guide": "教學與簡介",
-    "intro_guide_desc": "觀看 75 秒簡介影片與快速上手導覽"
+    "intro_guide_desc": "觀看 75 秒簡介影片與快速上手導覽",
+    "more_section_title": "更多設定",
+    "feature_help_title": "關於此設定",
+    "feature_gated_badge": "更新 App 以使用原生畫面",
+    "feature_gated_help": "此設定在較新版本的 App 中有原生畫面。請更新 App 以在此使用，或先在網頁版開啟。",
+    "feature_web_help": "此設定會在網頁檢視中開啟，因為這個 App 版本尚未內建原生畫面。你現在可以在網頁版使用。",
+    "open_on_web": "在網頁開啟"
   },
   "entity": {
     "rename": "重新命名實體",

--- a/ios-app/package-lock.json
+++ b/ios-app/package-lock.json
@@ -47,7 +47,10 @@
         "zustand": "^5.0.11"
       },
       "devDependencies": {
+        "@types/jest": "^29.5.14",
         "@types/react": "~19.2.2",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.4.11",
         "typescript": "~5.9.2"
       }
     },
@@ -1554,6 +1557,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@callstack/react-theme-provider": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.9.tgz",
@@ -2572,6 +2582,88 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/create-cache-key-function": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
@@ -2599,6 +2691,33 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
@@ -2616,6 +2735,136 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/reporters/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -2623,6 +2872,53 @@
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3683,6 +3979,17 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.3.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
@@ -4302,6 +4609,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -4337,6 +4657,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase": {
@@ -4387,6 +4717,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chrome-launcher": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
@@ -4423,6 +4763,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "license": "MIT"
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cli-cursor": {
@@ -4477,6 +4824,24 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -4649,6 +5014,28 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4704,6 +5091,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/deepmerge": {
@@ -4773,11 +5175,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/dnssd-advertise": {
       "version": "1.1.4",
@@ -4838,6 +5260,19 @@
       "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "license": "ISC"
     },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4895,6 +5330,23 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
@@ -5006,6 +5458,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/expo": {
@@ -5998,6 +6526,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -6041,6 +6582,38 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -6144,6 +6717,13 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -6193,6 +6773,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/i18next": {
@@ -6248,6 +6838,26 @@
       },
       "engines": {
         "node": ">=16.x"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -6330,6 +6940,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6346,6 +6966,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -6400,6 +7033,361 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-config/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jest-config/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -6451,6 +7439,36 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
@@ -6485,11 +7503,253 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-runtime/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -6538,6 +7798,26 @@
         "jest-get-type": "^29.6.3",
         "leven": "^3.1.0",
         "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6615,6 +7895,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6965,6 +8252,13 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -7074,6 +8368,29 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -7539,6 +8856,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -7601,6 +8928,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -7609,6 +8943,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-forge": {
       "version": "1.4.0",
@@ -7653,6 +8994,19 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nullthrows": {
@@ -7885,6 +9239,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-png": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/parse-png/-/parse-png-2.1.0.tgz",
@@ -7989,6 +9362,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/plist": {
@@ -8129,6 +9515,23 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/query-string": {
@@ -8823,6 +10226,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -8837,6 +10253,16 @@
       "resolved": "https://registry.npmjs.org/resolve-workspace-root/-/resolve-workspace-root-2.0.1.tgz",
       "integrity": "sha512-nR23LHAvaI6aHtMg6RWoaHpdR4D881Nydkzi2CixINyg9T00KgaJdJI6Vwty+Ps8WLxZHuxsS0BseWjxSA4C+w==",
       "license": "MIT"
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/restore-cursor": {
       "version": "2.0.0",
@@ -8958,9 +10384,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9327,6 +10753,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -9351,6 +10791,39 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/structured-headers": {
@@ -9641,6 +11114,72 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.8.0",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -9703,6 +11242,20 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici-types": {
@@ -9869,6 +11422,21 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/validate-npm-package-name": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
@@ -9965,6 +11533,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -10130,6 +11705,19 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
@@ -48,8 +49,18 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.14",
     "@types/react": "~19.2.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.11",
     "typescript": "~5.9.2"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/services/__tests__/**/*.test.ts"
+    ]
   },
   "private": true
 }

--- a/ios-app/services/__tests__/settingsManifest.test.ts
+++ b/ios-app/services/__tests__/settingsManifest.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Pure-logic tests for the Stage-2 iOS client manifest resolver
+ * (ios-app/services/settingsManifest.ts).
+ *
+ * Mirrors the Android reference tests at parity:
+ *   - app/src/test/java/com/hank/clawlive/settings/SettingsManifestResolverTest.kt
+ *   - app/src/test/java/com/hank/clawlive/settings/SettingsManifestSyncTest.kt
+ * and the backend contract in backend/lib/settings-manifest.js +
+ * the worked version-gate example in docs/specs/settings-manifest-spec.md §3.
+ *
+ * No React Native / Expo deps — the resolver is a pure module.
+ */
+
+import {
+  nativeSupport,
+  compareVersions,
+  resolveFeature,
+  resolve,
+  isVersionGated,
+  planDynamicRows,
+  NativeSupport,
+  FeatureSurface,
+  type SettingsManifest,
+  type SettingsManifestFeature,
+} from '../settingsManifest';
+
+// ── native flag normalisation ─────────────────────────────────────────────────
+
+describe('nativeSupport', () => {
+  test('normalises true / "partial" / false (mirrors Android)', () => {
+    expect(nativeSupport(true)).toBe(NativeSupport.FULL);
+    expect(nativeSupport('partial')).toBe(NativeSupport.PARTIAL);
+    expect(nativeSupport('PARTIAL')).toBe(NativeSupport.PARTIAL);
+    expect(nativeSupport(false)).toBe(NativeSupport.NONE);
+    expect(nativeSupport(null)).toBe(NativeSupport.NONE);
+    expect(nativeSupport(undefined)).toBe(NativeSupport.NONE);
+    // "true" as a JSON string still means natively renderable.
+    expect(nativeSupport('true')).toBe(NativeSupport.FULL);
+    // Any unknown string fails safe to web.
+    expect(nativeSupport('maybe')).toBe(NativeSupport.NONE);
+  });
+});
+
+// ── compareVersions parity with backend ───────────────────────────────────────
+
+describe('compareVersions', () => {
+  test('matches backend semantics', () => {
+    expect(compareVersions('1.0.0', '2.5.0')).toBe(-1);
+    expect(compareVersions('2.5.0', '2.5.0')).toBe(0);
+    expect(compareVersions('3.0.0', '2.5.0')).toBe(1);
+    // Missing segments treated as 0.
+    expect(compareVersions('1.0', '1.0.0')).toBe(0);
+    expect(compareVersions('1.0.1', '1.0')).toBe(1);
+    // Suffixed build names tolerated (leading digits only).
+    expect(compareVersions('2.5.0-debug', '2.5.0')).toBe(0);
+  });
+});
+
+// ── version gating (spec §3 worked example: companion_petdx) ───────────────────
+
+function feature(native: boolean | string, minVer: string): SettingsManifestFeature {
+  return {
+    key: 'companion_petdx',
+    name: 'Companion (PetDX)',
+    enabled: true,
+    native,
+    webFallback: 'https://eclawbot.com/portal/settings.html?focus=companion_petdx',
+    minAppVersion: minVer,
+  };
+}
+
+describe('resolveFeature — version gate decision table', () => {
+  test('native true, old app below minVersion -> downgraded to WEB', () => {
+    const r = resolveFeature(feature(true, '2.5.0'), '1.0.0');
+    expect(r.surface).toBe(FeatureSurface.WEB);
+    expect(r.webFallback).toBe(
+      'https://eclawbot.com/portal/settings.html?focus=companion_petdx'
+    );
+  });
+
+  test('native true, app AT minVersion -> NATIVE', () => {
+    expect(resolveFeature(feature(true, '2.5.0'), '2.5.0').surface).toBe(
+      FeatureSurface.NATIVE
+    );
+  });
+
+  test('native true, app ABOVE minVersion -> NATIVE', () => {
+    expect(resolveFeature(feature(true, '2.5.0'), '3.0.0').surface).toBe(
+      FeatureSurface.NATIVE
+    );
+  });
+
+  test('partial above gate -> NATIVE_PLUS_WEB', () => {
+    expect(resolveFeature(feature('partial', '1.0.0'), '1.0.0').surface).toBe(
+      FeatureSurface.NATIVE_PLUS_WEB
+    );
+  });
+
+  test('partial below gate -> WEB', () => {
+    expect(resolveFeature(feature('partial', '2.0.0'), '1.0.0').surface).toBe(
+      FeatureSurface.WEB
+    );
+  });
+
+  test('native false -> always WEB, even on a brand new app', () => {
+    // rotate_secret / switch_device today: native:false on both platforms.
+    expect(resolveFeature(feature(false, '0.0.0'), '99.0.0').surface).toBe(
+      FeatureSurface.WEB
+    );
+  });
+
+  test('missing/blank appVersion -> trusts declared native (no downgrade)', () => {
+    expect(resolveFeature(feature(true, '2.5.0'), null).surface).toBe(
+      FeatureSurface.NATIVE
+    );
+    expect(resolveFeature(feature(true, '2.5.0'), '').surface).toBe(
+      FeatureSurface.NATIVE
+    );
+    expect(resolveFeature(feature(true, '2.5.0'), undefined).surface).toBe(
+      FeatureSurface.NATIVE
+    );
+  });
+});
+
+// ── manifest-level resolve ────────────────────────────────────────────────────
+
+describe('resolve — manifest level', () => {
+  test('drops disabled and gates each', () => {
+    const manifest: SettingsManifest = {
+      platform: 'ios',
+      appVersion: '1.0.0',
+      stage: 1,
+      features: [
+        { key: 'account_identity', name: 'Account & Identity', enabled: true, native: true, webFallback: 'wf_a', minAppVersion: '1.0.0' },
+        { key: 'rotate_secret', name: 'Rotate Secret', enabled: true, native: false, webFallback: 'wf_r', minAppVersion: '0.0.0' },
+        { key: 'companion_petdx', name: 'Companion', enabled: true, native: true, webFallback: 'wf_c', minAppVersion: '2.5.0' },
+        { key: 'hidden_feature', name: 'Hidden', enabled: false, native: true, webFallback: 'wf_h', minAppVersion: '1.0.0' },
+      ],
+    };
+    const resolved = resolve(manifest, '1.0.0');
+    // disabled feature dropped
+    expect(resolved.map((r) => r.key)).toEqual([
+      'account_identity',
+      'rotate_secret',
+      'companion_petdx',
+    ]);
+    expect(resolved[0].surface).toBe(FeatureSurface.NATIVE); // account: native at 1.0.0
+    expect(resolved[1].surface).toBe(FeatureSurface.WEB); // rotate_secret: native:false
+    expect(resolved[2].surface).toBe(FeatureSurface.WEB); // companion gated out (1.0.0<2.5.0)
+  });
+
+  test('null manifest -> empty', () => {
+    expect(resolve(null, '1.0.0')).toEqual([]);
+    expect(resolve(undefined, '1.0.0')).toEqual([]);
+  });
+});
+
+// ── Stage-2 dynamic row planner (port of SettingsManifestSyncTest) ─────────────
+
+function f(
+  key: string,
+  native: boolean | string,
+  opts: { enabled?: boolean; minVer?: string; webFallback?: string } = {}
+): SettingsManifestFeature {
+  return {
+    key,
+    name: key.charAt(0).toUpperCase() + key.slice(1),
+    enabled: opts.enabled ?? true,
+    native,
+    webFallback:
+      opts.webFallback ?? `https://eclawbot.com/portal/settings.html?focus=${key}`,
+    minAppVersion: opts.minVer ?? '0.0.0',
+  };
+}
+
+function manifest(...features: SettingsManifestFeature[]): SettingsManifest {
+  return { platform: 'ios', appVersion: '1.0.0', stage: 1, features };
+}
+
+describe('planDynamicRows — Stage-2 auto-sync delta', () => {
+  test('NEW web-only feature with no native row -> emits web row (the payoff)', () => {
+    const rows = planDynamicRows(manifest(f('rotate_secret', false)), '1.0.94');
+    expect(rows.length).toBe(1);
+    expect(rows[0].key).toBe('rotate_secret');
+    expect(rows[0].gated).toBe(false);
+    expect(rows[0].webFallback).toBe(
+      'https://eclawbot.com/portal/settings.html?focus=rotate_secret'
+    );
+  });
+
+  test('native feature the static screen renders -> no dynamic row', () => {
+    const rows = planDynamicRows(
+      manifest(
+        f('subscription', true, { minVer: '1.0.0' }),
+        f('language', true, { minVer: '1.0.0' }),
+        f('notifications', true, { minVer: '1.0.0' })
+      ),
+      '1.0.94'
+    );
+    expect(rows).toEqual([]);
+  });
+
+  test('web-backed static row (kanban_nudge) -> not duplicated', () => {
+    const rows = planDynamicRows(manifest(f('kanban_nudge', false)), '1.0.94');
+    expect(rows).toEqual([]);
+  });
+
+  test('disabled feature -> dropped', () => {
+    const rows = planDynamicRows(
+      manifest(f('agent_policy', false, { enabled: false })),
+      '1.0.94'
+    );
+    expect(rows).toEqual([]);
+  });
+
+  test('version-gated NATIVE feature with a static row -> gated help row', () => {
+    // subscription declares native at 2.5.0 but app is 1.0.0 -> static native row
+    // can't be honored -> surface a gated help row.
+    const rows = planDynamicRows(
+      manifest(f('subscription', true, { minVer: '2.5.0' })),
+      '1.0.0'
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].key).toBe('subscription');
+    expect(rows[0].gated).toBe(true);
+  });
+
+  test('NEW native-declared feature gated out, no static row -> gated web row', () => {
+    const rows = planDynamicRows(
+      manifest(f('companion_v2', true, { minVer: '3.0.0' })),
+      '1.0.0'
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].key).toBe('companion_v2');
+    expect(rows[0].gated).toBe(true);
+  });
+
+  test('isVersionGated distinguishes gated vs plain web-only', () => {
+    expect(isVersionGated(f('x', true, { minVer: '2.0.0' }), '1.0.0')).toBe(true);
+    expect(isVersionGated(f('x', true, { minVer: '1.0.0' }), '1.0.0')).toBe(false);
+    expect(isVersionGated(f('x', false), '1.0.0')).toBe(false);
+    expect(isVersionGated(f('x', true, { minVer: '2.0.0' }), null)).toBe(false);
+  });
+
+  test('null manifest -> no rows (caller keeps static screen)', () => {
+    expect(planDynamicRows(null, '1.0.0')).toEqual([]);
+    expect(planDynamicRows(undefined, '1.0.0')).toEqual([]);
+  });
+
+  test('live-like iOS manifest -> only the features iOS does not render natively surface', () => {
+    // Reflects the iOS static screen: account/subscription/language/notifications/
+    // invite/wallet/my_rentals/files/feedback render natively; kanban_nudge is a
+    // web-backed static row. channel_api / display / chat_prefs /
+    // developer_broadcast / companion_petdx are NOT in the iOS static screen, so
+    // the manifest auto-surfaces them (the drift-fix the seam exists for).
+    const rows = planDynamicRows(
+      manifest(
+        f('account_identity', true, { minVer: '1.0.0' }),
+        f('channel_api', true, { minVer: '1.0.0' }), // not in iOS static -> web row
+        f('subscription', true, { minVer: '1.0.0' }),
+        f('invite', true, { minVer: '1.0.0' }),
+        f('language', true, { minVer: '1.0.0' }),
+        f('display', true, { minVer: '1.0.0' }), // not in iOS static -> web row
+        f('chat_prefs', true, { minVer: '1.0.0' }), // not in iOS static -> web row
+        f('rental_management', false), // NEW web-only -> row
+        f('notifications', 'partial', { minVer: '1.0.0' }),
+        f('developer_broadcast', true, { minVer: '1.0.0' }), // not in iOS static -> web row
+        f('agent_policy', false), // NEW web-only -> row
+        f('kanban_nudge', false), // web-backed static row -> skip
+        f('passive_health', false), // NEW web-only -> row
+        f('wallet', true, { minVer: '1.0.0' }),
+        f('my_rentals', true, { minVer: '1.0.0' }),
+        f('files', true, { minVer: '1.0.0' }),
+        f('companion_petdx', true, { minVer: '1.0.0' }), // not in iOS static -> web row
+        f('feedback', true, { minVer: '1.0.0' }),
+        f('rotate_secret', false), // NEW web-only -> row
+        f('switch_device', false) // NEW web-only -> row
+      ),
+      '1.0.94'
+    );
+    expect(rows.map((r) => r.key)).toEqual([
+      'channel_api',
+      'display',
+      'chat_prefs',
+      'rental_management',
+      'developer_broadcast',
+      'agent_policy',
+      'passive_health',
+      'companion_petdx',
+      'rotate_secret',
+      'switch_device',
+    ]);
+    expect(rows.some((r) => r.gated)).toBe(false);
+  });
+});

--- a/ios-app/services/api.ts
+++ b/ios-app/services/api.ts
@@ -409,6 +409,22 @@ export const contactsApi = {
     apiClient.get('/api/chat/history-by-code', { params: { publicCode, limit } }),
 };
 
+// ── Settings Manifest (auto-sync seam, Stage 2) ──────────────
+// Public GET — pure capability descriptor, no auth (mirrors /api/version).
+// Sending appVersion + platform lets the backend apply the minAppVersion gate.
+// See backend/lib/settings-manifest.js + docs/specs/settings-manifest-spec.md and
+// the Android ClawApiService.getSettingsManifest reference.
+
+import type { SettingsManifestResponse } from './settingsManifest';
+
+export const settingsManifestApi = {
+  /** Fetch the settings manifest at launch (Stage 2 consume). */
+  get: (appVersion?: string | null, platform: 'ios' | 'android' = 'ios') =>
+    apiClient.get<SettingsManifestResponse>('/api/settings-manifest', {
+      params: { appVersion: appVersion ?? undefined, platform },
+    }),
+};
+
 // ── Misc APIs ────────────────────────────────────────────────
 
 export const miscApi = {

--- a/ios-app/services/settingsManifest.ts
+++ b/ios-app/services/settingsManifest.ts
@@ -1,0 +1,323 @@
+/**
+ * Client-side model + resolver for the settings auto-sync seam (Stage 2, iOS half).
+ *
+ * TypeScript port of the Android reference
+ * `app/src/main/java/com/hank/clawlive/settings/SettingsManifest.kt`
+ * (`SettingsManifestResolver`) + `SettingsManifestSync.kt`, kept at exact parity so
+ * both platforms resolve the same manifest identically.
+ *
+ * The backend ships `GET /api/settings-manifest?appVersion=&platform=ios` (Stage 1,
+ * see backend/lib/settings-manifest.js + docs/specs/settings-manifest-spec.md).
+ * Each enabled feature carries a `native` capability flag and a `webFallback` URL.
+ * The app must, per feature, decide how to surface it:
+ *
+ *   native === true       -> render the native screen for that feature
+ *   native === "partial"  -> render native UI + a "more on web" link -> webFallback
+ *   native === false      -> open webFallback in a WebView
+ *
+ * The backend already applies the `minAppVersion` version gate when the app sends
+ * `appVersion`. This client resolver mirrors that gate locally so the decision is
+ * correct EVEN IF the app failed to send `appVersion` (e.g. the manifest was cached,
+ * or fetched without the query param). A native flag the running binary cannot honor
+ * is therefore never trusted blindly: if the running app version is below the
+ * feature's `minAppVersion`, the feature is downgraded to the web fallback.
+ *
+ * IMPORTANT (matches Android client + card_411b8098): the LIVE endpoint returns
+ * `native` and `minAppVersion` as SCALARS (true | "partial" | false  /  "1.0.0"),
+ * NOT the spec §6.1 per-platform object — the backend resolves the platform before
+ * sending. This module consumes the scalar shape, same as the Android client.
+ *
+ * This file is PURE TypeScript (no React Native / Expo deps) so the decision logic
+ * is unit-testable in isolation.
+ */
+
+/** One feature row as returned by GET /api/settings-manifest. */
+export interface SettingsManifestFeature {
+  key: string;
+  name: string;
+  enabled: boolean;
+  /**
+   * The JSON `native` field: true | "partial" | false. Use {@link nativeSupport}
+   * to normalise it; never branch on this raw field directly.
+   */
+  native: boolean | string;
+  webFallback: string;
+  minAppVersion: string;
+  /** Stage-3 field registry (object | null); carried verbatim, not gated. */
+  schema?: unknown;
+}
+
+/** Top-level manifest envelope: GET /api/settings-manifest. */
+export interface SettingsManifest {
+  platform: string;
+  appVersion?: string | null;
+  generatedAt?: string | null;
+  stage: number;
+  schemaVersion?: number;
+  features: SettingsManifestFeature[];
+}
+
+/** API response wrapper: { success, manifest }. */
+export interface SettingsManifestResponse {
+  success: boolean;
+  manifest?: SettingsManifest | null;
+  error?: string | null;
+}
+
+/** Normalised native-support level for one feature on this platform. */
+export enum NativeSupport {
+  FULL = 'FULL',
+  PARTIAL = 'PARTIAL',
+  NONE = 'NONE',
+}
+
+/**
+ * How the app should surface one resolved feature.
+ *
+ * - NATIVE          : render the native screen (NativeSupport.FULL).
+ * - NATIVE_PLUS_WEB : render native UI + a "more on web" link to webFallback
+ *                     (NativeSupport.PARTIAL).
+ * - WEB             : open webFallback in a WebView (NativeSupport.NONE, or a higher
+ *                     level downgraded by the version gate).
+ */
+export enum FeatureSurface {
+  NATIVE = 'NATIVE',
+  NATIVE_PLUS_WEB = 'NATIVE_PLUS_WEB',
+  WEB = 'WEB',
+}
+
+/** A feature after the client version gate has been applied. */
+export interface ResolvedFeature {
+  key: string;
+  name: string;
+  surface: FeatureSurface;
+  webFallback: string;
+}
+
+/**
+ * Parse the raw `native` JSON value (true | "partial" | false) into an enum.
+ * Mirrors Android `SettingsManifestResolver.nativeSupport`.
+ */
+export function nativeSupport(raw: unknown): NativeSupport {
+  if (raw === true) return NativeSupport.FULL;
+  if (typeof raw === 'string') {
+    if (raw.toLowerCase() === 'partial') return NativeSupport.PARTIAL;
+    // Any non-"partial" string ("false", "true", "") -> fail safe; "true" is FULL,
+    // everything else is "not natively renderable" -> web fallback.
+    return raw.toLowerCase() === 'true' ? NativeSupport.FULL : NativeSupport.NONE;
+  }
+  return NativeSupport.NONE;
+}
+
+/** Take the leading run of digits of a version segment ("3-debug" -> 3), default 0. */
+function segmentToInt(seg: string): number {
+  const m = seg.match(/^\d+/);
+  return m ? parseInt(m[0], 10) : 0;
+}
+
+/**
+ * Compare two dotted version strings. Returns -1 / 0 / 1. Mirrors
+ * backend/lib/settings-manifest.js `compareVersions` and Android
+ * `SettingsManifestResolver.compareVersions` (non-numeric or missing segments
+ * treated as 0; suffixes like "1.2.3-debug" tolerated).
+ */
+export function compareVersions(v1: string, v2: string): number {
+  const a = String(v1).split('.').map(segmentToInt);
+  const b = String(v2).split('.').map(segmentToInt);
+  const n = Math.max(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    const p1 = a[i] ?? 0;
+    const p2 = b[i] ?? 0;
+    if (p1 < p2) return -1;
+    if (p1 > p2) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Resolve one feature against the running app version, applying the minAppVersion
+ * gate. A FULL/PARTIAL native flag is downgraded to the web surface when the
+ * running app is older than the feature's minAppVersion.
+ *
+ * @param appVersion the running app's version. When null/blank, the declared native
+ *   level is trusted (the backend reports it as declared when no appVersion is sent).
+ */
+export function resolveFeature(
+  feature: SettingsManifestFeature,
+  appVersion: string | null | undefined
+): ResolvedFeature {
+  const declared = nativeSupport(feature.native);
+  let gated: NativeSupport;
+  if (declared === NativeSupport.NONE) {
+    gated = NativeSupport.NONE;
+  } else if (!appVersion || appVersion.trim() === '') {
+    gated = declared;
+  } else if (compareVersions(appVersion, feature.minAppVersion) < 0) {
+    // Running app predates native support for this feature -> web fallback.
+    gated = NativeSupport.NONE;
+  } else {
+    gated = declared;
+  }
+
+  let surface: FeatureSurface;
+  switch (gated) {
+    case NativeSupport.FULL:
+      surface = FeatureSurface.NATIVE;
+      break;
+    case NativeSupport.PARTIAL:
+      surface = FeatureSurface.NATIVE_PLUS_WEB;
+      break;
+    default:
+      surface = FeatureSurface.WEB;
+  }
+
+  return {
+    key: feature.key,
+    name: feature.name,
+    surface,
+    webFallback: feature.webFallback,
+  };
+}
+
+/**
+ * Resolve every ENABLED feature in the manifest into a render plan. Disabled
+ * features are dropped (the app surfaces nothing for them). Mirrors Android
+ * `SettingsManifestResolver.resolve`.
+ */
+export function resolve(
+  manifest: SettingsManifest | null | undefined,
+  appVersion: string | null | undefined
+): ResolvedFeature[] {
+  if (!manifest) return [];
+  return manifest.features
+    .filter((f) => f.enabled)
+    .map((f) => resolveFeature(f, appVersion));
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Stage-2 auto-sync planner (port of SettingsManifestSync.kt)
+//
+// Turns the resolved manifest into the *extra* settings rows the running iOS
+// binary doesn't already render natively. The static settings screen
+// (ios-app/app/(tabs)/settings.tsx) hand-wires some features (Account /
+// Subscription / Language / Notifications / Wallet / …). The manifest's value is
+// the AUTO-SYNC seam: a NEW web-only feature (native:false) or a native feature
+// gated out by the running app version is surfaced WITHOUT a rebuild by opening the
+// web fallback. This planner computes exactly that delta.
+// ────────────────────────────────────────────────────────────────────────────
+
+/** A settings row the manifest asks the app to surface beyond its static screen. */
+export interface DynamicSettingsRow {
+  key: string;
+  name: string;
+  webFallback: string;
+  /**
+   * True when this feature DECLARES native support but the running app version is
+   * below its minAppVersion — i.e. it was downgraded to the web fallback by the
+   * version gate. The UI shows the "?" gated-help affordance (update app / open on
+   * web) rather than presenting it as a plain web-only feature.
+   */
+  gated: boolean;
+}
+
+/**
+ * Manifest feature keys this iOS binary already renders as native settings rows
+ * (hand-wired in ios-app/app/(tabs)/settings.tsx). A key here means "the static
+ * screen covers it, don't add a dynamic row when the manifest also says native".
+ *
+ * NOTE: this list reflects what the iOS static screen ACTUALLY renders natively,
+ * which is intentionally narrower than the Android list — keys the iOS screen does
+ * NOT render (channel_api, display, chat_prefs, developer_broadcast,
+ * companion_petdx) are deliberately absent so the manifest auto-surfaces them as
+ * web rows. That is exactly the drift-fix the seam exists for. Keep in sync with
+ * the static screen.
+ */
+export const nativeRowKeys: ReadonlySet<string> = new Set([
+  'account_identity',
+  'subscription',
+  'language',
+  'notifications',
+  'invite',
+  'wallet',
+  'my_rentals',
+  'files',
+  'feedback',
+  'logout',
+]);
+
+/**
+ * Manifest feature keys the static screen already surfaces via its OWN web link (a
+ * hand-wired row that opens the portal). The manifest agrees these are web, so the
+ * static row is correct — no dynamic duplicate needed.
+ */
+export const webBackedStaticRowKeys: ReadonlySet<string> = new Set(['kanban_nudge']);
+
+const staticallyCoveredKeys: ReadonlySet<string> = new Set([
+  ...nativeRowKeys,
+  ...webBackedStaticRowKeys,
+]);
+
+/**
+ * Decide whether a feature DECLARES native support yet was gated to the web by the
+ * running app version (vs being plain web-only). Used to flag rows so the UI shows
+ * "update app / open on web" help instead of a generic web row. Mirrors Android
+ * `SettingsManifestSync.isVersionGated`.
+ */
+export function isVersionGated(
+  feature: SettingsManifestFeature,
+  appVersion: string | null | undefined
+): boolean {
+  const declared = nativeSupport(feature.native);
+  if (declared === NativeSupport.NONE) return false; // genuinely web-only, not gated
+  if (!appVersion || appVersion.trim() === '') return false; // no version -> trusted
+  return compareVersions(appVersion, feature.minAppVersion) < 0;
+}
+
+/**
+ * Plan the dynamic rows to append to the static settings screen. Mirrors Android
+ * `SettingsManifestSync.planDynamicRows` decision-for-decision.
+ *
+ * @param manifest   the manifest envelope (null/failed fetch -> no extra rows; the
+ *                   caller keeps its static screen as graceful degradation).
+ * @param appVersion the running app version, for the client-side version gate.
+ */
+export function planDynamicRows(
+  manifest: SettingsManifest | null | undefined,
+  appVersion: string | null | undefined
+): DynamicSettingsRow[] {
+  if (!manifest) return [];
+  const resolved = resolve(manifest, appVersion);
+  const byKey = new Map(manifest.features.map((f) => [f.key, f]));
+
+  const rows: DynamicSettingsRow[] = [];
+  for (const r of resolved) {
+    // Feature renders natively this binary already covers -> nothing to add.
+    if (r.surface === FeatureSurface.NATIVE && nativeRowKeys.has(r.key)) continue;
+    // NATIVE_PLUS_WEB / WEB that the static screen already covers via its own row
+    // (native row OR web-backed row) -> the static screen is enough.
+    if (staticallyCoveredKeys.has(r.key) && r.surface !== FeatureSurface.WEB) {
+      // partial native already rendered statically; no separate web row.
+      continue;
+    }
+    // A WEB-surfaced feature the static screen already covers (e.g. a native row
+    // the manifest gated out, or a web-backed static row that is already the web
+    // surface) -> only add a row if it is NOT statically covered at all.
+    if (r.surface === FeatureSurface.WEB && staticallyCoveredKeys.has(r.key)) {
+      const feat = byKey.get(r.key);
+      const gated = !!feat && isVersionGated(feat, appVersion);
+      // Static native row exists but the manifest gated it out -> the static row
+      // would present a control the binary can't fully honor; surface a gated help
+      // row so the user can reach the web version.
+      if (gated && nativeRowKeys.has(r.key)) {
+        rows.push({ key: r.key, name: r.name, webFallback: r.webFallback, gated: true });
+      }
+      continue;
+    }
+    // Everything else: a feature with no native static row that the manifest routes
+    // to the web -> THIS is the zero-rebuild auto-sync payoff.
+    const feat = byKey.get(r.key);
+    const gated = !!feat && isVersionGated(feat, appVersion);
+    rows.push({ key: r.key, name: r.name, webFallback: r.webFallback, gated });
+  }
+  return rows;
+}


### PR DESCRIPTION
## Summary
iOS half of **settings-manifest Stage 2** (card_411b809848bc1470f2c52d1b). The iOS settings screen now consumes `GET /api/settings-manifest` at launch and renders entries per the manifest's `native` flag — the zero-rebuild auto-sync seam.

- **Android parity reference:** Stage 2 Android = PR #3585; resolver = `SettingsManifestResolver` from PR #3575.
- **Parent / spec:** card_6dbb98223cadc793a96f4246 / `docs/specs/settings-manifest-spec.md`.

## What it does (decision table — mirrors Android `SettingsManifestResolver` / `SettingsManifestSync`)
On launch, GET `/api/settings-manifest?appVersion=<app.json version>&platform=ios`, then per enabled feature:
| Manifest state | iOS behavior |
|---|---|
| `native:true` + iOS already renders it natively | use native (no extra row) |
| `native:true` for a feature iOS does NOT render natively | **web row** → WebView fallback (drift-fix) |
| `native:"partial"` | native + "more on web" (NATIVE_PLUS_WEB); statically-covered ones add no extra row |
| `native:false` | **web row** → WebView fallback |
| declares native but `appVersion < minAppVersion` | **gated** row + `?` help (what / needs / next-step), opens web |
| fetch fails / 5xx / parse error / null manifest | **graceful degrade** — existing static settings screen left untouched |

Live-endpoint note (matches card + Android client): the endpoint returns `native` / `minAppVersion` as **scalars** (`true | "partial" | false` / `"1.0.0"`), NOT the spec §6.1 per-platform object. The client consumes the scalar shape.

## Files added / changed
- **`ios-app/services/settingsManifest.ts`** (new) — pure TS port of the Android resolver + sync planner (no RN deps): `nativeSupport`, `compareVersions`, `resolveFeature`, `resolve`, `isVersionGated`, `planDynamicRows`. iOS `nativeRowKeys` reflects what the iOS static screen actually renders (narrower than Android), so `channel_api` / `display` / `chat_prefs` / `developer_broadcast` / `companion_petdx` auto-surface as web rows.
- **`ios-app/services/api.ts`** — `settingsManifestApi.get(appVersion, platform='ios')` (public GET, mirrors Android `ClawApiService.getSettingsManifest`).
- **`ios-app/app/(tabs)/settings.tsx`** — launch fetch (`useEffect`), "More settings" auto-synced rows, `react-native-webview` modal fallback, gated `?` help dialog with "Open on web".
- **`ios-app/i18n/en.json` / `zh-TW.json` / `zh-CN.json`** — 6 new `settings.*` keys (EN source + zh-TW + zh-CN translations).
- **`ios-app/services/__tests__/settingsManifest.test.ts`** (new) + jest/ts-jest devDeps + `jest` config + `test` script in `package.json`.

## Tests — RUN, all green ✅ (verified)
`cd ios-app && npm test` → **20/20 passing** (ts-jest, node env). Mirrors the Android `SettingsManifestResolverTest` + `SettingsManifestSyncTest` tables: `native true→native`, `false→webFallback`, gated when `appVersion<minAppVersion`, partial above/below gate, missing appVersion→trust declared, disabled dropped, null manifest→empty (static-degrade), and a live-like iOS manifest delta. `tsc --noEmit` clean for all files in this PR (pre-existing unrelated errors in wallet/mission/etc. untouched).

## ⚠️ BUILD-GATED — what remains UNVERIFIED
This PR is **build-gated**. The resolver logic + wiring are unit-verified, but the **on-device render behavior is NOT verified** and requires an **Expo iOS build + iOS Simulator run** to confirm the card's acceptance:
- [ ] native screen renders for native features
- [ ] webFallback opens in the RN WebView
- [ ] gated state shows the `?` help (what / needs / next-step)
- [ ] fetch-failure degrades to the static screen

**Deferred to Hank's morning** for the Expo build + simulator vision-check before close-out. **Do not merge until simulator-verified.**

- **Verified:** resolver decision table (unit), TS types, i18n keys present in 3 locales.
- **Unverified (build-gated):** actual iOS render / WebView / gated / degrade in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)