### PR TITLE
fix(wallpaper): close 1.1.7 black-screen process-death paths (BLK-FGS/OOM/RENDER) — v1.1.8 (card_f9b2cc2d/card_f22e489c)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 117
-        versionName = "1.1.7"
+        versionCode = 118
+        versionName = "1.1.8"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/hank/clawlive/ClawApplication.kt
+++ b/app/src/main/java/com/hank/clawlive/ClawApplication.kt
@@ -44,9 +44,23 @@ class ClawApplication : Application() {
                 trySyncFlushCrashToServer(throwable, recentLines)
             } catch (_: Exception) {
                 // Must not throw — always let default handler run
-            } finally {
-                defaultHandler?.uncaughtException(thread, throwable)
             }
+            // BLK-FGS recovery (card_f9b2cc2d): a foreground-service-policy throwable
+            // (ForegroundServiceStartNotAllowed / DidNotStartInTime / RemoteServiceException
+            // with an FGS message) is a recoverable OS policy rejection, NOT a real
+            // app crash. The call sites are now guarded, but as belt-and-braces: if
+            // one still reaches here, letting the default handler run would kill this
+            // shared process and take the live wallpaper down with it (pure black,
+            // needs app restart). Swallow ONLY this narrow class so the process — and
+            // the wallpaper engine — survive; it was already logged + recorded above.
+            if (isRecoverableForegroundServiceCrash(throwable)) {
+                try {
+                    com.google.firebase.crashlytics.FirebaseCrashlytics.getInstance().recordException(throwable)
+                } catch (_: Throwable) {}
+                Timber.e(throwable, "[App] swallowed recoverable FGS crash (${throwable.javaClass.simpleName}) — keeping process + wallpaper alive")
+                return@setDefaultUncaughtExceptionHandler
+            }
+            defaultHandler?.uncaughtException(thread, throwable)
         }
 
         // 4. Initialize TelemetryHelper early (centralized here)
@@ -207,4 +221,30 @@ class ClawApplication : Application() {
 
     private fun escapeJson(s: String): String =
         s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r")
+
+    /**
+     * BLK-FGS (card_f9b2cc2d): true only for the narrow class of foreground-service
+     * policy rejections that are recoverable — swallowing these keeps the shared
+     * process (and the live wallpaper engine) alive instead of dying to a pure-black
+     * screen. Walks the cause chain; matches by class name so it works across API
+     * levels (ForegroundServiceStartNotAllowedException, RemoteServiceException$
+     * ForegroundServiceDidNotStartInTimeException, etc.) without compile-time deps.
+     */
+    private fun isRecoverableForegroundServiceCrash(t: Throwable?): Boolean {
+        var cur = t
+        var depth = 0
+        while (cur != null && depth < 8) {
+            val name = cur.javaClass.name
+            val msg = cur.message ?: ""
+            if (name.contains("ForegroundServiceStartNotAllowedException") ||
+                name.contains("ForegroundServiceDidNotStartInTimeException") ||
+                (name.contains("RemoteServiceException") && msg.contains("ForegroundService"))
+            ) {
+                return true
+            }
+            cur = cur.cause
+            depth++
+        }
+        return false
+    }
 }

--- a/app/src/main/java/com/hank/clawlive/MainActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MainActivity.kt
@@ -76,10 +76,19 @@ class MainActivity : AppCompatActivity() {
 
         // TTS foreground service (bot voice replies)
         val ttsIntent = Intent(this, com.hank.clawlive.service.TtsService::class.java)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            startForegroundService(ttsIntent)
-        } else {
-            startService(ttsIntent)
+        // BLK-FGS (card_f9b2cc2d): a foreground-service start must never crash the
+        // process — it shares the process with the live wallpaper engine, so an
+        // uncaught ForegroundServiceStartNotAllowedException here turns the
+        // wallpaper pure-black until app restart.
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                startForegroundService(ttsIntent)
+            } else {
+                startService(ttsIntent)
+            }
+        } catch (t: Throwable) {
+            Timber.e(t, "[Main] tts startForegroundService refused (${t.javaClass.simpleName})")
+            try { com.google.firebase.crashlytics.FirebaseCrashlytics.getInstance().recordException(t) } catch (_: Throwable) {}
         }
 
         observeLocationRequests()

