### PR TITLE
fix(portal): name the target in destructive confirm dialogs (itemName) — card_00753bad

### DIFF
--- a/backend/public/portal/admin.html
+++ b/backend/public/portal/admin.html
@@ -1463,7 +1463,7 @@
         }
 
         async function revokeSkill(skillId) {
-            if (!await showConfirm({ message: i18n.t('skill_contrib_revoke_confirm'), danger: true })) return;
+            if (!await showConfirm({ message: i18n.t('skill_contrib_revoke_confirm'), danger: true, itemName: skillId })) return;
             try {
                 await apiCall('DELETE', '/api/skill-templates/' + encodeURIComponent(skillId));
                 showToast(i18n.t('skill_contrib_revoked'), 'success');
@@ -1474,7 +1474,7 @@
         }
 
         async function revokeSoul(soulId) {
-            if (!await showConfirm({ message: i18n.t('soul_contrib_revoke_confirm'), danger: true })) return;
+            if (!await showConfirm({ message: i18n.t('soul_contrib_revoke_confirm'), danger: true, itemName: soulId })) return;
             try {
                 await apiCall('DELETE', '/api/soul-templates/' + encodeURIComponent(soulId));
                 showToast(i18n.t('soul_contrib_revoked'), 'success');
@@ -1485,7 +1485,7 @@
         }
 
         async function revokeRule(ruleId) {
-            if (!await showConfirm({ message: i18n.t('rule_contrib_revoke_confirm'), danger: true })) return;
+            if (!await showConfirm({ message: i18n.t('rule_contrib_revoke_confirm'), danger: true, itemName: ruleId })) return;
             try {
                 await apiCall('DELETE', '/api/rule-templates/' + encodeURIComponent(ruleId));
                 showToast(i18n.t('rule_contrib_revoked'), 'success');

--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -1502,7 +1502,7 @@
         }
 
         async function toggleBlockFromList(publicCode, currentlyBlocked) {
-            if (!currentlyBlocked && !await showConfirm({ message: t('cardholder_block_confirm', 'Block this agent? They will not be able to send you messages.'), danger: true })) return;
+            if (!currentlyBlocked && !await showConfirm({ message: t('cardholder_block_confirm', 'Block this agent? They will not be able to send you messages.'), danger: true, itemName: publicCode })) return;
             try {
                 await apiCall('PATCH', `/api/contacts/${publicCode}`, {
                     deviceId: currentUser.deviceId,
@@ -1541,7 +1541,7 @@
             const card = collectedCards.find(c => c.publicCode === publicCode);
             if (!card) return;
             const newBlocked = !card.blocked;
-            if (newBlocked && !await showConfirm({ message: t('cardholder_block_confirm', 'Block this agent?'), danger: true })) return;
+            if (newBlocked && !await showConfirm({ message: t('cardholder_block_confirm', 'Block this agent?'), danger: true, itemName: card.name || card.publicCode })) return;
             try {
                 await apiCall('PATCH', `/api/contacts/${publicCode}`, {
                     deviceId: currentUser.deviceId,
@@ -1579,7 +1579,7 @@
         async function removeCard(publicCode) {
             const card = collectedCards.find(c => c.publicCode === publicCode);
             const name = card ? (card.name || card.publicCode) : publicCode;
-            if (!await showConfirm({ message: t('cardholder_remove_confirm', `Remove ${name} from card holder?`).replace('{name}', name), danger: true })) return;
+            if (!await showConfirm({ message: t('cardholder_remove_confirm', `Remove ${name} from card holder?`).replace('{name}', name), danger: true, itemName: name })) return;
             try {
                 await apiCall('DELETE', '/api/contacts', {
                     deviceId: currentUser.deviceId,
@@ -1648,7 +1648,7 @@
         }
 
         async function unfriend(publicCode) {
-            if (!await showConfirm({ message: t('cardholder_unfriend_confirm', 'Remove this friend?'), danger: true })) return;
+            if (!await showConfirm({ message: t('cardholder_unfriend_confirm', 'Remove this friend?'), danger: true, itemName: publicCode })) return;
             try {
                 await apiCall('DELETE', `/api/contacts/${publicCode}/unfriend`, {
                     deviceId: currentUser.deviceId,

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -5412,7 +5412,7 @@
             if (event) event.stopPropagation();
             const contact = contacts.find(c => c.publicCode === publicCode);
             const name = contact ? (contact.name || contact.publicCode) : publicCode;
-            if (!await showConfirm({ message: i18n.t('chat_contacts_remove_confirm').replace('{name}', name), danger: true })) return;
+            if (!await showConfirm({ message: i18n.t('chat_contacts_remove_confirm').replace('{name}', name), danger: true, itemName: name })) return;
             try {
                 await apiCall('DELETE', '/api/contacts', {
                     deviceId: currentUser.deviceId,
@@ -8473,7 +8473,8 @@
         async function schedCancel(id) {
             const ok = await showConfirm({
                 message: i18n.t('chat_schedule_delete_confirm') || 'Cancel this scheduled message?',
-                danger: true
+                danger: true,
+                itemName: id
             });
             if (!ok) return;
             try {
@@ -8845,7 +8846,7 @@
             }
         }
         async function deleteR2File(fileId) {
-            if (!await showConfirm({ message: '確定刪除這個檔案？（無法復原）', danger: true })) return;
+            if (!await showConfirm({ message: '確定刪除這個檔案？（無法復原）', danger: true, itemName: fileId })) return;
             try {
                 const res = await fetch(API_BASE + '/api/files/' + encodeURIComponent(fileId), {
                     method: 'DELETE',

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -3537,7 +3537,7 @@
         }
 
         async function resetXdSettings(entityId) {
-            if (!await showConfirm({ message: i18n.t('dash_xd_reset_confirm'), danger: true })) return;
+            if (!await showConfirm({ message: i18n.t('dash_xd_reset_confirm'), danger: true, itemName: entityId })) return;
             try {
                 var data = await apiCall('DELETE', '/api/entity/cross-device-settings', {
                     deviceId: currentUser.deviceId,
@@ -3786,7 +3786,7 @@
         }
 
         async function deleteIdentity(entityId) {
-            if (!await showConfirm({ message: i18n.t('dash_id_clear_confirm') + entityId + '?', danger: true })) return;
+            if (!await showConfirm({ message: i18n.t('dash_id_clear_confirm') + entityId + '?', danger: true, itemName: entityId })) return;
             try {
                 var data = await apiCall('DELETE', '/api/entity/identity', {
                     deviceId: currentUser.deviceId,

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -946,7 +946,7 @@
         }
 
         async function deleteFolder(name) {
-            if (!await showConfirm({ message: i18n.t('files_folder_delete_confirm').replace('%1$s', name), danger: true })) return;
+            if (!await showConfirm({ message: i18n.t('files_folder_delete_confirm').replace('%1$s', name), danger: true, itemName: name })) return;
             const folders = getFileFolders().filter(f => f !== name);
             saveFileFolders(folders);
             // Remove folder assignments
@@ -1392,7 +1392,7 @@
         async function deleteFile(idx) {
             const file = allFiles[idx];
             if (!file) return;
-            if (!await showConfirm({ message: i18n.t('files_delete_confirm', 'Are you sure you want to delete this file?'), danger: true })) return;
+            if (!await showConfirm({ message: i18n.t('files_delete_confirm', 'Are you sure you want to delete this file?'), danger: true, itemName: file.text || file.url })) return;
 
             try {
                 const resp = await apiCall(

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -3007,7 +3007,7 @@
         async function deleteAutomation(cardId) {
             const card = findCard(cardId);
             if (!card) return;
-            if (!await showConfirm({ message: t('kb_auto_delete_confirm', `Delete automation "${card.title}"? This will archive the card.`), danger: true })) return;
+            if (!await showConfirm({ message: t('kb_auto_delete_confirm', `Delete automation "${card.title}"? This will archive the card.`), itemName: card.title || card.id, danger: true })) return;
             const btn = document.querySelector('.kb-auto-action-btn.delete');
             await withAutoAction(btn, () => apiCall('DELETE', `/api/mission/card/${cardId}?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`), {
                 closeOnDone: true, successMsg: '🗑 ' + t('toast_entity_deleted', 'Deleted'),

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -2886,7 +2886,9 @@
         }
 
         async function deleteNotePage(noteId) {
-            if (!await showConfirm({ message: i18n.t('mc_confirm_delete'), danger: true })) return;
+            const note = dashboard.notes.find(n => n.id === noteId);
+            const itemName = note ? (note.title || note.id) : noteId;
+            if (!await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) return;
             try {
                 await apiCall('DELETE', '/api/mission/note/page', {
                     deviceId: currentUser.deviceId,
@@ -3368,7 +3370,9 @@
         }
 
         async function deleteSkill(id) {
-            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), danger: true })) {
+            const skill = dashboard.skills.find(s => s.id === id);
+            const itemName = skill ? (skill.title || skill.id) : id;
+            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
                 dashboard.skills = dashboard.skills.filter(s => s.id !== id);
                 markChanged();
                 renderSkills();
@@ -3384,7 +3388,9 @@
             menu.style.top = e.clientY + 'px';
 
             menu.querySelector('.context-menu-item').onclick = async () => {
-                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), danger: true })) {
+                const skill = dashboard.skills.find(s => s.id === id);
+                const itemName = skill ? (skill.title || skill.id) : id;
+                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
                     dashboard.skills = dashboard.skills.filter(s => s.id !== id);
                     markChanged();
                     renderSkills();
@@ -3495,7 +3501,9 @@
         }
 
         async function deleteRule(id) {
-            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), danger: true })) {
+            const rule = dashboard.rules.find(r => r.id === id);
+            const itemName = rule ? (rule.name || rule.id) : id;
+            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
                 dashboard.rules = dashboard.rules.filter(r => r.id !== id);
                 markChanged();
                 renderRules();
@@ -3511,7 +3519,9 @@
             menu.style.top = e.clientY + 'px';
 
             menu.querySelector('.context-menu-item').onclick = async () => {
-                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), danger: true })) {
+                const rule = dashboard.rules.find(r => r.id === id);
+                const itemName = rule ? (rule.name || rule.id) : id;
+                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
                     dashboard.rules = dashboard.rules.filter(r => r.id !== id);
                     markChanged();
                     renderRules();
@@ -3708,7 +3718,9 @@
         }
 
         async function deleteSoul(id) {
-            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), danger: true })) {
+            const soul = dashboard.souls.find(s => s.id === id);
+            const itemName = soul ? (soul.name || soul.id) : id;
+            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
                 dashboard.souls = dashboard.souls.filter(s => s.id !== id);
                 markChanged();
                 renderSouls();
@@ -3724,7 +3736,9 @@
             menu.style.top = e.clientY + 'px';
 
             menu.querySelector('.context-menu-item').onclick = async () => {
-                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), danger: true })) {
+                const soul = dashboard.souls.find(s => s.id === id);
+                const itemName = soul ? (soul.name || soul.id) : id;
+                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
                     dashboard.souls = dashboard.souls.filter(s => s.id !== id);
                     markChanged();
                     renderSouls();

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -3379,7 +3379,7 @@
             const msg = rosterT(confirmKey, action === 'manual_rebind'
                 ? `This will terminate ${activeCount} active rentals and issue refunds from your wallet. Continue?`
                 : 'Apply this manual owner action?');
-            const ok = await showConfirm({ title: rosterT('settings_roster_confirm_title', 'Confirm roster action'), message: msg, danger: ['archive','manual_rebind'].includes(action) });
+            const ok = await showConfirm({ title: rosterT('settings_roster_confirm_title', 'Confirm roster action'), message: msg, itemName: targetId, danger: ['archive','manual_rebind'].includes(action) });
             if (!ok) return;
             try {
                 if (targetType === 'listing') {


### PR DESCRIPTION
## Card
card_00753bad — destructive modal: portal callers missing `itemName` → deletion target not shown.

## What
`showConfirm({message, danger, itemName})` (portal/shared/api.js) renders a strip naming the item being destroyed **only** when `itemName` is passed (it even dev-warns when `danger:true` is called without it). ~14 `danger:true` callers across 8 portal pages omitted it, so delete/block/revoke dialogs didn't show **what** was being destroyed.

Adds an in-scope `itemName` to each (skillId/soulId/ruleId, publicCode/name/card.name, file caption/name, entityId, card.title, note/skill/rule/soul title||id, roster targetId). Pure data into the existing, already-rendered itemName strip — **no modal component change**, low visual risk.

Intentionally untouched: bulk/global ops (clear-all-drawings, reset-org-chart), non-`danger` confirms, and the legacy positional `showConfirm(msg, cb)` form.

## Verification
- Diff is surgical (every `itemName` on a `danger:true` call; bulk/non-danger skipped).
- CI: inline-script parse / ESLint / Critical portal pages / i18n.
- Spot vision-check of a representative delete dialog to confirm the item strip renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)