### PR TITLE
feat(ios): Settings update-available chip → App Store (card_1771f826)

### DIFF
--- a/ios-app/app/(tabs)/settings.tsx
+++ b/ios-app/app/(tabs)/settings.tsx
@@ -22,11 +22,12 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import i18next from 'i18next';
 import { useAuthStore } from '../../store/authStore';
-import { authApi, settingsManifestApi } from '../../services/api';
+import { authApi, settingsManifestApi, miscApi } from '../../services/api';
 import {
   planDynamicRows,
   type DynamicSettingsRow,
 } from '../../services/settingsManifest';
+import { shouldShowChip, appStoreDeepLink, appStoreHttpsLink } from '../../services/updateChip';
 import { Alert, Linking } from 'react-native';
 import { SUPPORTED_LANGUAGES } from '../../i18n';
 import Constants from 'expo-constants';
@@ -84,6 +85,54 @@ export default function SettingsScreen() {
       cancelled = true;
     };
   }, [appVersion]);
+
+  // ── Update-available chip (card_1771f826) ──────────────────────────────────
+  // iOS counterpart of the Android update chip (card_28a8290a): GET /api/version
+  // and surface a chip ONLY when the backend says an update is available AND a
+  // local version-compare confirms latest is strictly newer (shouldShowChip).
+  // Tapping it deep-links to the App Store product page (itms-apps://, Apple-
+  // compliant — the user taps "Update" there; no silent install). Any failure
+  // leaves the chip hidden (graceful — never a false "update" prompt).
+  const [updateLatest, setUpdateLatest] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await miscApi.getVersion();
+        const u = res?.data?.update;
+        if (cancelled) return;
+        if (shouldShowChip(u?.available, appVersion, u?.latestVersion)) {
+          setUpdateLatest((u?.latestVersion ?? '').trim() || null);
+        }
+      } catch {
+        // offline / 5xx / parse — keep chip hidden
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [appVersion]);
+
+  const openAppStoreUpdate = async () => {
+    try {
+      const canDeep = await Linking.canOpenURL(appStoreDeepLink);
+      await Linking.openURL(canDeep ? appStoreDeepLink : appStoreHttpsLink);
+    } catch {
+      Linking.openURL(appStoreHttpsLink).catch(() => {});
+    }
+  };
+
+  const showUpdateHelp = () => {
+    Alert.alert(
+      t('settings.update_help_title', 'App update available'),
+      t('settings.update_help_body', {
+        current: appVersion,
+        latest: updateLatest ?? '',
+        defaultValue:
+          'A newer version (v{{latest}}) is available; you are on v{{current}}. Tap Update to open the App Store, then tap Update there to install — Apple does not allow in-app installs.',
+      }),
+    );
+  };
 
   const openWebFallback = (row: DynamicSettingsRow) => {
     setHelpRow(null);
@@ -385,6 +434,34 @@ export default function SettingsScreen() {
           >
             {t('settings.app_version', { version: appVersion })}
           </Text>
+          {updateLatest && (
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'center',
+                marginTop: 8,
+              }}
+            >
+              <Button
+                mode="contained-tonal"
+                compact
+                icon="arrow-up-circle-outline"
+                onPress={openAppStoreUpdate}
+              >
+                {t('settings.update_available', {
+                  latest: updateLatest,
+                  defaultValue: 'Update available · v{{latest}}',
+                })}
+              </Button>
+              <IconButton
+                icon="help-circle-outline"
+                size={18}
+                onPress={showUpdateHelp}
+                accessibilityLabel={t('settings.update_help_title', 'App update available')}
+              />
+            </View>
+          )}
         </View>
       </ScrollView>
 

--- a/ios-app/i18n/en.json
+++ b/ios-app/i18n/en.json
@@ -265,7 +265,10 @@
     "feature_gated_badge": "Update app for native screen",
     "feature_gated_help": "This setting has a native screen in a newer app version. Update the app to get it here, or open it on the web now.",
     "feature_web_help": "This setting opens in a web view because the native screen isn't in this app version yet. You can use it on the web now.",
