### PR TITLE
fix(wallpaper): spritesheet LOADING never leaves entities invisible — kill v1.1.5 pure-black regression (v1.1.6, card_f9b2cc2d)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 115
-        versionName = "1.1.5"
+        versionCode = 116
+        versionName = "1.1.6"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
+++ b/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
@@ -50,7 +50,25 @@ class CompanionRepository(
     private val ioScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     init {
-        descriptorCache.putAll(snapshotCache.loadCompanionMap())
+        val restored = snapshotCache.loadCompanionMap()
+        descriptorCache.putAll(restored)
+        // card_f9b2cc2d v1.1.6: warm the spritesheet bitmap cache for restored
+        // companions so the first frames after a cold engine (re)create paint the
+        // real avatar instead of a blank LOADING gap. Without this the renderer
+        // sees "spritesheet descriptor present, sheet absent" → DrawResult.LOADING
+        // and, with no custom background, a pure-black wallpaper until the lazy
+        // per-frame load happens to land. Best-effort, off the main thread.
+        if (restored.isNotEmpty()) {
+            ioScope.launch {
+                restored.values.forEach { companion ->
+                    if (companion.assetType == "spritesheet") {
+                        companion.spritesheetUrl()?.takeIf { it.isNotBlank() }?.let { url ->
+                            runCatching { sheetCache.getOrLoad(url) { loadBitmap(url) } }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /** Returns the cached companion for an entity, or null until a fetch lands. */

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -42,6 +42,21 @@ class ClawRenderer(
     private val lastBubbleDurationByEntity = mutableMapOf<Int, Long>()
     private val bubblePulseStartedByEntity = mutableMapOf<Int, Long>()
 
+    // card_f9b2cc2d v1.1.6 regression fix. A spritesheet whose bitmap is not in
+    // sheetCache returns DrawResult.LOADING, which historically painted NOTHING
+    // (to avoid a companion-switch flash to the default lobster, card_9e52c7b).
+    // But after a cold engine (re)create — CompanionRepository restores the
+    // spritesheet DESCRIPTOR from snapshot but not the sheet bitmap — or a cache
+    // eviction / failed reload, that LOADING persists for many ticks (or forever
+    // if the sheet can never be fetched). With no custom background the canvas is
+    // solid black, so invisible entities = the "pure black, no text, no
+    // exception" resume bug. We keep a short no-paint grace for genuinely brief
+    // loads (no flash), but once an entity has been continuously LOADING past the
+    // grace window we draw the procedural fallback so an entity is NEVER
+    // invisible for more than ~0.75s, regardless of why the sheet is missing.
+    private val spritesheetLoadingSinceMs = mutableMapOf<Int, Long>()
+    private val spritesheetStuckReported = mutableSetOf<Int>()
+
     private data class BubbleDrawTarget(
         val entity: EntityStatus,
         val centerX: Float,
@@ -348,6 +363,30 @@ class ClawRenderer(
                     recordException(e)
                 }
             } catch (_: Exception) { /* crashlytics unavailable — Timber already logged */ }
+        }
+    }
+
+    // card_f9b2cc2d v1.1.6: a spritesheet stuck in LOADING past the grace window
+    // (sheet genuinely unavailable) fell back to the procedural drawer instead of
+    // staying invisible. Record the field cause once per stuck episode (cleared
+    // when the entity next draws a real frame) so we learn WHICH sheet/companion
+    // is failing without per-frame Crashlytics spam.
+    private fun reportSpritesheetStuckLoading(entityId: Int, companion: CompanionDetail?, loadingMs: Long) {
+        if (!spritesheetStuckReported.add(entityId)) return
+        Timber.w("Spritesheet stuck LOADING ${loadingMs}ms for entity $entityId (companion=${companion?.id}) → procedural fallback")
+        try {
+            com.google.firebase.crashlytics.FirebaseCrashlytics.getInstance().apply {
+                setCustomKey("stuck_entity_id", entityId)
+                setCustomKey("stuck_loading_ms", loadingMs)
+                setCustomKey("stuck_companion_id", companion?.id ?: "null")
+                recordException(
+                    IllegalStateException(
+                        "wallpaper spritesheet stuck LOADING ${loadingMs}ms entity=$entityId → procedural fallback (card_f9b2cc2d)"
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "stuck-loading crashlytics report failed")
         }
     }
 
@@ -975,11 +1014,31 @@ class ClawRenderer(
         }
 
         when (drawResult) {
-            SpritesheetCompanionDrawer.DrawResult.DRAWN,
-            SpritesheetCompanionDrawer.DrawResult.LOADING -> Unit
+            SpritesheetCompanionDrawer.DrawResult.DRAWN -> {
+                // Healthy frame — clear this entity's LOADING-grace tracker.
+                spritesheetLoadingSinceMs.remove(entity.entityId)
+                spritesheetStuckReported.remove(entity.entityId)
+            }
+            SpritesheetCompanionDrawer.DrawResult.LOADING -> {
+                // Sheet not yet in cache. A brief load paints nothing this tick
+                // (no flash to the default lobster). But a SUSTAINED LOADING —
+                // cold snapshot restore, cache eviction, or a reload that never
+                // lands — must not leave the entity invisible (the pure-black
+                // bug). Once continuously LOADING past the grace window, draw the
+                // procedural fallback (color-matched via the companion descriptor)
+                // so an entity is never invisible for more than the grace.
+                // (card_f9b2cc2d v1.1.6)
+                val since = spritesheetLoadingSinceMs.getOrPut(entity.entityId) { nowMs }
+                if (shouldFallbackForStuckSpritesheet(since, nowMs)) {
+                    reportSpritesheetStuckLoading(entity.entityId, companion, nowMs - since)
+                    drawLobsterAtPosition(canvas, centerX, charY, entity, scale, companion, facingDirection)
+                }
+            }
             SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED,
-            SpritesheetCompanionDrawer.DrawResult.ERROR ->
+            SpritesheetCompanionDrawer.DrawResult.ERROR -> {
+                spritesheetLoadingSinceMs.remove(entity.entityId)
                 drawLobsterAtPosition(canvas, centerX, charY, entity, scale, companion, facingDirection)
+            }
         }
 
         // Draw Name and Status Group BELOW the entity
@@ -1648,5 +1707,26 @@ class ClawRenderer(
         private const val CONVERSATION_GROUP_WINDOW_MS = 2_000L
         private const val CONVERSATION_EVENT_STALE_MS = 120_000L
         private const val MAX_SEEN_CONVERSATIONS = 128
+
+        /**
+         * card_f9b2cc2d v1.1.6: how long a spritesheet may stay in LOADING (and
+         * paint nothing) before the renderer falls back to the procedural drawer
+         * so the entity is never invisible. Short enough the user never sees a
+         * long black gap; long enough a quick disk-decode load doesn't flash the
+         * procedural lobster (preserves the no-flash intent of card_9e52c7b).
+         */
+        const val SPRITESHEET_LOADING_GRACE_MS = 750L
+
+        /**
+         * Pure decision for the LOADING grace window (unit-tested without a
+         * Context). Returns true once a spritesheet has been continuously LOADING
+         * for at least [graceMs]. [loadingSinceMs] is the wall-clock ms when
+         * LOADING first began for this entity (0 means "not currently tracked").
+         */
+        fun shouldFallbackForStuckSpritesheet(
+            loadingSinceMs: Long,
+            nowMs: Long,
+            graceMs: Long = SPRITESHEET_LOADING_GRACE_MS
+        ): Boolean = loadingSinceMs > 0L && nowMs - loadingSinceMs >= graceMs
     }
 }

--- a/app/src/test/java/com/hank/clawlive/SpritesheetLoadingGraceTest.kt
+++ b/app/src/test/java/com/hank/clawlive/SpritesheetLoadingGraceTest.kt
@@ -1,0 +1,80 @@
+package com.hank.clawlive
+
+import com.hank.clawlive.engine.ClawRenderer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [ClawRenderer.shouldFallbackForStuckSpritesheet] — the
+ * grace-window decision that fixes the v1.1.5 pure-black regression
+ * (card_f9b2cc2d).
+ *
+ * Root cause: a spritesheet companion whose bitmap is missing from the cache
+ * returns DrawResult.LOADING, which paints nothing this frame. After a cold
+ * engine (re)create (the descriptor is restored from snapshot but the sheet is
+ * not) or a cache eviction / failed reload, that LOADING persists for many
+ * ticks — so every spritesheet entity stays invisible and, with no custom
+ * background (canvas is solid black), the wallpaper is pure black with no text
+ * and no exception. The fix keeps a short no-paint grace for genuinely brief
+ * loads (no flash to the default lobster, preserving card_9e52c7b) but, once
+ * LOADING has persisted past the grace, draws the procedural fallback so an
+ * entity is never invisible for more than the grace window.
+ *
+ * These run on the host JVM — the decision is a pure Long-arithmetic function
+ * on the companion object, with no Android dependencies.
+ */
+class SpritesheetLoadingGraceTest {
+
+    @Test
+    fun `brief loading within grace does not fall back`() {
+        val start = 10_000L
+        // One 33ms draw tick, and ~half the grace: still painting nothing so a
+        // quick disk-decode load never flashes the procedural lobster.
+        assertFalse(ClawRenderer.shouldFallbackForStuckSpritesheet(start, start + 33))
+        assertFalse(ClawRenderer.shouldFallbackForStuckSpritesheet(start, start + 374))
+    }
+
+    @Test
+    fun `sustained loading past grace falls back to procedural`() {
+        val start = 10_000L
+        assertTrue(
+            ClawRenderer.shouldFallbackForStuckSpritesheet(
+                start,
+                start + ClawRenderer.SPRITESHEET_LOADING_GRACE_MS + 1
+            )
+        )
+        // The 25-second field report (Hank's repro) must fall back, not stay black.
+        assertTrue(ClawRenderer.shouldFallbackForStuckSpritesheet(start, start + 25_000))
+    }
+
+    @Test
+    fun `grace boundary is inclusive`() {
+        val start = 0L
+        assertTrue(
+            ClawRenderer.shouldFallbackForStuckSpritesheet(
+                start + 1, // since>0 so it is tracked
+                1 + ClawRenderer.SPRITESHEET_LOADING_GRACE_MS
+            )
+        )
+        assertFalse(
+            ClawRenderer.shouldFallbackForStuckSpritesheet(
+                start + 1,
+                ClawRenderer.SPRITESHEET_LOADING_GRACE_MS // exactly grace-1 elapsed
+            )
+        )
+    }
+
+    @Test
+    fun `untracked entity (since=0) never falls back`() {
+        // since==0 means "not currently tracked"; never treat epoch 0 as an
+        // ancient loading-start that would force an immediate (wrong) fallback.
+        assertFalse(ClawRenderer.shouldFallbackForStuckSpritesheet(0L, 10_000L))
+    }
+
+    @Test
+    fun `grace window is the documented 750ms`() {
+        assertEquals(750L, ClawRenderer.SPRITESHEET_LOADING_GRACE_MS)
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -21,6 +21,7 @@ import org.junit.runners.Suite
     ChatEchoSuppressionTest::class,
     WallpaperWanderControllerTest::class,
     EngineLifecycleControllerTest::class,
+    SpritesheetLoadingGraceTest::class,
     CompanionDescriptorAnimationTest::class,
     NavResumeControllerTest::class,
     NotificationPreferenceCatalogTest::class,


### PR DESCRIPTION
## P0 regression — wallpaper pure-black (Hank-direct, card_f9b2cc2d)

### Symptom
v1.1.5 still goes **pure black** ~3s after switching to the home screen — no text, no navy placeholder, no red error frame. A full app restart was needed to recover.

### Root cause (code-confirmed)
A spritesheet-companion entity whose sheet bitmap is **not in `sheetCache`** returns `DrawResult.LOADING`, and `drawSingleEntityAt` **deliberately painted nothing** on LOADING (to avoid a companion-switch flash to the default lobster — card_9e52c7b). That assumes LOADING is always a single transient tick.

The sheet goes missing when:
1. **Cold engine (re)create** — `CompanionRepository.init` restores the spritesheet **descriptor** from snapshot but **not** the sheet bitmap → first frames are guaranteed misses; and/or
2. **cache eviction / failed reload**.

With no custom background image the canvas is `drawColor(BLACK)` by design, so every spritesheet entity rendering nothing = **pure black, no text, no exception** — exactly the prior Crashlytics instrumentation's blind spot (it only fired on thrown exceptions / surface-stuck, never on a "successful" all-blank frame).

### Fix (v1.1.6, versionCode 116)
- **`ClawRenderer`** — LOADING keeps a **750ms no-paint grace** (preserves the no-flash intent for genuinely brief loads), then falls back to the **procedural drawer** so an entity is **never invisible for more than ~0.75s**, regardless of why the sheet is missing. The stuck-LOADING fallback records a Crashlytics non-fatal (entity, companion id, loading ms) — capturing the silent path the prior fix couldn't see.
- **`CompanionRepository.init`** — preload restored spritesheet sheets off the main thread so the first frames after a (re)create paint the real avatar instead of a blank gap.
- **Unit test** — `SpritesheetLoadingGraceTest` covers the pure grace-window decision (`shouldFallbackForStuckSpritesheet`), registered in `UnitTestSuite`.

### Validation
- `:app:testDebugUnitTest` ✅ (incl. new SpritesheetLoadingGraceTest, in UnitTestSuite)
- `bundleRelease` ✅ signed AAB, versionCode 116 / versionName 1.1.6
- Pending: Hank device-test on internal track (same repro: switch to home, leave it).

### Why this is the durable fix
Earlier versions (1.1.3–1.1.5) hardened the draw loop / surface / per-stage exceptions, but the black here is a **"successful" all-blank frame**, not a crash or stalled loop. This makes entity visibility independent of the sheet cache state — the procedural fallback needs no cached bitmap, so the wallpaper can never go fully blank again from a missing sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)