### PR TITLE
fix(point-edit): graceful 503 + single-line log when Chromium missing (ErrLog 9-card flood)

### DIFF
--- a/backend/point-edit-resolver.js
+++ b/backend/point-edit-resolver.js
@@ -317,11 +317,31 @@ router.post('/resolve-coordinate', resolveCoordinateLimiter, async (req, res) =>
         }
         return res.json(target);
     } catch (err) {
-        console.error('[point-edit] resolver failure:', err);
+        // Concise, single-line message. Playwright prints a multi-line "install
+        // browsers" banner (╔══ … npx playwright install … <3 Playwright Team)
+        // when the Chromium executable is missing; logging the full err object
+        // makes the prod ErrLog monitor split that banner into ~9 separate ERROR
+        // cards. Log ONE line and, for the capability gap, degrade to 503.
+        const firstLine = String(err && err.message ? err.message : err).split('\n')[0];
+        const browserMissing = /Executable doesn't exist|playwright install|browserType\.launch/i
+            .test(err && err.message ? err.message : '');
+        if (browserMissing) {
+            // Headless Chromium isn't provisioned in this runtime (nixpacks prod
+            // runs `npm install` only, not `npx playwright install`). Treat as a
+            // disabled capability, not a crash. To ENABLE point-edit in prod, add
+            // `npx playwright install --with-deps chromium` to the build.
+            console.error('[point-edit] headless Chromium unavailable in this runtime — point-edit disabled (enable via `npx playwright install chromium`)');
+            return res.status(503).json({
+                success: false,
+                error: 'point_edit_unavailable',
+                message: 'Point-edit (headless browser) is not available in this environment.',
+            });
+        }
+        console.error('[point-edit] resolver failure:', firstLine);
         return res.status(500).json({
             success: false,
             error: 'resolver_failure',
-            message: err.message,
+            message: firstLine,
         });
     }
 });

--- a/backend/tests/jest/point-edit-resolver-browser-missing.test.js
+++ b/backend/tests/jest/point-edit-resolver-browser-missing.test.js
@@ -1,0 +1,66 @@
+/**
+ * Graceful-degrade test for point-edit-resolver: when headless Chromium is not
+ * provisioned in the runtime (nixpacks prod runs `npm install` only, not
+ * `npx playwright install`), POST /resolve-coordinate must return 503 and log
+ * ONE concise line — NOT Playwright's multi-line "install browsers" banner,
+ * which the prod ErrLog monitor split into ~9 separate ERROR cards.
+ */
+
+'use strict';
+
+process.env.RATE_LIMIT_DISABLED = '1';
+
+jest.mock('playwright', () => {
+    // Mirror the real Playwright error: first line is the launch failure, then a
+    // multi-line ASCII banner telling you to run `npx playwright install`.
+    const bannerErr = new Error([
+        "browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1234/chrome-linux/chrome",
+        '╔═════════════════════════════════════════════════════════╗',
+        '║ Looks like Playwright was just installed or updated.     ║',
+        '║ Please run the following command to download new browsers:',
+        '║     npx playwright install                               ║',
+        '║ <3 Playwright Team                                       ║',
+        '╚═════════════════════════════════════════════════════════╝',
+    ].join('\n'));
+    return { chromium: { launch: jest.fn().mockRejectedValue(bannerErr) } };
+});
+
+const express = require('express');
+const request = require('supertest');
+const resolver = require('../../point-edit-resolver');
+
+function makeApp() {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/point-edit', resolver.router);
+    return app;
+}
+
+describe('point-edit graceful-degrade when Chromium executable is missing', () => {
+    test('returns 503 point_edit_unavailable and logs a single concise line (no banner)', async () => {
+        const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const r = await request(makeApp())
+            .post('/api/point-edit/resolve-coordinate')
+            .send({ x: 10, y: 10, viewportW: 800, viewportH: 600, url: 'https://eclawbot.com/portal/info.html' });
+
+        expect(r.status).toBe(503);
+        expect(r.body).toMatchObject({ success: false, error: 'point_edit_unavailable' });
+
+        // The whole point: the prod ErrLog monitor splits MULTI-LINE output into
+        // one card per line. The log must be a single concise line — not the
+        // multi-line banner. Discriminate on banner-only markers (box-drawing +
+        // signature), NOT on "npx playwright install" (our one-line hint may
+        // legitimately reference that command).
+        const logged = errSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+        expect(logged).not.toContain('╔');
+        expect(logged).not.toContain('║');
+        expect(logged).not.toMatch(/<3 Playwright Team/);
+        // Our concise failure line is present, and there is no embedded newline
+        // banner (each console.error call is one line).
+        expect(logged).toMatch(/point-edit.*unavailable/i);
+        expect(errSpy.mock.calls.every((c) => !String(c.join(' ')).includes('\n'))).toBe(true);
+
+        errSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
## ErrLog flood triage — ~9 cards, one root cause

`/api/point-edit/resolve-coordinate` launches headless Chromium (Playwright). Prod (nixpacks) runs `npm install` only — **never `npx playwright install`** — so the Chromium binary is absent; every call fails with `browserType.launch: Executable doesn't exist` + Playwright's multi-line install banner. The handler logged the full `err`, so the prod ErrLog monitor split that banner into **~9 separate ERROR cards** (╔══ / ║ / `npx playwright install` / `<3 Playwright Team` / …).

### Fix
In the resolve-coordinate catch: log **one concise line** and, for the browser-missing capability gap, degrade to **HTTP 503 `point_edit_unavailable`** (not 500-with-banner). Non-browser failures still log a concise first-line + 500. Severity now matches reality (a disabled capability logged once), per the no-benign-error rule.

To **enable** point-edit in prod (currently a no-op there): add `npx playwright install --with-deps chromium` to the nixpacks build — left as an explicit image-size tradeoff, not bundled here.

### Tests
New `point-edit-resolver-browser-missing.test.js`: mocks `launch` rejecting with the banner → asserts 503 + a single concise line (no ╔/║/"Playwright Team", no embedded newline). **24/24** point-edit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)