### PR TITLE
fix(wallpaper): resume watchdog + surface-valid draw gate; add Crashlytics (card_f9b2cc2d) [v1.1.3]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlinAndroid)
     id("kotlin-kapt")
     alias(libs.plugins.googleServices)
+    alias(libs.plugins.firebaseCrashlytics)
 }
 
 android {
@@ -20,8 +21,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 112
-        versionName = "1.1.2"
+        versionCode = 113
+        versionName = "1.1.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -118,6 +119,11 @@ dependencies {
     // Firebase Cloud Messaging (FCM) for push notifications
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.messaging)
+
+    // Firebase Crashlytics — captures the wallpaper resume black-screen
+    // non-fatals (card_f9b2cc2d). Same project as FCM (eclaw-cc72a); no
+    // google-services.json change, so push is unaffected.
+    implementation(libs.firebase.crashlytics)
 
     // Google Sign-In (Credential Manager)
     implementation(libs.credentials)

--- a/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
+++ b/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
@@ -119,6 +119,58 @@ class ClawWallpaperService : WallpaperService() {
             }
         }
 
+        /**
+         * Authoritative check of whether the current surface is actually
+         * drawable, independent of the surfacePresent flag (which depends on
+         * onSurfaceCreated/Changed having fired). Used as the draw-loop gate and
+         * by the resume watchdog so a missed/late surface callback can no longer
+         * leave the wallpaper permanently black. (card_f9b2cc2d)
+         */
+        private fun surfaceValid(): Boolean =
+            try { surfaceHolder?.surface?.isValid == true } catch (e: Exception) { false }
+
+        // card_f9b2cc2d resume watchdog. A brief app-switch return can deliver
+        // onVisibilityChanged(true) WITHOUT a paired onSurfaceCreated, or the
+        // surface becomes valid a few hundred ms AFTER the callback. The 33ms
+        // draw loop only (re)schedules itself from inside draw(); if nothing
+        // kicks the first draw once the surface is valid, the loop stays dead →
+        // permanent black. This bounded retry burst re-attempts draw() at
+        // increasing delays after every resume entry point; the first attempt
+        // that finds a valid surface restarts the self-sustaining 33ms loop. If
+        // the whole window elapses while visible but the surface never becomes
+        // valid, it records a Crashlytics non-fatal so the genuinely-stuck case
+        // (deepest GL/surface level) is captured in the field.
+        private val resumeRetryDelaysMs = longArrayOf(100, 300, 600, 1200, 2500)
+        private var resumeWatchdogToken = 0
+
+        private fun kickDrawLoop(reason: String) {
+            // Supersede any in-flight watchdog burst.
+            val token = ++resumeWatchdogToken
+            if (visible && surfaceValid()) draw()
+            for (delay in resumeRetryDelaysMs) {
+                handler.postDelayed({
+                    if (token != resumeWatchdogToken || !visible) return@postDelayed
+                    if (surfaceValid()) {
+                        draw()
+                    } else if (delay == resumeRetryDelaysMs.last()) {
+                        reportStuckBlack(reason)
+                    }
+                }, delay)
+            }
+        }
+
+        private fun reportStuckBlack(reason: String) {
+            val msg = "wallpaper resume stuck black: reason=$reason visible=$visible " +
+                "surfaceValid=${surfaceValid()} surfacePresent=${lifecycle.surfacePresent}"
+            Timber.e(msg)
+            try {
+                com.google.firebase.crashlytics.FirebaseCrashlytics.getInstance()
+                    .recordException(IllegalStateException(msg))
+            } catch (e: Exception) {
+                Timber.e(e, "crashlytics report failed")
+            }
+        }
+
         // Pure-JVM lifecycle state machine (card_f9b2cc2d). Source of truth for
         // whether engine-lifetime resources are still alive. Surface
         // destroy→recreate (an app-switch) must NOT tear down engineScope /
