### PR TITLE
fix(portal): guard checkAuth in publisher.html init so an auth.js 522 can't brick it at Loading (card_8da798aa, #6 handoff)

### DIFF
--- a/backend/public/portal/publisher.html
+++ b/backend/public/portal/publisher.html
@@ -375,7 +375,21 @@
         async function init() {
             renderNav('mission');
             if (typeof renderFooter === 'function') renderFooter();
-            currentUser = await checkAuth();
+            // card_8da798aa (#6 finding): an intermittent 522 on shared/auth.js
+            // leaves checkAuth undefined, and an unguarded `await checkAuth()`
+            // throws a ReferenceError that aborts init() — the page then stays
+            // stuck on the "Loading" state forever. Guard exactly like the admin
+            // pages already do (typeof checkAuth === 'function') and never let an
+            // auth dependency failure block render: the platform list is public
+            // and publishing uses a localStorage API key, so auth here is only
+            // optional personalization (currentUser is read null-safely below).
+            try {
+                if (typeof checkAuth === 'function') {
+                    currentUser = await checkAuth();
+                }
+            } catch (e) {
+                console.warn('[publisher] checkAuth unavailable; rendering unauthenticated', e);
+            }
             document.getElementById('loadingState').style.display = 'none';
             document.getElementById('pageContent').style.display = 'block';
             hydrateApiKey();

--- a/backend/tests/jest/publisher-page-ui.test.js
+++ b/backend/tests/jest/publisher-page-ui.test.js
@@ -5,6 +5,20 @@ describe('publisher page self-improvement UI', () => {
     const pagePath = path.join(__dirname, '../../public/portal/publisher.html');
     const html = fs.readFileSync(pagePath, 'utf8');
 
+    test('init() guards checkAuth so an auth.js load failure cannot brick the page at Loading (card_8da798aa)', () => {
+        // Intermittent 522 on shared/auth.js leaves checkAuth undefined; an
+        // unguarded `await checkAuth()` throws and the page stays stuck on the
+        // loading state. init() must guard the call and still reveal content.
+        expect(html).toContain("if (typeof checkAuth === 'function')");
+        expect(html).toContain('currentUser = await checkAuth();');
+        // the guarded call is wrapped so a throw can't abort init()
+        const init = html.slice(html.indexOf('async function init()'), html.indexOf('function hydrateApiKey()'));
+        expect(init).toMatch(/try\s*\{[\s\S]*typeof checkAuth === 'function'[\s\S]*await checkAuth\(\)[\s\S]*\}\s*catch/);
+        // render must still happen after the guarded auth block
+        expect(init).toContain("document.getElementById('loadingState').style.display = 'none';");
+        expect(init).toContain("document.getElementById('pageContent').style.display = 'block';");
+    });
+
     test('renders a live platform result panel and filter controls', () => {
         expect(html).toContain('class="platform-result-panel" id="platformResultPanel" role="status" aria-live="polite" aria-atomic="true"');
         expect(html).toContain('id="platformResultSummary" data-i18n="pub_result_loading"');


### PR DESCRIPTION
## Problem (diagnosed by #6 via Computer Use; #6 then handed off — out of Codex credits)
`/portal/publisher.html` intermittently hung on **"Loading…"** in production. Root cause: an intermittent **522** on the shared `shared/auth.js` static asset leaves `checkAuth` undefined, and publisher.html's **unguarded `await checkAuth()`** in `init()` throws a `ReferenceError` that aborts `init()` before it reveals `#pageContent` → the page stays stuck on the loading state until a reload.

## Fix
Guard the call exactly like the **admin pages already do** (`typeof checkAuth === 'function'`) and wrap it in `try/catch`, so an auth-dependency load failure can never block render:
```js
try { if (typeof checkAuth === 'function') currentUser = await checkAuth(); }
catch (e) { console.warn('[publisher] checkAuth unavailable; rendering unauthenticated', e); }
```
Safe here: auth on this page is **optional personalization** — the platform list is public, publishing uses a `localStorage` API key, and `currentUser` is already read null-safely (`(window.currentUser && window.currentUser.deviceId) || ''`).

## Scope note (deliberately bounded)
**19 portal pages** share the unguarded `await checkAuth()` pattern. This PR fixes only the page #6 flagged (publisher.html — auth-optional, so silent-degrade is correct). The auth-**required** pages (dashboard/settings/wallet/kanban/…) need a *different*, considered fix — resilient `auth.js` reload / reconnect overlay, **not** a silent skip (which would just swap "stuck Loading" for "empty unauth page"). That's tracked on card_8da798aa, not blind-swept at once.

## Test
`publisher-page-ui.test.js` asserts `init()` guards + `try/catch`-wraps `checkAuth` and still reveals content. 5/5 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)