--- a/app/src/main/java/com/hank/clawlive/data/local/WallpaperSpritesheetDiskCache.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/WallpaperSpritesheetDiskCache.kt
@@ -32,8 +32,11 @@ class WallpaperSpritesheetDiskCache private constructor(context: Context) {
                 file.delete()
                 null
             }
-        } catch (e: Exception) {
-            Timber.w(e, "Failed to load wallpaper spritesheet cache")
+        } catch (e: Throwable) {
+            // BLK-OOM (card_f9b2cc2d): decodeFile throws OutOfMemoryError (an Error, not
+            // Exception) on a huge/corrupt cached sheet. Catch Throwable so it can't
+            // escape to the process-killing uncaught handler; drop the bad file + null.
+            Timber.w(e, "Failed to load wallpaper spritesheet cache (${e.javaClass.simpleName})")
             file.delete()
             null
         }

--- a/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
+++ b/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
@@ -47,7 +47,14 @@ class CompanionRepository(
     private val diskSheetCache = WallpaperSpritesheetDiskCache.getInstance(context)
     private val descriptorCache = ConcurrentHashMap<Int, CompanionDetail>()
     private val sheetCache = SheetBitmapCache(maxEntries = 8)
-    private val ioScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    // BLK-OOM (card_f9b2cc2d): a CoroutineExceptionHandler so ANY uncaught throwable
+    // on this IO scope (incl. OutOfMemoryError) is contained here and never reaches
+    // the process-killing default uncaught handler (which would black the wallpaper).
+    private val ioScope = CoroutineScope(
+        Dispatchers.IO + SupervisorJob() + kotlinx.coroutines.CoroutineExceptionHandler { _, e ->
+            Timber.e(e, "[CompanionRepo] contained uncaught on ioScope (${e.javaClass.simpleName})")
+        }
+    )
 
     init {
         val restored = snapshotCache.loadCompanionMap()
@@ -188,8 +195,13 @@ class CompanionRepository(
                     diskSheetCache.save(url, bytes)
                 }
             }
-        } catch (e: Exception) {
-            Timber.e(e, "Spritesheet decode failed for $url")
+        } catch (e: Throwable) {
+            // BLK-OOM (card_f9b2cc2d): BitmapFactory throws java.lang.OutOfMemoryError
+            // (an Error, NOT an Exception) on an oversized/corrupt sheet. Catching only
+            // Exception let it escape this IO coroutine → ClawApplication uncaught handler
+            // → process death → pure-black wallpaper. Catch Throwable; null falls back to
+            // the already-guarded LOADING/procedural render.
+            Timber.e(e, "Spritesheet decode failed for $url (${e.javaClass.simpleName})")
             null
         }
     }

--- a/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
+++ b/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
@@ -85,12 +85,28 @@ class ClawFcmService : FirebaseMessagingService() {
                 putExtra("tts_text", body)
                 putExtra("tts_entity_name", title)
             }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                startForegroundService(ttsIntent)
-            } else {
-                startService(ttsIntent)
+            // BLK-FGS (card_f9b2cc2d): on Android 12+ a background-restricted app
+            // throws ForegroundServiceStartNotAllowedException at THIS call site —
+            // and FCM is delivered precisely while the app is backgrounded (e.g.
+            // user just switched to home). The exception is thrown back to the
+            // caller BEFORE TtsService runs, so TtsService's own try/catch cannot
+            // catch it; uncaught here it kills the shared process and takes the
+            // live wallpaper down with it (pure black, needs app restart). Guard it
+            // and fall through to a normal notification so the message is never lost.
+            var ttsStarted = false
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    startForegroundService(ttsIntent)
+                } else {
+                    startService(ttsIntent)
+                }
+                ttsStarted = true
+            } catch (t: Throwable) {
+                Timber.e(t, "[FCM] tts startForegroundService refused (${t.javaClass.simpleName}); falling back to notification")
+                try { com.google.firebase.crashlytics.FirebaseCrashlytics.getInstance().recordException(t) } catch (_: Throwable) {}
             }