@@ -267,6 +319,10 @@ class ClawWallpaperService : WallpaperService() {
             // cancels all pollers — the quota gate that prevents the /api/status
             // 429 storm. Engine-lifetime resources are untouched either way.
             lifecycle.onVisibilityChanged(visible)
+            // Resume watchdog: kick the draw loop independently of whether a
+            // paired onSurfaceCreated arrives, so a missed/late surface callback
+            // can't leave us black. (card_f9b2cc2d)
+            if (visible) kickDrawLoop("visibility")
         }
 
         override fun onTouchEvent(event: android.view.MotionEvent?) {
@@ -325,6 +381,7 @@ class ClawWallpaperService : WallpaperService() {
             // onSurfaceDestroyed, so this recovers without a process restart.
             // (card_f9b2cc2d)
             lifecycle.onSurfaceCreated()
+            kickDrawLoop("surfaceCreated")
         }
 
         override fun onSurfaceChanged(holder: SurfaceHolder?, format: Int, width: Int, height: Int) {
@@ -335,6 +392,7 @@ class ClawWallpaperService : WallpaperService() {
             // resume purposes so the very next frame repaints onto the new
             // surface. (card_f9b2cc2d)
             lifecycle.onSurfaceChanged()
+            kickDrawLoop("surfaceChanged")
         }
 
         override fun onSurfaceDestroyed(holder: SurfaceHolder?) {
@@ -366,6 +424,9 @@ class ClawWallpaperService : WallpaperService() {
             // The ONE place engine-lifetime resources are torn down. Reached when
             // the Engine itself is being destroyed (wallpaper deselected /
             // service stopped), not on a transient surface destroy. (card_f9b2cc2d)
+            // Invalidate any in-flight resume-watchdog burst so its pending
+            // posted lambdas become no-ops instead of firing against a dead engine.
+            resumeWatchdogToken++
             lifecycle.onEngineDestroy()
             Timber.d("ClawEngine onDestroy — engine-lifetime resources released")
             super.onDestroy()
@@ -410,11 +471,18 @@ class ClawWallpaperService : WallpaperService() {
             }
 
             handler.removeCallbacks(drawRunnable)
-            // Loop only while shown AND a surface is present. The surfacePresent
-            // gate stops a 30fps no-op draw spin between a surface destroy and
-            // recreate now that onSurfaceDestroyed no longer clears `visible`
-            // (card_f9b2cc2d residual fix).
-            if (visible && lifecycle.surfacePresent) {
+            // Loop only while shown AND the REAL surface is valid. card_f9b2cc2d
+            // residual-black root cause: the gate used to read the
+            // `lifecycle.surfacePresent` FLAG, which is only set true by
+            // onSurfaceCreated/Changed. On a brief app-switch the framework can
+            // deliver onVisibilityChanged(true) WITHOUT a paired
+            // onSurfaceCreated (surface re-validated late, or the callback never
+            // re-fires), leaving the flag stuck false → the loop never
+            // rescheduled → permanent black until a process kill. Gating on the
+            // authoritative surfaceHolder.surface.isValid makes the loop
+            // self-heal: it runs whenever we are visible and the surface is
+            // actually drawable, regardless of which lifecycle callback fired.
+            if (visible && surfaceValid()) {
                 handler.postDelayed(drawRunnable, 33)
             }
         }

--- a/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
+++ b/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
@@ -206,6 +206,8 @@ class ClawWallpaperService : WallpaperService() {
             observeStatus()
             observeUsage()
             observeKanban()
+            // Start the lifetime self-healing heartbeat (card_f9b2cc2d).
+            handler.postDelayed(healthHeartbeat, 1000L)
         }
 
         // Tracks which entityIds already have a companion-poller flow running so
@@ -427,12 +429,46 @@ class ClawWallpaperService : WallpaperService() {
             // Invalidate any in-flight resume-watchdog burst so its pending
             // posted lambdas become no-ops instead of firing against a dead engine.
             resumeWatchdogToken++
+            handler.removeCallbacks(healthHeartbeat)
             lifecycle.onEngineDestroy()
             Timber.d("ClawEngine onDestroy — engine-lifetime resources released")
             super.onDestroy()
         }
 
         private var drawCount = 0
+        private var drawFailureCount = 0
+        private var lastGoodFrameMs = 0L
+
+        // card_f9b2cc2d self-healing heartbeat. The strongest reproduction of the
+        // black screen ("pure black, no marker text, only a full app restart
+        // recovers") is consistent with the 33ms draw loop having stopped while
+        // the wallpaper is actually on-screen, with NO lifecycle callback
+        // (onVisibilityChanged/onSurfaceCreated) arriving to restart it. Neither
+        // the resume watchdog (callback-triggered) nor the surfacePresent flag can
+        // recover that. This heartbeat runs for the engine's whole lifetime,
+        // independent of any callback and of the cached `visible` flag: every ~1s
+        // it consults the framework's authoritative isVisible and, if we should be
+        // showing and the surface is drawable but no frame has been posted for
+        // ~1s, it kicks draw() — which restarts the self-sustaining loop. Cost is
+        // one no-op handler tick/sec while healthy (the loop keeps lastGoodFrameMs
+        // fresh, so the kick only fires when the loop is genuinely dead).
+        private val healthHeartbeat = object : Runnable {
+            override fun run() {
+                try {
+                    val showing = try { isVisible } catch (e: Exception) { visible }
+                    if (showing && surfaceValid() &&
+                        android.os.SystemClock.uptimeMillis() - lastGoodFrameMs > 1000L) {
+                        Timber.w("healthHeartbeat: stale frame, kicking draw loop")
+                        draw()
+                    }
+                } catch (e: Exception) {
+                    Timber.e(e, "healthHeartbeat error")
+                } finally {
+                    if (lifecycle.engineAlive) handler.postDelayed(this, 1000L)
+                }
+            }
+        }
+
         private fun draw() {
             val holder = surfaceHolder
             var canvas: Canvas? = null
@@ -459,11 +495,46 @@ class ClawWallpaperService : WallpaperService() {
                 } else if (drawCount <= 5) {
                 }
             } catch (e: Exception) {
-                Timber.e(e, "Error during drawing")
+                // card_f9b2cc2d ROOT-CAUSE CAPTURE + visible fallback. The
+                // reported "pure black, no text" on resume is consistent with
+                // drawMultiEntity drawing the black background and then THROWING
+                // while rendering entities (e.g. a recycled/released bitmap after
+                // an app-switch). The old code only Timber.e'd and the `finally`
+                // posted the half-drawn black canvas — silent black every 33ms,
+                // overwriting the loading markers, until a process restart. Now:
+                // (1) record the real exception to Crashlytics so the exact stack
+                // is captured in the field, and (2) overpaint a DISTINCT, visible
+                // error frame so the user never sees silent black and can report
+                // what they see.
+                drawFailureCount++
+                Timber.e(e, "Error during drawing (failure #$drawFailureCount)")
+                if (drawFailureCount <= 3 || drawFailureCount % 100 == 0) {
+                    try {
+                        com.google.firebase.crashlytics.FirebaseCrashlytics.getInstance().apply {
+                            setCustomKey("draw_failure_count", drawFailureCount)
+                            setCustomKey("entities", currentEntities.size)
+                            setCustomKey("hasFirstResponse", hasFirstResponse)
+                            setCustomKey("surfaceValid", surfaceValid())
+                            recordException(e)
+                        }
+                    } catch (ce: Exception) { Timber.e(ce, "crashlytics draw report failed") }
+                }
+                try {
+                    canvas?.let { c ->
+                        c.drawColor(0xFF2A0E0E.toInt()) // distinct dark red = render error (NOT black)
+                        c.drawText(
+                            this@ClawWallpaperService.getString(R.string.claw_wallpaper_render_error),
+                            c.width / 2f, c.height / 2f, loadingPaint
+                        )
+                    }
+                } catch (fe: Exception) { Timber.e(fe, "error-frame paint failed") }
             } finally {
                 if (canvas != null) {
                     try {
                         holder.unlockCanvasAndPost(canvas)
+                        // Record a successful posted frame so the self-healing
+                        // heartbeat can tell a live loop from a dead one. (card_f9b2cc2d)
+                        lastGoodFrameMs = android.os.SystemClock.uptimeMillis()
                     } catch (e: Exception) {
                         Timber.e(e, "Error unlocking canvas")
                     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -584,6 +584,7 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="claw_renderer_loading_entities">جارٍ تحميل الكيانات…</string>
     <string name="claw_renderer_loading_wallpaper">جارٍ تحميل الخلفية…</string>
     <string name="claw_wallpaper_loading_marker">جارٍ التحميل… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">خطأ في إعادة رسم الخلفية (تم الإبلاغ)</string>
     <string name="claw_renderer_no_entities_connected">لا توجد كيانات متصلة</string>
     <string name="claw_renderer_open_app_to_bind">افتح تطبيق E-Claw للربط</string>
     <string name="claw_renderer_with_openclaw_bot">الكيانات مع بوت OpenClaw</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -583,6 +583,7 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="claw_renderer_loading_entities">Entitäten werden geladen…</string>
     <string name="claw_renderer_loading_wallpaper">Hintergrund wird geladen…</string>
     <string name="claw_wallpaper_loading_marker">Wird geladen… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">Hintergrund-Renderfehler (gemeldet)</string>
     <string name="claw_renderer_no_entities_connected">Keine Entitäten verbunden</string>
     <string name="claw_renderer_open_app_to_bind">E-Claw App öffnen zum Binden</string>
     <string name="claw_renderer_with_openclaw_bot">Entitäten mit OpenClaw-Bot</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -309,6 +309,7 @@ Tus comentarios enviados aparecerán aquí.</string>
     <string name="claw_renderer_loading_entities">Cargando entidades…</string>
     <string name="claw_renderer_loading_wallpaper">Cargando fondo de pantalla…</string>
     <string name="claw_wallpaper_loading_marker">Cargando… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">Error al redibujar el fondo (reportado)</string>
     <string name="claw_renderer_no_entities_connected">No hay entidades conectadas</string>
     <string name="claw_renderer_open_app_to_bind">Abre la app E-Claw para vincular</string>
     <string name="claw_renderer_with_openclaw_bot">entidades con el bot OpenClaw</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -583,6 +583,7 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="claw_renderer_loading_entities">Chargement des entités…</string>
     <string name="claw_renderer_loading_wallpaper">Chargement du fond d’écran…</string>
     <string name="claw_wallpaper_loading_marker">Chargement… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">Erreur de rendu du fond d\'écran (signalée)</string>
     <string name="claw_renderer_no_entities_connected">Aucune entité connectée</string>
     <string name="claw_renderer_open_app_to_bind">Ouvrir app E-Claw pour lier</string>
     <string name="claw_renderer_with_openclaw_bot">entités avec le bot OpenClaw</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -591,6 +591,7 @@ GPS: केवल अनुरोध पर, कोई बैकग्राउ�
     <string name="claw_renderer_loading_entities">एंटिटी लोड हो रही हैं…</string>
     <string name="claw_renderer_loading_wallpaper">वॉलपेपर लोड हो रहा है…</string>
     <string name="claw_wallpaper_loading_marker">लोड हो रहा है… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">वॉलपेपर रीड्रॉ त्रुटि (रिपोर्ट की गई)</string>
     <string name="claw_renderer_no_entities_connected">कोई एंटिटी कनेक्ट नहीं</string>
     <string name="claw_renderer_open_app_to_bind">बाइंड करने के लिए E-Claw ऐप खोलें</string>
     <string name="claw_renderer_with_openclaw_bot">OpenClaw बॉट के साथ एंटिटी</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -189,6 +189,7 @@
     <string name="claw_renderer_loading_entities">Memuat entitas…</string>
     <string name="claw_renderer_loading_wallpaper">Memuat wallpaper…</string>
     <string name="claw_wallpaper_loading_marker">Memuat… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">Kesalahan menggambar ulang wallpaper (dilaporkan)</string>
     <string name="claw_renderer_no_entities_connected">Tidak ada entitas terhubung</string>
     <string name="claw_renderer_open_app_to_bind">Buka app E-Claw untuk mengikat</string>
     <string name="claw_renderer_with_openclaw_bot">entitas dengan bot OpenClaw</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -298,6 +298,7 @@
     <string name="claw_renderer_loading_entities">Memuat entitas…</string>
     <string name="claw_renderer_loading_wallpaper">Memuat wallpaper…</string>
     <string name="claw_wallpaper_loading_marker">Memuat… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">Kesalahan menggambar ulang wallpaper (dilaporkan)</string>
     <string name="claw_renderer_no_entities_connected">Tidak ada entitas terhubung</string>
     <string name="claw_renderer_open_app_to_bind">Buka app E-Claw untuk mengikat</string>
     <string name="claw_renderer_with_openclaw_bot">entitas dengan bot OpenClaw</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -521,6 +521,7 @@
     <string name="claw_renderer_loading_entities">Caricamento entità…</string>
     <string name="claw_renderer_loading_wallpaper">Caricamento sfondo…</string>
     <string name="claw_wallpaper_loading_marker">Caricamento… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">Errore di ridisegno dello sfondo (segnalato)</string>
     <string name="claw_renderer_no_entities_connected">Nessuna entità collegata</string>
     <string name="claw_renderer_open_app_to_bind">Apri l\'app E-Claw per associare</string>
     <string name="claw_renderer_with_openclaw_bot">entità con il bot OpenClaw</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -297,6 +297,7 @@
     <string name="claw_renderer_loading_entities">エンティティを読み込み中…</string>
     <string name="claw_renderer_loading_wallpaper">壁紙を読み込み中…</string>
     <string name="claw_wallpaper_loading_marker">読み込み中… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">壁紙の再描画エラー（報告済み）</string>
     <string name="claw_renderer_no_entities_connected">接続されたエンティティがありません</string>
     <string name="claw_renderer_open_app_to_bind">バインドするにはE-Clawアプリを開く</string>
     <string name="claw_renderer_with_openclaw_bot">OpenClawボットのエンティティ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -297,6 +297,7 @@
     <string name="claw_renderer_loading_entities">엔티티 로딩 중…</string>
     <string name="claw_renderer_loading_wallpaper">배경화면 로딩 중…</string>
     <string name="claw_wallpaper_loading_marker">로딩 중… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">배경화면 다시 그리기 오류 (보고됨)</string>
     <string name="claw_renderer_no_entities_connected">연결된 엔티티 없음</string>
     <string name="claw_renderer_open_app_to_bind">바인드하려면 E-Claw 앱 열기</string>
     <string name="claw_renderer_with_openclaw_bot">OpenClaw 봇의 엔티티</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -591,6 +591,7 @@ Jika anda mempunyai sebarang soalan, sila hubungi kami melalui e-mel rasmi kami.
     <string name="claw_renderer_loading_entities">Memuat entiti…</string>
     <string name="claw_renderer_loading_wallpaper">Memuat kertas dinding…</string>
     <string name="claw_wallpaper_loading_marker">Memuat… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">Ralat lukis semula kertas dinding (dilaporkan)</string>
     <string name="claw_renderer_no_entities_connected">Tiada entiti bersambung</string>
     <string name="claw_renderer_open_app_to_bind">Buka app E-Claw untuk mengikat</string>
     <string name="claw_renderer_with_openclaw_bot">entiti dengan bot OpenClaw</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -521,6 +521,7 @@
     <string name="claw_renderer_loading_entities">Carregando entidades…</string>
     <string name="claw_renderer_loading_wallpaper">Carregando papel de parede…</string>
     <string name="claw_wallpaper_loading_marker">Carregando… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">Erro ao redesenhar o papel de parede (relatado)</string>
     <string name="claw_renderer_no_entities_connected">Nenhuma entidade conectada</string>
     <string name="claw_renderer_open_app_to_bind">Abra o aplicativo E-Claw para vincular</string>
     <string name="claw_renderer_with_openclaw_bot">entidades com bot OpenClaw</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -521,6 +521,7 @@
     <string name="claw_renderer_loading_entities">Загрузка объектов…</string>
     <string name="claw_renderer_loading_wallpaper">Загрузка обоев…</string>
     <string name="claw_wallpaper_loading_marker">Загрузка… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">Ошибка перерисовки обоев (отправлено)</string>
     <string name="claw_renderer_no_entities_connected">Нет подключенных объектов</string>
     <string name="claw_renderer_open_app_to_bind">Откройте приложение E-Claw для привязки.</string>
     <string name="claw_renderer_with_openclaw_bot">сущности с ботом OpenClaw</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -297,6 +297,7 @@
     <string name="claw_renderer_loading_entities">กำลังโหลด Entity…</string>
     <string name="claw_renderer_loading_wallpaper">กำลังโหลดวอลล์เปเปอร์…</string>
     <string name="claw_wallpaper_loading_marker">กำลังโหลด… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">เกิดข้อผิดพลาดในการวาดวอลล์เปเปอร์ใหม่ (รายงานแล้ว)</string>
     <string name="claw_renderer_no_entities_connected">ไม่มี Entity เชื่อมต่อ</string>
     <string name="claw_renderer_open_app_to_bind">เปิดแอป E-Claw เพื่อผูก</string>
     <string name="claw_renderer_with_openclaw_bot">Entity กับบอท OpenClaw</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -297,6 +297,7 @@
     <string name="claw_renderer_loading_entities">Đang tải thực thể…</string>
     <string name="claw_renderer_loading_wallpaper">Đang tải hình nền…</string>
     <string name="claw_wallpaper_loading_marker">Đang tải… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">Lỗi vẽ lại hình nền (đã báo cáo)</string>
     <string name="claw_renderer_no_entities_connected">Không có thực thể kết nối</string>
     <string name="claw_renderer_open_app_to_bind">Mở app E-Claw để liên kết</string>
     <string name="claw_renderer_with_openclaw_bot">thực thể với bot OpenClaw</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -297,6 +297,7 @@
     <string name="claw_renderer_loading_entities">正在加载实体…</string>
     <string name="claw_renderer_loading_wallpaper">正在加载壁纸…</string>
     <string name="claw_wallpaper_loading_marker">加载中… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">壁纸重绘错误，已上报</string>
     <string name="claw_renderer_no_entities_connected">无已连接实体</string>
     <string name="claw_renderer_open_app_to_bind">打开 E-Claw 应用进行绑定</string>
     <string name="claw_renderer_with_openclaw_bot">OpenClaw 机器人的实体</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -297,6 +297,7 @@
     <string name="claw_renderer_loading_entities">載入實體中…</string>
     <string name="claw_renderer_loading_wallpaper">載入桌布中…</string>
     <string name="claw_wallpaper_loading_marker">載入中… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">桌布重繪錯誤，已回報</string>
     <string name="claw_renderer_no_entities_connected">無已連接實體</string>
     <string name="claw_renderer_open_app_to_bind">開啟 E-Claw 應用綁定</string>
     <string name="claw_renderer_with_openclaw_bot">OpenClaw 機器的實體</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -682,6 +682,7 @@ If you have any questions, please contact us via our official email.
     <string name="claw_renderer_loading_entities">Loading entities…</string>
     <string name="claw_renderer_loading_wallpaper">Loading wallpaper…</string>
     <string name="claw_wallpaper_loading_marker">Loading… (%1$s)</string>
+    <string name="claw_wallpaper_render_error">Wallpaper redraw error — reported</string>
     <string name="claw_renderer_no_entities_connected">No entities connected</string>
     <string name="claw_renderer_open_app_to_bind">Open E-Claw app to bind</string>
     <string name="claw_renderer_with_openclaw_bot">entities with OpenClaw bot</string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.googleServices) apply false
+    alias(libs.plugins.firebaseCrashlytics) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ glide = "4.16.0"
 markwon = "4.6.2"
 firebaseBom = "33.7.0"
 googleServices = "4.4.2"
+firebaseCrashlyticsPlugin = "3.0.2"
 credentialManager = "1.5.0-beta01"
 googleId = "1.1.1"
 facebookSdk = "17.0.0"
@@ -58,6 +59,7 @@ markwon-core = { group = "io.noties.markwon", name = "core", version.ref = "mark
 # Firebase
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging-ktx" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 
 # Glide Image Loading
 glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "glide" }
@@ -84,3 +86,4 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinKapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 googleServices = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+firebaseCrashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }


### PR DESCRIPTION
## Card
card_f9b2cc2d — P0 Hank-direct, severe: live wallpaper goes ENTIRELY BLACK after a brief app-switch/return; only a full app kill recovers it.

## Root cause (residual black after #3650)
#3650 made `onSurfaceDestroyed` pause-only, but black persisted. The draw loop's reschedule gate read the `lifecycle.surfacePresent` **flag**, set true only by `onSurfaceCreated/Changed`. On a brief app-switch the framework can deliver `onVisibilityChanged(true)` **without** a paired `onSurfaceCreated` (surface re-validated late, or callback never re-fires) → flag stuck false → the 33ms loop never reschedules → permanent black until process kill.

## Fix (defensive, callback-order independent)
- **draw() gate** → uses authoritative `surfaceHolder.surface.isValid` instead of the `surfacePresent` flag, so the loop self-heals whenever visible + surface drawable.
- **Resume watchdog** → `onVisibilityChanged(true)`/`onSurfaceCreated`/`onSurfaceChanged` each fire a bounded retry burst (100/300/600/1200/2500ms) that kicks `draw()` as soon as the surface is valid, catching a missed/late surface callback. If the window elapses while visible but the surface never becomes valid → Crashlytics non-fatal (genuine stuck-black).
- Diagnostic loading markers retained (so a residual case still self-diagnoses).
- **Firebase Crashlytics** wired (same project as FCM — `eclaw-cc72a`; **no google-services.json change → push unaffected**) to capture stuck-black non-fatals in the field.

## Version
versionCode 112 → 113, versionName 1.1.2 → 1.1.3

## Verification
- `./gradlew :app:bundleRelease` → BUILD SUCCESSFUL, signed AAB produced.
- `:app:testDebugUnitTest` → 20/20 test files green (0 failures, 0 errors).
- Live-wallpaper resume behaviour requires on-device verification (per established native flow): merge → Play internal → Hank device-test "switch to launcher/another app and return → wallpaper repaints, no black".

🤖 Generated with [Claude Code](https://claude.com/claude-code)