### PR TITLE
feat(android): wallpaper bubble-duration slider max 20s → 10min (card_c421110c)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 104
+        versionCode = 106
         versionName = "1.0.96"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/androidTest/java/com/hank/clawlive/WallpaperMoreSettingsUiTest.kt
+++ b/app/src/androidTest/java/com/hank/clawlive/WallpaperMoreSettingsUiTest.kt
@@ -62,10 +62,10 @@ class WallpaperMoreSettingsUiTest {
                 assertEquals(18, prefs.wallpaperBubbleDurationSeconds)
                 durationSlider.value = 300f
                 assertEquals(300, prefs.wallpaperBubbleDurationSeconds)
-                prefs.wallpaperBubbleDurationSeconds = 1
-                assertEquals(5, prefs.wallpaperBubbleDurationSeconds)
+                prefs.wallpaperBubbleDurationSeconds = 0
+                assertEquals(1, prefs.wallpaperBubbleDurationSeconds) // clamps up to MIN=1
                 prefs.wallpaperBubbleDurationSeconds = 999
-                assertEquals(300, prefs.wallpaperBubbleDurationSeconds)
+                assertEquals(600, prefs.wallpaperBubbleDurationSeconds) // clamps down to MAX=600 (10 min)
                 prefs.wallpaperBubbleDurationSeconds = LayoutPreferences.WALLPAPER_BUBBLE_DURATION_DEFAULT_SECONDS
             }
         }

--- a/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
@@ -646,7 +646,11 @@ class LayoutPreferences private constructor(context: Context) {
         const val RESET_WINDOW_5H_WEEKLY = "5h_weekly"
 
         const val WALLPAPER_BUBBLE_DURATION_MIN_SECONDS = 1
-        const val WALLPAPER_BUBBLE_DURATION_MAX_SECONDS = 20
+        // Max raised 20s → 600s (10 min) per Hank request (card_c421110c). This
+        // single constant drives both the setter clamp (coerceIn below) and the
+        // WallpaperMoreSettings slider's valueTo, so the slider now reaches 10 min;
+        // secondsLabel() already renders ≥60s as "N 分鐘 / N 分 M 秒".
+        const val WALLPAPER_BUBBLE_DURATION_MAX_SECONDS = 600
         const val WALLPAPER_BUBBLE_DURATION_DEFAULT_SECONDS = 5
         const val WALLPAPER_COLLISION_REACTION_DURATION_MIN_SECONDS = 1
         const val WALLPAPER_COLLISION_REACTION_DURATION_MAX_SECONDS = 20

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -918,7 +918,7 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="wallpaper_setting_speech_bubbles">消息气泡</string>
     <string name="wallpaper_setting_speech_bubbles_desc">在伙伴旁显示实体状态与最近消息。</string>
     <string name="wallpaper_setting_bubble_duration">消息气泡停留时间</string>
-    <string name="wallpaper_setting_bubble_duration_desc">调整壁纸气泡存在时间，可从 1 到 20 秒；聊天聚集会在这个 TTL 结束后回到原位。</string>
+    <string name="wallpaper_setting_bubble_duration_desc">调整壁纸气泡存在时间，可从 1 秒到 10 分钟；聊天聚集会在这个 TTL 结束后回到原位。</string>
     <string name="wallpaper_setting_bubble_duration_value">%1$d 秒</string>
     <string name="wallpaper_setting_bubble_duration_minutes_value">%1$d 分钟</string>
     <string name="wallpaper_setting_bubble_duration_minutes_seconds_value">%1$d 分 %2$d 秒</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -832,7 +832,7 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="wallpaper_setting_speech_bubbles">訊息泡泡</string>
     <string name="wallpaper_setting_speech_bubbles_desc">在夥伴旁顯示實體狀態與最近訊息。</string>
     <string name="wallpaper_setting_bubble_duration">訊息泡泡停留時間</string>
-    <string name="wallpaper_setting_bubble_duration_desc">調整桌布泡泡存在時間，可從 1 到 20 秒；聊天聚集會在這個 TTL 結束後回到原位。</string>
+    <string name="wallpaper_setting_bubble_duration_desc">調整桌布泡泡存在時間，可從 1 秒到 10 分鐘；聊天聚集會在這個 TTL 結束後回到原位。</string>
     <string name="wallpaper_setting_bubble_duration_value">%1$d 秒</string>
     <string name="wallpaper_setting_bubble_duration_minutes_value">%1$d 分鐘</string>
     <string name="wallpaper_setting_bubble_duration_minutes_seconds_value">%1$d 分 %2$d 秒</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,7 +136,7 @@
     <string name="wallpaper_setting_speech_bubbles">Message bubbles</string>
     <string name="wallpaper_setting_speech_bubbles_desc">Show entity status and recent messages near each companion.</string>
     <string name="wallpaper_setting_bubble_duration">Message bubble duration</string>
-    <string name="wallpaper_setting_bubble_duration_desc">Controls how long wallpaper bubbles stay visible, from 1 to 20 seconds. Conversation walking returns home when this TTL ends.</string>
+    <string name="wallpaper_setting_bubble_duration_desc">Controls how long wallpaper bubbles stay visible, from 1 second to 10 minutes. Conversation walking returns home when this TTL ends.</string>
     <string name="wallpaper_setting_bubble_duration_value">%1$d sec</string>
     <string name="wallpaper_setting_bubble_duration_minutes_value">%1$d min</string>
     <string name="wallpaper_setting_bubble_duration_minutes_seconds_value">%1$d min %2$d sec</string>


### PR DESCRIPTION
## Scope
Hank-direct: the wallpaper **More Settings → 'message bubble duration'** slider should reach **10 minutes** (was 20s).

## Implementation (minimal — single source of truth)
`LayoutPreferences.WALLPAPER_BUBBLE_DURATION_MAX_SECONDS` drives **both** the setter clamp (`coerceIn`) and `WallpaperMoreSettingsActivity`'s slider `valueTo`, so:
- **20 → 600** extends the clamp + the slider max to 10 min.
- `secondsLabel()` already renders ≥60s as "N 分鐘 / N 分 M 秒" (strings already exist en/zh-TW/zh-CN); slider keeps **1s precision** (`stepSize=1f`).
- desc strings (en/zh-TW/zh-CN): "1 to 20 seconds" → "1 second to 10 minutes".
- `WallpaperMoreSettingsUiTest`: corrected now-consistent clamp assertions (min→1, max→600); prior 300/5 were stale (and `slider.value=300f` was out-of-range at the old valueTo=20).
- versionCode 104 → 106 (105 already on Play internal).

## Acceptance
- Slider drags to "10 分鐘"; value persists (clamped ≤600); bubble TTL reflects the setting.
- **Verification:** build v106 AAB → Play **internal testing track** → Hank device-test (no automated device pipeline; native).

## Out-of-scope
No formatter/renderer change (already minute-aware).

## User POV
Wallpaper users can keep message bubbles up to 10 minutes instead of 20 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)