### PR TITLE
fix(chat): keep mobile greeting topic inline

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -329,7 +329,7 @@
             font-size: 14px; line-height: 1.5; display: flex; flex-direction: column; gap: 8px;
         }
         body.dark .greet-banner { background: #23262f; border-color: #3a3f4d; }
-        .greet-banner-text { display: flex; align-items: flex-start; gap: 6px; }
+        .greet-banner-text { display: block; overflow-wrap: anywhere; }
         .greet-chips { display: flex; flex-wrap: wrap; gap: 6px; }
         .greet-chip {
             border: 1px solid var(--primary, #5b6cff); color: var(--primary, #5b6cff);

--- a/backend/tests/jest/chat-greeting.test.js
+++ b/backend/tests/jest/chat-greeting.test.js
@@ -18,4 +18,13 @@ describe('greet banner — theme-token regression guard (card_079ea943)', () => 
             expect(tokens).toMatch(new RegExp(t.replace(/[-]/g, '\\-') + '\\s*:'));
         }
     });
+    test('returning-topic text wraps inline on mobile instead of flex columns', () => {
+        const ruleStart = src.indexOf('.greet-banner-text {');
+        const ruleEnd = src.indexOf('.greet-chips', ruleStart);
+        const rule = src.slice(ruleStart, ruleEnd);
+
+        expect(rule).toMatch(/display:\s*block/);
+        expect(rule).toMatch(/overflow-wrap:\s*anywhere/);
+        expect(rule).not.toMatch(/display:\s*flex/);
+    });
 });


### PR DESCRIPTION
## Summary
- Fixes #3687.
- Changes the chat returning-topic greeting text from a flex row to inline block flow so long remembered topics wrap as a readable sentence on mobile.
- Adds a Jest guard to prevent the greeting text from regressing back into flex-column wrapping.

## QA / UIUX Regression
- npm run lint
- node scripts/i18n-check.js
- npm run smoke:portal
- node tests/test-ux-static-audit.js
- npx jest chat-greeting + focused portal/chat/i18n/kanban/dashboard suite: 32 suites, 353 tests
- node tests/e2e/portal-uiux-smoke.spec.js: 39 pages x 2 viewports, 0 failures
- production live validation before fix: 110 passed, 1 auth-smoke skipped due missing broadcast creds, 0 failed

## Visual Evidence
- Desktop/mobile chat screenshots captured for kanban card card_d312ee5b5727c94359e25c43.