### PR TITLE
feat(kanban): API-controllable auto-P0 escalation toggle, default-skip cron cards (card_a0c2bc798affdf0a6310f5bb)

### DIFF
--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -21,6 +21,19 @@ const DEFAULTS = {
     // Stop-mode pauses stale-card nudges for an entity without changing card ownership.
     // Exposed through per-entity overrides; device default remains false.
     kanban_nudge_stop_mode: false,
+    // Auto-escalation master switch (card_a0c2bc798affdf0a6310f5bb / Hank-direct).
+    // Governs the clock-triggered L2/L3 ladder: priority-bump (L2),
+    // P0-stalled supervisor ping + auto-block (L3). When false, ONLY L1 standard
+    // nudges fire — no priority changes, no supervisor pings, no auto-block.
+    // Device-wide settable via PUT /api/device-preferences.
+    kanban_auto_escalate_enabled: true,
+    // When true (default), automation cards NEVER auto-escalate even if the master
+    // switch above is on. "Automation card" = cron母卡 (is_automation=true) OR a
+    // cron-spawned child card (is_auto_generated=true, the "[Auto] … (date)" rows).
+    // This is the cron-noise fix: those child cards never have their own owner
+    // working them, so the L2/L3 ladder fired "🚨 P0 stalled 主管請介入" every
+    // interval. They still get L1 nudges so the work isn't forgotten.
+    kanban_auto_escalate_skip_automation: true,
     // Phase 2 (card_e066cb6b / kanban-nudge-spec.md §6): per-entity overrides on top
     // of the device-wide defaults above. Shape: { "<entityId>": { ...partialPrefs } }.
     // Only the keys in NUDGE_ENTITY_OVERRIDE_KEYS may be overridden — batch_size and
@@ -55,6 +68,12 @@ const NUDGE_STATUS_OPTIONS = new Set(KanbanStatus.NUDGEABLE_STATUSES);
 
 function coerceValue(key, raw) {
     const def = DEFAULTS[key];
+    // Auto-escalation toggles accept a real boolean OR the string 'true'/'false'
+    // (a bare `!!raw` would coerce the string 'false' to true — wrong for an API
+    // that may serialize the flag as a query/JSON string).
+    if (key === 'kanban_auto_escalate_enabled' || key === 'kanban_auto_escalate_skip_automation') {
+        return raw === true || raw === 'true';
+    }
     if (typeof def === 'boolean') return !!raw;
     if (typeof def === 'number') {
         const n = Number(raw);

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -3372,6 +3372,19 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 : KanbanStatus.NUDGE_DEFAULT_STATUSES
         );
 
+        // Auto-escalation toggles (card_a0c2bc798affdf0a6310f5bb / Hank-direct).
+        // Master switch defaults true; automation-skip defaults true. Both gate ONLY
+        // the clock-triggered L2/L3 ladder below — L1 standard nudges always run so
+        // skipped cards are never forgotten.
+        const autoEscalateEnabled = basePrefs.kanban_auto_escalate_enabled !== false;            // default true
+        const skipAutomationEscalation = basePrefs.kanban_auto_escalate_skip_automation !== false; // default true
+        // A card counts as "automation" for escalation-skip if it's a cron母卡
+        // (is_automation) OR a cron-spawned child (is_auto_generated, the
+        // "[Auto] … (date)" rows). The child INSERT sets is_auto_generated=true but
+        // NOT is_automation, and the child cards are the ones flooding the supervisor
+        // with "🚨 P0 stalled" pings — so both flags must be checked here.
+        const isAutomationCard = (card) => card.is_automation === true || card.is_auto_generated === true;
+
         // Phase 2 (kanban-nudge-spec.md §6): per-entity overrides.
         // Cached resolution keyed on entityId, computed once per tick.
         const entityPrefsCache = new Map();
@@ -3494,13 +3507,22 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 ? Date.now() - new Date(card.last_stale_nudge_at).getTime()
                 : Infinity;
 
-            if (elapsedMs >= blockAfterMs && card.status !== 'blocked' && sinceLast > intervalMs) {
-                await fireBlockEscalation(card, filterNudgeStoppedRecipients(buildEscalationRecipients(card)));
-                continue;
-            }
-            if (elapsedMs >= escalateAfterMs && sinceLast > intervalMs) {
-                const fired = await fireLevelTwoEscalation(card, filterNudgeStoppedRecipients(buildEscalationRecipients(card)));
-                if (fired) continue;
+            // Auto-escalation gate (card_a0c2bc798affdf0a6310f5bb): suppress the
+            // L2/L3 ladder when the master switch is off, or (default) when this is
+            // an automation card and skip-automation is on. The card still falls
+            // through to the L1 push below so it isn't forgotten — only the
+            // priority-bump / P0-stalled-ping / auto-block escalations are skipped.
+            const escalationAllowed = autoEscalateEnabled && !(skipAutomationEscalation && isAutomationCard(card));
+
+            if (escalationAllowed) {
+                if (elapsedMs >= blockAfterMs && card.status !== 'blocked' && sinceLast > intervalMs) {
+                    await fireBlockEscalation(card, filterNudgeStoppedRecipients(buildEscalationRecipients(card)));
+                    continue;
+                }
+                if (elapsedMs >= escalateAfterMs && sinceLast > intervalMs) {
+                    const fired = await fireLevelTwoEscalation(card, filterNudgeStoppedRecipients(buildEscalationRecipients(card)));
+                    if (fired) continue;
+                }
             }
             // Level 1 candidate if enough interval has passed.
             if (sinceLast > intervalMs) level1Pending.push(card);

--- a/backend/tests/jest/kanban-auto-escalate-toggle.test.js
+++ b/backend/tests/jest/kanban-auto-escalate-toggle.test.js
@@ -1,0 +1,273 @@
+'use strict';
+
+/**
+ * card_a0c2bc798affdf0a6310f5bb (Hank-direct P0) — API-controllable auto-P0
+ * escalation toggle, defaulting to SKIP escalation on automation (cron) cards.
+ *
+ * Root cause being fixed: cron-spawned child cards ("[Auto] … (date)") are
+ * is_auto_generated=true. They have no owner actively working them, so the
+ * clock-triggered L2/L3 ladder in processDeviceStaleCards fired
+ * "🚨 P0 stalled 主管請介入" supervisor pings (+ priority bumps + auto-block)
+ * every interval — a confirmed push-flood.
+ *
+ * Two device-preference keys gate the ladder:
+ *   kanban_auto_escalate_enabled         (master, default true)
+ *   kanban_auto_escalate_skip_automation (default true — automation cards never
+ *                                         auto-escalate even if master is on)
+ *
+ * Pinned here:
+ *   1. DEFAULTS / coercion contract in device-preferences.js.
+ *   2. Source-grep invariants on processDeviceStaleCards (gate present, L1 push
+ *      stays OUTSIDE the gate so skipped cards aren't forgotten).
+ *   3. Behavioural smoke: reconstruct processDeviceStaleCards in isolation with
+ *      stubbed deps and assert the escalation calls fire / don't fire per prefs.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const devicePrefs = require('../../device-preferences');
+
+const kanbanSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'kanban.js'),
+    'utf8'
+);
+
+function extractFunctionBody(src, signature) {
+    const start = src.indexOf(signature);
+    if (start === -1) throw new Error(`function not found: ${signature}`);
+    const open = src.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) return src.slice(open, i + 1);
+        }
+    }
+    throw new Error(`unterminated function: ${signature}`);
+}
+
+// ════════════════════════════════════════════════════════════════
+// 1. device-preferences contract
+// ════════════════════════════════════════════════════════════════
+describe('device-preferences: auto-escalate toggles', () => {
+    test('both keys ship in DEFAULTS, default true', () => {
+        expect(devicePrefs.DEFAULTS).toHaveProperty('kanban_auto_escalate_enabled', true);
+        expect(devicePrefs.DEFAULTS).toHaveProperty('kanban_auto_escalate_skip_automation', true);
+    });
+
+    test('updatePrefs accepts the keys (they are in DEFAULTS → settable via API)', () => {
+        // The PUT endpoint filters incoming prefs to Object.keys(DEFAULTS); being
+        // in DEFAULTS is what makes a key API-settable. Guard against accidental
+        // removal of either key from the settable surface.
+        expect(Object.keys(devicePrefs.DEFAULTS)).toEqual(
+            expect.arrayContaining([
+                'kanban_auto_escalate_enabled',
+                'kanban_auto_escalate_skip_automation',
+            ])
+        );
+    });
+
+    test('boolean coercion handles real boolean and string forms', () => {
+        // getPrefs returns { ...DEFAULTS, ...stored }; updatePrefs persists the
+        // coerced value. We exercise coercion through updatePrefs by wiring a
+        // capture pool, since coerceValue itself is module-private.
+        const captured = [];
+        const fakePool = {
+            query: async (sql, params) => {
+                captured.push({ sql, params });
+                return { rows: [] };
+            },
+        };
+        return (async () => {
+            await devicePrefs.initTable(fakePool);
+            await devicePrefs.updatePrefs('dev-x', {
+                kanban_auto_escalate_enabled: 'false',
+                kanban_auto_escalate_skip_automation: true,
+            });
+            // The INSERT carries a JSON blob of coerced prefs as params[1].
+            const insert = captured.find(c => /INSERT INTO device_preferences/.test(c.sql));
+            expect(insert).toBeTruthy();
+            const persisted = JSON.parse(insert.params[1]);
+            // 'false' string must coerce to boolean false (NOT truthy !!('false')).
+            expect(persisted.kanban_auto_escalate_enabled).toBe(false);
+            expect(persisted.kanban_auto_escalate_skip_automation).toBe(true);
+        })();
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 2. Source-grep invariants on processDeviceStaleCards
+// ════════════════════════════════════════════════════════════════
+describe('processDeviceStaleCards — escalation gate invariants', () => {
+    const body = extractFunctionBody(kanbanSrc, 'async function processDeviceStaleCards(deviceId, cards)');
+
+    test('derives autoEscalateEnabled + skipAutomationEscalation from prefs (default true)', () => {
+        expect(body).toMatch(/autoEscalateEnabled\s*=\s*basePrefs\.kanban_auto_escalate_enabled\s*!==\s*false/);
+        expect(body).toMatch(/skipAutomationEscalation\s*=\s*basePrefs\.kanban_auto_escalate_skip_automation\s*!==\s*false/);
+    });
+
+    test('treats both is_automation and is_auto_generated as automation cards', () => {
+        // The cron child cards that flood are is_auto_generated=true (NOT
+        // is_automation) — both flags MUST be checked or the default skip misses them.
+        expect(body).toMatch(/is_automation\s*===\s*true/);
+        expect(body).toMatch(/is_auto_generated\s*===\s*true/);
+    });
+
+    test('escalationAllowed gate combines master switch + automation skip', () => {
+        expect(body).toMatch(
+            /escalationAllowed\s*=\s*autoEscalateEnabled\s*&&\s*!\(\s*skipAutomationEscalation\s*&&\s*isAutomationCard\(card\)\s*\)/
+        );
+    });
+
+    test('both L2/L3 escalation calls are inside the escalationAllowed gate', () => {
+        const gateIdx = body.indexOf('if (escalationAllowed) {');
+        expect(gateIdx).toBeGreaterThan(-1);
+        const blockIdx = body.indexOf('fireBlockEscalation');
+        const l2Idx = body.indexOf('fireLevelTwoEscalation');
+        expect(blockIdx).toBeGreaterThan(gateIdx);
+        expect(l2Idx).toBeGreaterThan(gateIdx);
+    });
+
+    test('L1 push stays OUTSIDE the gate (skipped cards are not forgotten)', () => {
+        // The `if (sinceLast > intervalMs) level1Pending.push(card)` line must come
+        // AFTER the closing of the escalationAllowed block, so cards that skip
+        // escalation still fall through to standard L1 nudges.
+        const l1Idx = body.indexOf('level1Pending.push(card)');
+        const gateIdx = body.indexOf('if (escalationAllowed) {');
+        expect(l1Idx).toBeGreaterThan(gateIdx);
+        // The escalation block closes before the L1 push (the L1 push is not nested
+        // inside the gate): there is a `}` between the last escalation `continue`
+        // and the L1 push.
+        const l2BranchIdx = body.indexOf('fireLevelTwoEscalation');
+        const between = body.slice(l2BranchIdx, l1Idx);
+        expect(between).toMatch(/}\s*}\s*\/\/ Level 1 candidate/);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 3. Behavioural smoke — reconstruct processDeviceStaleCards with stubs
+// ════════════════════════════════════════════════════════════════
+describe('processDeviceStaleCards — behavioural escalation gate', () => {
+    const fnBody = extractFunctionBody(kanbanSrc, 'async function processDeviceStaleCards(deviceId, cards)');
+
+    // Build a fresh harness per scenario so call logs don't leak between tests.
+    function makeHarness(basePrefs) {
+        const calls = { block: [], l2: [], l1: [] };
+
+        const deps = {
+            devicePrefs: {
+                getPrefs: async () => basePrefs,
+                // No per-entity overrides in these scenarios — return base verbatim.
+                mergeEntityOverride: (base) => ({ ...base }),
+            },
+            KanbanStatus: {
+                NUDGE_DEFAULT_STATUSES: ['todo', 'in_progress', 'review'],
+            },
+            DEFAULT_ESCALATE_MS: 6 * 3600 * 1000,
+            DEFAULT_BLOCK_MS: 12 * 3600 * 1000,
+            loadDependencyGating: async () => ({ blocked: new Set(), unblockedSince: new Map() }),
+            loadEntityNudgeLog: async () => new Map(),
+            sortCardsByNudgeMode: (cards) => cards,
+            cardHasFreshRecipient: () => true,
+            buildEscalationRecipients: (card) => card.assigned_bots || [],
+            fireBlockEscalation: async (card) => { calls.block.push(card.id); },
+            fireLevelTwoEscalation: async (card) => { calls.l2.push(card.id); return true; },
+            fireLevelOneNudge: async (card) => { calls.l1.push(card.id); },
+            console: { log: () => {}, error: () => {} },
+        };
+
+        // eslint-disable-next-line no-new-func
+        const fn = new Function(
+            'devicePrefs', 'KanbanStatus', 'DEFAULT_ESCALATE_MS', 'DEFAULT_BLOCK_MS',
+            'loadDependencyGating', 'loadEntityNudgeLog', 'sortCardsByNudgeMode',
+            'cardHasFreshRecipient', 'buildEscalationRecipients',
+            'fireBlockEscalation', 'fireLevelTwoEscalation', 'fireLevelOneNudge', 'console',
+            `return async function processDeviceStaleCards(deviceId, cards) ${fnBody}`
+        )(
+            deps.devicePrefs, deps.KanbanStatus, deps.DEFAULT_ESCALATE_MS, deps.DEFAULT_BLOCK_MS,
+            deps.loadDependencyGating, deps.loadEntityNudgeLog, deps.sortCardsByNudgeMode,
+            deps.cardHasFreshRecipient, deps.buildEscalationRecipients,
+            deps.fireBlockEscalation, deps.fireLevelTwoEscalation, deps.fireLevelOneNudge, deps.console
+        );
+
+        return { fn, calls };
+    }
+
+    // 13h past status_changed_at → past blockAfterMs (12h) → would hit L3 if allowed.
+    const STALE_13H = new Date(Date.now() - 13 * 3600 * 1000).toISOString();
+
+    function card(overrides) {
+        return {
+            id: 'card_x',
+            device_id: 'dev1',
+            title: 'test',
+            priority: 'P2',
+            status: 'in_progress',
+            status_changed_at: STALE_13H,
+            last_stale_nudge_at: null,
+            assigned_bots: [1],
+            is_automation: false,
+            is_auto_generated: false,
+            config: {},
+            ...overrides,
+        };
+    }
+
+    const DEFAULT_PREFS = {
+        kanban_nudge_batch_size: 1,
+        kanban_nudge_priority_mode: 'priority_first',
+        kanban_nudge_interval_minutes: 180,
+        kanban_nudge_per_entity_throttle: true,
+        kanban_nudge_stop_mode: false,
+        kanban_nudge_statuses: ['todo', 'in_progress', 'review'],
+        kanban_nudge_per_entity_overrides: {},
+        kanban_auto_escalate_enabled: true,
+        kanban_auto_escalate_skip_automation: true,
+    };
+
+    test('DEFAULT prefs: is_auto_generated cron child does NOT escalate (no L3/L2), still L1-nudged', async () => {
+        const { fn, calls } = makeHarness({ ...DEFAULT_PREFS });
+        await fn('dev1', [card({ id: 'cron_child', is_auto_generated: true })]);
+        expect(calls.block).toEqual([]);   // no auto-block / P0-stalled ping
+        expect(calls.l2).toEqual([]);      // no priority bump
+        expect(calls.l1).toEqual(['cron_child']); // not forgotten — L1 still fires
+    });
+
+    test('DEFAULT prefs: is_automation cron母卡 also skips escalation', async () => {
+        const { fn, calls } = makeHarness({ ...DEFAULT_PREFS });
+        await fn('dev1', [card({ id: 'cron_mom', is_automation: true })]);
+        expect(calls.block).toEqual([]);
+        expect(calls.l2).toEqual([]);
+        expect(calls.l1).toEqual(['cron_mom']);
+    });
+
+    test('DEFAULT prefs: a NON-automation stale card DOES escalate (L3 fires)', async () => {
+        const { fn, calls } = makeHarness({ ...DEFAULT_PREFS });
+        await fn('dev1', [card({ id: 'human_card' })]);
+        expect(calls.block).toEqual(['human_card']); // L3 auto-block path fires
+        expect(calls.l1).toEqual([]);                // L3 continued past L1
+    });
+
+    test('master switch off: even a NON-automation card does NOT escalate (L1 only)', async () => {
+        const { fn, calls } = makeHarness({
+            ...DEFAULT_PREFS,
+            kanban_auto_escalate_enabled: false,
+        });
+        await fn('dev1', [card({ id: 'human_card' })]);
+        expect(calls.block).toEqual([]);
+        expect(calls.l2).toEqual([]);
+        expect(calls.l1).toEqual(['human_card']);
+    });
+
+    test('skip-automation off (master on): automation card escalates again', async () => {
+        const { fn, calls } = makeHarness({
+            ...DEFAULT_PREFS,
+            kanban_auto_escalate_skip_automation: false,
+        });
+        await fn('dev1', [card({ id: 'cron_child', is_auto_generated: true })]);
+        expect(calls.block).toEqual(['cron_child']);
+    });
+});


### PR DESCRIPTION
## Card
card_a0c2bc798affdf0a6310f5bb (Hank-direct **P0**) — 看板 auto-P0 升級開關，API 可控 + 預設對 automation cron 卡關閉。

## Problem (confirmed push-flood)
Cron-spawned child cards (`[Auto] … (date)`) hit the clock-triggered L2/L3 stale-escalation ladder in `processDeviceStaleCards` and fired `🚨 P0 stalled 主管請介入` supervisor pings (plus priority bumps + auto-block) **every interval**. These child cards have no owner actively working them, so they perpetually look "stale".

## Fix
Two new device-preference keys (in `backend/device-preferences.js` `DEFAULTS`, settable per device via `PUT /api/device-preferences`):

| key | default | meaning |
|---|---|---|
| `kanban_auto_escalate_enabled` | `true` | master on/off for the L2/L3 ladder (priority-bump **L2**, P0-stalled supervisor ping + auto-block **L3**). `false` ⇒ only L1 standard nudges fire. |
| `kanban_auto_escalate_skip_automation` | `true` | automation cards **never** auto-escalate even when the master switch is on (the cron-noise fix). |

`processDeviceStaleCards` gates **only** the two L2/L3 escalation `if` blocks behind:
```js
const escalationAllowed = autoEscalateEnabled && !(skipAutomationEscalation && isAutomationCard(card));
```
Skipped cards still fall through to the **L1 nudge** path, so work is never forgotten — only the priority-bump / P0-stalled-ping / auto-block escalations are suppressed.

## ⚠️ Root-cause detail (important)
The flooding cron child cards are **`is_auto_generated = true`, NOT `is_automation = true`** — the recurring child-card `INSERT` (kanban.js ~3978) sets `is_auto_generated=true` but never sets `is_automation` (DB default `FALSE`). Gating on `is_automation` alone (as a naive reading would) **would not catch the flood**. So `isAutomationCard()` checks **both** flags:
```js
const isAutomationCard = (card) => card.is_automation === true || card.is_auto_generated === true;
```
This is in-scope for the stated goal (stop the cron-noise flood). The cron母卡 (`is_automation=true`) is already filtered out of the stale SELECT by the recurring-schedule clause, so in practice this gate is what stops the **child** cards.

## How to set the prefs (curl)
Replace `<DEVICE_ID>` / `<DEVICE_SECRET>` with the device owner's credentials.

Disable auto-escalation entirely:
```bash
curl -X PUT https://eclawbot.com/api/device-preferences \
  -H "Content-Type: application/json" \
  -d '{"deviceId":"<DEVICE_ID>","deviceSecret":"<DEVICE_SECRET>","prefs":{"kanban_auto_escalate_enabled":false}}'
```
Re-enable escalation but keep cron cards quiet (this is the default):
```bash
curl -X PUT https://eclawbot.com/api/device-preferences \
  -H "Content-Type: application/json" \
  -d '{"deviceId":"<DEVICE_ID>","deviceSecret":"<DEVICE_SECRET>","prefs":{"kanban_auto_escalate_enabled":true,"kanban_auto_escalate_skip_automation":true}}'
```
Make automation cards escalate again (opt back in):
```bash
curl -X PUT https://eclawbot.com/api/device-preferences \
  -H "Content-Type: application/json" \
  -d '{"deviceId":"<DEVICE_ID>","deviceSecret":"<DEVICE_SECRET>","prefs":{"kanban_auto_escalate_skip_automation":false}}'
```
The keys accept a real boolean or the strings `"true"`/`"false"` (string `"false"` correctly coerces to `false`).

## Tests
New `backend/tests/jest/kanban-auto-escalate-toggle.test.js` (13 tests):
- `DEFAULTS` contract + the two keys are settable (in `DEFAULTS` → accepted by the PUT filter).
- Boolean coercion: `'false'` → `false` (not `!!('false')`).
- Source-grep gate invariants: gate present, checks both flags, L1 push stays OUTSIDE the gate.
- Behavioural smoke (reconstructs `processDeviceStaleCards` with stubs): cron child (`is_auto_generated`) + cron mom (`is_automation`) skip L2/L3 but still L1-nudge; non-automation card escalates; master-off suppresses escalation for everyone; skip-automation-off re-enables it.

Targeted run (real jest): all kanban + device-pref + parity suites — **381/381 pass, 35 suites**. Full `tests/jest` parallel run: 5211 pass / 17 skipped; the only red is `parity-aliases-3286` which **passes in isolation** (unrelated cross-suite handle-leak flake, nothing to do with this change — it tests VAPID/telemetry aliases).

## Out of scope
- Time-interval (cadence) tuning for escalation is not changed here; the existing per-entity `kanban_nudge_interval_minutes` already governs L1/L2/L3 firing cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gvuBUeX9NfbNNswNsGYmC