### PR TITLE
feat(android): settings update-available chip + Play Core in-app update (card_28a8290a)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,6 +96,10 @@ dependencies {
     implementation(libs.billing)
     implementation(libs.play.integrity)
 
+    // Google Play Core In-App Update (Settings update-available chip — card_28a8290a)
+    implementation(libs.play.app.update)
+    implementation(libs.play.app.update.ktx)
+
     // Room Database for chat history
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)

--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -1,5 +1,6 @@
 package com.hank.clawlive
 
+import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Intent
@@ -12,6 +13,9 @@ import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
@@ -51,6 +55,13 @@ import com.hank.clawlive.settings.NotificationPreferenceCatalog
 import com.hank.clawlive.settings.NotificationPreferenceCategory
 import com.hank.clawlive.settings.DynamicSettingsRow
 import com.hank.clawlive.settings.SettingsManifestSync
+import com.hank.clawlive.settings.UpdateChipDecision
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.UpdateAvailability
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.hank.clawlive.ui.AiChatFabHelper
 import com.hank.clawlive.ui.BottomNavHelper
 import com.hank.clawlive.ui.EntityChipHelper
@@ -61,12 +72,32 @@ import androidx.core.os.LocaleListCompat
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
+private const val PLAY_STORE_FALLBACK_URL =
+    "https://play.google.com/store/apps/details?id=com.hank.clawlive"
+
 class SettingsActivity : AppCompatActivity() {
 
     private lateinit var billingManager: BillingManager
     private lateinit var usageManager: UsageManager
     private val layoutPrefs: LayoutPreferences by lazy { LayoutPreferences.getInstance(this) }
     private val deviceManager: DeviceManager by lazy { DeviceManager.getInstance(this) }
+
+    // ── Settings update-available chip (card_28a8290a) ──
+    private val appUpdateManager: AppUpdateManager by lazy { AppUpdateManagerFactory.create(this) }
+    // Receives the result of the Play Core In-App Update IMMEDIATE flow.
+    private val updateFlowLauncher: ActivityResultLauncher<IntentSenderRequest> =
+        registerForActivityResult(StartIntentSenderForResult()) { result ->
+            if (result.resultCode != RESULT_OK) {
+                // User cancelled the full-screen IMMEDIATE update, or it failed to
+                // launch/download. Offer the Play Store as a manual fallback rather
+                // than leaving them stuck.
+                Timber.w("[UpdateChip] In-app update flow result=${result.resultCode} — offering store fallback")
+                openStoreFallback()
+            }
+        }
+    // Cached store URL from the last /api/version response (Play Store deep link).
+    private var updateStoreUrl: String = PLAY_STORE_FALLBACK_URL
+    private var updateLatestVersion: String = ""
 
     // UI elements
     private lateinit var cardSubscription: MaterialCardView
@@ -172,6 +203,7 @@ class SettingsActivity : AppCompatActivity() {
         observeSubscriptionState()
         updateEntityCount()
         displayAppVersion()
+        checkForUpdateChip()
         setupDeveloperCollapsible()
         setupNotifCollapsible()
         setupBroadcastSettingsCollapsible()
@@ -982,6 +1014,131 @@ class SettingsActivity : AppCompatActivity() {
         } catch (e: Exception) {
             e.printStackTrace()
         }
+    }
+
+    // ============================================
+    // UPDATE-AVAILABLE CHIP + PLAY CORE IN-APP UPDATE (card_28a8290a)
+    // ============================================
+
+    /**
+     * Decide whether to show the "update available" chip next to the version row.
+     *
+     * Reuses the EXISTING version-fetch seam: GET /api/version via
+     * [NetworkModule.api.checkAppVersion] (the same call MainActivity uses for its
+     * launch-time update dialog). The backend compares the client version against
+     * LATEST_APP_VERSION server-side and returns `update.available` + latestVersion +
+     * storeUrl. We additionally cross-check locally via [UpdateChipDecision] so a
+     * stale flag can never produce a *false* update prompt.
+     *
+     * Graceful degradation (spec Acceptance): any failure / null update block / blank
+     * version leaves the chip GONE — never crash, never a false "update now" prompt.
+     */
+    private fun checkForUpdateChip() {
+        val installedVersion = deviceManager.appVersion
+        if (installedVersion.isBlank() || installedVersion == "unknown") return
+
+        lifecycleScope.launch {
+            val versionInfo = runCatching {
+                NetworkModule.api.checkAppVersion(installedVersion)
+            }.getOrElse { e ->
+                Timber.d(e, "[UpdateChip] /api/version fetch failed — chip stays hidden")
+                return@launch
+            }
+
+            val update = versionInfo.update
+            val show = UpdateChipDecision.shouldShowChip(
+                available = update?.available,
+                installedVersion = installedVersion,
+                latestVersion = update?.latestVersion
+            )
+            if (!show || update == null) return@launch
+
+            updateStoreUrl = update.storeUrl.ifBlank { PLAY_STORE_FALLBACK_URL }
+            updateLatestVersion = update.latestVersion
+            showUpdateChip(installedVersion, update.latestVersion, update.releaseNotes)
+        }
+    }
+
+    private fun showUpdateChip(currentVersion: String, latestVersion: String, releaseNotes: String?) {
+        val row = findViewById<LinearLayout>(R.id.updateChipRow)
+        val chip = findViewById<Chip>(R.id.chipUpdateAvailable)
+        val help = findViewById<ImageButton>(R.id.btnUpdateHelp)
+
+        chip.setOnClickListener { startInAppUpdate() }
+        help.setOnClickListener { showUpdateHelpDialog(currentVersion, latestVersion, releaseNotes) }
+        row.visibility = View.VISIBLE
+    }
+
+    /**
+     * Launch the Play Core In-App Update IMMEDIATE flow: full-screen update UI,
+     * background download, then restart — the user stays in-app (~30s). If Play
+     * reports no immediate update is available (e.g. sideloaded build, Play absent,
+     * or update not yet rolled out to this device) we fall back to the store.
+     */
+    private fun startInAppUpdate() {
+        val infoTask = runCatching { appUpdateManager.appUpdateInfo }.getOrElse { e ->
+            Timber.w(e, "[UpdateChip] appUpdateInfo unavailable — store fallback")
+            openStoreFallback()
+            return
+        }
+        infoTask
+            .addOnSuccessListener { info ->
+                val canImmediate = info.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+                    info.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
+                if (canImmediate) {
+                    runCatching {
+                        appUpdateManager.startUpdateFlowForResult(
+                            info,
+                            updateFlowLauncher,
+                            AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE).build()
+                        )
+                    }.onFailure { e ->
+                        Timber.w(e, "[UpdateChip] startUpdateFlowForResult failed — store fallback")
+                        openStoreFallback()
+                    }
+                } else {
+                    Timber.d("[UpdateChip] Play immediate update not available — store fallback")
+                    openStoreFallback()
+                }
+            }
+            .addOnFailureListener { e ->
+                Timber.w(e, "[UpdateChip] appUpdateInfo failed — store fallback")
+                openStoreFallback()
+            }
+    }
+
+    /**
+     * Store fallback chain: market://details deep link (opens the Play app directly),
+     * then the https://play.google.com/... web URL if the Play Store app is absent.
+     */
+    private fun openStoreFallback() {
+        val marketUri = Uri.parse("market://details?id=$packageName")
+        try {
+            startActivity(Intent(Intent.ACTION_VIEW, marketUri))
+        } catch (e: ActivityNotFoundException) {
+            try {
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(updateStoreUrl)))
+            } catch (e2: Exception) {
+                Timber.e(e2, "[UpdateChip] No store available to open")
+                Toast.makeText(this, getString(R.string.update_store_unavailable), Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+
+    private fun showUpdateHelpDialog(currentVersion: String, latestVersion: String, releaseNotes: String?) {
+        val message = buildString {
+            append(getString(R.string.update_help_body, currentVersion, latestVersion))
+            if (!releaseNotes.isNullOrBlank()) {
+                append("\n\n")
+                append(releaseNotes)
+            }
+        }
+        MaterialAlertDialogBuilder(this)
+            .setTitle(getString(R.string.update_help_title))
+            .setMessage(message)
+            .setPositiveButton(getString(R.string.update_now)) { _, _ -> startInAppUpdate() }
+            .setNegativeButton(getString(R.string.update_later), null)
+            .show()
     }
 
     // ============================================

--- a/app/src/main/java/com/hank/clawlive/settings/UpdateChipDecision.kt
+++ b/app/src/main/java/com/hank/clawlive/settings/UpdateChipDecision.kt
@@ -1,0 +1,50 @@
+package com.hank.clawlive.settings
+
+/**
+ * Pure-logic decision for the Settings "update-available" chip
+ * (card_28a8290a, per parent card_dfb85157189c3255300dc86e spec).
+ *
+ * The chip is shown ONLY when we are confident a newer build exists. The single
+ * source of truth for "newer build exists" is the backend `/api/version` response
+ * (`update.available`), which the backend computes by comparing the client's
+ * `appVersion` against `LATEST_APP_VERSION` (see backend/index.js `/api/version`).
+ *
+ * We do NOT re-implement the server's comparison here; instead we mirror it as a
+ * local, defensive cross-check so a stale/garbled `available` flag can never produce
+ * a *false* update prompt:
+ *   - chip shows  iff  server says available AND a local version-compare also says
+ *     the latest string is strictly greater than the installed version.
+ *   - any fetch failure / null update block / blank version => chip HIDDEN
+ *     (graceful degradation — never a false "update now" prompt; see Acceptance).
+ *
+ * Local version comparison reuses [SettingsManifestResolver.compareVersions]
+ * (the existing dotted-version comparator, tolerant of suffixes like "1.2.3-debug"
+ * and mirrors backend/lib/settings-manifest.js), so we don't invent a new one.
+ *
+ * No Android dependencies — covered by a JVM unit test.
+ */
+object UpdateChipDecision {
+
+    /**
+     * @param available the backend's `update.available` flag (null when no update
+     *   block was returned, e.g. fetch failed or no appVersion sent).
+     * @param installedVersion the running build's versionName (BuildConfig.VERSION_NAME).
+     * @param latestVersion the backend's `update.latestVersion`.
+     * @return true if the update chip should be visible.
+     */
+    fun shouldShowChip(
+        available: Boolean?,
+        installedVersion: String?,
+        latestVersion: String?
+    ): Boolean {
+        // Backend must affirmatively say an update is available.
+        if (available != true) return false
+        // Both version strings must be present and non-blank to compare safely.
+        val installed = installedVersion?.trim().orEmpty()
+        val latest = latestVersion?.trim().orEmpty()
+        if (installed.isEmpty() || latest.isEmpty()) return false
+        // Defensive local cross-check: only show when latest is strictly newer.
+        // Equal or older latest (clock skew / stale flag) => safe default: hide.
+        return SettingsManifestResolver.compareVersions(installed, latest) < 0
+    }
+}

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1285,7 +1285,41 @@
                 android:gravity="center"
                 android:textColor="@color/text_white_50"
                 android:textSize="12sp"
-                android:layout_marginBottom="16dp"/>
+                android:layout_marginBottom="8dp"/>
+
+            <!-- Update-available chip (card_28a8290a). GONE until /api/version
+                 reports a newer build; tapping it runs the Play Core In-App Update
+                 IMMEDIATE flow (background download + restart, ~30s, stays in-app),
+                 falling back to the Play Store. The "?" icon explains what/needs/next. -->
+            <LinearLayout
+                android:id="@+id/updateChipRow"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:layout_marginBottom="16dp"
+                android:visibility="gone">
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chipUpdateAvailable"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/update_now"
+                    app:chipIcon="@android:drawable/stat_sys_download"
+                    style="@style/Widget.Material3.Chip.Assist"/>
+
+                <ImageButton
+                    android:id="@+id/btnUpdateHelp"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginStart="4dp"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:contentDescription="@string/update_help_title"
+                    android:src="@android:drawable/ic_menu_help"
+                    app:tint="@color/text_white_50"/>
+
+            </LinearLayout>
 
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -806,6 +806,10 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="update_title">تحديث متاح</string>
     <string name="update_message">إصدار جديد (v%s) متاح. حدّث للحصول على أفضل تجربة!</string>
     <string name="update_now">تحديث الآن</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">حول هذا التحديث</string>
+    <string name="update_help_body">إصدارك %1$s ← الأحدث %2$s. اضغط "تحديث الآن" للتحديث داخل التطبيق مباشرةً (حوالي 30 ثانية، دون مغادرة التطبيق). إذا لم يتوفر التحديث داخل التطبيق، فسيُفتح متجر Play.</string>
+    <string name="update_store_unavailable">تعذّر فتح المتجر للتحديث. يُرجى التحديث من Google Play.</string>
     <string name="update_later">لاحقًا</string>
 
     <!-- Card Holder -->    <string name="card_holder_capabilities">القدرات</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -805,6 +805,10 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="update_title">Update verfügbar</string>
     <string name="update_message">Eine neue Version (v%s) ist verfügbar. Aktualisieren Sie für die beste Erfahrung!</string>
     <string name="update_now">Jetzt aktualisieren</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">Über dieses Update</string>
+    <string name="update_help_body">Deine Version %1$s → neueste %2$s. Tippe auf „Jetzt aktualisieren“, um direkt in der App zu aktualisieren (etwa 30 Sekunden, ohne die App zu verlassen). Falls das In-App-Update nicht verfügbar ist, öffnet sich der Play Store.</string>
+    <string name="update_store_unavailable">Store konnte zum Aktualisieren nicht geöffnet werden. Bitte über Google Play aktualisieren.</string>
     <string name="update_later">Später</string>
 
     <!-- Card Holder -->    <string name="card_holder_capabilities">Fähigkeiten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -763,6 +763,10 @@ Tu suscripción permanece activa y puedes reenlazar en cualquier momento (sujeto
     <string name="update_later">Más Tarde</string>
     <string name="update_message">Una nueva versión (v%s) está disponible. ¡Actualiza para la mejor experiencia!</string>
     <string name="update_now">Actualizar Ahora</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">Acerca de esta actualización</string>
+    <string name="update_help_body">Tu versión %1$s → última %2$s. Toca «Actualizar Ahora» para actualizar dentro de la app (unos 30 segundos, sin salir). Si la actualización en la app no está disponible, se abrirá Play Store.</string>
+    <string name="update_store_unavailable">No se pudo abrir la tienda para actualizar. Actualiza desde Google Play.</string>
     <string name="update_title">Actualización Disponible</string>
     <string name="upload">Subir</string>
     <string name="upload_error">Error al subir</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -805,6 +805,10 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="update_title">Mise à jour disponible</string>
     <string name="update_message">Une nouvelle version (v%s) est disponible. Mettez à jour pour la meilleure expérience !</string>
     <string name="update_now">Mettre à jour</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">À propos de cette mise à jour</string>
+    <string name="update_help_body">Votre version %1$s → dernière %2$s. Appuyez sur « Mettre à jour » pour mettre à jour directement dans l\'application (environ 30 secondes, sans la quitter). Si la mise à jour intégrée n\'est pas disponible, le Play Store s\'ouvre.</string>
+    <string name="update_store_unavailable">Impossible d\'ouvrir le store pour la mise à jour. Veuillez mettre à jour depuis Google Play.</string>
     <string name="update_later">Plus tard</string>
 
     <!-- Card Holder -->    <string name="card_holder_capabilities">Capacités</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -813,6 +813,10 @@ GPS: केवल अनुरोध पर, कोई बैकग्राउ�
     <string name="update_title">अपडेट उपलब्ध</string>
     <string name="update_message">एक नया वर्शन (v%s) उपलब्ध है। सर्वोत्तम अनुभव के लिए अपडेट करें!</string>
     <string name="update_now">अभी अपडेट करें</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">इस अपडेट के बारे में</string>
+    <string name="update_help_body">आपका वर्शन %1$s → नवीनतम %2$s. ऐप के अंदर ही अपडेट करने के लिए "अभी अपडेट करें" पर टैप करें (लगभग 30 सेकंड, ऐप छोड़ने की ज़रूरत नहीं)। अगर इन-ऐप अपडेट उपलब्ध नहीं है, तो Play Store खुलेगा।</string>
+    <string name="update_store_unavailable">अपडेट के लिए स्टोर नहीं खोल सके। कृपया Google Play से अपडेट करें।</string>
     <string name="update_later">बाद में</string>
 
     <!-- Card Holder -->    <string name="card_holder_capabilities">क्षमताएं</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -772,6 +772,10 @@
     <string name="update_later">Nanti</string>
     <string name="update_message">Versi baru (v%s) sudah tersedia. Perbarui untuk pengalaman terbaik!</string>
     <string name="update_now">Perbarui Sekarang</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">Tentang pembaruan ini</string>
+    <string name="update_help_body">Versi Anda %1$s → terbaru %2$s. Ketuk "Perbarui Sekarang" untuk memperbarui langsung di dalam aplikasi (sekitar 30 detik, tanpa keluar aplikasi). Jika pembaruan dalam aplikasi tidak tersedia, Play Store akan terbuka.</string>
+    <string name="update_store_unavailable">Tidak dapat membuka toko untuk memperbarui. Silakan perbarui dari Google Play.</string>
     <string name="update_title">Pembaruan Tersedia</string>
     <string name="upgrade_plan">Upgrade Paket</string>
     <string name="upload">Unggah</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -746,6 +746,10 @@ Jika ada pertanyaan, silakan hubungi kami melalui email resmi kami.
     <string name="update_later">Nanti</string>
     <string name="update_message">Versi baru (v%s) sudah tersedia. Perbarui untuk pengalaman terbaik!</string>
     <string name="update_now">Perbarui Sekarang</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">Tentang pembaruan ini</string>
+    <string name="update_help_body">Versi Anda %1$s → terbaru %2$s. Ketuk "Perbarui Sekarang" untuk memperbarui langsung di dalam aplikasi (sekitar 30 detik, tanpa keluar aplikasi). Jika pembaruan dalam aplikasi tidak tersedia, Play Store akan terbuka.</string>
+    <string name="update_store_unavailable">Tidak dapat membuka toko untuk memperbarui. Silakan perbarui dari Google Play.</string>
     <string name="update_title">Pembaruan Tersedia</string>
     <string name="upload">Unggah</string>
     <string name="upload_error">Gagal mengunggah</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -713,6 +713,10 @@
     <string name="update_title">Aggiornamento disponibile</string>
     <string name="update_message">Una nuova versione (v%s) è disponibile. </string>
     <string name="update_now">Aggiorna ora</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">Informazioni su questo aggiornamento</string>
+    <string name="update_help_body">La tua versione %1$s → ultima %2$s. Tocca "Aggiorna ora" per aggiornare direttamente nell\'app (circa 30 secondi, senza uscire). Se l\'aggiornamento in-app non è disponibile, si apre il Play Store.</string>
+    <string name="update_store_unavailable">Impossibile aprire lo store per l\'aggiornamento. Aggiorna da Google Play.</string>
     <string name="update_later">Dopo</string>
     <string name="card_holder_capabilities">Capacità</string>
     <string name="card_holder_tags">Tag</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -745,6 +745,10 @@ GPS：オンデマンドのみ、バックグラウンド追跡なし、サー�
     <string name="update_later">後で</string>
     <string name="update_message">新しいバージョン (v%s) が利用可能です。最高の体験のためにアップデートしてください！</string>
     <string name="update_now">今すぐ更新</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">このアップデートについて</string>
+    <string name="update_help_body">現在のバージョン %1$s → 最新 %2$s。「今すぐ更新」をタップすると、アプリ内でそのまま更新できます（約30秒、アプリを離れる必要はありません）。アプリ内更新ができない場合は Play ストアが開きます。</string>
+    <string name="update_store_unavailable">ストアを開いて更新できませんでした。Google Play から更新してください。</string>
     <string name="update_title">アップデートがあります</string>
     <string name="upload">アップロード</string>
     <string name="upload_error">アップロードに失敗しました</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -745,6 +745,10 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="update_later">나중에</string>
     <string name="update_message">새 버전 (v%s)이 출시되었습니다. 최상의 경험을 위해 업데이트하세요!</string>
     <string name="update_now">지금 업데이트</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">이 업데이트 정보</string>
+    <string name="update_help_body">현재 버전 %1$s → 최신 %2$s. "지금 업데이트"를 누르면 앱을 벗어나지 않고 바로 업데이트됩니다(약 30초). 앱 내 업데이트를 사용할 수 없으면 Play 스토어가 열립니다.</string>
+    <string name="update_store_unavailable">업데이트를 위해 스토어를 열 수 없습니다. Google Play에서 업데이트해 주세요.</string>
     <string name="update_title">업데이트 가능</string>
     <string name="upload">업로드</string>
     <string name="upload_error">업로드 실패</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -813,6 +813,10 @@ Jika anda mempunyai sebarang soalan, sila hubungi kami melalui e-mel rasmi kami.
     <string name="update_title">Kemas Kini Tersedia</string>
     <string name="update_message">Versi baharu (v%s) tersedia. Kemas kini untuk pengalaman terbaik!</string>
     <string name="update_now">Kemas Kini Sekarang</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">Tentang kemas kini ini</string>
+    <string name="update_help_body">Versi anda %1$s → terkini %2$s. Ketik "Kemas Kini Sekarang" untuk mengemas kini terus dalam apl (kira-kira 30 saat, tanpa keluar apl). Jika kemas kini dalam apl tiada, Gedung Play akan dibuka.</string>
+    <string name="update_store_unavailable">Tidak dapat membuka gedung untuk mengemas kini. Sila kemas kini dari Google Play.</string>
     <string name="update_later">Kemudian</string>
 
     <!-- Card Holder -->    <string name="card_holder_capabilities">Keupayaan</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -713,6 +713,10 @@
     <string name="update_title">Atualização disponível</string>
     <string name="update_message">Uma nova versão (v%s) está disponível. </string>
     <string name="update_now">Atualizar agora</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">Sobre esta atualização</string>
+    <string name="update_help_body">Sua versão %1$s → mais recente %2$s. Toque em "Atualizar agora" para atualizar dentro do app (cerca de 30 segundos, sem sair). Se a atualização no app não estiver disponível, a Play Store será aberta.</string>
+    <string name="update_store_unavailable">Não foi possível abrir a loja para atualizar. Atualize pela Google Play.</string>
     <string name="update_later">Mais tarde</string>
     <string name="card_holder_capabilities">Capacidades</string>
     <string name="card_holder_tags">Etiquetas</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -713,6 +713,10 @@
     <string name="update_title">Доступно обновление</string>
     <string name="update_message">Доступна новая версия (v%s). </string>
     <string name="update_now">Обновить сейчас</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">Об этом обновлении</string>
+    <string name="update_help_body">Ваша версия %1$s → последняя %2$s. Нажмите «Обновить сейчас», чтобы обновить прямо в приложении (около 30 секунд, не выходя из него). Если обновление в приложении недоступно, откроется Play Маркет.</string>
+    <string name="update_store_unavailable">Не удалось открыть магазин для обновления. Обновите через Google Play.</string>
     <string name="update_later">Позже</string>
     <string name="card_holder_capabilities">Возможности</string>
     <string name="card_holder_tags">Теги</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -745,6 +745,10 @@ GPS：รับตามความต้องการเท่านั้�
     <string name="update_later">ภายหลัง</string>
     <string name="update_message">เวอร์ชันใหม่ (v%s) พร้อมใช้งานแล้ว อัปเดตเพื่อประสบการณ์ที่ดีที่สุด!</string>
     <string name="update_now">อัปเดตเลย</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">เกี่ยวกับการอัปเดตนี้</string>
+    <string name="update_help_body">เวอร์ชันของคุณ %1$s → ล่าสุด %2$s แตะ "อัปเดตเลย" เพื่ออัปเดตภายในแอปได้ทันที (ประมาณ 30 วินาที ไม่ต้องออกจากแอป) หากอัปเดตในแอปไม่ได้ ระบบจะเปิด Play Store แทน</string>
+    <string name="update_store_unavailable">เปิดสโตร์เพื่ออัปเดตไม่ได้ โปรดอัปเดตจาก Google Play</string>
     <string name="update_title">มีอัปเดตใหม่</string>
     <string name="upload">อัปโหลด</string>
     <string name="upload_error">อัปโหลดล้มเหลว</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -745,6 +745,10 @@ Nếu có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi qua
     <string name="update_later">Để sau</string>
     <string name="update_message">Phiên bản mới (v%s) đã sẵn sàng. Cập nhật để có trải nghiệm tốt nhất!</string>
     <string name="update_now">Cập nhật ngay</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">Giới thiệu về bản cập nhật này</string>
+    <string name="update_help_body">Phiên bản của bạn %1$s → mới nhất %2$s. Nhấn "Cập nhật ngay" để cập nhật ngay trong ứng dụng (khoảng 30 giây, không cần rời ứng dụng). Nếu không cập nhật được trong ứng dụng, Cửa hàng Play sẽ mở ra.</string>
+    <string name="update_store_unavailable">Không mở được cửa hàng để cập nhật. Vui lòng cập nhật từ Google Play.</string>
     <string name="update_title">Có bản cập nhật mới</string>
     <string name="upload">Tải lên</string>
     <string name="upload_error">Tải lên thất bại</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -749,6 +749,10 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="update_later">稍后再说</string>
     <string name="update_message">新版本 (v%s) 已推出，立即更新以获得最佳体验！</string>
     <string name="update_now">立即更新</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">关于此更新</string>
+    <string name="update_help_body">你的版本 %1$s → 最新 %2$s。点「立即更新」直接在 App 内更新（约 30 秒，无需离开 App）。若无法在 App 内更新，将改为打开 Play 商店。</string>
+    <string name="update_store_unavailable">无法打开商店进行更新，请改到 Google Play 更新。</string>
     <string name="update_title">有新版本可用</string>
     <string name="upload">上传</string>
     <string name="upload_error">上传失败</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -768,6 +768,10 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="update_later">稍後再說</string>
     <string name="update_message">新版本 (v%s) 已推出，立即更新以獲得最佳體驗！</string>
     <string name="update_now">立即更新</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">關於此更新</string>
+    <string name="update_help_body">你的版本 %1$s → 最新 %2$s。點「立即更新」直接在 App 內更新（約 30 秒，不用離開 App）。若無法在 App 內更新，將改為開啟 Play 商店。</string>
+    <string name="update_store_unavailable">無法開啟商店進行更新，請改到 Google Play 更新。</string>
     <string name="update_title">有新版本可用</string>
     <string name="upload">上傳</string>
     <string name="upload_error">上傳失敗</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -916,6 +916,10 @@ If you have any questions, please contact us via our official email.
     <string name="update_message">A new version (v%s) is available. Update for the best experience!</string>
     <string name="update_now">Update Now</string>
     <string name="update_later">Later</string>
+    <!-- Settings update-available chip (card_28a8290a) -->
+    <string name="update_help_title">About this update</string>
+    <string name="update_help_body">Your version %1$s → latest %2$s. Tap "Update Now" to update right inside the app (about 30 seconds, no need to leave). If in-app update isn\'t available, the Play Store opens instead.</string>
+    <string name="update_store_unavailable">Couldn\'t open the store to update. Please update from Google Play.</string>
 
     <!-- Card Holder (shared by MainActivity agent-card editor) -->
     <string name="card_holder_capabilities">Capabilities</string>

--- a/app/src/test/java/com/hank/clawlive/settings/UpdateChipDecisionTest.kt
+++ b/app/src/test/java/com/hank/clawlive/settings/UpdateChipDecisionTest.kt
@@ -1,0 +1,137 @@
+package com.hank.clawlive.settings
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for the Settings update-available chip decision
+ * ([UpdateChipDecision], card_28a8290a). No Android dependencies.
+ *
+ * Standalone (intentionally NOT registered in [com.hank.clawlive.UnitTestSuite]) so
+ * this PR doesn't textually collide with the open wallpaper PR #3650 which also edits
+ * UnitTestSuite.kt. Still runnable directly:
+ *   ./gradlew :app:testDebugUnitTest --tests "*UpdateChipDecisionTest*"
+ */
+class UpdateChipDecisionTest {
+
+    @Test
+    fun `different version with server available shows chip`() {
+        assertTrue(
+            UpdateChipDecision.shouldShowChip(
+                available = true,
+                installedVersion = "1.0.96",
+                latestVersion = "1.0.97"
+            )
+        )
+    }
+
+    @Test
+    fun `major jump shows chip`() {
+        assertTrue(
+            UpdateChipDecision.shouldShowChip(
+                available = true,
+                installedVersion = "1.0.96",
+                latestVersion = "2.0.0"
+            )
+        )
+    }
+
+    @Test
+    fun `same version hides chip even if server says available`() {
+        // Defensive cross-check: stale/garbled available flag must not produce a
+        // false "update now" prompt when the versions are actually equal.
+        assertFalse(
+            UpdateChipDecision.shouldShowChip(
+                available = true,
+                installedVersion = "1.0.96",
+                latestVersion = "1.0.96"
+            )
+        )
+    }
+
+    @Test
+    fun `installed newer than latest hides chip`() {
+        assertFalse(
+            UpdateChipDecision.shouldShowChip(
+                available = true,
+                installedVersion = "1.1.0",
+                latestVersion = "1.0.96"
+            )
+        )
+    }
+
+    @Test
+    fun `server not available hides chip`() {
+        assertFalse(
+            UpdateChipDecision.shouldShowChip(
+                available = false,
+                installedVersion = "1.0.96",
+                latestVersion = "1.0.97"
+            )
+        )
+    }
+
+    @Test
+    fun `null available (fetch failed) hides chip`() {
+        assertFalse(
+            UpdateChipDecision.shouldShowChip(
+                available = null,
+                installedVersion = "1.0.96",
+                latestVersion = "1.0.97"
+            )
+        )
+    }
+
+    @Test
+    fun `blank installed version hides chip - safe default`() {
+        assertFalse(
+            UpdateChipDecision.shouldShowChip(
+                available = true,
+                installedVersion = "",
+                latestVersion = "1.0.97"
+            )
+        )
+    }
+
+    @Test
+    fun `blank latest version hides chip - safe default`() {
+        assertFalse(
+            UpdateChipDecision.shouldShowChip(
+                available = true,
+                installedVersion = "1.0.96",
+                latestVersion = "   "
+            )
+        )
+    }
+
+    @Test
+    fun `unknown installed version hides chip - safe default`() {
+        // DeviceManager.appVersion returns "unknown" when packageInfo lookup fails;
+        // "unknown" vs "1.0.97" compares as 0.0.0 < 1.0.97, but the caller guards on
+        // "unknown" before invoking. Verify the comparator itself stays safe for
+        // garbage that slips through: a non-numeric installed string is treated as
+        // 0.0.0, which IS strictly less than a real latest, so it would show — hence
+        // the caller's explicit "unknown" guard is the real safety net. Here we just
+        // assert malformed-but-equal stays hidden.
+        assertFalse(
+            UpdateChipDecision.shouldShowChip(
+                available = true,
+                installedVersion = "garbage",
+                latestVersion = "garbage"
+            )
+        )
+    }
+
+    @Test
+    fun `suffixed version compares numerically`() {
+        // "1.0.96-debug" should be treated as 1.0.96 < 1.0.97 -> show.
+        assertTrue(
+            UpdateChipDecision.shouldShowChip(
+                available = true,
+                installedVersion = "1.0.96-debug",
+                latestVersion = "1.0.97"
+            )
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ googleId = "1.1.1"
 facebookSdk = "17.0.0"
 playServicesLocation = "21.3.0"
 playIntegrity = "1.6.0"
+playAppUpdate = "2.1.0"
 
 [libraries]
 billing = { group = "com.android.billingclient", name = "billing-ktx", version.ref = "billing" }
@@ -75,6 +76,8 @@ play-services-location = { group = "com.google.android.gms", name = "play-servic
 
 # Google Play Integrity
 play-integrity = { group = "com.google.android.play", name = "integrity", version.ref = "playIntegrity" }
+play-app-update = { group = "com.google.android.play", name = "app-update", version.ref = "playAppUpdate" }
+play-app-update-ktx = { group = "com.google.android.play", name = "app-update-ktx", version.ref = "playAppUpdate" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## What (card_28a8290a, per parent SPEC card_dfb85157189c3255300dc86e)

Adds an **update-available chip** to the Android Settings screen, next to the version row. When the installed build differs from the live `/api/version` latest, the chip appears; tapping it runs the **Google Play Core In-App Update IMMEDIATE flow** (full-screen update UI → background download → restart, user stays in-app, ~30s), falling back to `market://details?id=com.hank.clawlive` and then the `https://play.google.com/...` web URL if the Play Store app is absent.

## How it reuses existing version-fetch code

- The version data comes from the **existing** `GET /api/version` seam — `NetworkModule.api.checkAppVersion(version)` returning `UpdateInfo { available, latestVersion, currentVersion, storeUrl, releaseNotes }`. This is the *same* call `MainActivity.checkForAppUpdate()` already uses for its launch-time update dialog. No new endpoint, no new model. The backend (`backend/index.js` `/api/version`) already computes `update.available` server-side via `compareVersions`.
- Installed version is read from the existing `DeviceManager.appVersion`.
- A new pure-JVM `UpdateChipDecision.shouldShowChip(...)` adds a defensive **local** cross-check using the **existing** `SettingsManifestResolver.compareVersions` (the dotted-version comparator that mirrors `backend/lib/settings-manifest.js`) — so a stale/garbled `available` flag can never produce a *false* "update now" prompt. Any fetch failure / null update block / blank version ⇒ chip stays GONE (graceful degradation, per spec Acceptance).

## Activity result wiring

`registerForActivityResult(StartIntentSenderForResult())` receives the `AppUpdateManager` IMMEDIATE flow result; on cancel/failure it falls back to the store chain.

## ? help affordance (Globe-user)

A `?` icon next to the chip opens a dialog: **current → latest version**, an **"Update now"** CTA, plus a short what/needs/next-step explanation of the in-app-update vs store-fallback behaviour. Visible to all Android users, all locales.

## Dependency

`gradle/libs.versions.toml` + `app/build.gradle.kts`: add `com.google.android.play:app-update` + `app-update-ktx` `2.1.0`.

## i18n

New user-visible strings — `update_help_title`, `update_help_body` (`%1$s` current → `%2$s` latest), `update_store_unavailable` — added to the default locale **and all 17 translated locales** in this PR (zh-rTW, zh-rCN, ja, ko, th, vi, id, in, fr, de, es, pt-rBR, it, ru, ar, hi, ms). Reused existing strings `update_now` / `update_later`. Nothing hardcoded.

## Tests (run locally — REAL run, not fabricated)

`./gradlew :app:testDebugUnitTest --tests "*UpdateChipDecisionTest*"` → **BUILD SUCCESSFUL, 10/10 passed** (0 failures/errors/skipped). Covers: newer/major-jump → show; same/older → hide; server `available=false`/`null` → hide; blank installed/latest → safe-default hide; suffixed `1.0.96-debug` → numeric compare. `compileDebugKotlin` also succeeded, confirming the SettingsActivity Play Core integration compiles against the real artifacts.

`UpdateChipDecisionTest` is intentionally **standalone** (NOT registered in `UnitTestSuite.kt`) to avoid a textual conflict with the open wallpaper **PR #3650**, which also edits `UnitTestSuite.kt`. It still runs via `--tests`. The merger can add it to the suite after #3650 lands if desired.

## ⚠️ BUILD-GATED — DO NOT MERGE until verified on device

This PR has only been verified by **unit test + Kotlin compile**. The user-facing behaviour requires an **Android build + device/emulator run** and is **deferred to Hank's morning**:

**UNVERIFIED (needs build + device):**
- Chip actually appears in Settings on a version mismatch, and stays hidden when on the latest build / when `/api/version` fails.
- Play Core IMMEDIATE in-app update flow launches and completes (full-screen → download → restart). Requires a Play-internal-test/closed-track build (Play Core only serves updates for app versions distributed via Play).
- `market://` → `https://play.google.com/...` store fallback when in-app update is unavailable.
- `?` help dialog rendering across locales.

**VERIFIED:**
- `UpdateChipDecision` logic: 10/10 unit tests pass.
- Debug variant compiles with the new Play Core dependency + Activity result API.
- Net diff is `app/`-only (+ `gradle/libs.versions.toml`); no backend CRLF churn (confirmed via `git diff --cached --numstat origin/main`: total 1 deletion, the intentional `tvAppVersion` bottom-margin tweak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)