### PR TITLE
fix(audit): companion rating-cache RMW + harden 5 weekly-audit rules (card_f9b2cc2d)

### DIFF
--- a/backend/agent-improvement/audit-rules.js
+++ b/backend/agent-improvement/audit-rules.js
@@ -40,6 +40,116 @@ const TEST_PATH_HINTS = Object.freeze([
 const HANK_HEX_DEVICE = '480def4c-2183-4d8e-afd0-b131ae89adcc';
 const HANK_HEX_REGEX = new RegExp(HANK_HEX_DEVICE, 'g');
 
+// ─────────────────────────────────────────────────────────────────────────
+// Schema-derived table classification (card_f9... weekly-audit precision pass,
+// 2026-06-22). Regenerate with a balanced-paren CREATE TABLE / ALTER TABLE ADD
+// COLUMN scan over the whole backend tree:
+//   node -e '<walk *.js/*.sql, mark a table entity-scoped iff its column block
+//            contains `entity_id`>'
+// (721 files / 126 tables at time of writing → 27 entity-scoped, 99 device-grain.)
+//
+// USED AS A *SUPPRESS-LIST* (not an allow-list) so the classification fails
+// SAFE: a table absent here is treated as entity-scoped and STILL fires. So a
+// newly-added entity_id table is caught even before this list is regenerated;
+// only a newly-added device-grain table produces (harmless) noise until added.
+// A device-grain table has no entity_id column → a `WHERE device_id = $1` read
+// on it cannot leak one entity's rows into another's view.
+const DEVICE_GRAIN_TABLES = new Set([
+    'agent_card_holder', 'ai_chat_queries', 'ai_chat_requests', 'arena_comments',
+    'arena_exams', 'arena_feedback', 'arena_leaderboard', 'arena_sessions',
+    'blogger_tokens', 'bot_interviews', 'bot_listings', 'bot_reviews',
+    'channel_accounts', 'channel_registrations', 'channel_repair_log',
+    'channel_repair_log_meta', 'chat_integrity_reports', 'chat_uploads',
+    'community_messages', 'community_ratings', 'companions', 'cross_device_contacts',
+    'custom_domains', 'device_preferences', 'device_telemetry', 'device_vars',
+    'device_vars_audit', 'devices', 'disputes', 'feedback', 'feedback_photos',
+    'form_submissions', 'fraud_detection_log', 'free_bot_tos_agreements',
+    'friend_requests', 'gatekeeper_blocks', 'gatekeeper_violations',
+    'idempotency_keys', 'invite_clicks', 'invite_codes', 'invite_redemptions',
+    'invite_rewards', 'kanban_card_dependencies', 'kanban_card_links',
+    'kanban_card_tags', 'kanban_cards', 'kanban_comments', 'kanban_files',
+    'kanban_notes', 'kanban_pending_notify', 'kanban_tags', 'lifecycle_event_log',
+    'message_reactions', 'mindmap_edges', 'mindmap_node_anchors', 'mission_dashboard',
+    'mission_items', 'mission_note_card_links', 'mission_notes', 'mission_rules',
+    'mission_sync_log', 'note_pages', 'notification_preferences', 'notifications',
+    'oauth_authorization_codes', 'oauth_clients', 'oauth_tokens', 'official_bots',
+    'outbound_msg_pending', 'page_views', 'pending_ack', 'pending_cross_messages',
+    'portal_beacons', 'pricing_market_snapshots', 'push_ack_log', 'push_health_run',
+    'push_subscriptions', 'redirect_events', 'rental_contracts', 'rental_cooldowns',
+    'rental_rebind_audit_log', 'rental_snapshots', 'rental_usage_events', 'roles',
+    'rule_contributions', 'scheduled_messages', 'site_page_views', 'skill_contributions',
+    'soul_contributions', 'tappay_transactions', 'topup_orders', 'usage_tracking',
+    'user_accounts', 'user_blacklist', 'user_credit_scores', 'user_roles',
+    'wallet_ledger', 'wallets', 'wordpress_tokens',
+]);
+
+/** Lines that are pure comments / JSDoc continuations (no executable code). */
+function isCommentLine(line) {
+    const t = line.trim();
+    return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*') || t.startsWith('*/');
+}
+
+/** Nearest SQL table a matched line belongs to (backward scan, same statement). */
+function nearestSqlTable(lines, idx) {
+    for (let i = idx; i >= Math.max(0, idx - 12); i--) {
+        const m = /\b(?:FROM|UPDATE|JOIN|INTO)\s+([a-z_][a-z0-9_]*)/i.exec(lines[i]);
+        if (m) return m[1].toLowerCase();
+    }
+    return null;
+}
+
+// contextFilter(idx, lines) → return TRUE to KEEP the finding, FALSE to suppress
+// (same true=keep convention as filePathFilter). These read a small window of
+// surrounding lines so a single-line regex can be made statement-aware.
+
+/**
+ * db-query-missing-entity-id-filter precision: a bare `WHERE device_id = $1` is
+ * only a multi-tenant leak when (a) the table actually has an entity_id column
+ * AND (b) entity_id is not filtered anywhere in the statement.
+ */
+function ctxEntityScopedLeak(idx, lines) {
+    // (a) entity_id IS filtered (this line or a continuation) → correctly scoped.
+    const ENTITY_FILTER = /(?:WHERE|AND|,|\(|\bON)\s*[a-z_.]*\bentity_id\b\s*(?:=|<>|!=|\bIS\b|\bIN\b)/i;
+    for (let i = idx; i <= Math.min(lines.length - 1, idx + 3); i++) {
+        if (ENTITY_FILTER.test(lines[i])) return false;
+    }
+    // (b) device-grain table → no entity_id column to leak.
+    const tbl = nearestSqlTable(lines, idx);
+    if (tbl && DEVICE_GRAIN_TABLES.has(tbl)) return false;
+    return true; // entity-scoped table, unfiltered → keep for review
+}
+
+/** RMW race: atomic upserts (ON CONFLICT/DO UPDATE) and row-locked
+ *  (SELECT … FOR UPDATE) writes are not lost-update races. */
+function ctxNonAtomicWrite(idx, lines) {
+    if (/\b(?:ON\s+CONFLICT|DO\s+UPDATE)\b/i.test(lines[idx])) return false;
+    for (let i = idx; i >= Math.max(0, idx - 25); i--) {
+        if (/\bFOR\s+UPDATE\b/i.test(lines[i])) return false;
+    }
+    return true;
+}
+
+/** owner-only-user-query: user_accounts is UNIQUE(device_id) (auth_schema.sql)
+ *  → exactly one row per device, so LIMIT 1 is correct, not a multi-user bug. */
+function ctxNotSingleRowPerDeviceTable(idx, lines) {
+    if (/\bFROM\s+user_accounts\b/i.test(lines[idx])) return false;
+    return true;
+}
+
+/**
+ * entity-id-from-body-unverified: the read `const entityId = req.body.entityId`
+ * is a near-universal pattern; it is only an IDOR when the handler trusts it
+ * WITHOUT validating the caller. Suppress when a caller-auth check appears near
+ * the read. Fail-safe: no recognized auth token in window → KEEP the finding.
+ */
+function ctxBodyEntityIdHasAuth(idx, lines) {
+    const AUTH = /\b(?:safeEqual|authenticate|checkAdminAuth|isValidEntityId|requireAuth|verifyBotSecret|botAuth|effectiveEntityId)\b/;
+    for (let i = Math.max(0, idx - 15); i <= Math.min(lines.length - 1, idx + 45); i++) {
+        if (AUTH.test(lines[i])) return false;
+    }
+    return true;
+}
+
 /** @type {AuditRule[]} */
 const RULES = [
     // ── Dimension A: platform compliance ───────────────────────────────
@@ -85,8 +195,14 @@ const RULES = [
         // Words with the publicCode shape (6 alnum, letter+digit) that are NOT
         // publicCodes — encodings, hash algos, mime fragments. Without this
         // blocklist, `base64`/`sha256` flooded the report with 42 false hits and
-        // ~0 true positives on the live tree (see PR scope notes).
-        falseHits: Object.freeze(['base64', 'sha256', 'sha224', 'sha384', 'sha512', 'md5sum', 'ripemd', 'crc32c']),
+        // ~0 true positives on the live tree (see PR scope notes). `oauth2`/
+        // `latin1` are protocol/encoding constants; `a1b1c1` is a run-length
+        // test fixture ("abc"→"a1b1c1") — added 2026-06-22 audit triage.
+        falseHits: Object.freeze(['base64', 'sha256', 'sha224', 'sha384', 'sha512', 'md5sum', 'ripemd', 'crc32c', 'oauth2', 'latin1', 'a1b1c1']),
+        // JSDoc / inline-comment examples (e.g. `* - "abc123" 6-char publicCode`,
+        // `// legit user 'alice1'`, `* ProductTour.register('track1', …)`) are
+        // documentation, not shipped identifiers — skip pure comment lines.
+        skipComments: true,
         allowFiles: TEST_PATH_HINTS.concat(['/migrations/', '/api-docs', 'api_refs']),
     },
     {
@@ -126,6 +242,7 @@ const RULES = [
         // SELECT ... FROM <table> WHERE device_id = $n   LIMIT 1   (no entity/user key)
         pattern: /FROM\s+\w+\s+WHERE\s+device_id\s*=\s*\$\d+\s+LIMIT\s+1\b/i,
         filePathFilter: (p) => /\.(js|sql)$/.test(p) && !/\.test\./.test(p),
+        contextFilter: ctxNotSingleRowPerDeviceTable,
         allowFiles: TEST_PATH_HINTS.concat(['/devices', '/auth', '/migrations/']),
     },
 
@@ -138,6 +255,7 @@ const RULES = [
         rationale: 'Tables with entity_id columns (counters, episodes, drawer state) need WHERE filters on both device_id AND entity_id; otherwise rows from one entity leak into another\'s view.',
         pattern: /WHERE\s+device_id\s*=\s*\$\d+\s*$/im,
         filePathFilter: (p) => /\.(js|sql)$/.test(p),
+        contextFilter: ctxEntityScopedLeak,
         allowFiles: TEST_PATH_HINTS.concat(['/devices', '/auth', '/migrations/']),
     },
     {
@@ -190,6 +308,7 @@ const RULES = [
         // tight to the body-read assignment shape.
         pattern: /\b(?:const|let|var)\s+entityId\s*=\s*(?:req\.)?body\.entityId\b/,
         filePathFilter: (p) => /\.(js)$/.test(p) && !/\.test\./.test(p),
+        contextFilter: ctxBodyEntityIdHasAuth,
         allowFiles: TEST_PATH_HINTS.slice(),
     },
     {
@@ -198,10 +317,15 @@ const RULES = [
         severity: 'P1',
         title: 'Non-atomic read-modify-write on a shared counter/column',
         rationale: 'Two entities acting on the same card/message/counter in parallel can lost-update when the code does `SELECT ... ; <compute> ; UPDATE ... SET col = <newValue>`. Use an atomic `SET col = col + 1` / `ON CONFLICT` / row lock instead of a JS round-trip.',
-        // SET <col> = <number literal> on a counter-shaped column name — the tell of
-        // "I computed the new value in JS and wrote it back" rather than `col = col + N`.
-        pattern: /\bSET\s+(?:\w+_)?(?:count|counter|total|seq|version|balance)\s*=\s*\$?\d/i,
+        // SET <col> = $n on a counter-shaped column name — the tell of "I computed
+        // the new value in JS (a bound param) and wrote it back" rather than an
+        // in-place `col = col + N`. Require the `$` param: a bare literal (`= 0`,
+        // `= 1`) is a constant reset / version stamp, not a read-modify-write.
+        pattern: /\bSET\s+(?:\w+_)?(?:count|counter|total|seq|version|balance)\s*=\s*\$\d/i,
         filePathFilter: (p) => /\.(js|sql)$/.test(p) && !/\.test\./.test(p),
+        // Atomic upserts (ON CONFLICT … DO UPDATE) and row-locked writes
+        // (SELECT … FOR UPDATE earlier in the statement) are not lost-update races.
+        contextFilter: ctxNonAtomicWrite,
         allowFiles: TEST_PATH_HINTS.concat(['/migrations/']),
     },
     {
@@ -262,6 +386,9 @@ function scanText(filePath, text) {
         const re = new RegExp(rule.pattern.source, rule.pattern.flags.includes('g') ? rule.pattern.flags : rule.pattern.flags + 'g');
         for (let lineNo = 0; lineNo < lines.length; lineNo++) {
             const line = lines[lineNo];
+            // Pure comment / JSDoc lines are documentation, not shipped code —
+            // skip them for rules that opt in (e.g. publicCode examples).
+            if (rule.skipComments && isCommentLine(line)) continue;
             re.lastIndex = 0;
             const m = re.exec(line);
             if (m) {
@@ -271,6 +398,12 @@ function scanText(filePath, text) {
                 if (rule.falseHits && rule.falseHits.length) {
                     const matched = m[0].replace(/^['"`]|['"`]$/g, '').toLowerCase();
                     if (rule.falseHits.includes(matched)) continue;
+                }
+                // Statement-aware suppression: a rule may inspect a small window
+                // of surrounding lines. Returns true to KEEP, false to suppress.
+                if (typeof rule.contextFilter === 'function'
+                    && !rule.contextFilter(lineNo, lines)) {
+                    continue;
                 }
                 findings.push({
                     ruleId: rule.id,

--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -681,9 +681,11 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
     });
 
     // ── POST /api/companion/:id/rating ────────────────────────────
-    // Body: { stars: 1..5 }. Upsert per (device, entity). Recompute
-    // companions.rating_avg + rating_count atomically (well, two queries —
-    // good enough for v1; trigger upgrade can come with comment moderation).
+    // Body: { stars: 1..5 }. Upsert per (device, entity), then recompute the
+    // denormalized companions.rating_avg + rating_count. The upsert + recompute
+    // run in one transaction under a `SELECT … FOR UPDATE` lock on the cache row
+    // so concurrent raters of the same companion serialize and cannot lost-update
+    // the cached aggregate (weekly-audit RMW finding card_f9b2cc2d triage).
     router.post('/:id/rating', authReader, async (req, res) => {
         const { id } = req.params;
         if (!/^[a-z0-9-]{1,80}$/i.test(id)) {
@@ -712,48 +714,65 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
             }
 
             const now = Date.now();
-            const existsRes = await pool.query(
-                `SELECT id FROM companion_ratings
-                  WHERE companion_id = $1
-                    AND device_id = $2
-                    AND entity_id IS NOT DISTINCT FROM $3`,
-                [id, req.botAuth.deviceId, req.botAuth.entityId]
-            );
-            if (existsRes.rowCount > 0) {
-                await pool.query(
-                    `UPDATE companion_ratings
-                        SET stars = $1, updated_at = $2
-                      WHERE id = $3`,
-                    [stars, now, existsRes.rows[0].id]
-                );
-            } else {
-                await pool.query(
-                    `INSERT INTO companion_ratings
-                        (device_id, entity_id, companion_id, stars, created_at, updated_at)
-                     VALUES ($1, $2, $3, $4, $5, $5)`,
-                    [req.botAuth.deviceId, req.botAuth.entityId, id, stars, now]
-                );
-            }
+            const client = await pool.connect();
+            let ratingCount, ratingAvg;
+            try {
+                await client.query('BEGIN');
+                // Serialize concurrent raters of THIS companion on the cache row,
+                // so the recompute-and-write below cannot lost-update.
+                await client.query('SELECT 1 FROM companions WHERE id = $1 FOR UPDATE', [id]);
 
-            const aggRes = await pool.query(
-                `SELECT COUNT(*)::int AS n, AVG(stars)::real AS avg
-                   FROM companion_ratings WHERE companion_id = $1`,
-                [id]
-            );
-            const { n, avg } = aggRes.rows[0];
-            await pool.query(
-                `UPDATE companions
-                    SET rating_count = $1, rating_avg = $2
-                  WHERE id = $3`,
-                [n, avg, id]
-            );
+                const existsRes = await client.query(
+                    `SELECT id FROM companion_ratings
+                      WHERE companion_id = $1
+                        AND device_id = $2
+                        AND entity_id IS NOT DISTINCT FROM $3`,
+                    [id, req.botAuth.deviceId, req.botAuth.entityId]
+                );
+                if (existsRes.rowCount > 0) {
+                    await client.query(
+                        `UPDATE companion_ratings
+                            SET stars = $1, updated_at = $2
+                          WHERE id = $3`,
+                        [stars, now, existsRes.rows[0].id]
+                    );
+                } else {
+                    await client.query(
+                        `INSERT INTO companion_ratings
+                            (device_id, entity_id, companion_id, stars, created_at, updated_at)
+                         VALUES ($1, $2, $3, $4, $5, $5)`,
+                        [req.botAuth.deviceId, req.botAuth.entityId, id, stars, now]
+                    );
+                }
+
+                // Recompute the denormalized cache in a single atomic statement —
+                // the COUNT/AVG aggregate is evaluated inside the same UPDATE (no
+                // SELECT-then-UPDATE round-trip), under the row lock above.
+                const upd = await client.query(
+                    `UPDATE companions c
+                        SET rating_count = sub.n, rating_avg = sub.avg
+                       FROM (SELECT COUNT(*)::int AS n, AVG(stars)::real AS avg
+                               FROM companion_ratings WHERE companion_id = $1) sub
+                      WHERE c.id = $1
+                  RETURNING sub.n AS n, sub.avg AS avg`,
+                    [id]
+                );
+                await client.query('COMMIT');
+                ratingCount = upd.rows[0]?.n ?? 0;
+                ratingAvg = upd.rows[0]?.avg ?? null;
+            } catch (txErr) {
+                await client.query('ROLLBACK').catch(() => {});
+                throw txErr;
+            } finally {
+                client.release();
+            }
 
             res.json({
                 success: true,
                 companionId: id,
                 stars,
-                ratingAvg: avg,
-                ratingCount: n,
+                ratingAvg,
+                ratingCount,
             });
         } catch (err) {
             log('error', 'companion', `[Companion] rating post failed: ${err.message}`);

--- a/backend/tests/jest/audit-rules.test.js
+++ b/backend/tests/jest/audit-rules.test.js
@@ -134,6 +134,123 @@ describe('audit-rules — falseHits suppression', () => {
     });
 });
 
+// ─── 2026-06-22 weekly-audit precision pass (card_f9b2cc2d triage) ──────────
+// Each rule below produced 0 true positives but 2–52 false positives/week.
+// These tests pin the new suppressions AND that real positives still fire.
+describe('audit-rules — precision pass: publicCode comments + encoding constants', () => {
+    test("does NOT flag 'oauth2' / 'latin1' / 'a1b1c1' (encoding/test constants)", () => {
+        const text = "authMode: 'oauth2'; const e = 'latin1'; const rle = 'a1b1c1';";
+        expect(audit.scanText('backend/x.js', text)
+            .some(r => r.ruleId === 'hardcoded-public-code-literal')).toBe(false);
+    });
+    test('does NOT flag publicCode-shaped literals inside comment / JSDoc lines', () => {
+        const text = [
+            "  *   - \"abc123\"   6-char publicCode (cross-device)",
+            "  // legit display name like 'alice1'",
+            "  *   ProductTour.register('track1', [",
+        ].join('\n');
+        expect(audit.scanText('backend/x.js', text)
+            .some(r => r.ruleId === 'hardcoded-public-code-literal')).toBe(false);
+    });
+    test('STILL flags a real publicCode literal in executable code', () => {
+        expect(audit.scanText('backend/x.js', "speakTo(['3xa3h4']);")
+            .some(r => r.ruleId === 'hardcoded-public-code-literal')).toBe(true);
+    });
+});
+
+describe('audit-rules — precision pass: RMW upsert / row-lock / literal', () => {
+    test('does NOT flag ON CONFLICT … DO UPDATE upsert (atomic)', () => {
+        const sql = 'INSERT ... ON CONFLICT (device_id) DO UPDATE SET violation_count = $2, is_blocked = $3';
+        expect(audit.scanText('backend/gatekeeper.js', sql)
+            .some(r => r.ruleId === 'cross-entity-read-modify-write-race')).toBe(false);
+    });
+    test('does NOT flag a literal-constant reset (SET violation_count = 0)', () => {
+        const sql = 'UPDATE gatekeeper_blocks SET violation_count = 0, is_blocked = FALSE WHERE device_id = $1';
+        expect(audit.scanText('backend/gatekeeper.js', sql)
+            .some(r => r.ruleId === 'cross-entity-read-modify-write-race')).toBe(false);
+    });
+    test('does NOT flag a write guarded by SELECT … FOR UPDATE earlier in the txn', () => {
+        const sql = [
+            "await c.query('SELECT 1 FROM companions WHERE id = $1 FOR UPDATE', [id]);",
+            "await c.query('UPDATE companions SET rating_count = $1 WHERE id = $2', [n, id]);",
+        ].join('\n');
+        expect(audit.scanText('backend/companion-api.js', sql)
+            .some(r => r.ruleId === 'cross-entity-read-modify-write-race')).toBe(false);
+    });
+    test('STILL flags a bare non-atomic counter write-back ($n, no lock/upsert)', () => {
+        const sql = 'await db.query("UPDATE cards SET comment_count = $2 WHERE id = $1", [id, n]);';
+        expect(audit.scanText('backend/api_card.js', sql)
+            .some(r => r.ruleId === 'cross-entity-read-modify-write-race')).toBe(true);
+    });
+});
+
+describe('audit-rules — precision pass: owner-only single-row-per-device table', () => {
+    test('does NOT flag user_accounts (UNIQUE(device_id) → 1 row/device)', () => {
+        const sql = "'SELECT language FROM user_accounts WHERE device_id = $1 LIMIT 1'";
+        expect(audit.scanText('backend/kanban.js', sql)
+            .some(r => r.ruleId === 'owner-only-user-query-assumption')).toBe(false);
+    });
+    test('STILL flags LIMIT 1 on a non-unique table', () => {
+        const sql = "'SELECT name FROM profiles WHERE device_id = $1 LIMIT 1'";
+        expect(audit.scanText('backend/api_profile.js', sql)
+            .some(r => r.ruleId === 'owner-only-user-query-assumption')).toBe(true);
+    });
+});
+
+describe('audit-rules — precision pass: db-query entity_id filter (schema-aware)', () => {
+    test('does NOT flag a device-grain table (no entity_id column)', () => {
+        const sql = [
+            'SELECT source_card_id FROM kanban_card_links',
+            ' WHERE device_id = $1',
+        ].join('\n');
+        expect(audit.scanText('backend/api_kanban_card_links.js', sql)
+            .some(r => r.ruleId === 'db-query-missing-entity-id-filter')).toBe(false);
+    });
+    test('does NOT flag when entity_id IS filtered on a continuation line', () => {
+        const sql = [
+            'SELECT x FROM entity_error_counters',
+            ' WHERE device_id = $1',
+            '   AND entity_id = $2',
+        ].join('\n');
+        expect(audit.scanText('backend/entity-status.js', sql)
+            .some(r => r.ruleId === 'db-query-missing-entity-id-filter')).toBe(false);
+    });
+    test('STILL flags an entity-scoped table read with no entity_id filter', () => {
+        const sql = [
+            'SELECT body FROM chat_messages',
+            ' WHERE device_id = $1',
+        ].join('\n');
+        expect(audit.scanText('backend/leak.js', sql)
+            .some(r => r.ruleId === 'db-query-missing-entity-id-filter')).toBe(true);
+    });
+    test('fails SAFE: unresolved table is kept (treated as entity-scoped)', () => {
+        // no FROM in window → cannot prove device-grain → keep the finding
+        const sql = 'WHERE device_id = $1';
+        expect(audit.scanText('backend/unknown.js', sql)
+            .some(r => r.ruleId === 'db-query-missing-entity-id-filter')).toBe(true);
+    });
+});
+
+describe('audit-rules — precision pass: body.entityId IDOR auth-awareness', () => {
+    test('does NOT flag when caller is validated (safeEqual botSecret nearby)', () => {
+        const code = [
+            'const entityId = req.body.entityId ?? req.query.entityId;',
+            'const entity = device.entities[eId];',
+            'if (!safeEqual(botSecret, entity.botSecret)) return res.status(403).json({});',
+        ].join('\n');
+        expect(audit.scanText('backend/index.js', code)
+            .some(r => r.ruleId === 'entity-id-from-body-unverified')).toBe(false);
+    });
+    test('STILL flags a body.entityId read with NO caller-auth check nearby', () => {
+        const code = [
+            'const entityId = req.body.entityId;',
+            'await pool.query("DELETE FROM widgets WHERE entity_id = $1", [entityId]);',
+        ].join('\n');
+        expect(audit.scanText('backend/leak.js', code)
+            .some(r => r.ruleId === 'entity-id-from-body-unverified')).toBe(true);
+    });
+});
+
 describe('audit-rules — file exemptions', () => {
     test('test paths exempt the Hank-UUID rule', () => {
         const text = "const d = '480def4c-2183-4d8e-afd0-b131ae89adcc';";

--- a/backend/tests/jest/companion-api.test.js
+++ b/backend/tests/jest/companion-api.test.js
@@ -16,8 +16,12 @@
 
 jest.mock('pg', () => {
     const mockQuery = jest.fn();
+    // POST /:id/rating runs its upsert + cache recompute in a transaction via
+    // pool.connect(); the client shares mockQuery so the positional queue still
+    // drives every query (pool.query lookups + client.query txn statements).
     const Pool = jest.fn().mockImplementation(() => ({
         query: mockQuery,
+        connect: jest.fn().mockResolvedValue({ query: mockQuery, release: jest.fn() }),
         end: jest.fn(),
     }));
     return { Pool, __mockQuery: mockQuery };
@@ -604,11 +608,13 @@ describe('companion-api: POST /:id/rating', () => {
             device_id: null, author_entity_id: null,
         };
         __mockQuery
-            .mockResolvedValueOnce({ rowCount: 1, rows: [baseCompanion] })       // companions lookup
+            .mockResolvedValueOnce({ rowCount: 1, rows: [baseCompanion] })       // companions lookup (pool.query)
+            .mockResolvedValueOnce({ rows: [] })                                 // BEGIN
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{}] })                  // SELECT 1 … FOR UPDATE
             .mockResolvedValueOnce({ rowCount: 0, rows: [] })                    // exists rating
-            .mockResolvedValueOnce({ rowCount: 1, rows: [] })                    // INSERT
-            .mockResolvedValueOnce({ rowCount: 1, rows: [{ n: 3, avg: 4.33 }] }) // agg
-            .mockResolvedValueOnce({ rowCount: 1, rows: [] });                   // UPDATE companions
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] })                    // INSERT rating
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ n: 3, avg: 4.33 }] }) // recompute UPDATE companions … RETURNING
+            .mockResolvedValueOnce({ rows: [] });                               // COMMIT
         const res = await request(makeApp())
             .post('/api/companion/petdx-pub/rating')
             .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
@@ -625,17 +631,19 @@ describe('companion-api: POST /:id/rating', () => {
             device_id: null, author_entity_id: null,
         };
         __mockQuery
-            .mockResolvedValueOnce({ rowCount: 1, rows: [baseCompanion] })
-            .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 99 }] })          // existing
-            .mockResolvedValueOnce({ rowCount: 1, rows: [] })                    // UPDATE rating
-            .mockResolvedValueOnce({ rowCount: 1, rows: [{ n: 1, avg: 2.0 }] })
-            .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+            .mockResolvedValueOnce({ rowCount: 1, rows: [baseCompanion] })       // [0] companions lookup
+            .mockResolvedValueOnce({ rows: [] })                                 // [1] BEGIN
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{}] })                  // [2] SELECT 1 … FOR UPDATE
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 99 }] })          // [3] existing rating
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] })                    // [4] UPDATE companion_ratings
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ n: 1, avg: 2.0 }] }) // [5] recompute
+            .mockResolvedValueOnce({ rows: [] });                               // [6] COMMIT
         const res = await request(makeApp())
             .post('/api/companion/petdx-pub/rating')
             .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
             .send({ stars: 2 });
         expect(res.status).toBe(200);