-    "open_on_web": "Open on web"
+    "open_on_web": "Open on web",
+    "update_available": "Update available · v{{latest}}",
+    "update_help_title": "App update available",
+    "update_help_body": "A newer version (v{{latest}}) is available; you are on v{{current}}. Tap Update to open the App Store, then tap Update there to install — Apple does not allow in-app installs."
   },
   "entity": {
     "rename": "Rename Entity",

--- a/ios-app/i18n/zh-CN.json
+++ b/ios-app/i18n/zh-CN.json
@@ -265,7 +265,10 @@
     "feature_gated_badge": "更新 App 以使用原生界面",
     "feature_gated_help": "此设置在较新版本的 App 中有原生界面。请更新 App 以在此使用，或先在网页版打开。",
     "feature_web_help": "此设置会在网页视图中打开，因为这个 App 版本尚未内建原生界面。你现在可以在网页版使用。",
-    "open_on_web": "在网页打开"
+    "open_on_web": "在网页打开",
+    "update_available": "有可用更新 · v{{latest}}",
+    "update_help_title": "有 App 更新",
+    "update_help_body": "有新版本(v{{latest}}),你当前是 v{{current}}。点“更新”打开 App Store,在那里点 Update 安装 — Apple 不允许 App 内直接安装。"
   },
   "entity": {
     "rename": "重命名实体",

--- a/ios-app/i18n/zh-TW.json
+++ b/ios-app/i18n/zh-TW.json
@@ -265,7 +265,10 @@
     "feature_gated_badge": "更新 App 以使用原生畫面",
     "feature_gated_help": "此設定在較新版本的 App 中有原生畫面。請更新 App 以在此使用，或先在網頁版開啟。",
     "feature_web_help": "此設定會在網頁檢視中開啟，因為這個 App 版本尚未內建原生畫面。你現在可以在網頁版使用。",
-    "open_on_web": "在網頁開啟"
+    "open_on_web": "在網頁開啟",
+    "update_available": "有可用更新 · v{{latest}}",
+    "update_help_title": "有 App 更新",
+    "update_help_body": "有新版本(v{{latest}}),你目前是 v{{current}}。點「更新」開啟 App Store,在那裡點 Update 安裝 — Apple 不允許 App 內直接安裝。"
   },
   "entity": {
     "rename": "重新命名實體",

--- a/ios-app/services/__tests__/updateChip.test.ts
+++ b/ios-app/services/__tests__/updateChip.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure-logic tests for the iOS Settings "update-available" chip decision
+ * (ios-app/services/updateChip.ts, card_1771f826).
+ *
+ * Mirrors the Android reference test:
+ *   app/src/test/java/com/hank/clawlive/settings/UpdateChipDecisionTest.kt
+ * No React Native / Expo deps — shouldShowChip is a pure module.
+ */
+import {
+  shouldShowChip,
+  APP_STORE_ID,
+  appStoreDeepLink,
+  appStoreHttpsLink,
+} from '../updateChip';
+
+describe('shouldShowChip', () => {
+  describe('shows ONLY when backend-available AND latest strictly newer', () => {
+    test('available + latest strictly newer -> show', () => {
+      expect(shouldShowChip(true, '1.0.0', '1.1.0')).toBe(true);
+      expect(shouldShowChip(true, '1.2.3', '2.0.0')).toBe(true);
+      // suffix-tolerant (mirrors backend/Android comparator)
+      expect(shouldShowChip(true, '1.0.0-debug', '1.0.1')).toBe(true);
+    });
+  });
+
+  describe('hides on any not-confident signal (never a false prompt)', () => {
+    test('available not true -> hide', () => {
+      expect(shouldShowChip(false, '1.0.0', '2.0.0')).toBe(false);
+      expect(shouldShowChip(null, '1.0.0', '2.0.0')).toBe(false);
+      expect(shouldShowChip(undefined, '1.0.0', '2.0.0')).toBe(false);
+    });
+
+    test('latest equal or older than installed -> hide (clock skew / stale flag)', () => {
+      expect(shouldShowChip(true, '2.0.0', '2.0.0')).toBe(false);
+      expect(shouldShowChip(true, '2.0.0', '1.5.0')).toBe(false);
+      // dotted-equality (1.0 == 1.0.0)
+      expect(shouldShowChip(true, '1.0.0', '1.0')).toBe(false);
+    });
+
+    test('blank / missing version strings -> hide', () => {
+      expect(shouldShowChip(true, '', '2.0.0')).toBe(false);
+      expect(shouldShowChip(true, '1.0.0', '')).toBe(false);
+      expect(shouldShowChip(true, '   ', '2.0.0')).toBe(false);
+      expect(shouldShowChip(true, null, '2.0.0')).toBe(false);
+      expect(shouldShowChip(true, '1.0.0', undefined)).toBe(false);
+    });
+  });
+});
+
+describe('App Store links', () => {
+  test('APP_STORE_ID matches eas.json ascAppId', () => {
+    expect(APP_STORE_ID).toBe('6762198865');
+  });
+  test('deep link uses itms-apps with the app id', () => {
+    expect(appStoreDeepLink).toBe('itms-apps://apps.apple.com/app/id6762198865');
+  });
+  test('https fallback uses the app id', () => {
+    expect(appStoreHttpsLink).toBe('https://apps.apple.com/app/id6762198865');
+  });
+});

--- a/ios-app/services/updateChip.ts
+++ b/ios-app/services/updateChip.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure-logic decision + store-link constants for the Settings
+ * "update-available" chip (card_1771f826, per parent card_dfb85157189c3255300dc86e
+ * spec). iOS counterpart of the Android `UpdateChipDecision` (card_28a8290a).
+ *
+ * The chip is shown ONLY when we are confident a newer build exists. The single
+ * source of truth for "newer build exists" is the backend `/api/version`
+ * response (`update.available` + `update.latestVersion`), which the backend
+ * computes by comparing the client's `appVersion` against `LATEST_APP_VERSION`.
+ *
+ * We do NOT re-implement the server's comparison; we mirror it as a local,
+ * defensive cross-check so a stale/garbled `available` flag can never produce a
+ * *false* update prompt:
+ *   - chip shows  iff  server says available AND a local version-compare also
+ *     says the latest string is strictly greater than the installed version.
+ *   - any fetch failure / null update block / blank version => chip HIDDEN
+ *     (graceful degradation — never a false "update now" prompt).
+ *
+ * Local version comparison reuses [compareVersions] from settingsManifest.ts
+ * (the existing dotted-version comparator, tolerant of suffixes like
+ * "1.2.3-debug" and mirroring backend/lib/settings-manifest.js), so we don't
+ * invent a new one.
+ *
+ * No React Native / Expo deps — covered by a Jest unit test. The actual store
+ * redirect (Linking.openURL) lives in the Settings screen, mirroring how the
+ * Android side keeps the Play Core flow in SettingsActivity, not in the pure
+ * decision object.
+ */
+import { compareVersions } from './settingsManifest';
+
+/**
+ * App Store Connect app id for EClaw (eas.json `ascAppId`; bundle
+ * com.eclawbot.app). Hardcoded per the card spec ("client 寫死 EClaw Apple App
+ * ID"). Used to build the App Store product links below.
+ */
+export const APP_STORE_ID = '6762198865';
+
+/**
+ * `itms-apps://` opens the App Store *app* directly on the EClaw product page —
+ * Apple-compliant (the user still taps "Update" there; no silent install) and
+ * the closest in-spec behaviour available to a managed Expo build. A native
+ * `SKStoreProductViewController` in-app overlay (truly "不離 App") would require
+ * a custom native module / config plugin — tracked as a follow-up; this card
+ * ships the spec's explicit `itms-apps://` path.
+ */
+export const appStoreDeepLink = `itms-apps://apps.apple.com/app/id${APP_STORE_ID}`;
+
+/** Universal https fallback when `itms-apps://` can't be handled (rare). */
+export const appStoreHttpsLink = `https://apps.apple.com/app/id${APP_STORE_ID}`;
+
+/**
+ * @param available the backend's `update.available` flag (null/undefined when no
+ *   update block was returned, e.g. fetch failed or no appVersion sent).
+ * @param installedVersion the running build's version (Constants.expoConfig.version).
+ * @param latestVersion the backend's `update.latestVersion`.
+ * @returns true if the update chip should be visible.
+ */
+export function shouldShowChip(
+  available: boolean | null | undefined,
+  installedVersion: string | null | undefined,
+  latestVersion: string | null | undefined,
+): boolean {
+  // Backend must affirmatively say an update is available.
+  if (available !== true) return false;
+  // Both version strings must be present and non-blank to compare safely.
+  const installed = (installedVersion ?? '').trim();
+  const latest = (latestVersion ?? '').trim();
+  if (installed.length === 0 || latest.length === 0) return false;
+  // Defensive local cross-check: only show when latest is strictly newer.
+  // Equal or older latest (clock skew / stale flag) => safe default: hide.
+  return compareVersions(installed, latest) < 0;
+}


### PR DESCRIPTION
## Scope
iOS counterpart of the Android update-chip (card_28a8290a / PR #3655). Settings screen shows a confident **"Update available · v<latest>"** chip + a `?` help row, tapping opens the App Store product page.

Parent spec: card_dfb85157189c3255300dc86e. Unblocked by #3651 (settingsManifest `compareVersions` export, merged).

## Implementation
- **services/updateChip.ts** (new, pure / no RN deps): `shouldShowChip(available, installed, latest)` shows the chip **only** when the backend `/api/version` says `update.available === true` **AND** a local `compareVersions` cross-check confirms `latest` is strictly newer. Any fetch failure / null update block / blank version ⇒ chip **hidden** (graceful degradation — never a false "update now" prompt). App Store links: `itms-apps://apps.apple.com/app/id6762198865` deep link + `https://` fallback (ascAppId from eas.json).
- **settings.tsx**: `miscApi.getVersion()` on mount → `shouldShowChip` → render chip after the app-version line; `?` IconButton explains *why* (Apple disallows in-app installs; user taps Update in the App Store). `Linking.canOpenURL` → deep link, else https.
- **i18n en/zh-TW/zh-CN**: `settings.update_available` / `update_help_title` / `update_help_body`.

## Acceptance
- Chip visible iff backend-available **and** locally-confirmed-newer; hidden on equal/older/blank/fetch-fail.
- Tap → App Store (Apple-compliant; no silent install).
- `?` help states the requirement + concrete next step (globe-user / empty-state UX per spec).

## Test plan / Evidence
- `services/__tests__/updateChip.test.ts` — **7/7 pass** (mirrors Android `UpdateChipDecisionTest.kt`): show-cases, all hide-cases (not-available / equal-or-older / blank), and App Store link/id assertions.
- `npx tsc --noEmit`: **0 new errors** in touched files (updateChip.ts / settings.tsx); pre-existing baseline errors (e.g. file-manager expo-file-system `cacheDirectory` drift) untouched.

## Out-of-scope (follow-up)
`SKStoreProductViewController` in-app overlay (truly 不離 App) needs a custom native module / config plugin — noted in updateChip.ts header. This PR ships the spec's explicit `itms-apps://` path + https fallback.

## User POV
On an outdated build, a user opening Settings sees a one-tap **Update** chip with a clear `?` explanation, instead of silently running stale code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)