### PR TITLE
fix(wallpaper): isolate TtsService in :tts process — kill the residual FGS-deadline black screen (card_f9b2cc2d) [v1.1.9]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 118
-        versionName = "1.1.8"
+        versionCode = 119
+        versionName = "1.1.9"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -189,9 +189,18 @@
             </intent-filter>
         </service>
 
+        <!-- card_f9b2cc2d: run TtsService in an isolated ":tts" process. A
+             startForegroundService() that misses the OS 5s startForeground()
+             deadline triggers an ASYNC system kill (ForegroundServiceDidNotStart-
+             InTimeException) that no in-process try/catch can intercept. While the
+             service shared the main process, that kill took the live-wallpaper
+             engine down with it (pure black, needs app restart). Isolating it gives
+             the FGS its own idle main looper (so it makes the deadline) AND scopes
+             any residual kill to the :tts process, leaving the wallpaper alive. -->
         <service
             android:name=".service.TtsService"
             android:exported="false"
+            android:process=":tts"
             android:foregroundServiceType="mediaPlayback" />
 
         <!-- Facebook SDK -->

--- a/app/src/main/java/com/hank/clawlive/ClawApplication.kt
+++ b/app/src/main/java/com/hank/clawlive/ClawApplication.kt
@@ -2,6 +2,7 @@ package com.hank.clawlive
 
 import android.app.Application
 import android.content.Context
+import android.os.Build
 import com.google.firebase.messaging.FirebaseMessaging
 import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.remote.NetworkModule
@@ -31,6 +32,19 @@ class ClawApplication : Application() {
         }
         val fileTree = FileTimberTree(this)
         Timber.plant(fileTree)
+
+        // card_f9b2cc2d: TtsService now runs in an isolated ":tts" process (see
+        // AndroidManifest) so an FGS-deadline kill can never take the main process
+        // (and the live wallpaper) down. The Application object is instantiated in
+        // EVERY process, but the heavy main-process bootstrap below — Telemetry,
+        // FCM token self-heal, Play Integrity, pending-crash upload, FCM channels —
+        // must run ONLY in the main process. Re-running it in :tts would double-
+        // register the FCM token and waste startup. Bail out after Timber so the
+        // :tts process keeps just enough for TtsService's own logging.
+        if (isTtsProcess()) {
+            Timber.i("ClawApplication: running in :tts process — minimal init only")
+            return
+        }
 
         // 2. Initialize crash log manager
         CrashLogManager.init(this)