-        const updateCall = __mockQuery.mock.calls[2];
+        const updateCall = __mockQuery.mock.calls[4];
         expect(updateCall[0]).toMatch(/UPDATE companion_ratings/);
         expect(updateCall[1][0]).toBe(2);
     });


### PR DESCRIPTION
## Weekly multi-tenant audit follow-up (card_f9b2cc2d triage)

Background: triaged this week's 5 weekly-audit subcards (owner-only 2, RMW-race 4, db-query 52, publicCode 13, body-entityId 5 = 76 hits) against `origin/main @181c98de`. **0 confirmed cross-tenant leaks.** Exactly one real issue (a P2 correctness race); the other 75 are false positives that re-fire + auto-escalate to P0 every cycle.

### 1. Real fix — `companion-api.js` rating-cache race
`POST /:id/rating` did `SELECT COUNT/AVG` then a separate `UPDATE companions SET rating_count/rating_avg` (non-atomic RMW). Concurrent raters of the same companion could lost-update the **denormalized cache** (true rows in `companion_ratings` never lost; only the cached count/avg drifted). Not a cross-tenant leak — `companions` is a shared community catalog.

Fix: upsert + recompute in one transaction under `SELECT 1 … FOR UPDATE` on the companions row (raters serialize), recompute in a single atomic `UPDATE … FROM (SELECT COUNT/AVG …) … RETURNING`.

