### PR TITLE
fix(tts): startForeground on every start + START_NOT_STICKY — fix FGS crash killing process → wallpaper black (v1.1.7, card_f9b2cc2d)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 116
-        versionName = "1.1.6"
+        versionCode = 117
+        versionName = "1.1.7"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/hank/clawlive/service/TtsService.kt
+++ b/app/src/main/java/com/hank/clawlive/service/TtsService.kt
@@ -37,6 +37,7 @@ class TtsService : Service(), TextToSpeech.OnInitListener {
 
     private var tts: TextToSpeech? = null
     private var ttsReady = false
+    private var isForeground = false
     private val serviceScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private val utteranceCounter = AtomicInteger(0)
 
@@ -44,25 +45,22 @@ class TtsService : Service(), TextToSpeech.OnInitListener {
         super.onCreate()
         Timber.d("[TTS] Service created")
         createNotificationChannel()
-        // Guard against ForegroundServiceStartNotAllowedException (Android 12+/API 31+):
-        // calling startForeground() while the app is background-restricted throws and crashes.
-        // Catch it, log gracefully, and stop the service instead of crashing.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            try {
-                startForeground(NOTIFICATION_ID, buildNotification("TTS 語音服務就緒"))
-            } catch (e: android.app.ForegroundServiceStartNotAllowedException) {
-                Timber.e(e, "[TTS] startForeground blocked — app is background-restricted (API ${Build.VERSION.SDK_INT}); stopping service gracefully")
-                stopSelf()
-                return
-            }
-        } else {
-            startForeground(NOTIFICATION_ID, buildNotification("TTS 語音服務就緒"))
-        }
+        if (!ensureForeground()) return
         tts = TextToSpeech(this, this)
         observeTtsFlow()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // card_f9b2cc2d: a service launched via startForegroundService() MUST call
+        // startForeground() within the OS deadline (~5s) on EVERY start command —
+        // not just the first. If it doesn't, the system kills the WHOLE app process
+        // with RemoteServiceException$ForegroundServiceDidNotStartInTimeException,
+        // which takes the live-wallpaper engine (same process) down with it: the
+        // wallpaper goes pure-black and only relaunching the app recovers it.
+        // onCreate covers the first start; this covers sticky/redelivered restarts
+        // (app backgrounded / memory pressure) where onCreate does not re-run.
+        if (!ensureForeground()) return START_NOT_STICKY
+
         // Handle FCM fallback: when the app receives an FCM with category=tts,
         // it can start this service with extras
         intent?.getStringExtra("tts_text")?.let { text ->
@@ -72,7 +70,32 @@ class TtsService : Service(), TextToSpeech.OnInitListener {
             val entityName = intent.getStringExtra("tts_entity_name") ?: "Bot"
             speak(text, lang, speed, pitch, entityName)
         }
-        return START_STICKY
+        // START_NOT_STICKY: do NOT let the system auto-restart this FGS with a null
+        // intent — a sticky restart re-arms the startForeground() deadline and is the
+        // path that produced the DidNotStartInTime process-kill. It is recreated on
+        // the next app launch / TTS event, which is sufficient for voice playback.
+        return START_NOT_STICKY
+    }
+
+    /**
+     * Promote to foreground, fulfilling the startForegroundService() contract.
+     * Idempotent. Returns false (and stops the service) if the platform refuses
+     * the promotion (e.g. ForegroundServiceStartNotAllowedException when started
+     * background-restricted). Crucially it never lets a foreground-service
+     * exception propagate — an uncaught one would crash the process and kill the
+     * live wallpaper too. card_f9b2cc2d.
+     */
+    private fun ensureForeground(): Boolean {
+        if (isForeground) return true
+        return try {
+            startForeground(NOTIFICATION_ID, buildNotification("TTS 語音服務就緒"))
+            isForeground = true
+            true
+        } catch (e: Exception) {
+            Timber.e(e, "[TTS] startForeground failed (${e.javaClass.simpleName}); stopping service instead of crashing the process")
+            try { stopSelf() } catch (_: Exception) {}
+            false
+        }
     }
 
     override fun onBind(intent: Intent?): IBinder? = null


### PR DESCRIPTION
## The real root cause of the wallpaper pure-black bug (after 6 renderer fixes missed it)

Crashlytics (eclaw-cc72a) shows the **only fatal crash**:
`android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException` (ActivityThread → `Context.startForegroundService`).

This kills the **whole app process** → the live-wallpaper engine (same process) dies with it → **pure black, no text, no draw-exception, recoverable only by relaunching the app**. That's why 6 versions of renderer/surface/spritesheet fixes changed nothing — the bug was never in the renderer.

### Code bug
- `MainActivity.onCreate` always calls `startForegroundService(TtsService)` → the OS requires `startForeground()` within ~5s.
- `TtsService` called `startForeground()` only in `onCreate`, **not `onStartCommand`**, and returned **`START_STICKY`**.
- On a sticky/redelivered restart (app backgrounded ~3s after home / memory pressure), `onStartCommand` runs without `startForeground()` → deadline missed → **`ForegroundServiceDidNotStartInTimeException`** → process killed → wallpaper black.
- This `TtsService` code is **unchanged across 1.1.1–1.1.6**, matching the version-stable symptom.

### Fix (v1.1.7, versionCode 117)
- `ensureForeground()` — `startForeground()` guarded against **every** exception (incl. `ForegroundServiceStartNotAllowedException`) → `stopSelf()` instead of crashing the process; idempotent.
- `onStartCommand` calls `ensureForeground()` **first**, fulfilling the FGS contract on every start command.
- `return START_NOT_STICKY` — the system no longer sticky-restarts the FGS with a null intent (the path that re-armed the deadline). TTS is recreated on next app launch / TTS event.

### Validation
- `assembleDebug` + `bundleRelease` ✅ (versionCode 117 / 1.1.7).
- Debug build installed on emulator: app launches, **no crash, no regression**, wallpaper renders.
- **Caveat (honest):** device/timing-specific — does **not** reproduce on a fast emulator (`onCreate` beats the deadline there), so it needs a **device-test on 1.1.7** to confirm. Renderer instrumentation from 1.1.3–1.1.6 is retained as a backup signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)