### PR TITLE
feat(chat): multi-quote — quotes accumulate (unlimited), entity receives every quote (card_277c80f5)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -7896,25 +7896,20 @@
 
             let finalText = text;
             if (replyContexts.length) {
-                // Embed his_<uuid> token per quote so each referenced bubble renders
-                // as a clickable chip for everyone (sender + recipient bots see it
-                // inline and can scroll back). messages.id is a UUID, so we validate
-                // the canonical 8-4-4-4-12 form and skip the token if it doesn't
-                // match (no silent digit-stripping). One "↩ …" LINE per quote so the
-                // recipient entity receives EVERY quote, not just the last (card_277c80f5).
+                // One "↩ …" line per quote so the recipient entity receives EVERY
+                // quote, not just the last (card_277c80f5). his_<uuid> token per quote
+                // keeps each referenced bubble a clickable chip (validate canonical
+                // UUID; skip token otherwise). Newlines collapsed → block joined by
+                // '\n', split from body by '\n\n' so stripReplyQuotePrefix stays correct.
                 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
                 const quoteLines = replyContexts.map(rc => {
-                    // Collapse newlines so each quote stays a single line; the block is
-                    // joined by '\n' and separated from the body by '\n\n', which keeps
-                    // stripReplyQuotePrefix() (cuts at first '\n\n') correct.
                     const oneLine = (rc.text || '').replace(/\s*\n+\s*/g, ' ');
                     const excerpt = oneLine.length > 80 ? oneLine.slice(0, 80) + '…' : oneLine;
                     const rawMsgId = rc.msgId ? String(rc.msgId).trim().toLowerCase() : '';
                     const hisToken = UUID_RE.test(rawMsgId) ? ` his_${rawMsgId}` : '';
                     return `↩ ${rc.senderName}:${hisToken} "${excerpt}"`;
                 });
-                const quoteBlock = quoteLines.join('\n');
-                finalText = text ? `${quoteBlock}\n\n${text}` : quoteBlock;
+                finalText = text ? `${quoteLines.join('\n')}\n\n${text}` : quoteLines.join('\n');
                 clearReplyContext();
             }
             finalText = normalizeTargetSlashForSend(finalText);

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -624,6 +624,16 @@
         .reply-preview-text { color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
         .reply-preview-cancel { background: none; border: none; cursor: pointer; color: var(--text-muted); font-size: 18px; padding: 0 2px; flex-shrink: 0; line-height: 1; }
         .reply-preview-cancel:hover { color: var(--text); }
+        /* ── Multi-quote chips (card_277c80f5): many quotes accumulate, each removable ── */
+        .reply-preview-list { flex: 1; min-width: 0; display: flex; flex-wrap: wrap; gap: 4px; max-height: 88px; overflow-y: auto; align-items: flex-start; }
+        .reply-preview-chip { display: inline-flex; align-items: center; gap: 4px; max-width: 100%; background: rgba(127,127,127,0.14); border-radius: 10px; padding: 2px 4px 2px 8px; font-size: 0.8em; line-height: 1.3; }
+        .reply-preview-chip-sender { font-weight: 600; color: var(--primary); flex-shrink: 0; }
+        .reply-preview-chip-text { color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 200px; }
+        .reply-preview-chip-x { background: none; border: none; cursor: pointer; color: var(--text-muted); font-size: 14px; line-height: 1; padding: 0 2px; flex-shrink: 0; }
+        .reply-preview-chip-x:hover { color: var(--text); }
+        .reply-preview-help { flex-shrink: 0; cursor: help; color: var(--text-muted); border: 1px solid var(--text-muted); border-radius: 50%; width: 16px; height: 16px; display: inline-flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 600; align-self: center; }
+        .reply-preview-help:hover { color: var(--text); border-color: var(--text); }
+        @media (max-width: 480px) { .reply-preview-chip-text { max-width: 130px; } }
 
         /* Typing indicator */
         .typing-indicator {
@@ -3702,10 +3712,8 @@
                 <div class="file-preview-bar" id="filePreviewBar"></div>
                 <!-- Reply Preview Bar -->
                 <div class="reply-preview-bar" id="replyPreviewBar">
-                    <div class="reply-preview-content">
-                        <div class="reply-preview-sender" id="replyPreviewSender"></div>
-                        <div class="reply-preview-text" id="replyPreviewText"></div>
-                    </div>
+                    <div class="reply-preview-list" id="replyPreviewList"></div>
+                    <span class="reply-preview-help" id="replyPreviewHelp" title="">?</span>
                     <button class="reply-preview-cancel" onclick="clearReplyContext()" data-i18n-title="chat_reply_cancel" title="Cancel reply">✕</button>
                 </div>
                 <!-- Slash Command Suggestions -->
@@ -7239,10 +7247,13 @@
             }
         }
 
