### PR TITLE
fix(vault): web vault-save paths send expectedUpdatedAt etag (card_9bd4b4c0)

### DIFF
--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -3544,13 +3544,22 @@
             const vars = loadLocalVars();
             if (Object.keys(vars).length === 0) return;
             try {
-                const result = await apiCall('POST', '/api/device-vars', {
+                // GET first to obtain updatedAt, then POST WITH expectedUpdatedAt so this
+                // background merge can't clobber a concurrent edit (optimistic lock) and
+                // doesn't trip the server's "POST without expectedUpdatedAt" warn
+                // (card_9bd4b4c0). Mirrors chat.html / env-vars.html.
+                const body = {
                     deviceId: currentUser.deviceId,
                     deviceSecret: currentUser.deviceSecret,
                     vars,
                     locked,
                     source: 'web'
-                });
+                };
+                try {
+                    const serverData = await apiCall('GET', `/api/device-vars?deviceId=${currentUser.deviceId}&deviceSecret=${currentUser.deviceSecret}`);
+                    if (serverData && serverData.updatedAt) body.expectedUpdatedAt = serverData.updatedAt;
+                } catch (_) { /* non-fatal — proceed without etag (first-time sync) */ }
+                const result = await apiCall('POST', '/api/device-vars', body);
                 if (result && result.mergedVars) {
                     localStorage.setItem(VARS_STORAGE_KEY(), JSON.stringify(result.mergedVars));
                 }

--- a/backend/public/portal/publisher-setup.html
+++ b/backend/public/portal/publisher-setup.html
@@ -290,12 +290,17 @@
             try {
                 // POST /api/device-vars with source=web performs a merge that preserves
                 // existing keys from other sources (APP) while updating our 4 X keys.
-                const result = await apiCall('POST', '/api/device-vars', {
-                    deviceId: window.currentUser.deviceId,
-                    deviceSecret: window.currentUser.deviceSecret,
-                    vars,
-                    source: 'web'
-                });
+                // GET first to obtain updatedAt, then POST WITH expectedUpdatedAt so this
+                // save can't clobber a concurrent edit (optimistic lock) and doesn't trip
+                // the server's "POST without expectedUpdatedAt" warn (card_9bd4b4c0).
+                const _did = window.currentUser.deviceId;
+                const _dsec = window.currentUser.deviceSecret;
+                const body = { deviceId: _did, deviceSecret: _dsec, vars, source: 'web' };
+                try {
+                    const serverData = await apiCall('GET', `/api/device-vars?deviceId=${_did}&deviceSecret=${_dsec}`);
+                    if (serverData && serverData.updatedAt) body.expectedUpdatedAt = serverData.updatedAt;
+                } catch (_) { /* non-fatal — first-time save has no server row yet */ }
+                const result = await apiCall('POST', '/api/device-vars', body);
 
                 if (result && result.success) {
                     showResult(

--- a/backend/tests/jest/portal-vault-post-sends-etag.test.js
+++ b/backend/tests/jest/portal-vault-post-sends-etag.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+// card_9bd4b4c0 — recurring ErrLog "[Vars] POST without expectedUpdatedAt
+// against non-empty row (source=web)".
+//
+// Root cause: two web vault-save paths POSTed to /api/device-vars WITHOUT the
+// optimistic-lock token `expectedUpdatedAt`, so they (a) carried the same
+// multi-device last-write-wins race the etag protocol (PR #3422/3423) was meant
+// to close and (b) tripped the server's strict-no-etag warn guard
+// (index.js ~21956, covered by device-vars-strict-no-etag.test.js).
+//
+//   - backend/public/portal/publisher-setup.html  (deliberate 4-key X save)
+//   - backend/public/portal/mission.html          (background syncVarsToServer)
+//
+// chat.html and env-vars.html already did GET-then-POST-with-etag. This test
+// pins ALL web POST paths to that pattern so a future edit can't silently
+// regress one back to a no-etag POST and re-open this recurring card.
+
+const fs = require('fs');
+const path = require('path');
+
+const PORTAL_DIR = path.join(__dirname, '..', '..', 'public', 'portal');
+
+function read(file) {
+    return fs.readFileSync(path.join(PORTAL_DIR, file), 'utf8');
+}
+
+describe('portal vault-save paths send expectedUpdatedAt (card_9bd4b4c0)', () => {
+    test('publisher-setup.html GETs updatedAt then POSTs with expectedUpdatedAt', () => {
+        const src = read('publisher-setup.html');
+        // Reads the server snapshot to obtain the etag…
+        expect(src).toMatch(/apiCall\(\s*['"]GET['"]\s*,\s*[`'"]\/api\/device-vars/);
+        // …and threads it into the POST body as expectedUpdatedAt.
+        expect(src).toMatch(/body\.expectedUpdatedAt\s*=\s*serverData\.updatedAt/);
+        expect(src).toMatch(/apiCall\(\s*['"]POST['"]\s*,\s*['"]\/api\/device-vars['"]\s*,\s*body\s*\)/);
+    });
+
+    test('mission.html syncVarsToServer GETs updatedAt then POSTs with expectedUpdatedAt', () => {
+        const src = read('mission.html');
+        expect(src).toMatch(/apiCall\(\s*['"]GET['"]\s*,\s*[`'"]\/api\/device-vars/);
+        expect(src).toMatch(/body\.expectedUpdatedAt\s*=\s*serverData\.updatedAt/);
+        expect(src).toMatch(/apiCall\(\s*['"]POST['"]\s*,\s*['"]\/api\/device-vars['"]\s*,\s*body\s*\)/);
+    });
+
+    test('chat.html / env-vars.html keep their existing etag handling (regression guard)', () => {
+        expect(read('chat.html')).toMatch(/expectedUpdatedAt/);
+        expect(read('env-vars.html')).toMatch(/expectedUpdatedAt/);
+    });
+
+    // Comprehensive guard: ANY portal file that POSTs to /api/device-vars MUST
+    // also reference expectedUpdatedAt somewhere in the file. Catches a brand-new
+    // page that copies the old no-etag POST shape.
+    test('every portal file POSTing to /api/device-vars references expectedUpdatedAt', () => {
+        const offenders = [];
+        for (const file of fs.readdirSync(PORTAL_DIR)) {
+            if (!file.endsWith('.html')) continue;
+            const src = read(file);
+            const postsVault = /apiCall\(\s*['"]POST['"]\s*,\s*['"]\/api\/device-vars['"]/.test(src);
+            if (postsVault && !src.includes('expectedUpdatedAt')) {
+                offenders.push(file);
+            }
+        }
+        expect(offenders).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Scope
Close the recurring ErrLog card **[Vars] POST without expectedUpdatedAt against non-empty row (source=web)** (card_9bd4b4c0; siblings ×4 card_a28a4836, ×7 card_bd82fac5, plus ~10 prior closes) by fixing its **root cause** instead of status-closing it again.

Two web vault-save paths POSTed to `/api/device-vars` without the optimistic-lock token `expectedUpdatedAt`:
- `backend/public/portal/publisher-setup.html:293` — deliberate 4-key X-publisher save
- `backend/public/portal/mission.html:3547` — background `syncVarsToServer()`

Both now **GET `updatedAt` first → POST with `expectedUpdatedAt`**, mirroring `chat.html` / `env-vars.html` which already did this. This (a) closes the same multi-device last-write-wins race the etag protocol (PR #3422/3423) was built to prevent, and (b) stops tripping the server strict-no-etag warn guard (`index.js` ~21956) that the 6h ErrLog monitor keeps re-filing.

## Acceptance
- `publisher-setup.html` and `mission.html` send `expectedUpdatedAt` on the vault POST.
- No behavior change when there's no server row yet (first-time save) — GET failure is caught, POST proceeds without the token (server's `existingKeyCount > 0` guard only fires on non-empty rows).
- Server-side merge semantics (cross-source key preservation) unchanged.

## Test plan
- New `backend/tests/jest/portal-vault-post-sends-etag.test.js` (source-grep, mirrors the existing `device-vars-strict-no-etag.test.js` style): asserts both fixed paths GET-then-POST-with-etag, regression-guards chat/env-vars, and a comprehensive guard that **any** portal file POSTing the vault references `expectedUpdatedAt` (so a new page can't silently re-introduce the bug).
- `npx jest portal-vault-post-sends-etag device-vars-strict-no-etag` → **14/14 green** locally.

## Evidence plan
Jest log attached to the kanban card; this is a client-JS change verified by source-grep test (no rendered-UI surface change — the save buttons look/behave identically, only the request body gains a field). Post-merge: the 6h ErrLog monitor should stop re-filing this card.

## Out-of-scope
- Flipping `VAULT_STRICT_NO_ETAG` from `warn` to `reject` (separate ops decision once mobile/Android also ship etag-aware writes — tracked on card_908a34a9).
- Android/app-side vault writes (native client, separate path).

## User POV
Owners saving X-publisher credentials or editing vault vars on the web portal no longer risk a concurrent edit on another device/tab silently clobbering their save; a stale write is rejected and re-merged rather than lost. No visible UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)