-            return  // Don't show a notification for TTS
+            if (ttsStarted) return  // spoke via service; no notification needed
+            // else: fall through to show a normal notification carrying the body
         }
 
         // Keep the foreground channel consistent with the channel the backend

--- a/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
+++ b/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
@@ -494,9 +494,12 @@ class ClawWallpaperService : WallpaperService() {
                     }
                 } else if (drawCount <= 5) {
                 }
-            } catch (e: Exception) {
-                // card_f9b2cc2d ROOT-CAUSE CAPTURE + visible fallback. The
-                // reported "pure black, no text" on resume is consistent with
+            } catch (e: Throwable) {
+                // card_f9b2cc2d ROOT-CAUSE CAPTURE + visible fallback. catch THROWABLE
+                // (not just Exception) so a render-thread OutOfMemoryError [BLK-RENDER]
+                // (an Error) also paints the visible error frame below instead of
+                // escaping to the process-killing uncaught handler → pure black.
+                // The reported "pure black, no text" on resume is consistent with
                 // drawMultiEntity drawing the black background and then THROWING
                 // while rendering entities (e.g. a recycled/released bitmap after
                 // an app-switch). The old code only Timber.e'd and the `finally`


### PR DESCRIPTION
## Hank device-tested 1.1.7 → pure-black-no-text STILL recurred
A 6-path audit found the v1.1.7 `TtsService` FGS fix targeted the wrong layer (it only wrapped the start *inside* the service). All components share **one process** (no `android:process` in the manifest), so any uncaught throw kills the live-wallpaper engine too → pure black until app restart. Three process-death paths were reachable and uncovered:

### BLK-FGS (primary, high confidence)
`ForegroundServiceStartNotAllowedException` is thrown by the OS **at the `startForegroundService()` call site** when the app is background-restricted (Android 12+). FCM arrives exactly while backgrounded (user switched to home) → `ClawFcmService` tts branch threw **uncaught** — `TtsService`'s own try/catch can't catch it (thrown before the service runs). Timing matches the report exactly.
- `ClawFcmService`: guard + **fall through to a normal notification** (message never lost).
- `MainActivity`: guard the onCreate start.
- `ClawApplication`: narrow recovery — swallow ONLY recoverable foreground-service-policy throwables so the process + wallpaper survive.

### BLK-OOM / BLK-SPRITE
`BitmapFactory` throws `OutOfMemoryError` (an **Error**, not Exception) on an oversized/corrupt sheet; every decoder caught only `Exception` → OOM escaped the IO coroutine → process death. Widened both decode catches to `Throwable` + added a `CoroutineExceptionHandler` to `ioScope`.

### BLK-RENDER
Widened the wallpaper draw-loop catch from `Exception` to `Throwable` so a render-thread OOM paints the existing distinct error frame instead of escaping. (Loading marker already paints navy `#0B1220`, not black.)

## Suffix codes
BLK-FGS / BLK-OOM / BLK-SPRITE / BLK-RENDER are referenced in code comments + log lines for field diagnosis.

## Version
versionCode 117→118, versionName 1.1.7→**1.1.8**.

## Verification
Android CI builds this branch (compile gate). Then Hank device-test on 1.1.8: switch-to-home repeatedly + trigger a tts push while backgrounded — should no longer black-screen.

## Follow-up (next commit, NOT this PR)
A dedicated `WallpaperDiagnosticPainter` that stamps the active **BLK-XXX** code + a "桌布加載中…" loading animation on every fallback frame (the diagnosability/UX layer Hank asked for). The crash-prevention here is the functional fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)