### PR TITLE
fix(kanban): nudge carries an explicit task-lifecycle directive, not just a tool-list (card_c0819f4e)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -674,6 +674,32 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     ? getMissionApiHints(API_BASE, pushDeviceId, pushEid, entity.botSecret)
                     : '';
 
+                // ── 2b. Task-lifecycle directive (card_c0819f4e) ──
+                // The hint block above is a passive TOOL LIST — it shows the
+                // "Move card" curl but never tells the assigned agent that it is
+                // OBLIGATED to advance this card's status when it starts/finishes.
+                // A stateless agent (e.g. Hermes/#5) does the work, reports in
+                // chat, and never moves the card → it sits in todo/in_progress and
+                // re-nudges forever. This directive names the SPECIFIC card id and
+                // states the obligation explicitly, so even an agent with no
+                // persistent todo knows exactly which card to move and that a chat
+                // reply does not close it. Wording is status-agnostic ("if
+                // assigned to you and not yet finished") so it is correct for
+                // nudges, assignments, reopens and reviewer asks alike.
+                const lifecycleDirective = cardId
+                    ? `\n\n[KANBAN LIFECYCLE — ACTION REQUIRED]\n` +
+                      `This notification concerns card ${cardId}. If it is assigned to you and not yet finished:\n` +
+                      `• when you START working, move it to in_progress\n` +
+                      `• when you COMPLETE the work, move it to done (or review if it needs sign-off)\n` +
+                      `Replying in chat does NOT change the card's status — you MUST call the "Move card" tool ` +
+                      `below with CARD_ID=${cardId} and newStatus=in_progress|review|done. ` +
+                      `A card left unmoved keeps re-nudging and auto-escalating.`
+                    : '';
+
+                // Hints + lifecycle directive travel together so the obligation
+                // sits right next to the Move card command in every push path.
+                const missionBlock = kanbanHints + lifecycleDirective;
+
                 // ── 3. Build full message with description ──
                 const descBlock = description
                     ? `\n\n[TASK DESCRIPTION]\n${description}\n[/TASK DESCRIPTION]`
@@ -688,7 +714,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                         eclaw_context: {
                             expectsReply: true,
                             silentToken: '[SILENT]',
-                            missionHints: kanbanHints,
+                            missionHints: missionBlock,
                         }
                     }, entity.channelAccountId);
                     console.log(`[Kanban] Channel push to entity ${pushEid}@${pushDeviceId}: ${result.pushed ? 'OK' : result.reason}`);
@@ -699,7 +725,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                         `[KANBAN NOTIFICATION] ${message}`,
                         descBlock,
                         `[NOTIFICATION — NO REPLY EXPECTED] This is a Kanban task notification. Take action on the card as needed.`,
-                        kanbanHints,
+                        missionBlock,
                     ].filter(Boolean).join('\n');
 
                     const pushResult = await pushToBot(entity, pushDeviceId, 'kanban_notification', { message: pushMsg });
@@ -713,7 +739,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
 
                 } else if (pushToEntity) {
                     // Legacy fallback
-                    const pushMsg = `[KANBAN NOTIFICATION] ${message}${descBlock}${kanbanHints}`;
+                    const pushMsg = `[KANBAN NOTIFICATION] ${message}${descBlock}${missionBlock}`;
                     await pushToEntity(pushDeviceId, pushEid, pushMsg);
                     console.log(`[Kanban] Legacy push to entity ${pushEid}@${pushDeviceId}`);
                 }

