### PR TITLE
fix(wallpaper): residual black on brief app-switch — onSurfaceDestroyed must not clear visible (card_f9b2cc2d)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 106
-        versionName = "1.0.96"
+        versionCode = 107
+        versionName = "1.0.97"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/hank/clawlive/engine/EngineLifecycleController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/EngineLifecycleController.kt
@@ -104,7 +104,13 @@ class EngineLifecycleController(private val hooks: Hooks) {
      */
     fun onSurfaceDestroyed() {
         surfacePresent = false
-        visible = false
+        // Do NOT clear `visible` here — visibility is owned exclusively by
+        // onVisibilityChanged. A *brief* app-switch can destroy→recreate the
+        // surface with NO visibility toggle (the system never sends
+        // onVisibilityChanged(false)/(true)). If we cleared `visible`, the
+        // following onSurfaceCreated would skip its draw (visible==false) and
+        // nothing would ever repaint until a full process restart — the residual
+        // black screen card_f9b2cc2d users still hit after the engineScope fix.
         hooks.stopDrawLoop()
         // engineAlive stays true. No releaseEngineResources() here.
     }

--- a/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
+++ b/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
@@ -289,10 +289,19 @@ class ClawWallpaperService : WallpaperService() {
             // engineScope.launch{} was a no-op and draw() used a released
             // renderer → black until a full process restart. We now only stop
             // the draw loop and mark not-visible; engineScope / renderer /
-            // companionRepository survive for the next onSurfaceCreated. Pollers
-            // already get the quota gate via onVisibilityChanged(false), which
-            // fires before the surface is destroyed.
-            visible = false
+            // companionRepository survive for the next onSurfaceCreated.
+            //
+            // RESIDUAL black (card_f9b2cc2d, still reported after the engineScope
+            // fix): this used to also do `visible = false`. A BRIEF app-switch
+            // destroys→recreates the surface with NO onVisibilityChanged toggle,
+            // so that spurious visible=false was never restored — the next
+            // onSurfaceCreated's resume + the draw-loop reschedule (both gated on
+            // `visible`) never ran → permanent black until a process restart,
+            // exactly matching "even the loading-entities text never appears".
+            // Visibility is owned SOLELY by onVisibilityChanged; do NOT clear it
+            // here. The loop is halted by stopDrawLoop() (lifecycle hook) and is
+            // additionally gated on lifecycle.surfacePresent so it cannot spin
+            // while the surface is gone.
             lifecycle.onSurfaceDestroyed()
             Timber.d("onSurfaceDestroyed (paused, engine-lifetime preserved)")
         }
@@ -345,7 +354,11 @@ class ClawWallpaperService : WallpaperService() {
             }
 
             handler.removeCallbacks(drawRunnable)
-            if (visible) {
+            // Loop only while shown AND a surface is present. The surfacePresent
+            // gate stops a 30fps no-op draw spin between a surface destroy and
+            // recreate now that onSurfaceDestroyed no longer clears `visible`
+            // (card_f9b2cc2d residual fix).
+            if (visible && lifecycle.surfacePresent) {
                 handler.postDelayed(drawRunnable, 33)
             }
         }

--- a/app/src/test/java/com/hank/clawlive/EngineLifecycleControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/EngineLifecycleControllerTest.kt
@@ -150,4 +150,28 @@ class EngineLifecycleControllerTest {
         assertTrue(c.surfacePresent)
         assertTrue(c.engineAlive)
     }
+
+    @Test
+    fun briefAppSwitchSurfaceOnlyCycleStillRedraws() {
+        // Regression card_f9b2cc2d (residual black after the engineScope fix):
+        // a *brief* app-switch can destroy then recreate the surface with NO
+        // onVisibilityChanged toggle. `visible` must survive the surface-destroy
+        // so the following onSurfaceCreated redraws — otherwise the wallpaper
+        // stays black until a full process restart (exactly the user's report:
+        // "even the loading-entities text never appears").
+        val (c, hooks) = controller()
+        c.onEngineCreate()
+        c.onSurfaceCreated()
+        c.onVisibilityChanged(true)
+        val restartsAfterShow = hooks.restartCount
+
+        // Surface-only cycle: NO onVisibilityChanged(false)/(true) around it.
+        c.onSurfaceDestroyed()
+        assertTrue("visible must survive a surface-only destroy", c.visible)
+        c.onSurfaceCreated()
+
+        assertTrue("must redraw on surface recreate without a visibility toggle",
+            hooks.restartCount > restartsAfterShow)
+        assertTrue("engine stays alive across the surface-only cycle", c.engineAlive)
+    }
 }


### PR DESCRIPTION
## Scope
The earlier fix (#3650) stopped `onSurfaceDestroyed` from tearing down `engineScope`, but users **still hit a full black screen** (even the loading-entities text never appears) after a *brief* app-switch. This fixes the residual cause.

## Root cause (confirmed with #6, source analysis)
Both `EngineLifecycleController` AND `ClawEngine` cleared `visible = false` in `onSurfaceDestroyed`. A **brief** app-switch destroys→recreates the surface with **no** `onVisibilityChanged` toggle, so that spurious `visible=false` was never restored — the subsequent `onSurfaceCreated` resume + the draw-loop reschedule (both gated on `visible`) never ran → permanent black until a full process restart. The #3650 unit test only covered the controller, so it couldn't catch the **Engine's own** `visible` field.

## Fix
- `EngineLifecycleController.onSurfaceDestroyed`: stop clearing `visible` (owned solely by `onVisibilityChanged`).
- `ClawEngine.onSurfaceDestroyed`: same — drop `visible = false`; draw loop is halted by `stopDrawLoop()` and the reschedule is now also gated on `lifecycle.surfacePresent` so it can't spin while the surface is gone.
- New unit test `briefAppSwitchSurfaceOnlyCycleStillRedraws` (surface-only cycle, no visibility toggle → redraws); existing 6 tests pass.
- versionCode 106→107, versionName 1.0.96→1.0.97 (distinguishable build on Play internal).

Companion sprite cache ruled out (#6: no pause/offline clear point; that would only drop Pet/Dex appearance, not full-black).

## Acceptance
- Unit: EngineLifecycleControllerTest 7/7 (incl. new regression).
- **Device:** v107 on Play internal → Hank: set live wallpaper → Home → other app → return → no black screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)