### PR TITLE
fix(wallpaper): guard null fromCharacter in render loop — stop black-screen NPE (card_f22e489c)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -826,7 +826,13 @@ class ClawRenderer(
             entity.messageQueue.orEmpty().mapNotNull { queueItem ->
                 val text = queueItem.text?.trim().orEmpty()
                 if (text.isBlank()) return@mapNotNull null
-                if (queueItem.fromCharacter.isBlank()) return@mapNotNull null
+                // Gson can bypass Kotlin null-safety: user/scheduled messages lack
+                // fromCharacter (backend only sets it on entity-to-entity messages), so a
+                // null slips into this non-null-typed field. Calling .isBlank() directly
+                // threw NPE on every draw frame → blank/black wallpaper (card_f22e489c).
+                // Mirror the same defensive guard StateRepository already uses.
+                @Suppress("SENSELESS_COMPARISON")
+                if (queueItem.fromCharacter == null || queueItem.fromCharacter.isBlank()) return@mapNotNull null
                 if (queueItem.fromEntityId !in entityIds) return@mapNotNull null
                 if (queueItem.fromEntityId == entity.entityId && queueItem.routingMode != "broadcast") {
                     return@mapNotNull null


### PR DESCRIPTION
## Root cause (evidence-based, not speculative)
The wallpaper-black-screen regression (card_f22e489c) is **not** process death / FGS — it's a **render NPE** on every draw frame.

`ClawRenderer.refreshConversationGroups()` (ClawRenderer.kt:829) calls `.isBlank()` directly on `queueItem.fromCharacter`. That field is declared non-null `String` (EntityStatus.kt:78 `MessageQueueItem`) but is **null at runtime** for user/scheduled messages — the backend only sets `fromCharacter` on entity-to-entity messages, and Gson bypasses Kotlin null-safety. The Kotlin non-null intrinsic throws `NullPointerException: Parameter specified as non-null is null: ...isBlank` → the draw frame can't paint → solid black. The process stays alive (PID unchanged), so it never reaches Crashlytics (field crash-free stayed 100%, and the FGS crash issue is confined to old 1.1.3–1.1.6).

### Captured on emulator (v1.1.8) via live logcat during reproduction
```
render stage failed: layout
java.lang.NullPointerException: Parameter specified as non-null is null: method kotlin.text.StringsKt__StringsKt.isBlank, parameter <this>
  at ClawRenderer.refreshConversationGroups(ClawRenderer.kt:829)
  at ClawRenderer.drawMultiEntity(ClawRenderer.kt:629)
  at ClawWallpaperService$ClawEngine.draw(ClawWallpaperService.kt:485)
  ← onVisibilityChanged → restartInactivePollersAndDraw → draw
```
3276× the same NPE, PID unchanged throughout. Repro: send a user message → swipe-up Home (wallpaper becomes visible) → ~3s → black.

## Fix
Mirror the **exact** defensive guard the codebase already uses for this same field in `StateRepository.kt:381` (which has a comment: *user/scheduled messages lack fromCharacter; Gson can bypass Kotlin null safety*). ClawRenderer.kt:829 was the one site that omitted the `== null` guard. One-file change, no data-class type change, no compile ripple.

## Verification
- `./gradlew :app:assembleDebug` ✅ BUILD SUCCESSFUL; installed in-place on emulator (login/binding preserved).
- ⚠️ Final on-device A/B (Claw wallpaper re-set + repro on fixed build) **pending** — the emulator's live wallpaper reverted to the system default after app restarts and could not be re-set to ClawWallpaperService via adb on this image. Owner (#2/Hank) to re-set the Claw live wallpaper and run the repro on the already-installed fixed APK for final sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)