--- a/backend/tests/jest/kanban-nudge-lifecycle-directive.test.js
+++ b/backend/tests/jest/kanban-nudge-lifecycle-directive.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+/**
+ * card_c0819f4e — Kanban notifications must carry an explicit task-lifecycle
+ * directive, not just a passive API tool-list.
+ *
+ * Root cause (Hank-direct): getMissionApiHints lists the "Move card" curl but
+ * never tells the assigned agent it is OBLIGATED to advance the card's status
+ * on start/completion. A stateless agent (e.g. Hermes/#5) does the work,
+ * reports in chat, and never moves the card → it sits in todo/in_progress and
+ * re-nudges + auto-escalates forever. The fix injects a directive that names
+ * the SPECIFIC card id and states the obligation, shipped in every push path.
+ *
+ * Style: static source-grep, matching kanban-done-device-push-wiring.test.js
+ * (the kanban module requires a live pg pool, so behavioral mocking is not the
+ * convention for this module). These pin the structural invariants so the
+ * directive cannot silently rot or get dropped from a push path.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const kanbanSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'kanban.js'),
+    'utf8'
+);
+
+describe('kanban notify → task-lifecycle directive (card_c0819f4e)', () => {
+    test('builds a lifecycleDirective gated on cardId', () => {
+        expect(kanbanSrc).toMatch(/const lifecycleDirective = cardId\s*\?/);
+    });
+
+    test('directive names the SPECIFIC card id (not just the CARD_ID placeholder)', () => {
+        const block = kanbanSrc.slice(kanbanSrc.indexOf('const lifecycleDirective = cardId'));
+        // The actual card id must be interpolated so even a stateless agent
+        // knows which card to move (the whole point of the fix).
+        expect(block).toMatch(/concerns card \$\{cardId\}/);
+        expect(block).toMatch(/CARD_ID=\$\{cardId\}/);
+    });
+
+    test('directive states the move-on-start / move-on-complete obligation', () => {
+        const block = kanbanSrc.slice(kanbanSrc.indexOf('const lifecycleDirective = cardId')).slice(0, 1200);
+        expect(block).toMatch(/in_progress/);
+        expect(block).toMatch(/done \(or review/);
+        // Replying in chat must be explicitly called out as NOT closing the card.
+        expect(block).toMatch(/Replying in chat does NOT change the card's status/);
+        expect(block).toMatch(/Move card/);
+    });
+
+    test('hints + directive are combined into one missionBlock', () => {
+        expect(kanbanSrc).toMatch(/const missionBlock = kanbanHints \+ lifecycleDirective;/);
+    });
+
+    test('ALL three push paths ship missionBlock (channel / webhook / legacy), not bare kanbanHints', () => {
+        // channel path
+        expect(kanbanSrc).toMatch(/missionHints: missionBlock,/);
+        // webhook path: missionBlock is an element of the pushMsg array
+        const webhookBlock = kanbanSrc.slice(kanbanSrc.indexOf('Non-channel: build full push message')).slice(0, 400);
+        expect(webhookBlock).toMatch(/missionBlock,/);
+        // legacy path
+        expect(kanbanSrc).toMatch(/\$\{descBlock\}\$\{missionBlock\}/);
+
+        // Guard: no push path may still emit the bare kanbanHints variable —
+        // every consumer must go through missionBlock so the directive travels.
+        expect(kanbanSrc).not.toMatch(/missionHints: kanbanHints,/);
+        expect(kanbanSrc).not.toMatch(/\$\{descBlock\}\$\{kanbanHints\}/);
+    });
+});


### PR DESCRIPTION
## Problem (Hank-direct)
The kanban notification's hint block (`getMissionApiHints`) is a **passive API tool-list** — it shows the `Move card` curl with a generic `CARD_ID` placeholder, but never tells the assigned agent it is **obligated** to advance the card's status. A stateless agent (e.g. Hermes/#5) does the work, reports in chat, and **never moves the card** → it sits in todo/in_progress and re-nudges + auto-escalates forever.

Hank: *"這是 EClaw 看板任務狀態的系統提示不夠明顯嗎？例如 任務完成要 API mark down"* — yes, exactly.

## Fix
`notifyEntities` (backend/kanban.js) now builds a **lifecycle directive** (gated on `cardId`) that:
- names the **specific card id** (so even a stateless agent knows which card to move — not the `CARD_ID` placeholder);
- states the obligation: move to `in_progress` on start, `done`/`review` on completion;
- spells out that **replying in chat does NOT change the card's status** — the agent must call the Move card tool.

It's combined with the hints into one `missionBlock` shipped in **all three push paths** (channel / webhook / legacy), so the obligation always sits next to the Move card command. Wording is status-agnostic (*"if assigned to you and not yet finished"*) → correct for nudges, assignments, reopens, and reviewer asks alike. Benefits **every** agent (globe-user), not just #5.

## Why this is the right layer
The stuck-card root cause was traced (Docker logs) to delivery being healthy but agents never calling the move API — so the fix is the **notification prompt**, not delivery. This makes the obligation explicit + actionable at the source every agent reads.

## Test
`tests/jest/kanban-nudge-lifecycle-directive.test.js` (static source-grep, matching the kanban module's pg-pool test convention) pins: the directive wording, the specific-card-id interpolation (`concerns card ${cardId}` + `CARD_ID=${cardId}`), `missionBlock = kanbanHints + lifecycleDirective`, and that every push path ships `missionBlock` (guards against any path regressing to bare `kanbanHints`). 5/5 pass locally; `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)