@@ -97,6 +111,31 @@ class ClawApplication : Application() {
         reportPlayIntegrityStartup()
 
         Timber.i("ClawApplication initialized")
+    }
+
+    /** True when this Application instance is hosting the isolated ":tts" process. */
+    private fun isTtsProcess(): Boolean {
+        val name = currentProcessName() ?: return false
+        return name.endsWith(":tts")
+    }
+
+    /**
+     * Current process name. Uses the framework API on P+ and falls back to
+     * /proc/self/cmdline on API 24–27 (minSdk is 24). Returns null if it cannot
+     * be determined — callers treat null as "assume main process".
+     */
+    private fun currentProcessName(): String? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            return try { getProcessName() } catch (_: Throwable) { null }
+        }
+        return try {
+            java.io.File("/proc/self/cmdline").readText()
+                .substringBefore('\u0000')
+                .trim()
+                .ifEmpty { null }
+        } catch (_: Throwable) {
+            null
+        }
     }
 
     private fun reportPlayIntegrityStartup() {

--- a/app/src/main/java/com/hank/clawlive/data/remote/SocketManager.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/SocketManager.kt
@@ -1,6 +1,8 @@
 package com.hank.clawlive.data.remote
 
 import android.content.Context
+import android.content.Intent
+import android.os.Build
 import com.hank.clawlive.BuildConfig
 import com.hank.clawlive.data.local.DeviceManager
 import io.socket.client.IO
@@ -46,6 +48,13 @@ object SocketManager {
 
     fun connect(context: Context) {
         if (isInitialized) return
+
+        // card_f9b2cc2d: TtsService now lives in an isolated ":tts" process, so the
+        // socket's in-process ttsFlow can't reach it. Hold the application context
+        // (never an Activity — these socket callbacks outlive any screen) so the
+        // device:tts handler can forward each utterance across the process boundary
+        // via an explicit Intent.
+        val appCtx = context.applicationContext
 
         val dm = DeviceManager.getInstance(context)
         val deviceId = dm.deviceId
@@ -116,6 +125,31 @@ object SocketManager {
                     val json = args.firstOrNull() as? JSONObject ?: return@on
                     Timber.d("[Socket] device:tts: $json")
                     _ttsFlow.tryEmit(json)
+                    // card_f9b2cc2d: forward to the isolated :tts process via Intent.
+                    // TtsService.onStartCommand reads these extras and speaks. Wrapped
+                    // in try/catch because a backgrounded startForegroundService() can
+                    // throw ForegroundServiceStartNotAllowedException on Android 12+;
+                    // an uncaught throw here would kill the MAIN process (and the live
+                    // wallpaper), the very crash this whole change exists to prevent.
+                    try {
+                        val text = json.optString("text", "")
+                        if (text.isNotEmpty()) {
+                            val ttsIntent = Intent(appCtx, com.hank.clawlive.service.TtsService::class.java).apply {
+                                putExtra("tts_text", text)
+                                putExtra("tts_lang", json.optString("lang", "zh-TW"))
+                                putExtra("tts_speed", json.optDouble("speed", 1.0).toFloat())
+                                putExtra("tts_pitch", json.optDouble("pitch", 1.0).toFloat())
+                                putExtra("tts_entity_name", json.optString("entityName", "Bot"))
+                            }
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                appCtx.startForegroundService(ttsIntent)
+                            } else {
+                                appCtx.startService(ttsIntent)
+                            }
+                        }
+                    } catch (e: Exception) {
+                        Timber.e(e, "[Socket] Failed to start :tts TtsService for device:tts")
+                    }
                 }
 
                 on("location_request") { args ->


### PR DESCRIPTION
## Problem
The residual ~1/10 **"send msg → Home → ~3s → pure-black wallpaper, needs app restart"** survived every v1.1.3–1.1.8 in-process mitigation (render resilience, `startForeground` on every start, `START_NOT_STICKY`, FGS-crash swallow).

**Root cause:** a `startForegroundService()` that misses the OS ~5s `startForeground()` deadline is killed by the system via an **async** `ForegroundServiceDidNotStartInTimeException` (thrown by ActivityManager, *not* synchronously inside `startForeground()`), so the in-process try/catch in `TtsService.ensureForeground()` can never intercept it. While `TtsService` shared the **main** process, that kill took the live-wallpaper engine down with it → pure black until relaunch.

## Fix — process isolation (guaranteed, not just prevention)
- **AndroidManifest**: `TtsService` gets `android:process=":tts"`. The FGS now has its own idle main looper (makes the deadline) **and** any residual deadline-kill is scoped to the `:tts` process — the wallpaper in the main process survives.
- **ClawApplication.onCreate**: bail out after Timber when running in `:tts` (new `isTtsProcess()`/`currentProcessName()`, `getProcessName()` on P+ / `/proc/self/cmdline` on 24–27) so the heavy main-process bootstrap (Telemetry, FCM self-heal, Play Integrity, crash upload, channels) does **not** re-run / double-register in the isolated process.
- **SocketManager**: the socket `device:tts` event can no longer reach the now cross-process `TtsService` via the in-process `ttsFlow`, so forward each utterance with `startForegroundService(Intent + tts_text/lang/speed/pitch/entity)`, wrapped in try/catch so a backgrounded start can't crash the main process either.

## Verification (emulator Pixel_9a, vc119 debug)
- App boots clean: **main pid + `:tts` pid** both spawn; 0 FATAL / 0 `DidNotStartInTime`.
- Process guard fires: `:tts` logs `"running in :tts process — minimal init only"`; full init + FCM register only in main (no double-register).
- TTS not regressed: `[TTS] Engine initialized successfully` **inside the `:tts` process** (Google TTS cmn-TW loaded).
- **The fix, proven**: `run-as kill -9` of the `:tts` process (the exact thing the FGS-deadline kill does) leaves the **main process (wallpaper host) UNCHANGED and healthy** — FCM/WebView/Socket all still alive. Pre-isolation that same kill blacked the wallpaper.

## Notes
- Reopens card_f9b2cc2d (was prematurely closed at v1.1.8; the residual black screen was still reproducible — Hank reproduced it on the simulator).
- Version bump 118→**119** / 1.1.8→**1.1.9**. (Branch name says vc118 but the commit ships vc119.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)