### PR TITLE
fix(push): downgrade unbound-entity skip log warn→debug (ErrLog false page)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -12089,9 +12089,15 @@ app.post('/api/client/speak', idempotencyMiddleware, clientSpeakDedupeMiddleware
             console.warn(`[Push] ✗ No webhook registered for Device ${deviceId} Entity ${eId} - client will show dialog`);
             serverLog('warn', 'client_push', `Entity ${eId} no webhook`, { deviceId, entityId: eId });
         } else {
-            // No condition matched — entity is unbound or in unexpected state (#181 diagnostic)
-            console.warn(`[Push] ✗ Entity ${eId} skipped: bindingType=${entity.bindingType}, webhook=${!!entity.webhook}, isBound=${entity.isBound}`);
-            serverLog('warn', 'client_push', `Entity ${eId} skipped (no push condition matched)`, { deviceId, entityId: eId, metadata: { bindingType: entity.bindingType, hasWebhook: !!entity.webhook, isBound: entity.isBound } });
+            // Entity is UNBOUND (no bot bound to this slot) — there is nothing to
+            // push to, so skipping is expected, not an error. Real delivery gaps
+            // are still surfaced at warn by the branches above (push failed /
+            // bound-but-no-webhook). The #181 diagnostic that justified `warn`
+            // here is resolved; an unbound slot being skipped is a routine no-op,
+            // so log it at debug to keep severity == reality (no false ErrLog
+            // pages, e.g. a released free-bot slot). card_ ErrLog triage.
+            console.debug(`[Push] Entity ${eId} skipped (unbound): bindingType=${entity.bindingType}, webhook=${!!entity.webhook}, isBound=${entity.isBound}`);
+            serverLog('debug', 'client_push', `Entity ${eId} skipped (unbound — no push target)`, { deviceId, entityId: eId, metadata: { bindingType: entity.bindingType, hasWebhook: !!entity.webhook, isBound: entity.isBound } });
         }
 
         // Determine binding type for this entity


### PR DESCRIPTION
## ErrLog P1 triage — "[Push] ✗ Entity 0 skipped: bindingType=null, webhook=false"

The client-push fan-out (`backend/index.js`) iterates a device's entities to deliver a message. For an **unbound** slot (`bindingType=null`, `webhook=false`, `isBound=false`) there is no bot to push to, so it's skipped — but the skip was logged at `warn`, which the ErrLog cron escalates to a P1 page.

This is a **false page**: skipping an unbound slot is expected (e.g. the E2E test device's entity 0 — a free-borrowed bot that was released). The `warn` was a leftover **#181 diagnostic** (multi-entity push skip), now resolved.

### Fix
Downgrade **only the truly-unbound skip** to `debug` (console + serverLog). Severity now matches reality. Genuine delivery problems remain at `warn`:
- push attempted but failed → `warn` (unchanged)
- entity **bound** but no webhook registered → `warn` (unchanged)

Per the no-benign-error-label rule: every warn/error line is either fix-root-cause or downgrade-level — an unbound slot being skipped is a routine no-op, so it's `debug`.

### Verification
- `node -c backend/index.js` ✓
- No test asserts on this log line (grep clean) — won't break a source-grep test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)