### PR TITLE
fix(portal): persist community.html filters in URL (refresh-safe + shareable) — card_f6b61c8

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -1635,7 +1635,55 @@
         </div>`;
     }
 
-    function filterAndSort() { updateResultPanel(); loadBots(); }
+    function filterAndSort() { syncFiltersToUrl(); updateResultPanel(); loadBots(); }
+
+    // card_f6b61c8: persist the active filters in the URL (history.replaceState)
+    // so a refresh / back-nav / shared link keeps the user's search+sort+rate
+    // instead of resetting to the default plaza. Only manages its own keys so
+    // unrelated params (embed/tour/bot/#rental) are preserved. Never throws.
+    function syncFiltersToUrl() {
+        try {
+            const p = new URLSearchParams(window.location.search);
+            searchQuery ? p.set('q', searchQuery) : p.delete('q');
+            (currentSort && currentSort !== 'newest') ? p.set('sort', currentSort) : p.delete('sort');
+            (rateMin > 1) ? p.set('rateMin', String(rateMin)) : p.delete('rateMin');
+            (rateMax < 50) ? p.set('rateMax', String(rateMax)) : p.delete('rateMax');
+            const qs = p.toString();
+            history.replaceState(null, '', window.location.pathname + (qs ? '?' + qs : '') + window.location.hash);
+        } catch (_) { /* URL sync must never break filtering */ }
+    }
+
+    // card_f6b61c8: on load, restore filters from the URL into state + inputs.
+    // Called before the initial loadBots() so the restored values drive the
+    // first render. Clamps/sanitizes everything; never throws.
+    function restoreFiltersFromUrl() {
+        try {
+            const p = new URLSearchParams(window.location.search);
+            const q = p.get('q');
+            if (q) {
+                searchQuery = q.slice(0, 100);
+                const si = document.getElementById('searchInput');
+                if (si) si.value = searchQuery;
+                const sc = document.getElementById('searchClear');
+                if (sc && searchQuery) sc.classList.add('visible');
+            }
+            const sort = p.get('sort');
+            if (sort) {
+                currentSort = sort;
+                const ss = document.getElementById('sortSelect');
+                if (ss) ss.value = sort;
+            }
+            const rmin = parseInt(p.get('rateMin') || '', 10);
+            const rmax = parseInt(p.get('rateMax') || '', 10);
+            if (!isNaN(rmin)) { rateMin = Math.min(Math.max(rmin, 1), 50); const e = document.getElementById('rateMin'); if (e) e.value = String(rateMin); }
+            if (!isNaN(rmax)) { rateMax = Math.min(Math.max(rmax, 1), 50); const e = document.getElementById('rateMax'); if (e) e.value = String(rateMax); }
+            if (rateMin > rateMax) { const t = rateMin; rateMin = rateMax; rateMax = t; }
+            if (rateMin > 1 || rateMax < 50) {
+                const rv = document.getElementById('rateSliderValue');
+                if (rv) rv.textContent = rateMin + ' – ' + rateMax + ' e幣/1K';
+            }
+        } catch (_) { /* bad URL params must never block the page */ }
+    }
 
     /* ══════ Interactions ══════ */
     function setFilter(f, el) { currentFilter = f; document.querySelectorAll('.plaza-chip').forEach(c=>c.classList.remove('active')); el.classList.add('active'); filterAndSort(); }
@@ -2074,6 +2122,9 @@
     document.addEventListener('keydown', e => { if (e.key === 'Escape') closeDetail(); });
     function checkModalScroll() { const mc = document.getElementById('detailContent'); if (mc && mc.scrollHeight > mc.clientHeight) mc.classList.add('has-scroll'); }
 
+    // card_f6b61c8: restore filters from the URL before the first render so a
+    // refreshed / shared filtered link returns with the same search+sort+rate.
+    restoreFiltersFromUrl();
     const sortSelect = document.getElementById('sortSelect');
     if (sortSelect) sortSelect.value = currentSort;
 

--- a/backend/tests/jest/community-result-panel.test.js
+++ b/backend/tests/jest/community-result-panel.test.js
@@ -93,7 +93,7 @@ describe('community.html result context controls', () => {
     test('grid rendering keeps the result summary in sync with loaded and empty states', () => {
         expect(html).toContain('updateResultPanel(0, { error: options.error })');
         expect(html).toContain('updateResultPanel(bots.length)');
-        expect(html).toContain('function filterAndSort() { updateResultPanel(); loadBots(); }');
+        expect(html).toContain('function filterAndSort() { syncFiltersToUrl(); updateResultPanel(); loadBots(); }');
     });
 
     test('load errors use a distinct localized result and empty state', () => {
@@ -126,5 +126,35 @@ describe('community.html result context controls', () => {
                 .map(([locale]) => locale);
             expect(missingLocales).toEqual([]);
         });
+    });
+});
+
+describe('community.html filter URL persistence (card_f6b61c8)', () => {
+    test('filterAndSort syncs filters to the URL', () => {
+        expect(html).toContain('function filterAndSort() { syncFiltersToUrl(); updateResultPanel(); loadBots(); }');
+        expect(html).toContain('function syncFiltersToUrl()');
+        expect(html).toContain('history.replaceState(null,');
+    });
+
+    test('syncFiltersToUrl writes q/sort/rateMin/rateMax and clears defaults', () => {
+        const sync = html.slice(html.indexOf('function syncFiltersToUrl()'), html.indexOf('function restoreFiltersFromUrl()'));
+        expect(sync).toContain("searchQuery ? p.set('q', searchQuery) : p.delete('q')");
+        expect(sync).toContain("p.set('sort', currentSort) : p.delete('sort')");
+        expect(sync).toContain("p.set('rateMin', String(rateMin)) : p.delete('rateMin')");
+        expect(sync).toContain("p.set('rateMax', String(rateMax)) : p.delete('rateMax')");
+        // preserves unrelated params by starting from the current querystring
+        expect(sync).toContain('new URLSearchParams(window.location.search)');
+    });
+
+    test('restoreFiltersFromUrl runs before the initial render and rehydrates state + inputs', () => {
+        expect(html).toContain('function restoreFiltersFromUrl()');
+        // called before the first sortSelect.value assignment / bootstrap loadBots
+        const restoreIdx = html.indexOf('restoreFiltersFromUrl();\n    const sortSelect = document.getElementById(\'sortSelect\');');
+        expect(restoreIdx).toBeGreaterThan(-1);
+        const restore = html.slice(html.indexOf('function restoreFiltersFromUrl()'), html.indexOf('/* ══════ Interactions ══════ */'));
+        expect(restore).toContain("const q = p.get('q')");
+        expect(restore).toContain("if (si) si.value = searchQuery");
+        expect(restore).toContain("if (ss) ss.value = sort");
+        expect(restore).toContain('Math.min(Math.max(rmin, 1), 50)');
     });
 });


### PR DESCRIPTION
## Problem (hands-on finding, demo of the card_3c6fb87 convenience dimension)
On `/portal/community.html` (Bot Plaza), applying a search + sort then **reloading reset every filter** (`#searchInput`→'', `#sortSelect`→'newest'), and the **URL never reflected the filter** — so a refresh / back-nav lost the user's filtering and a filtered view couldn't be bookmarked or shared.

## Fix
- `syncFiltersToUrl()` at the `filterAndSort()` choke point writes the active filters (`q` / `sort` / `rateMin` / `rateMax`) to the URL via `history.replaceState` (only its own keys → preserves `embed`/`tour`/`bot`/`#rental`).
- `restoreFiltersFromUrl()` runs before the first render, rehydrating state + inputs from the URL (clamped/sanitized).
- Everything is `try/catch`-wrapped so a bad param or URL-API failure can never break filtering or block the page.

**Acceptance** (card): apply filter → URL updates → reload restores the same filter + results; copying the URL reproduces the filtered view. ✅

## Scope (bounded)
Covers search/sort/rate (the tested primary case). The chip-based **category + capability multi-select** are intentionally left out of this pass to avoid interacting with the `#rental` bootstrap branch — noted as a follow-up. The **? icon hint** is deferred (adds i18n surface); the functional persistence already meets acceptance.

## Test
`community-result-panel.test.js` asserts sync-at-`filterAndSort`, the write/clear logic, and restore-before-render. 10/10 pass; inline-script `node --check` clean.

Context: both Codex bots (#1/#6) are out of credits, so this UI-improvement work fell to me (#2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)