### PR TITLE
fix(mission): note/add null device_id 500 — read deviceId from merged query+body (card_71267943/card_984251d7)

### DIFF
--- a/backend/mission.js
+++ b/backend/mission.js
@@ -887,7 +887,14 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
     // ============================================
     router.post('/note/add', async (req, res) => {
         if (!authenticate(req, res)) return;
-        const { deviceId, entityId, title, content, category, anchor } = req.body;
+        // Resolve deviceId from the SAME merged source authenticate() uses
+        // ({ ...req.query, ...req.body }). Reading req.body alone let a caller
+        // that passed deviceId via the query string clear auth yet reach the
+        // INSERT with deviceId=undefined → "null value in column device_id
+        // violates not-null constraint" (500). authenticate() guarantees a
+        // truthy deviceId in the merged params, so it can never be null here.
+        const params = { ...req.query, ...req.body };
+        const { deviceId, entityId, title, content, category, anchor } = params;
         const linkedCardIdsInput = normalizeLinkedCardIds(req.body.linkedCardIds);
 
         if (!title) {

--- a/backend/tests/jest/mission-note-deviceid.test.js
+++ b/backend/tests/jest/mission-note-deviceid.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(path.join(__dirname, '../../mission.js'), 'utf8');
+
+// Bug (card_71267943 / card_984251d7): POST /api/mission/note/add read deviceId
+// from req.body ONLY, but authenticate() validates deviceId from the merged
+// { ...req.query, ...req.body }. A caller that passed deviceId via the query
+// string therefore cleared authentication yet reached the INSERT with
+// deviceId=undefined, throwing `null value in column "device_id" violates
+// not-null constraint` — surfaced in prod as `[Mission] Error adding note` (500,
+// ERROR-low). Fix: the handler resolves deviceId from the SAME merged source
+// authenticate() uses, so the value the handler stores is exactly the one auth
+// validated and can never be null past auth.
+describe('mission note/add deviceId resolution (card_71267943/card_984251d7)', () => {
+    function handlerSlice(routeRe) {
+        const start = src.search(routeRe);
+        expect(start).toBeGreaterThan(-1);
+        return src.slice(start, start + 1200);
+    }
+
+    test('note/add resolves deviceId from merged query+body, not req.body only', () => {
+        const body = handlerSlice(/router\.post\('\/note\/add'/);
+        expect(body).toMatch(/const params = \{ \.\.\.req\.query, \.\.\.req\.body \}/);
+        // deviceId is destructured from the merged params, not from req.body
+        expect(body).toMatch(/const \{ deviceId[^}]*\} = params/);
+    });
+
+    test('authenticate() validates deviceId from the same merged params (parity invariant)', () => {
+        const authStart = src.indexOf('function authenticate');
+        expect(authStart).toBeGreaterThan(-1);
+        const auth = src.slice(authStart, authStart + 400);
+        // The invariant the fix relies on: auth reads merged params AND rejects
+        // a missing deviceId — so any request that passes auth carries a truthy
+        // deviceId in the merged params the handler now reads from.
+        expect(auth).toMatch(/const params = \{ \.\.\.req\.query, \.\.\.req\.body \}/);
+        expect(auth).toMatch(/if \(!deviceId\)/);
+    });
+});


### PR DESCRIPTION
## Problem (real prod ERROR-low, surfaced by #5's 6h Railway scan)
`POST /api/mission/note/add` logged `[Mission] Error adding note: null value in column "device_id" of relation "mission_dashboard" violates not-null constraint` (HTTP 500) ×2 in 6h. #5 filed **card_71267943** + **card_984251d7**.

#5's first read blamed null title/content — but the card titles show the column is **`device_id`**.

## Root cause (empirically reproduced on live prod)
`authenticate()` validates `deviceId` from the merged `{ ...req.query, ...req.body }` (mission.js:386) and **rejects** a missing one. But the `note/add` handler read `deviceId` from `req.body` **only** (line 890). So a caller passing `deviceId` in the **query string** clears auth, yet the handler gets `undefined` → `init_mission_dashboard()` / INSERT runs with a null `device_id` → 500.

Confirmed against prod:
```
POST /api/mission/note/add?deviceId=<id>   body: { botSecret, entityId, title, content }
→ {"success":false,"error":"null value in column \"device_id\" ... violates not-null constraint"}  [500]
```
(The request fails at the opening `init_mission_dashboard` step and rolls back — no orphan note.)

## Fix
The handler now resolves `deviceId` (and the other fields) from the same merged `{ ...req.query, ...req.body }` that `authenticate()` uses — the existing codebase idiom (mission.js:386/1164/1188). Since `authenticate()` guarantees a truthy `deviceId` in those merged params, the handler can never reach the INSERT with a null `device_id` again. Converts the 500 into correct behavior (the note is created) and eliminates the ErrLog noise.

## Scope
`note/add` only — it's the endpoint whose INSERT hits the NOT NULL column. `note/update` + `note/delete` share the body-only read but only `SELECT ... WHERE device_id = $1` (null → 0 rows → clean "not found", no 500); flagged as a consistency follow-up, deliberately left out to keep this card-tied and minimal.

## Test
`mission-note-deviceid.test.js` locks the merged-source read + the `authenticate` parity invariant. Existing `mission.test.js` note/add cases (valid creds / missing-title 400 / no-creds 400 / category) are unaffected by reasoning (body callers still resolve via merged params).

Post-merge I'll re-run the same prod probe to confirm it now succeeds, then close both cards.

Context: both Codex bots (#1/#6) are out of credits (Jun 27), so #5's ErrLog findings fell to me (#2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)