### PR TITLE
fix(android): guard TtsService.startForeground against ForegroundServiceStartNotAllowedException (API 34+ crash, Play Vitals)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/service/TtsService.kt
+++ b/app/src/main/java/com/hank/clawlive/service/TtsService.kt
@@ -44,7 +44,20 @@ class TtsService : Service(), TextToSpeech.OnInitListener {
         super.onCreate()
         Timber.d("[TTS] Service created")
         createNotificationChannel()
-        startForeground(NOTIFICATION_ID, buildNotification("TTS 語音服務就緒"))
+        // Guard against ForegroundServiceStartNotAllowedException (Android 12+/API 31+):
+        // calling startForeground() while the app is background-restricted throws and crashes.
+        // Catch it, log gracefully, and stop the service instead of crashing.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            try {
+                startForeground(NOTIFICATION_ID, buildNotification("TTS 語音服務就緒"))
+            } catch (e: android.app.ForegroundServiceStartNotAllowedException) {
+                Timber.e(e, "[TTS] startForeground blocked — app is background-restricted (API ${Build.VERSION.SDK_INT}); stopping service gracefully")
+                stopSelf()
+                return
+            }
+        } else {
+            startForeground(NOTIFICATION_ID, buildNotification("TTS 語音服務就緒"))
+        }
         tts = TextToSpeech(this, this)
         observeTtsFlow()
     }


### PR DESCRIPTION
## Summary

- **Play Vitals crash**: `TtsService.onCreate` → `android.app.ForegroundServiceStartNotAllowedException` on API 36 (Android 16), device: Vivo Y29s 5G, versionCode 100
- `startForeground()` was called unconditionally in `onCreate()` with no guard — on Android 12+ (API 31+) this throws `ForegroundServiceStartNotAllowedException` when the app is in background-restricted state, crashing the service
- Bundles into v1.1.0 — no versionCode/versionName bump

## Fix Applied

**Fix 1 — `TtsService.kt:onCreate` (primary safety net)**:
Wrapped `startForeground()` in `Build.VERSION.SDK_INT >= Build.VERSION_CODES.S` guard with `try/catch` for `ForegroundServiceStartNotAllowedException`. On catch: logs the exception with Timber.e() and calls `stopSelf()` gracefully — no crash.

**Fix 2 — AndroidManifest.xml**: Already present (`android:foregroundServiceType="mediaPlayback"` on the TtsService entry, and `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permission). No manifest changes needed.

## Pre-existing State (no change needed)

- `android:foregroundServiceType="mediaPlayback"` — already declared at `AndroidManifest.xml:195`
- `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permission — already present at `AndroidManifest.xml:12`

## Test Plan

- [ ] Install debug APK on Android 12+ device (or emulator API 31+) with app force-stopped/background-restricted
- [ ] Trigger TtsService via FCM with `category=tts` — confirm no crash, service stops gracefully
- [ ] Install on Android < 12 (API < 31) — confirm normal `startForeground` path still works
- [ ] Check Logcat for `[TTS] startForeground blocked` on restricted start

## Build

`./gradlew :app:assembleDebug` — BUILD SUCCESS, 1 file changed (14 insertions, 1 deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gvuBUeX9NfbNNswNsGYmC