### PR TITLE
fix(wallpaper): multi-level distinct loading markers for every black-screen path (card_f9b2cc2d)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 111
-        versionName = "1.1.1"
+        versionCode = 112
+        versionName = "1.1.2"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
+++ b/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
@@ -1,11 +1,14 @@
 package com.hank.clawlive.service
 
 import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
 import android.os.Handler
 import android.os.Looper
 import android.service.wallpaper.WallpaperService
 import android.view.SurfaceHolder
 import timber.log.Timber
+import com.hank.clawlive.R
 import com.hank.clawlive.engine.ClawRenderer
 import com.hank.clawlive.engine.EngineLifecycleController
 import com.hank.clawlive.data.model.AgentStatus
@@ -74,6 +77,47 @@ class ClawWallpaperService : WallpaperService() {
         private var hasFirstResponse = false
 
         private val drawRunnable = Runnable { draw() }
+
+        // card_f9b2cc2d diagnostic+mitigation: paint for the multi-level loading
+        // markers. Each black-screen-prone entry point paints a DISTINCT labelled
+        // "Loading… (<where>)" frame DIRECTLY (independent of the draw loop), so
+        // (a) the user never sees raw black on resume, and (b) which label shows
+        // tells us exactly which path was hit (vs still-pure-black = the Engine
+        // never even got the callback → deepest surface/GL level).
+        private val loadingPaint = Paint().apply {
+            color = Color.WHITE
+            textAlign = Paint.Align.CENTER
+            isAntiAlias = true
+            textSize = 38f
+        }
+
+        /**
+         * Lock the surface and paint ONE labelled loading frame immediately,
+         * bypassing the draw loop. Safe to call from any lifecycle callback —
+         * if the real draw loop then runs it simply overwrites this; if it does
+         * NOT (the bug), this stays on screen instead of black. `where` is the
+         * diagnostic marker (surface / resume / changed).
+         */
+        private fun paintLoadingMarker(where: String, holder: SurfaceHolder? = surfaceHolder) {
+            val h = holder ?: return
+            var canvas: Canvas? = null
+            try {
+                canvas = h.lockCanvas() ?: return
+                canvas.drawColor(0xFF0B1220.toInt()) // dark navy — deliberate surface, not black
+                val cx = canvas.width / 2f
+                val cy = canvas.height / 2f
+                val label = this@ClawWallpaperService.getString(
+                    R.string.claw_wallpaper_loading_marker, where
+                )
+                canvas.drawText(label, cx, cy, loadingPaint)
+            } catch (e: Exception) {
+                Timber.e(e, "paintLoadingMarker($where) failed")
+            } finally {
+                if (canvas != null) {
+                    try { h.unlockCanvasAndPost(canvas) } catch (e: Exception) { Timber.e(e, "marker unlock failed") }
+                }
+            }
+        }
 
         // Pure-JVM lifecycle state machine (card_f9b2cc2d). Source of truth for
         // whether engine-lifetime resources are still alive. Surface
@@ -212,6 +256,11 @@ class ClawWallpaperService : WallpaperService() {
         override fun onVisibilityChanged(visible: Boolean) {
             this.visible = visible
             Timber.d("onVisibilityChanged: $visible")
+            // Becoming visible (returning to the home screen) is the moment the
+            // app-switch black is reported. Paint "Loading… (resume)" directly so
+            // the very first visible frame is never raw black; the draw loop (if
+            // it resumes via the controller below) overwrites it immediately.
+            if (visible) paintLoadingMarker("resume")
             // Delegate to the lifecycle controller. When shown it restarts any
             // poller that was cancelled while hidden (card_a7baa3b0b1151099d4523428
             // close-out) and redraws. When hidden it stops the draw loop and
@@ -263,6 +312,12 @@ class ClawWallpaperService : WallpaperService() {
         override fun onSurfaceCreated(holder: SurfaceHolder?) {
             super.onSurfaceCreated(holder)
             Timber.d("onSurfaceCreated")
+            // Paint a labelled loading frame on the FRESH surface immediately,
+            // before the draw loop is asked to resume. If the loop resumes it
+            // overwrites this within ~33ms; if it does NOT (the persistent-black
+            // bug) the user sees "Loading… (surface)" instead of raw black, and
+            // the label tells us the surface WAS recreated but the loop stalled.
+            paintLoadingMarker("surface", holder)
             // Surface is back (e.g. returning from an app-switch). The framework
             // has already pointed `surfaceHolder` at the new surface. Resume
             // rendering if visible — restart any poller that went inactive and
@@ -275,6 +330,7 @@ class ClawWallpaperService : WallpaperService() {
         override fun onSurfaceChanged(holder: SurfaceHolder?, format: Int, width: Int, height: Int) {
             super.onSurfaceChanged(holder, format, width, height)
             Timber.d("onSurfaceChanged ${width}x$height")
+            paintLoadingMarker("changed", holder)
             // Geometry/format change (rotation, etc.). Treat like a recreate for
             // resume purposes so the very next frame repaints onto the new
             // surface. (card_f9b2cc2d)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -583,6 +583,7 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="wallpaper_no_bound_entities">لا توجد كيانات مربوطة</string>
     <string name="claw_renderer_loading_entities">جارٍ تحميل الكيانات…</string>
     <string name="claw_renderer_loading_wallpaper">جارٍ تحميل الخلفية…</string>
+    <string name="claw_wallpaper_loading_marker">جارٍ التحميل… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">لا توجد كيانات متصلة</string>
     <string name="claw_renderer_open_app_to_bind">افتح تطبيق E-Claw للربط</string>
     <string name="claw_renderer_with_openclaw_bot">الكيانات مع بوت OpenClaw</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -582,6 +582,7 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="wallpaper_no_bound_entities">Keine gebundenen Entitäten</string>
     <string name="claw_renderer_loading_entities">Entitäten werden geladen…</string>
     <string name="claw_renderer_loading_wallpaper">Hintergrund wird geladen…</string>
+    <string name="claw_wallpaper_loading_marker">Wird geladen… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">Keine Entitäten verbunden</string>
     <string name="claw_renderer_open_app_to_bind">E-Claw App öffnen zum Binden</string>
     <string name="claw_renderer_with_openclaw_bot">Entitäten mit OpenClaw-Bot</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -308,6 +308,7 @@ Tus comentarios enviados aparecerán aquí.</string>
     <string name="wallpaper_no_bound_entities">Sin entidades vinculadas</string>
     <string name="claw_renderer_loading_entities">Cargando entidades…</string>
     <string name="claw_renderer_loading_wallpaper">Cargando fondo de pantalla…</string>
+    <string name="claw_wallpaper_loading_marker">Cargando… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">No hay entidades conectadas</string>
     <string name="claw_renderer_open_app_to_bind">Abre la app E-Claw para vincular</string>
     <string name="claw_renderer_with_openclaw_bot">entidades con el bot OpenClaw</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -582,6 +582,7 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="wallpaper_no_bound_entities">Aucune entité liée</string>
     <string name="claw_renderer_loading_entities">Chargement des entités…</string>
     <string name="claw_renderer_loading_wallpaper">Chargement du fond d’écran…</string>
+    <string name="claw_wallpaper_loading_marker">Chargement… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">Aucune entité connectée</string>
     <string name="claw_renderer_open_app_to_bind">Ouvrir app E-Claw pour lier</string>
     <string name="claw_renderer_with_openclaw_bot">entités avec le bot OpenClaw</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -590,6 +590,7 @@ GPS: केवल अनुरोध पर, कोई बैकग्राउ�
     <string name="wallpaper_no_bound_entities">कोई बाउंड एंटिटी नहीं</string>
     <string name="claw_renderer_loading_entities">एंटिटी लोड हो रही हैं…</string>
     <string name="claw_renderer_loading_wallpaper">वॉलपेपर लोड हो रहा है…</string>
+    <string name="claw_wallpaper_loading_marker">लोड हो रहा है… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">कोई एंटिटी कनेक्ट नहीं</string>
     <string name="claw_renderer_open_app_to_bind">बाइंड करने के लिए E-Claw ऐप खोलें</string>
     <string name="claw_renderer_with_openclaw_bot">OpenClaw बॉट के साथ एंटिटी</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -188,6 +188,7 @@
     <string name="choose_plan_title">Pilih Paket</string>
     <string name="claw_renderer_loading_entities">Memuat entitas…</string>
     <string name="claw_renderer_loading_wallpaper">Memuat wallpaper…</string>
+    <string name="claw_wallpaper_loading_marker">Memuat… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">Tidak ada entitas terhubung</string>
     <string name="claw_renderer_open_app_to_bind">Buka app E-Claw untuk mengikat</string>
     <string name="claw_renderer_with_openclaw_bot">entitas dengan bot OpenClaw</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -297,6 +297,7 @@
     <string name="wallpaper_no_bound_entities">Tidak ada entitas yang terikat</string>
     <string name="claw_renderer_loading_entities">Memuat entitas…</string>
     <string name="claw_renderer_loading_wallpaper">Memuat wallpaper…</string>
+    <string name="claw_wallpaper_loading_marker">Memuat… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">Tidak ada entitas terhubung</string>
     <string name="claw_renderer_open_app_to_bind">Buka app E-Claw untuk mengikat</string>
     <string name="claw_renderer_with_openclaw_bot">entitas dengan bot OpenClaw</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -520,6 +520,7 @@
     <string name="wallpaper_no_bound_entities">Nessuna entità vincolata</string>
     <string name="claw_renderer_loading_entities">Caricamento entità…</string>
     <string name="claw_renderer_loading_wallpaper">Caricamento sfondo…</string>
+    <string name="claw_wallpaper_loading_marker">Caricamento… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">Nessuna entità collegata</string>
     <string name="claw_renderer_open_app_to_bind">Apri l\'app E-Claw per associare</string>
     <string name="claw_renderer_with_openclaw_bot">entità con il bot OpenClaw</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -296,6 +296,7 @@
     <string name="wallpaper_no_bound_entities">バインドされたエンティティがありません</string>
     <string name="claw_renderer_loading_entities">エンティティを読み込み中…</string>
     <string name="claw_renderer_loading_wallpaper">壁紙を読み込み中…</string>
+    <string name="claw_wallpaper_loading_marker">読み込み中… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">接続されたエンティティがありません</string>
     <string name="claw_renderer_open_app_to_bind">バインドするにはE-Clawアプリを開く</string>
     <string name="claw_renderer_with_openclaw_bot">OpenClawボットのエンティティ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -296,6 +296,7 @@
     <string name="wallpaper_no_bound_entities">바인드된 엔티티가 없습니다</string>
     <string name="claw_renderer_loading_entities">엔티티 로딩 중…</string>
     <string name="claw_renderer_loading_wallpaper">배경화면 로딩 중…</string>
+    <string name="claw_wallpaper_loading_marker">로딩 중… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">연결된 엔티티 없음</string>
     <string name="claw_renderer_open_app_to_bind">바인드하려면 E-Claw 앱 열기</string>
     <string name="claw_renderer_with_openclaw_bot">OpenClaw 봇의 엔티티</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -590,6 +590,7 @@ Jika anda mempunyai sebarang soalan, sila hubungi kami melalui e-mel rasmi kami.
     <string name="wallpaper_no_bound_entities">Tiada entiti terikat</string>
     <string name="claw_renderer_loading_entities">Memuat entiti…</string>
     <string name="claw_renderer_loading_wallpaper">Memuat kertas dinding…</string>
+    <string name="claw_wallpaper_loading_marker">Memuat… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">Tiada entiti bersambung</string>
     <string name="claw_renderer_open_app_to_bind">Buka app E-Claw untuk mengikat</string>
     <string name="claw_renderer_with_openclaw_bot">entiti dengan bot OpenClaw</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -520,6 +520,7 @@
     <string name="wallpaper_no_bound_entities">Sem entidades vinculadas</string>
     <string name="claw_renderer_loading_entities">Carregando entidades…</string>
     <string name="claw_renderer_loading_wallpaper">Carregando papel de parede…</string>
+    <string name="claw_wallpaper_loading_marker">Carregando… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">Nenhuma entidade conectada</string>
     <string name="claw_renderer_open_app_to_bind">Abra o aplicativo E-Claw para vincular</string>
     <string name="claw_renderer_with_openclaw_bot">entidades com bot OpenClaw</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -520,6 +520,7 @@
     <string name="wallpaper_no_bound_entities">Нет связанных сущностей</string>
     <string name="claw_renderer_loading_entities">Загрузка объектов…</string>
     <string name="claw_renderer_loading_wallpaper">Загрузка обоев…</string>
+    <string name="claw_wallpaper_loading_marker">Загрузка… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">Нет подключенных объектов</string>
     <string name="claw_renderer_open_app_to_bind">Откройте приложение E-Claw для привязки.</string>
     <string name="claw_renderer_with_openclaw_bot">сущности с ботом OpenClaw</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -296,6 +296,7 @@
     <string name="wallpaper_no_bound_entities">ไม่มีเอนทิตีที่ถูกผูกไว้</string>
     <string name="claw_renderer_loading_entities">กำลังโหลด Entity…</string>
     <string name="claw_renderer_loading_wallpaper">กำลังโหลดวอลล์เปเปอร์…</string>
+    <string name="claw_wallpaper_loading_marker">กำลังโหลด… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">ไม่มี Entity เชื่อมต่อ</string>
     <string name="claw_renderer_open_app_to_bind">เปิดแอป E-Claw เพื่อผูก</string>
     <string name="claw_renderer_with_openclaw_bot">Entity กับบอท OpenClaw</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -296,6 +296,7 @@
     <string name="wallpaper_no_bound_entities">Không có thực thể được liên kết</string>
     <string name="claw_renderer_loading_entities">Đang tải thực thể…</string>
     <string name="claw_renderer_loading_wallpaper">Đang tải hình nền…</string>
+    <string name="claw_wallpaper_loading_marker">Đang tải… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">Không có thực thể kết nối</string>
     <string name="claw_renderer_open_app_to_bind">Mở app E-Claw để liên kết</string>
     <string name="claw_renderer_with_openclaw_bot">thực thể với bot OpenClaw</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -296,6 +296,7 @@
     <string name="wallpaper_no_bound_entities">无已绑定实体</string>
     <string name="claw_renderer_loading_entities">正在加载实体…</string>
     <string name="claw_renderer_loading_wallpaper">正在加载壁纸…</string>
+    <string name="claw_wallpaper_loading_marker">加载中… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">无已连接实体</string>
     <string name="claw_renderer_open_app_to_bind">打开 E-Claw 应用进行绑定</string>
     <string name="claw_renderer_with_openclaw_bot">OpenClaw 机器人的实体</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -296,6 +296,7 @@
     <string name="wallpaper_no_bound_entities">無已綁定實體</string>
     <string name="claw_renderer_loading_entities">載入實體中…</string>
     <string name="claw_renderer_loading_wallpaper">載入桌布中…</string>
+    <string name="claw_wallpaper_loading_marker">載入中… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">無已連接實體</string>
     <string name="claw_renderer_open_app_to_bind">開啟 E-Claw 應用綁定</string>
     <string name="claw_renderer_with_openclaw_bot">OpenClaw 機器的實體</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -681,6 +681,7 @@ If you have any questions, please contact us via our official email.
     <string name="wallpaper_no_bound_entities">No bound entities</string>
     <string name="claw_renderer_loading_entities">Loading entities…</string>
     <string name="claw_renderer_loading_wallpaper">Loading wallpaper…</string>
+    <string name="claw_wallpaper_loading_marker">Loading… (%1$s)</string>
     <string name="claw_renderer_no_entities_connected">No entities connected</string>
     <string name="claw_renderer_open_app_to_bind">Open E-Claw app to bind</string>
     <string name="claw_renderer_with_openclaw_bot">entities with OpenClaw bot</string>


### PR DESCRIPTION
## v1.1.1 still black on resume + placeholder didn't show

Hank's device test: wallpaper **still goes black** on app-switch resume, and the v1.1.1 "載入桌布中…" placeholder **never appeared** → the black is NOT the renderer bg-fallback path (the only one that placeholder covered). It's deeper: on resume the **draw loop isn't painting**, so `ClawRenderer` never runs (no placeholder, no "Loading entities…" text → pure black).

## Fix (per Hank's diagnostic idea)
Instrument **every black-prone entry point** with a **distinct, directly-painted** loading marker (`paintLoadingMarker()`) that bypasses the 33ms draw loop — so the surface is never raw black on resume, **and the label that shows pinpoints the path**:

| where | marker | meaning if seen |
|---|---|---|
| `onSurfaceCreated` | `Loading… (surface)` | surface recreated but loop stalled |
| `onVisibilityChanged(true)` | `Loading… (resume)` | visible-path |
| `onSurfaceChanged` | `Loading… (changed)` | geometry path |
| renderer bg-fallback (existing) | `載入桌布中…` | bg image loading |
| **still pure black, no marker** | — | Engine never got the callback → framework didn't recreate surface / Engine dead = deepest GL/surface layer |

`paintLoadingMarker` locks the holder and paints one labelled frame independent of the draw loop, so it shows even when the loop is dead; the real frame overwrites within ~33ms when healthy.

## Details
- i18n: `claw_wallpaper_loading_marker` in all 18 locales (the `(%1$s)` path token stays latin = diagnostic-readable)
- versionCode 111→112 / 1.1.2; built + **shipped to Play internal** (status=completed)
- `:app:testDebugUnitTest` green (EngineLifecycleControllerTest unchanged); AAB signed + uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)