### PR TITLE
fix(wallpaper): resilient per-stage render — one bad entity can't blank the frame (card_f9b2cc2d) [v1.1.4]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 113
-        versionName = "1.1.3"
+        versionCode = 114
+        versionName = "1.1.4"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -329,6 +329,28 @@ class ClawRenderer(
         Timber.d("ClawRenderer resources released")
     }
 
+    // card_f9b2cc2d resilient-render fix. The wallpaper went pure black on resume
+    // because drawMultiEntity drew the background and then THREW while rendering an
+    // entity/stage (e.g. a recycled bitmap or a transient null after an
+    // app-switch); the exception propagated out and the engine posted only the
+    // half-drawn black frame. A single bad entity or sub-stage must never blank the
+    // whole wallpaper. Each entity and each render stage is now wrapped so a failure
+    // is contained (that one entity/stage is skipped this frame) and the rest of the
+    // frame still draws. Failures are recorded to Crashlytics once per distinct
+    // stage key so we still learn the exact cause without per-frame spam.
+    private val reportedRenderErrors = HashSet<String>()
+    private fun reportRenderStageError(stage: String, e: Throwable) {
+        Timber.e(e, "render stage failed: $stage")
+        if (reportedRenderErrors.add(stage)) {
+            try {
+                com.google.firebase.crashlytics.FirebaseCrashlytics.getInstance().apply {
+                    setCustomKey("render_stage", stage)
+                    recordException(e)
+                }
+            } catch (_: Exception) { /* crashlytics unavailable — Timber already logged */ }
+        }
+    }
+
     // ============================================
     // MULTI-ENTITY RENDERING
     // ============================================
@@ -585,13 +607,17 @@ class ClawRenderer(
             nowMs = nowMs,
             reactionDurationMs = layoutPrefs.wallpaperCollisionReactionDurationMs
         )
-        kanbanRenderer.drawBackground(
-            canvas = canvas,
-            entities = entities,
-            basePositions = basePositions,
-            baseScale = baseScale,
-            nowMs = nowMs
-        )
+        try {
+            kanbanRenderer.drawBackground(
+                canvas = canvas,
+                entities = entities,
+                basePositions = basePositions,
+                baseScale = baseScale,
+                nowMs = nowMs
+            )
+        } catch (e: Exception) {
+            reportRenderStageError("kanbanBackground", e)
+        }
         if (layoutPrefs.wallpaperAdaptiveEffectsEnabled) {
             renderDiagnostics.recordFrame(
                 walkingEntityCount = entities.count { wanderController.isWalking(it.entityId) },
@@ -630,38 +656,55 @@ class ClawRenderer(
                 } else {
                     effectiveState.wallpaperActionKey
                 }
-                drawSingleEntityAt(
-                    canvas,
-                    entity,
-                    cx,
-                    drawCy,
-                    finalScale,
-                    spritesheetState,
-                    nowMs,
-                    facingDirection,
-                    shouldMirrorSpritesheetForFacing(spritesheetState)
-                )
-                bubbleDrawTargets.add(BubbleDrawTarget(entity, cx, drawCy, finalScale))
+                try {
+                    drawSingleEntityAt(
+                        canvas,
+                        entity,
+                        cx,
+                        drawCy,
+                        finalScale,
+                        spritesheetState,
+                        nowMs,
+                        facingDirection,
+                        shouldMirrorSpritesheetForFacing(spritesheetState)
+                    )
+                    bubbleDrawTargets.add(BubbleDrawTarget(entity, cx, drawCy, finalScale))
+                } catch (e: Exception) {
+                    // card_f9b2cc2d: one bad entity must not blank the whole wallpaper.
+                    reportRenderStageError("entity:${entity.entityId}", e)
+                }
             }
         }
 
-        interactionState.effects.forEach { effect ->
-            drawInteractionEffect(canvas, effect, baseScale, nowMs)
+        try {
+            interactionState.effects.forEach { effect ->
+                drawInteractionEffect(canvas, effect, baseScale, nowMs)
+            }
+        } catch (e: Exception) {
+            reportRenderStageError("interactionEffects", e)
         }
 
-        usageOverlayRenderer.draw(canvas, usageSnapshot)
+        try {
+            usageOverlayRenderer.draw(canvas, usageSnapshot)
+        } catch (e: Exception) {
+            reportRenderStageError("usageOverlay", e)
+        }
 
         bubbleDrawTargets.forEach { target ->
-            drawSpeechBubbleForEntity(
-                canvas = canvas,
-                entity = target.entity,
-                centerX = target.centerX,
-                centerY = target.centerY,
-                scale = target.scale,
-                screenWidth = width,
-                nowMs = nowMs,
-                avoidBounds = bubbleAvoidBounds
-            )
+            try {
+                drawSpeechBubbleForEntity(
+                    canvas = canvas,
+                    entity = target.entity,
+                    centerX = target.centerX,
+                    centerY = target.centerY,
+                    scale = target.scale,
+                    screenWidth = width,
+                    nowMs = nowMs,
+                    avoidBounds = bubbleAvoidBounds
+                )
+            } catch (e: Exception) {
+                reportRenderStageError("bubble:${target.entity.entityId}", e)
+            }
         }
     }
 


### PR DESCRIPTION
## Card
card_f9b2cc2d — P0 Hank-direct. Follow-up to v1.1.3 (PR #3682).

## Confirmed root cause (from Hank's v1.1.3 device-test)
v1.1.3 shipped a hardened draw() catch that, instead of silently posting a half-drawn black frame, paints a distinct dark-red "render error" frame + records the exception to Crashlytics. **Hank's device showed that red frame** → confirms `draw()` draws the black background then **throws while rendering an entity/stage** (recycled bitmap / transient null after an app-switch). The whole frame was being lost.

## Fix
`drawMultiEntity` now wraps each render stage in its own try/catch so one failure is contained and the rest of the frame still renders:
- **per-entity** `drawSingleEntityAt` (most likely culprit: procedural avatar / effects / text on a bad bitmap)
- kanban background, interaction effects, usage overlay, per-entity speech bubbles

`reportRenderStageError(stage, e)` records to Crashlytics **once per distinct stage key** (`render_stage` custom key) — still captures the exact cause, no per-frame spam. Anything escaping `drawMultiEntity` is still caught by v1.1.3's `ClawWallpaperService.draw()` red-error fallback. Spritesheet entities already self-heal (the drawer returns DrawResult.ERROR, not throw).

## Version
versionCode 113 → 114, versionName 1.1.3 → 1.1.4

## Verification
- `:app:bundleRelease` BUILD SUCCESSFUL (signed AAB), `:app:testDebugUnitTest` 20/20 green.
- Device: after this, a brief app-switch return should render the wallpaper normally (bad entity/stage skipped, not blanked). Crashlytics `render_stage` key will name the exact failing stage for any residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)