### PR TITLE
fix(vault): parse BIGINT epoch-millis updated_at — restore etag/optimistic-lock (card_38b6f514)

### DIFF
--- a/backend/safe-date.js
+++ b/backend/safe-date.js
@@ -27,7 +27,20 @@
 function safeUpdatedAtToISO(row) {
     if (!row || row.updated_at === null || row.updated_at === undefined) return null;
     try {
-        const d = new Date(row.updated_at);
+        let v = row.updated_at;
+        // device_vars.updated_at is BIGINT epoch-millis, and node-postgres
+        // returns BIGINT (int8) as a STRING. `new Date("1782084491324")` is an
+        // Invalid Date — JS treats only a *number* as epoch-millis, not an
+        // all-digit string. Coerce an all-digit string to Number so it parses
+        // as epoch-millis. Without this, GET /api/device-vars returned
+        // updatedAt:null for EVERY row, so clients could never echo the
+        // optimistic-lock token and every non-empty-row vault POST tripped the
+        // "[Vars] POST without expectedUpdatedAt" warn (card_38b6f514); the 409
+        // stale-write check (index.js) was dead for the same reason. ISO /
+        // Date-string values (other tables' TIMESTAMPTZ) contain non-digits, so
+        // they skip coercion and parse exactly as before.
+        if (typeof v === 'string' && /^\d+$/.test(v)) v = Number(v);
+        const d = new Date(v);
         if (Number.isNaN(d.getTime())) return null;
         return d.toISOString();
     } catch (_) {

--- a/backend/tests/jest/safe-date.test.js
+++ b/backend/tests/jest/safe-date.test.js
@@ -90,6 +90,35 @@ describe('safeUpdatedAtToISO', () => {
         });
     });
 
+    describe('BIGINT epoch-millis returned as a STRING (card_38b6f514)', () => {
+        // device_vars.updated_at is BIGINT epoch-millis; node-postgres returns
+        // BIGINT (int8) as a STRING (no int8 type-parser is configured). Before
+        // the coercion fix, new Date("1750000000000") was an Invalid Date so the
+        // helper returned null — which made GET /api/device-vars emit
+        // updatedAt:null for every row, so clients could never echo the
+        // optimistic-lock token and every non-empty-row vault POST tripped the
+        // "[Vars] POST without expectedUpdatedAt" warn. The 409 stale-write
+        // check was dead for the same reason.
+
+        test('all-digit string (pg int8 shape) parses as epoch-millis, NOT null', () => {
+            const out = safeUpdatedAtToISO({ updated_at: '1750000000000' });
+            expect(out).toBe(new Date(1750000000000).toISOString());
+            expect(out).not.toBeNull();
+        });
+
+        test('string and number forms produce the same ISO', () => {
+            const ms = 1782084491324;
+            expect(safeUpdatedAtToISO({ updated_at: String(ms) }))
+                .toBe(safeUpdatedAtToISO({ updated_at: ms }));
+        });
+
+        test('non-digit (ISO) strings still parse and are NOT coerced to a number', () => {
+            // Guard the coercion is digit-only: ISO strings must keep working.
+            expect(safeUpdatedAtToISO({ updated_at: '2026-06-16T14:00:00Z' }))
+                .toBe('2026-06-16T14:00:00.000Z');
+        });
+    });
+
     describe('incident-class regression coverage', () => {
         // These mirror the actual shapes the pg driver was returning when the
         // 06-16 incidents fired. If any of these throw, the server is back in


### PR DESCRIPTION
## Scope
Fix the **true root cause** of the recurring ErrLog **[Vars] POST without expectedUpdatedAt against non-empty row (source=web)** (card_38b6f514 + the long ×1/×4/×6 series; the card the 6h prod-log monitor kept re-filing).

`device_vars.updated_at` is **BIGINT epoch-millis**, and node-postgres returns BIGINT (int8) as a **string** (no int8 type-parser is configured). `safeUpdatedAtToISO` did `new Date(row.updated_at)`, but `new Date("1782084491324")` is an **Invalid Date** (JS treats only a *number* as epoch-millis, not an all-digit string), so the helper returned `null` for every `device_vars` row.

Because the 2026-06-16 RCA deliberately chose null-over-throw, this failed **silently**:
- `GET /api/device-vars` returned `updatedAt: null` for every row → clients (chat/env-vars/mission/publisher-setup) could never echo the optimistic-lock token → **every** non-empty-row web vault POST tripped the warn. (PR #3658's client GET-then-POST was correct, but the server never handed back a usable token — which is why the warn persisted post-deploy at 23:22Z.)
- The 409 stale-write check (`index.js` ~21997) compared against `null` → the **entire optimistic-concurrency feature was dead**.

## Root-cause evidence
- Schema: `device_vars.updated_at BIGINT NOT NULL`; upsert writes `Date.now()` (a number) (`db.js`).
- No `pg.types.setTypeParser`/int8 parser anywhere in `backend/` → pg returns int8 as string.
- Empirical: `safeUpdatedAtToISO({updated_at: 1782084491324})` → ISO; `safeUpdatedAtToISO({updated_at: "1782084491324"})` → **null** (pre-fix).

## Fix
One change in `safe-date.js`: coerce an all-digit string to `Number` before `new Date()` so it parses as epoch-millis. ISO/Date-string values (other tables' TIMESTAMPTZ) contain non-digits → skip coercion → parse exactly as before. Still never throws (preserves the 06-16 crash-safety invariant).

## Acceptance
- `safeUpdatedAtToISO` returns a real ISO for BIGINT-as-string epoch-millis (was `null`).
- `GET /api/device-vars` now returns a non-null `updatedAt` → clients send `expectedUpdatedAt` → the `[Vars]` warn stops, and 409 stale-write detection works again.
- No behavior change for ISO/Date/number/null/garbage inputs.

## Test plan
- `backend/tests/jest/safe-date.test.js` gains a "BIGINT epoch-millis returned as a STRING (card_38b6f514)" block: all-digit string → ISO (not null); string form == number form; ISO strings still parse (digit-only coercion guard). **20/20 green** locally.
- `node -c backend/safe-date.js` passes. Change is inside `safe-date.js`, so the CI `new Date(...updated_at...)` grep ban is not tripped.

## Evidence plan
Jest log attached to the kanban card. Post-merge prod check: `GET /api/device-vars` returns a non-null `updatedAt`, and the 6h ErrLog monitor stops re-filing the `[Vars]` card.

## Out-of-scope
- Whether to flip `VAULT_STRICT_NO_ETAG` warn→reject (separate ops decision, card_908a34a9) — now meaningful again since the token finally flows.

## User POV
No visible UI change. Owners' vault saves now actually carry the optimistic-lock version, so a concurrent edit on another device/tab is detected (409 + re-merge) instead of silently last-write-wins — the protection that shipped in PR #3422/3423 but had been inert. Operators stop getting paged by the recurring `[Vars]` ErrLog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)