-        // ── Quote Reply State ──
-        let replyContext = null;
+        // ── Quote Reply State (multi-quote, card_277c80f5) ──
+        // replyContexts ACCUMULATES every quote the user adds — quoting again
+        // appends instead of overwriting, with no cap. sendMessage emits one
+        // "↩ …" line per entry so the recipient entity receives ALL of them.
+        let replyContexts = [];
         // Smart receiver auto-select — entityIds we auto-toggled-on for the
-        // current reply context. Cleared on reply clear, on send, and when
+        // current reply contexts. Cleared on reply clear, on send, and when
         // the user manually changes a checkbox (the hint badge belongs to
         // the auto-toggle, so a manual toggle revokes it).
         const autoToggledReceiverEntities = new Set();
@@ -7256,66 +7267,109 @@
             const meta = (kind === 'entity' && Number.isFinite(entityId))
                 ? { kind: 'chat-entity', entityId }
                 : { kind: 'chat-system' };
-            setReplyContext(msgId, sender, text);
-            applyAutoToggleReceivers(meta);
+            addReplyContext(msgId, sender, text, meta);
         }
 
-        function setReplyContext(msgId, senderName, text) {
+        // Append a quote (NEVER overwrites prior quotes). De-dupes by msgId when
+        // present, else by sender+text, so re-clicking the same message is a no-op.
+        function addReplyContext(msgId, senderName, text, meta) {
             const cleanText = stripReplyQuotePrefix(text);
-            replyContext = { msgId, senderName, text: cleanText };
-            document.getElementById('replyPreviewSender').textContent = senderName || '';
-            document.getElementById('replyPreviewText').textContent = cleanText || (i18n.t('chat_reply_media') || '(media)');
-            document.getElementById('replyPreviewBar').classList.add('show');
-            document.getElementById('messageInput').focus();
+            const key = msgId ? ('id:' + msgId) : ('tx:' + (senderName || '') + '|' + (cleanText || ''));
+            if (!replyContexts.some(rc => rc._key === key)) {
+                replyContexts.push({ msgId: msgId || null, senderName: senderName || '', text: cleanText || '', meta: meta || null, _key: key });
+            }
+            renderReplyPreviews();
+            recomputeAutoReceivers();
+            const input = document.getElementById('messageInput');
+            if (input) input.focus();
+        }
+
+        function removeReplyContextAt(idx) {
+            if (idx < 0 || idx >= replyContexts.length) return;
+            replyContexts.splice(idx, 1);
+            renderReplyPreviews();
+            recomputeAutoReceivers();
+        }
+
+        // Rebuild the reply bar as N removable chips. Empty → hide the bar.
+        function renderReplyPreviews() {
+            const bar = document.getElementById('replyPreviewBar');
+            const list = document.getElementById('replyPreviewList');
+            if (!bar || !list) return;
+            list.textContent = '';
+            if (replyContexts.length === 0) { bar.classList.remove('show'); return; }
+            const mediaLabel = (i18n && typeof i18n.t === 'function' && i18n.t('chat_reply_media')) || '(media)';
+            replyContexts.forEach((rc, i) => {
+                const chip = document.createElement('span');
+                chip.className = 'reply-preview-chip';
+                const s = document.createElement('span');
+                s.className = 'reply-preview-chip-sender';
+                s.textContent = rc.senderName || '';
+                const t = document.createElement('span');
+                t.className = 'reply-preview-chip-text';
+                t.textContent = rc.text || mediaLabel;
+                const x = document.createElement('button');
+                x.className = 'reply-preview-chip-x';
+                x.type = 'button';
+                x.textContent = '✕';
+                x.title = 'Remove';
+                x.addEventListener('click', () => removeReplyContextAt(i));
+                chip.appendChild(s); chip.appendChild(t); chip.appendChild(x);
+                list.appendChild(chip);
+            });
+            // ? help tooltip — set dynamically (not data-i18n) so i18n.apply can't
+            // clobber it; bilingual by document lang. No new dict key needed.
+            const help = document.getElementById('replyPreviewHelp');
+            if (help) {
+                const zh = (document.documentElement.lang || '').toLowerCase().startsWith('zh');
+                help.title = zh
+                    ? '你可以引用多則訊息，每一則都會一起送給對方；點晶片上的 ✕ 移除單筆，沒有數量上限。'
+                    : 'Quote multiple messages — each is sent together. Click ✕ on a chip to remove one. No limit.';
+            }
+            bar.classList.add('show');
         }
 
         function clearReplyContext() {
-            replyContext = null;
-            document.getElementById('replyPreviewBar').classList.remove('show');
+            replyContexts = [];
+            renderReplyPreviews();
             clearAllReceiverHints();
+            autoToggledReceiverEntities.clear();
         }
 
-        // Smart quote: activates the reply bar with source+excerpt, no full-content paste.
+        // Smart quote: APPEND source+excerpt as a new quote (no full-content paste).
         // meta carries origin info for smart receiver auto-select:
         //   { kind: 'card', cardAssignedBots: number[] }    — kanban card → toggle assigned bots
         //   { kind: 'chat-entity', entityId: number }       — chat msg from a bot → toggle that bot
         //   { kind: 'chat-system' | other }                 — no auto-toggle
-        // Multi-source rule: chat-entity wins over card (resolved at the caller).
         function quoteToChat(source, title, excerpt, meta) {
             const senderLabel = '📌 ' + source;
             const previewText = title + (excerpt ? ': ' + excerpt.slice(0, 60) + (excerpt.length > 60 ? '…' : '') : '');
-            setReplyContext(null, senderLabel, previewText);
-            applyAutoToggleReceivers(meta || {});
+            addReplyContext(null, senderLabel, previewText, meta || {});
         }
 
-        function applyAutoToggleReceivers(meta) {
+        // entityIds a single quote-meta wants auto-selected as recipients.
+        function entityIdsFromMeta(meta) {
+            if (!meta || typeof meta !== 'object') return [];
+            if (meta.kind === 'chat-entity' && Number.isFinite(meta.entityId)) return [meta.entityId];
+            if (meta.kind === 'card' && Array.isArray(meta.cardAssignedBots)) return meta.cardAssignedBots.filter(id => Number.isFinite(id));
+            return [];
+        }
+
+        // Recompute auto-selected recipients from the UNION of all current quotes'
+        // metas. Multi-quote must route to EVERY quoted sender (de-duped), not just
+        // the last quote — while staying exclusive vs. stale/default recipients
+        // (card_3462117951fa588df9ff8a95 "誤路由到 #1"). A manual toggle still revokes.
+        function recomputeAutoReceivers() {
             clearAllReceiverHints();
-            if (!meta || typeof meta !== 'object') return;
-            let entityIds = [];
-            if (meta.kind === 'chat-entity' && Number.isFinite(meta.entityId)) {
-                entityIds = [meta.entityId];
-            } else if (meta.kind === 'card' && Array.isArray(meta.cardAssignedBots)) {
-                entityIds = meta.cardAssignedBots.filter(id => Number.isFinite(id));
-            } else {
-                return;
-            }
-            // Only the quoted sender(s) that actually have a target checkbox can be
-            // auto-selected. If none are bound here (e.g. a cross-device sender),
-            // leave the existing selection untouched rather than wiping it blank.
+            const union = new Set();
+            replyContexts.forEach(rc => entityIdsFromMeta(rc.meta).forEach(eid => union.add(eid)));
+            // Only the quoted sender(s) that actually have a target checkbox here.
+            // If none are bound (e.g. cross-device), leave the selection untouched.
             const wanted = new Set();
-            entityIds.forEach(eid => {
-                if (document.querySelector('.target-entity-check input[type="checkbox"][data-entity="' + eid + '"]')) {
-                    wanted.add(eid);
-                }
+            union.forEach(eid => {
+                if (document.querySelector('.target-entity-check input[type="checkbox"][data-entity="' + eid + '"]')) wanted.add(eid);
             });
             if (wanted.size === 0) return;
-            // EXCLUSIVE auto-select: a quote of #6 must route to #6 ONLY. The old
-            // additive toggle left the prior/default recipient set checked, so
-            // replies leaked to whoever was already selected — typically #1, the
-            // first bound entity (card_3462117951fa588df9ff8a95 "誤路由到 #1").
-            // Clear every entity + contact checkbox first, then check exactly the
-            // quoted sender(s). The user can still re-add recipients manually
-            // afterwards (a manual toggle revokes that entry's auto hint).
             document.querySelectorAll('.target-entity-check input[type="checkbox"]').forEach(cb => {
                 cb.checked = wanted.has(Number(cb.dataset.entity));
             });
@@ -7841,18 +7895,26 @@
             if (!text && !hasFiles && !hasR2Refs) return;
 
             let finalText = text;
-            if (replyContext) {
-                const excerpt = replyContext.text.length > 80 ? replyContext.text.slice(0, 80) + '…' : replyContext.text;
-                // Embed his_<uuid> token in the prefix so the referenced bubble
-                // renders as a clickable chip for everyone (sender + recipient
-                // bots see it inline and can scroll back). messages.id is a
-                // UUID, so we validate the canonical 8-4-4-4-12 form and skip
-                // the token if it doesn't match (no silent digit-stripping).
+            if (replyContexts.length) {
+                // Embed his_<uuid> token per quote so each referenced bubble renders
+                // as a clickable chip for everyone (sender + recipient bots see it
+                // inline and can scroll back). messages.id is a UUID, so we validate
+                // the canonical 8-4-4-4-12 form and skip the token if it doesn't
+                // match (no silent digit-stripping). One "↩ …" LINE per quote so the
+                // recipient entity receives EVERY quote, not just the last (card_277c80f5).
                 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-                const rawMsgId = replyContext.msgId ? String(replyContext.msgId).trim().toLowerCase() : '';
-                const hisToken = UUID_RE.test(rawMsgId) ? ` his_${rawMsgId}` : '';
-                const quotePrefix = `↩ ${replyContext.senderName}:${hisToken} "${excerpt}"`;
-                finalText = text ? `${quotePrefix}\n\n${text}` : quotePrefix;
+                const quoteLines = replyContexts.map(rc => {
+                    // Collapse newlines so each quote stays a single line; the block is
+                    // joined by '\n' and separated from the body by '\n\n', which keeps
+                    // stripReplyQuotePrefix() (cuts at first '\n\n') correct.
+                    const oneLine = (rc.text || '').replace(/\s*\n+\s*/g, ' ');
+                    const excerpt = oneLine.length > 80 ? oneLine.slice(0, 80) + '…' : oneLine;
+                    const rawMsgId = rc.msgId ? String(rc.msgId).trim().toLowerCase() : '';
+                    const hisToken = UUID_RE.test(rawMsgId) ? ` his_${rawMsgId}` : '';
+                    return `↩ ${rc.senderName}:${hisToken} "${excerpt}"`;
+                });
+                const quoteBlock = quoteLines.join('\n');
+                finalText = text ? `${quoteBlock}\n\n${text}` : quoteBlock;
                 clearReplyContext();
             }
             finalText = normalizeTargetSlashForSend(finalText);

--- a/backend/tests/jest/chat-multiquote.test.js
+++ b/backend/tests/jest/chat-multiquote.test.js
@@ -42,8 +42,10 @@ describe('chat.html multi-quote accumulation (card_277c80f5)', () => {
     test('send emits one quote line per entry so the entity receives every quote', () => {
         const send = html.slice(html.indexOf('if (replyContexts.length) {'));
         expect(send).toContain('const quoteLines = replyContexts.map(rc => {');
-        expect(send).toContain('const quoteBlock = quoteLines.join(\'\\n\');');
-        expect(send).toContain('finalText = text ? `${quoteBlock}\\n\\n${text}` : quoteBlock;');
+        // one "↩ …" line per quote, joined by newline
+        expect(send).toContain("quoteLines.join('\\n')");
+        // the outgoing body is built from ALL quotes, not just the last
+        expect(send).toMatch(/finalText = text \?[^\n]*quoteLines\.join/);
         // newlines collapsed per quote so the block stays strip-compatible
         expect(send).toContain("(rc.text || '').replace(/\\s*\\n+\\s*/g, ' ')");
     });

--- a/backend/tests/jest/chat-multiquote.test.js
+++ b/backend/tests/jest/chat-multiquote.test.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const path = require('path');
+
+const html = fs.readFileSync(
+    path.join(__dirname, '../../public/portal/chat.html'),
+    'utf8',
+);
+
+// card_277c80f5 (Hank-direct): quoting more than once must ACCUMULATE quotes
+// (not overwrite), with no cap, and the recipient entity must receive EVERY
+// quote. Implemented in chat.html by turning the single `replyContext` into a
+// `replyContexts[]` array, rendering one removable chip per quote, and emitting
+// one "↩ …" line per quote at send time.
+describe('chat.html multi-quote accumulation (card_277c80f5)', () => {
+    test('quote state is an accumulating array, not a single overwriting object', () => {
+        expect(html).toContain('let replyContexts = [];');
+        // the old single-object state must be gone
+        expect(html).not.toContain('let replyContext = null;');
+    });
+
+    test('adding a quote appends (with de-dupe) instead of overwriting', () => {
+        const add = html.slice(html.indexOf('function addReplyContext('), html.indexOf('function removeReplyContextAt('));
+        expect(add).toContain('replyContexts.push(');
+        // de-dupe so re-clicking the same message is a no-op
+        expect(add).toContain('replyContexts.some(rc => rc._key === key)');
+        // both quote entry points append via addReplyContext
+        expect(html).toContain('addReplyContext(msgId, sender, text, meta);'); // handleReplyBtn
+        expect(html).toContain('addReplyContext(null, senderLabel, previewText, meta || {});'); // quoteToChat
+    });
+
+    test('each quote renders a chip with its own remove control', () => {
+        expect(html).toContain('function renderReplyPreviews()');
+        expect(html).toContain('function removeReplyContextAt(idx)');
+        expect(html).toContain("chip.className = 'reply-preview-chip'");
+        expect(html).toContain("x.addEventListener('click', () => removeReplyContextAt(i));");
+        // chip text uses textContent (no innerHTML) → no quote-content XSS
+        expect(html).toContain('t.textContent = rc.text || mediaLabel;');
+        // bar hides when there are no quotes
+        expect(html).toContain("if (replyContexts.length === 0) { bar.classList.remove('show'); return; }");
+    });
+
+    test('send emits one quote line per entry so the entity receives every quote', () => {
+        const send = html.slice(html.indexOf('if (replyContexts.length) {'));
+        expect(send).toContain('const quoteLines = replyContexts.map(rc => {');
+        expect(send).toContain('const quoteBlock = quoteLines.join(\'\\n\');');
+        expect(send).toContain('finalText = text ? `${quoteBlock}\\n\\n${text}` : quoteBlock;');
+        // newlines collapsed per quote so the block stays strip-compatible
+        expect(send).toContain("(rc.text || '').replace(/\\s*\\n+\\s*/g, ' ')");
+    });
+
+    test('auto-receivers union across ALL quotes (route to every quoted sender)', () => {
+        expect(html).toContain('function recomputeAutoReceivers()');
+        expect(html).toContain('replyContexts.forEach(rc => entityIdsFromMeta(rc.meta).forEach(eid => union.add(eid)));');
+    });
+
+    test('clear resets the whole array and the help affordance exists', () => {
+        const clear = html.slice(html.indexOf('function clearReplyContext()'), html.indexOf('function clearReplyContext()') + 240);
+        expect(clear).toContain('replyContexts = [];');
+        expect(html).toContain('id="replyPreviewList"');
+        expect(html).toContain('id="replyPreviewHelp"');
+    });
+});

--- a/backend/tests/jest/chat-quote-smart-receiver.test.js
+++ b/backend/tests/jest/chat-quote-smart-receiver.test.js
@@ -44,8 +44,12 @@ describe('chat quote-reply smart receiver — chat.html surface', () => {
         );
     });
 
-    test('applyAutoToggleReceivers dispatches on meta.kind for card / chat-entity', () => {
-        expect(chatHtml).toMatch(/function\s+applyAutoToggleReceivers\s*\(\s*meta\s*\)/);
+    test('entityIdsFromMeta dispatches on meta.kind for card / chat-entity', () => {
+        // Multi-quote refactor: the single-state applyAutoToggleReceivers(meta)
+        // was split into the pure dispatcher entityIdsFromMeta(meta) +
+        // recomputeAutoReceivers() which unions over replyContexts[].
+        expect(chatHtml).toMatch(/function\s+entityIdsFromMeta\s*\(\s*meta\s*\)/);
+        expect(chatHtml).toMatch(/function\s+recomputeAutoReceivers\s*\(\s*\)/);
         // Both code paths must be present so neither rule silently drops
         // (a regex match keeps both branches honest).
         expect(chatHtml).toMatch(/meta\.kind\s*===\s*['"]chat-entity['"]/);
@@ -116,10 +120,22 @@ describe('chat quote-reply smart receiver — chat.html surface', () => {
     // The auto-select must be EXCLUSIVE — clearing the residual/default
     // selection — otherwise a quote of #6 still leaks to whoever was already
     // checked (#1). This is the load-bearing assertion for card_3462...
-    test('applyAutoToggleReceivers clears every entity + contact checkbox before checking the sender', () => {
-        const fn = chatHtml.match(/function\s+applyAutoToggleReceivers\s*\(\s*meta\s*\)\s*\{[\s\S]*?\n        \}/);
-        expect(fn).not.toBeNull();
-        const body = fn[0];
+    test('recomputeAutoReceivers clears every entity + contact checkbox before checking the sender', () => {
+        const m = chatHtml.match(/function\s+recomputeAutoReceivers\s*\(\s*\)\s*\{/);
+        expect(m).not.toBeNull();
+        // brace-balance walk to capture the whole body
+        let depth = 1;
+        let i = m.index + m[0].length;
+        while (i < chatHtml.length && depth > 0) {
+            const ch = chatHtml[i];
+            if (ch === '{') depth++;
+            else if (ch === '}') depth--;
+            i++;
+        }
+        const body = chatHtml.slice(m.index, i);
+        // unions entityIdsFromMeta over every current quote (multi-quote routes
+        // to EVERY quoted sender, not just the last)
+        expect(body).toMatch(/replyContexts\.forEach\([\s\S]*?entityIdsFromMeta\(\s*rc\.meta\s*\)/);
         // resets all entity checkboxes to (wanted.has) and all contacts to false
         expect(body).toMatch(/\.target-entity-check input\[type="checkbox"\][\s\S]*?cb\.checked\s*=\s*wanted\.has\(Number\(cb\.dataset\.entity\)\)/);
         expect(body).toMatch(/\.target-contact-check input\[type="checkbox"\][\s\S]*?cb\.checked\s*=\s*false/);
@@ -222,11 +238,18 @@ describe('chat_receiver_hint_auto — i18n key parity across 12 locales', () => 
     });
 });
 
-describe('applyAutoToggleReceivers — behaviour against a hand-rolled DOM stub', () => {
+describe('recomputeAutoReceivers — behaviour against a hand-rolled DOM stub', () => {
     // jest.config.js uses testEnvironment:'node' with no jsdom. We extract
     // the function bodies from chat.html, evaluate them inside a tiny
-    // document-like shim, and exercise the three spec cases. This gives us
-    // a behavioural assertion without pulling in a new dep.
+    // document-like shim, and exercise the spec cases. This gives us a
+    // behavioural assertion without pulling in a new dep.
+    //
+    // Multi-quote refactor: the old single-state applyAutoToggleReceivers(meta)
+    // is gone. Auto-select is now driven by recomputeAutoReceivers() which
+    // unions entityIdsFromMeta(rc.meta) over a replyContexts[] array. The
+    // sandbox seeds that array (one entry per quoted meta) and then invokes
+    // recomputeAutoReceivers() — exactly how addReplyContext/removeReplyContextAt
+    // drive it in production.
     function makeStubDocument(entityIds) {
         const labels = entityIds.map(eid => {
             const cb = {
@@ -333,48 +356,65 @@ describe('applyAutoToggleReceivers — behaviour against a hand-rolled DOM stub'
         return chatHtml.slice(m.index, i);
     }
 
-    // Build a sandbox with the three functions we need + a stub document.
+    // Build a sandbox with the functions we need + a stub document.
     function makeSandbox(entityIds) {
         const stubDoc = makeStubDocument(entityIds);
+        const replyContexts = []; // seeded per-test, then recompute unions over it
         const sandbox = {
             document: stubDoc,
             autoToggledReceiverEntities: new Set(),
             i18n: { t: (k) => (k === 'chat_receiver_hint_auto' ? 'auto' : null) },
             persistTargetSelection: () => {},
             updateTargetAll: () => {},
+            replyContexts,
         };
-        // applyAutoToggleReceivers reads/writes autoToggledReceiverEntities,
-        // calls i18n.t, document.querySelector, etc. clearAllReceiverHints
-        // is invoked at the top, and clearReceiverHintForEntity is the
-        // companion. Extract all three.
+        // recomputeAutoReceivers reads the replyContexts array + writes
+        // autoToggledReceiverEntities, calls entityIdsFromMeta, i18n.t,
+        // document.querySelector, etc. clearAllReceiverHints is invoked at the
+        // top, clearReceiverHintForEntity is the companion. Extract all four.
         const body =
-            extractFunction('applyAutoToggleReceivers') +
+            extractFunction('recomputeAutoReceivers') +
+            '\n' +
+            extractFunction('entityIdsFromMeta') +
             '\n' +
             extractFunction('clearAllReceiverHints') +
             '\n' +
             extractFunction('clearReceiverHintForEntity');
-        // Wrap so the sandbox keys behave like free variables.
+        // Wrap so the sandbox keys behave like free variables. replyContexts is
+        // passed by reference; seed it via `quote(meta)` then call recompute()
+        // exactly like addReplyContext does in production.
         const fn = new Function(
             'document',
             'autoToggledReceiverEntities',
             'i18n',
             'persistTargetSelection',
             'updateTargetAll',
-            `${body}\nreturn { applyAutoToggleReceivers, clearAllReceiverHints, clearReceiverHintForEntity };`
+            'replyContexts',
+            `${body}\nreturn { recomputeAutoReceivers, entityIdsFromMeta, clearAllReceiverHints, clearReceiverHintForEntity };`
         );
-        const api = fn(
+        const inner = fn(
             sandbox.document,
             sandbox.autoToggledReceiverEntities,
             sandbox.i18n,
             sandbox.persistTargetSelection,
-            sandbox.updateTargetAll
+            sandbox.updateTargetAll,
+            replyContexts
         );
+        // `auto(meta)` mimics quoting a single message with `meta`, then
+        // recomputing — the production path through addReplyContext.
+        const api = {
+            ...inner,
+            auto(meta) {
+                replyContexts.push({ meta: meta || null });
+                inner.recomputeAutoReceivers();
+            },
+        };
         return { sandbox, api };
     }
 
     test('card source → each entity in cardAssignedBots is toggled on + badged', () => {
         const { sandbox, api } = makeSandbox([1, 2, 3]);
-        api.applyAutoToggleReceivers({ kind: 'card', cardAssignedBots: [1, 3] });
+        api.auto({ kind: 'card', cardAssignedBots: [1, 3] });
         const cb1 = sandbox.document.querySelector('[data-entity="1"]');
         const cb2 = sandbox.document.querySelector('[data-entity="2"]');
         const cb3 = sandbox.document.querySelector('[data-entity="3"]');
@@ -387,7 +427,7 @@ describe('applyAutoToggleReceivers — behaviour against a hand-rolled DOM stub'
 
     test('chat-entity source → only the sender entity is toggled', () => {
         const { sandbox, api } = makeSandbox([1, 5, 7]);
-        api.applyAutoToggleReceivers({ kind: 'chat-entity', entityId: 5 });
+        api.auto({ kind: 'chat-entity', entityId: 5 });
         expect(sandbox.document.querySelector('[data-entity="1"]').checked).toBe(false);
         expect(sandbox.document.querySelector('[data-entity="5"]').checked).toBe(true);
         expect(sandbox.document.querySelector('[data-entity="7"]').checked).toBe(false);
@@ -402,7 +442,7 @@ describe('applyAutoToggleReceivers — behaviour against a hand-rolled DOM stub'
         // simulate the default "all checked" / last-sent residual state
         sandbox.document.querySelector('[data-entity="1"]').checked = true;
         sandbox.document.querySelector('[data-entity="7"]').checked = true;
-        api.applyAutoToggleReceivers({ kind: 'chat-entity', entityId: 5 });
+        api.auto({ kind: 'chat-entity', entityId: 5 });
         expect(sandbox.document.querySelector('[data-entity="1"]').checked).toBe(false);
         expect(sandbox.document.querySelector('[data-entity="5"]').checked).toBe(true);
         expect(sandbox.document.querySelector('[data-entity="7"]').checked).toBe(false);
@@ -414,14 +454,14 @@ describe('applyAutoToggleReceivers — behaviour against a hand-rolled DOM stub'
     test('unbound sender → existing selection preserved (no exclusive wipe)', () => {
         const { sandbox, api } = makeSandbox([1, 2]);
         sandbox.document.querySelector('[data-entity="1"]').checked = true;
-        api.applyAutoToggleReceivers({ kind: 'chat-entity', entityId: 9 }); // 9 not bound
+        api.auto({ kind: 'chat-entity', entityId: 9 }); // 9 not bound
         expect(sandbox.document.querySelector('[data-entity="1"]').checked).toBe(true);
         expect(sandbox.document.querySelectorAll('.receiver-hint-auto').length).toBe(0);
     });
 
     test('chat-system source → no toggle, no badge', () => {
         const { sandbox, api } = makeSandbox([1, 2]);
-        api.applyAutoToggleReceivers({ kind: 'chat-system' });
+        api.auto({ kind: 'chat-system' });
         expect(sandbox.document.querySelector('[data-entity="1"]').checked).toBe(false);
         expect(sandbox.document.querySelector('[data-entity="2"]').checked).toBe(false);
         const badges = sandbox.document.querySelectorAll('.receiver-hint-auto');
@@ -430,9 +470,9 @@ describe('applyAutoToggleReceivers — behaviour against a hand-rolled DOM stub'
 
     test('empty / undefined meta → no-op', () => {
         const { sandbox, api } = makeSandbox([1, 2]);
-        api.applyAutoToggleReceivers(undefined);
-        api.applyAutoToggleReceivers({});
-        api.applyAutoToggleReceivers({ kind: 'card' }); // missing cardAssignedBots
+        api.auto(undefined);
+        api.auto({});
+        api.auto({ kind: 'card' }); // missing cardAssignedBots
         expect(sandbox.document.querySelector('[data-entity="1"]').checked).toBe(false);
         expect(sandbox.document.querySelector('[data-entity="2"]').checked).toBe(false);
         expect(sandbox.document.querySelectorAll('.receiver-hint-auto').length).toBe(0);
@@ -440,7 +480,7 @@ describe('applyAutoToggleReceivers — behaviour against a hand-rolled DOM stub'
 
     test('clearReceiverHintForEntity removes the badge for that entity', () => {
         const { sandbox, api } = makeSandbox([1, 2]);
-        api.applyAutoToggleReceivers({ kind: 'card', cardAssignedBots: [1, 2] });
+        api.auto({ kind: 'card', cardAssignedBots: [1, 2] });
         expect(sandbox.document.querySelectorAll('.receiver-hint-auto').length).toBe(2);
         api.clearReceiverHintForEntity(1);
         expect(sandbox.document.querySelectorAll('.receiver-hint-auto').length).toBe(1);

--- a/backend/tests/jest/chat-targets-static.test.js
+++ b/backend/tests/jest/chat-targets-static.test.js
@@ -21,7 +21,10 @@ describe('chat target selection safety', () => {
     test('sendMessage surfaces the existing select-entity error when no targets are selected', () => {
         const start = chatHtml.indexOf('async function sendMessage()');
         expect(start).toBeGreaterThan(0);
-        const body = chatHtml.slice(start, start + 5000);
+        // Window widened 5000 -> 6000 (card_277c80f5): the multi-quote block added
+        // ~lines to the top of sendMessage, pushing the (intact) no-target guard to
+        // ~offset 5100. The guard itself is unchanged; only its position moved.
+        const body = chatHtml.slice(start, start + 6000);
 
         expect(body).toContain('const targets = getSelectedTargets();');
         expect(body).toMatch(/targets\.local\.length\s*===\s*0\s*&&\s*targets\.contacts\.length\s*===\s*0/);


### PR DESCRIPTION
## Hank-direct (web_chat 2026-06-23) → P0
「多重引用：當引用超過一次時不會覆蓋之前的引用，而是額外增加引用，數量無上限。需要 E2E 驗證實體可以接收到用戶的每一個引用。」

## Before
`chat.html` held a single `replyContext`. Quoting a second message **overwrote** the first, so the recipient entity only ever received the **last** quote.

## After (`backend/public/portal/chat.html`)
Single `replyContext` → **`replyContexts[]` array** (accumulating, no cap):
- `handleReplyBtn` / `quoteToChat` append via `addReplyContext()` — de-duped by `msgId` (else sender+text) so re-clicking the same message is a no-op.
- Reply bar renders **one chip per quote**, each with its own ✕ remove; bar hides when empty. Chip text via `textContent` (no quote-content XSS). Chips wrap/scroll (desktop + mobile CSS, `@media ≤480px`).
- `sendMessage` emits **one `↩ <sender>:<his_token> "<excerpt>"` line per quote**, joined by `\n` then `\n\n` + body → the recipient entity receives **every** quote. Per-quote newlines collapsed so the block stays compatible with the existing `stripReplyQuotePrefix()` (cuts at first `\n\n`) — no change needed there.
- Smart auto-receivers now **union across all quotes' metas** (route to every quoted sender, de-duped) while staying exclusive vs stale defaults (the card_3462… "誤路由到 #1" guard).
- **? help** affordance in the reply bar (bilingual, set dynamically in `renderReplyPreviews` so `i18n.apply` can't clobber it; no new dict key → no i18n-consistency churn).

## Globe-user / Setup / ? icon
All worldwide users, any quote (bot or human); no setup. ? explains "quote multiple messages, each sent together, ✕ to remove one, no limit".

## Test
`chat-multiquote.test.js` (6/6 pass): array-not-single, append+de-dupe, per-chip render+remove (textContent), one-line-per-quote send join, receiver union, clear+help. Inline-script `node --check` clean.

## Acceptance / E2E (this card's requirement)
Post-merge I'll run Playwright on the deployed URL (desktop 1280×800 + mobile 390×844): quote N messages of one entity → send → verify from the **recipient side** that all N quotes arrived in order; screenshots to the card before close.

Context: #1/#6 Codex out of credits (Jun 27) → UI work on me (#2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)