### PR TITLE
fix(push): log benign push_timeout at info, not warn (card_52ee8e0c)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -12011,6 +12011,10 @@ app.post('/api/client/speak', idempotencyMiddleware, clientSpeakDedupeMiddleware
                 messageObj.delivered = true;
                 console.log(`[Push] ✓ Channel push OK for Device ${deviceId} Entity ${eId}`);
                 serverLog('info', 'client_push', `Entity ${eId} channel push OK`, { deviceId, entityId: eId, metadata: { source, mode: 'channel' } });
+            } else if (pushResult.reason === 'push_timeout') {
+                // Benign async-uncertain (see webhook path below) — info, not warn.
+                console.log(`[Push] ⏳ Channel push timeout for Device ${deviceId} Entity ${eId} — bot may reply async via /api/transform`);
+                serverLog('info', 'client_push', `Entity ${eId} channel push timeout (async-uncertain)`, { deviceId, entityId: eId, metadata: { mode: 'channel' } });
             } else {
                 console.warn(`[Push] ✗ Channel push failed for Device ${deviceId} Entity ${eId}: ${pushResult.reason}`);
                 serverLog('warn', 'client_push', `Entity ${eId} channel push failed: ${pushResult.reason}`, { deviceId, entityId: eId });
@@ -12071,6 +12075,12 @@ app.post('/api/client/speak', idempotencyMiddleware, clientSpeakDedupeMiddleware
                 messageObj.delivered = true;
                 console.log(`[Push] ✓ Successfully pushed to Device ${deviceId} Entity ${eId}`);
                 serverLog('info', 'client_push', `Entity ${eId} push OK`, { deviceId, entityId: eId, metadata: { source, webhookUrl: entity.webhook.url } });
+            } else if (pushResult.reason === 'push_timeout') {
+                // Benign async-uncertain: pushToBot already logged the timeout; the bot
+                // may still reply via /api/transform. Log at info so the prod-log ERROR
+                // monitor doesn't page a benign timeout (card_52ee8e0c et al.).
+                console.log(`[Push] ⏳ Device ${deviceId} Entity ${eId}: push timeout — bot may reply async via /api/transform`);
+                serverLog('info', 'client_push', `Entity ${eId} push timeout (async-uncertain)`, { deviceId, entityId: eId, metadata: { webhookUrl: entity.webhook?.url } });
             } else {
                 console.warn(`[Push] ✗ Failed to push to Device ${deviceId} Entity ${eId}: ${pushResult.reason}`);
                 serverLog('warn', 'client_push', `Entity ${eId} push failed: ${pushResult.reason}`, { deviceId, entityId: eId, metadata: { webhookUrl: entity.webhook?.url } });
@@ -19170,13 +19180,19 @@ async function pushToBot(entity, deviceId, eventType, payload, opts = {}) {
         const isAbort = err.name === 'AbortError' || err.name === 'TimeoutError'
             || /aborted|timeout/i.test(err.message || '');
 
-        // Log severity must match reality (no "benign error"): a gateway timeout is a
-        // known async-uncertain state (bot may still reply via /api/transform), so it is
-        // a WARN, not an ERROR. Reserve console.error + serverLog('error') for hard
-        // failures (ENOTFOUND / ECONNREFUSED / TLS / non-2xx). This stops benign
-        // push-timeout noise (esp. to offline/test devices) from paging as ERROR.
+        // Log severity must match reality (no "benign error"): a gateway timeout is
+        // EXPECTED operation, not a failure — the bot may still reply async via
+        // /api/transform after the 15s push window. So it is INFO, not warn/error.
+        // (A prior pass logged this at console.warn intending "not an ERROR", but the
+        // prod-log monitor buckets stderr — both console.warn AND console.error — as
+        // ERROR, so warn still paged. card_52ee8e0c: this benign push_timeout recurred
+        // as an ErrLog/ERROR card every 6h. Logging at info/console.log keeps it off
+        // stderr; the "which bot went silent" signal is preserved by entity.pushStatus
+        // + the no_reply axis counter below, independent of console level.) Reserve
+        // console.error + serverLog('error') for hard failures (ENOTFOUND /
+        // ECONNREFUSED / TLS / non-2xx).
         if (isAbort) {
-            console.warn(`[Push] ⏳ Device ${deviceId} Entity ${entity.entityId}: push gateway timeout (no 15s ack) — bot may reply async via /api/transform: ${err.message}`);
+            console.log(`[Push] ⏳ Device ${deviceId} Entity ${entity.entityId}: push gateway timeout (no 15s ack) — bot may reply async via /api/transform: ${err.message}`);
         } else {
             console.error(`[Push] ✗ Device ${deviceId} Entity ${entity.entityId}: Push error:`, err.message);
             console.error(`[Push] Full error:`, err);

--- a/backend/tests/jest/push-timeout-log-severity.test.js
+++ b/backend/tests/jest/push-timeout-log-severity.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+// card_52ee8e0c — recurring ErrLog "[Push] ⏳ ... push gateway timeout" and
+// "[Push] ✗ Failed to push ... (push_timeout)" cards (×N in backlog + ~8 prior
+// status-only closes).
+//
+// Root cause: a push_timeout is EXPECTED operation, not a failure — after the
+// 15s push window the bot may still reply async via /api/transform. The code
+// logged it at console.warn, but the prod-log monitor buckets ALL stderr
+// (console.warn AND console.error) as ERROR, so a benign async timeout paged as
+// an ERROR follow-up card every 6h. Fix: log push_timeout at info (console.log,
+// stdout); keep real failures at warn and hard connection errors at error.
+//
+// The "which bot went silent" signal is preserved independently via
+// entity.pushStatus + the entity-status no_reply axis counter, so dropping the
+// stderr line loses no observability.
+
+const fs = require('fs');
+const path = require('path');
+
+const indexSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'index.js'), 'utf8');
+
+describe('push_timeout logs at info, real failures stay warn/error (card_52ee8e0c)', () => {
+    test('pushToBot timeout (isAbort) branch uses console.log, NOT console.warn', () => {
+        // The abort branch line must be console.log now.
+        expect(indexSrc).toMatch(
+            /if \(isAbort\) \{\s*\n\s*console\.log\(`\[Push\] ⏳ Device \$\{deviceId\} Entity \$\{entity\.entityId\}: push gateway timeout \(no 15s ack\)/
+        );
+        // And must NOT have reverted to console.warn for that exact line.
+        expect(indexSrc).not.toMatch(
+            /console\.warn\(`\[Push\] ⏳ Device \$\{deviceId\} Entity \$\{entity\.entityId\}: push gateway timeout/
+        );
+    });
+
+    test('webhook caller gates push_timeout → console.log + serverLog(info)', () => {
+        expect(indexSrc).toMatch(
+            /\} else if \(pushResult\.reason === 'push_timeout'\) \{[\s\S]{0,400}?console\.log\(`\[Push\] ⏳ Device \$\{deviceId\} Entity \$\{eId\}: push timeout/
+        );
+        expect(indexSrc).toMatch(
+            /serverLog\('info', 'client_push', `Entity \$\{eId\} push timeout \(async-uncertain\)`/
+        );
+    });
+
+    test('channel caller gates push_timeout → console.log + serverLog(info)', () => {
+        expect(indexSrc).toMatch(
+            /serverLog\('info', 'client_push', `Entity \$\{eId\} channel push timeout \(async-uncertain\)`/
+        );
+    });
+
+    test('real (non-timeout) push failures still log at warn', () => {
+        // The else branches that fire for non-push_timeout reasons must remain warn.
+        expect(indexSrc).toMatch(/console\.warn\(`\[Push\] ✗ Failed to push to Device \$\{deviceId\} Entity \$\{eId\}: \$\{pushResult\.reason\}`/);
+        expect(indexSrc).toMatch(/console\.warn\(`\[Push\] ✗ Channel push failed for Device \$\{deviceId\} Entity \$\{eId\}: \$\{pushResult\.reason\}`/);
+    });
+
+    test('hard connection errors (non-abort) still log at console.error + serverLog(error)', () => {
+        // The isAbort=false branch must keep error-level severity for real failures.
+        expect(indexSrc).toMatch(/console\.error\(`\[Push\] ✗ Device \$\{deviceId\} Entity \$\{entity\.entityId\}: Push error:`/);
+        expect(indexSrc).toMatch(/serverLog\('error', 'push_error', `Entity \$\{entity\.entityId\} push exception/);
+    });
+});


### PR DESCRIPTION
## Scope
Close the recurring ErrLog cards **[Push] ⏳ ... push gateway timeout** and **[Push] ✗ Failed to push ... (push_timeout)** (card_52ee8e0c + 3 siblings card_4f9a840b / card_d78c32d3 / card_95b70e7b in backlog, ~8 prior status-only closes) by fixing the **root cause** instead of status-closing again.

A `push_timeout` is **expected operation**, not a failure: after the 15s push window the bot may still reply async via `/api/transform` (this is the platform's designed async-reply path). The code logged it at `console.warn` intending "not an ERROR", but the out-of-repo 6h prod-log monitor buckets **all stderr** (`console.warn` AND `console.error`) as ERROR — so a benign async timeout paged as an ERROR follow-up card every 6h. Same recurring-noise anti-pattern as the vault etag fix (#3658).

## Acceptance
- `pushToBot` abort/timeout branch logs at `console.log` (info), not `console.warn`.
- `/api/client/speak` webhook + channel callers gate `reason === 'push_timeout'` → `console.log` + `serverLog('info')`.
- Real (non-timeout) push failures still `console.warn`; hard connection errors (ENOTFOUND/ECONNREFUSED/TLS/non-2xx) still `console.error` + `serverLog('error')` — severity untouched.
- No observability lost: which-bot-went-silent is tracked by `entity.pushStatus` + the entity-status `no_reply` axis counter, independent of console level.

## Test plan
- New `backend/tests/jest/push-timeout-log-severity.test.js` (source-grep, mirrors `device-vars-strict-no-etag.test.js`): pins timeout→info, real-failure→warn, hard-error→error so a future edit can't silently re-page benign timeouts. **5/5 green** locally.
- `node -c backend/index.js` passes.

## Evidence plan
Jest log attached to the kanban card. Backend-only log-level change verified by source-grep test + full Backend CI. Post-merge: the 6h ErrLog monitor should stop re-filing the push_timeout cards.

## Out-of-scope
- The systemic monitor robustness (the Hermes 6h monitor should not bucket every console.warn/stderr line as ERROR) — that's a Hermes-owned monitor improvement, filed/routed separately.
- Sibling `serverLog('warn', ...)` not-pushed lines on the bot-to-bot / broadcast / cross-speak paths (different message text, not the recurring cards here); can adopt the same `push_timeout` gate later via a shared helper if they surface.

## User POV
No user-facing change. Operators stop getting paged by a recurring ERROR card for what is normal async-reply behavior; genuine push failures (offline bot, TLS, connection refused) still surface at warn/error as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)