### 2. Rule hardening — stop the false-positive re-fires
All suppressions **fail SAFE** (only quiet provably-non-violations; unknowns still fire):

| rule | before → after | how |
|---|---|---|
| hardcoded-public-code-literal | 13 → 0 | skip comment/JSDoc lines; falseHits += oauth2/latin1/a1b1c1 |
| cross-entity-RMW-race | 4 → 0 | require bound `$param`; skip `ON CONFLICT/DO UPDATE` + row-locked (`FOR UPDATE`) |
| owner-only-user-query | 2 → 0 | `user_accounts` is UNIQUE(device_id) → LIMIT 1 correct |
| entity-id-from-body-unverified | 5 → 0 | suppress when caller-auth (`safeEqual`/`authenticate`/…) near read; **no auth → still fires** |
| db-query-missing-entity-id-filter | 52 → 15 | suppress when `entity_id` IS filtered (continuation-aware) or table is device-grain (schema-derived 99-table suppress-list) |

The 15 db-query residuals are **entity-scoped-table** reads filtered by `device_id` only (owner dashboards) — they need auth-context judgment regex can't see, so they're correctly kept for review (follow-up: auth-context awareness as a rule-promotion candidate). The device-grain list is a *suppress-list* (not allow-list), so a newly-added `entity_id` table still fires even before regeneration.

New `scanText` capabilities: `rule.skipComments` + `rule.contextFilter(idx, lines)`.

### Tests
- `tests/jest/audit-rules.test.js`: +15 regression tests (each suppression + that real positives still fire). 33/33 pass.
- `tests/jest/companion-api.test.js`: updated `pg` mock (adds `connect()`) + the 2 rating tests for the txn sequence. 86/86 pass.
- **119/119** across both suites locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)