### PR TITLE
fix(ai-support): guard resolveIsAdmin against non-uuid principals (card_2c41721c)

### DIFF
--- a/backend/ai-support.js
+++ b/backend/ai-support.js
@@ -15,6 +15,17 @@ function getAnthropicClient() {
     return _anthropicClient;
 }
 
+// user_accounts.id is a Postgres `uuid`. Some callers in this file authenticate
+// by device secret only (no account) and synthesize a non-account principal
+// `req.user.userId = \`device_<deviceId>\``. Feeding that into a `WHERE id = $1`
+// uuid query throws `invalid input syntax for type uuid` and spams ERROR logs,
+// even though such device sessions can never be a user_accounts admin. Gate any
+// admin lookup on this so non-uuid principals short-circuit before the query.
+const ACCOUNT_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+function isAccountUuid(userId) {
+    return typeof userId === 'string' && ACCOUNT_UUID_RE.test(userId);
+}
+
 module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstructions, feedbackModule }) {
     const router = express.Router();
 
@@ -62,7 +73,12 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
     // `try{...} catch (_) {}` blocks which hid schema drift on user_accounts
     // (e.g. is_admin column rename would lock every admin out invisibly).
     async function resolveIsAdmin(userId) {
-        if (!userId) return false;
+        // Non-account principals (notably the device-secret `device_<deviceId>`
+        // synthetic ids set below) are never user_accounts admins and would
+        // throw `invalid input syntax for type uuid` against the uuid `id`
+        // column — short-circuit before the query instead of catching+logging
+        // a guaranteed miss as an ERROR.
+        if (!isAccountUuid(userId)) return false;
         try {
             const r = await chatPool.query('SELECT is_admin FROM user_accounts WHERE id = $1', [userId]);
             return r.rows[0]?.is_admin || false;
@@ -1827,3 +1843,6 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
 
     return { router, initSupportTable, closeIssue };
 };
+
+// Exported for unit testing the admin-principal guard (see resolveIsAdmin).
+module.exports.isAccountUuid = isAccountUuid;

--- a/backend/tests/jest/ai-support-resolve-isadmin-uuid.test.js
+++ b/backend/tests/jest/ai-support-resolve-isadmin-uuid.test.js
@@ -1,0 +1,47 @@
+/**
+ * resolveIsAdmin admin-principal guard — card_2c41721c
+ *
+ * Regression for the prod ERROR:
+ *   [AI-Support] resolveIsAdmin failed for device_11486328-5c39-45d5-9d7b-a6afc0519aee :
+ *   invalid input syntax for type uuid: "device_11486328-5c39-45d5-9d7b-a6afc0519aee"
+ *
+ * Device-secret-authenticated callers get a synthetic principal
+ * `req.user.userId = "device_<deviceId>"` (ai-support.js, 3 routes). Feeding
+ * that into `SELECT is_admin FROM user_accounts WHERE id = $1` (a uuid column)
+ * throws and used to be caught + logged as ERROR on every such request.
+ * `isAccountUuid()` now gates resolveIsAdmin so non-uuid principals short-circuit
+ * to `false` BEFORE the doomed query — behaviour-preserving (device sessions were
+ * never admins) and ERROR-free.
+ */
+const { isAccountUuid } = require('../../ai-support');
+
+describe('isAccountUuid — admin-lookup principal guard', () => {
+    test('the exact device principal from the prod ERROR is rejected (no uuid query)', () => {
+        expect(isAccountUuid('device_11486328-5c39-45d5-9d7b-a6afc0519aee')).toBe(false);
+    });
+
+    test('any device_<deviceId> synthetic principal is rejected', () => {
+        expect(isAccountUuid('device_abcdef01-2345-6789-abcd-ef0123456789')).toBe(false);
+        expect(isAccountUuid('device_not-a-uuid')).toBe(false);
+    });
+
+    test('a bare account uuid is accepted (real admins still resolve)', () => {
+        expect(isAccountUuid('11486328-5c39-45d5-9d7b-a6afc0519aee')).toBe(true);
+        expect(isAccountUuid('AABBCCDD-1122-3344-5566-778899AABBCC')).toBe(true); // case-insensitive
+    });
+
+    test('empty / null / non-string principals are rejected (matches !userId guard)', () => {
+        expect(isAccountUuid('')).toBe(false);
+        expect(isAccountUuid(null)).toBe(false);
+        expect(isAccountUuid(undefined)).toBe(false);
+        expect(isAccountUuid(12345)).toBe(false);
+        expect(isAccountUuid({})).toBe(false);
+    });
+
+    test('malformed uuid-ish strings are rejected (no partial / padded matches)', () => {
+        expect(isAccountUuid('11486328-5c39-45d5-9d7b')).toBe(false); // too short
+        expect(isAccountUuid('11486328-5c39-45d5-9d7b-a6afc0519aee-extra')).toBe(false); // trailing
+        expect(isAccountUuid(' 11486328-5c39-45d5-9d7b-a6afc0519aee')).toBe(false); // leading space
+        expect(isAccountUuid('zz486328-5c39-45d5-9d7b-a6afc0519aee')).toBe(false); // non-hex
+    });
+});


### PR DESCRIPTION
## Scope
Fixes the recurring prod ERROR (ErrLog card_2c41721c):
```
[AI-Support] resolveIsAdmin failed for device_11486328-5c39-45d5-9d7b-a6afc0519aee :
invalid input syntax for type uuid: "device_11486328-5c39-45d5-9d7b-a6afc0519aee"
```

## Root cause
`ai-support.js` authenticates some routes by device secret only (no account) and sets a **synthetic principal** `req.user.userId = \`device_<deviceId>\`` (lines 1161/1629/1707). `resolveIsAdmin(userId)` fed that into:
```sql
SELECT is_admin FROM user_accounts WHERE id = $1   -- id is a Postgres uuid
```
Postgres can't cast `"device_..."` to `uuid` → throws on every such request, caught and logged as **ERROR**. Device sessions are never `user_accounts` admins, so the query was a **guaranteed miss** regardless.

## Fix (behaviour-preserving, root-cause)
Add `isAccountUuid()` and short-circuit `resolveIsAdmin` to `false` for any non-uuid principal **before** the query — no doomed query, no ERROR. Real account uuids resolve exactly as before. Per the "error = 有問題" rule this is option (a) fix-root-cause, not tolerate.

## Test plan / Evidence
- New `backend/tests/jest/ai-support-resolve-isadmin-uuid.test.js` — **5/5 pass**: the exact prod `device_<uuid>` principal, other `device_` synthetics, valid/case-insensitive account uuids (real admins still resolve), null/empty/non-string, and malformed uuid-ish strings (no partial/padded match).
- Existing `ai-support` + `admin-auth` + `admin-operations` suites: **56/56 still pass** (no regression).
- ESLint: clean on `ai-support.js`.

## Out-of-scope
Whether a device-secret session that maps to an admin account *should* be treated as admin is a separate privilege-model question (current behaviour = not admin; this PR preserves that, only removes the ERROR). Not changed here.

## User POV
Admin-gated AI-Support routes keep returning 403 for device-only callers exactly as before — but the prod error log stops filling with a guaranteed-miss uuid cast failure on every device-authenticated request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)