### PR TITLE
fix(idle-dispatch): guard non-integer botId before SQL int cast (card_4e82263a)

### DIFF
--- a/backend/api_idle_dispatch.js
+++ b/backend/api_idle_dispatch.js
@@ -147,11 +147,20 @@ router.get('/bot-status/:botId', async (req, res) => {
             return res.status(401).json({ success: false, error: 'Authentication required' });
         }
 
-        const busy = await isBotBusy(deviceId, parseInt(botId));
+        // Validate botId is a real integer BEFORE it reaches the SQL int cast
+        // (isBotBusy does `to_jsonb($2::int)`). A non-numeric path param would
+        // otherwise parseInt → NaN → Postgres "invalid input syntax for type
+        // integer: \"NaN\"" (logged as "Bot status error"). Reject up front.
+        const botEntityId = Number.parseInt(botId, 10);
+        if (!Number.isInteger(botEntityId)) {
+            return res.status(400).json({ success: false, error: 'Invalid botId — must be an integer' });
+        }
+
+        const busy = await isBotBusy(deviceId, botEntityId);
 
         res.json({
             success: true,
-            botEntityId: parseInt(botId),
+            botEntityId,
             isBusy: busy,
             status: busy ? 'busy' : 'idle'
         });

--- a/backend/tests/jest/idle-dispatch-botstatus-nan.test.js
+++ b/backend/tests/jest/idle-dispatch-botstatus-nan.test.js
@@ -1,0 +1,83 @@
+/**
+ * idle-dispatch-botstatus-nan.test.js
+ * Regression for card_4e82263a — GET /bot-status/:botId used parseInt(botId)
+ * with no validation, so a non-numeric path param became NaN and reached
+ * isBotBusy's `to_jsonb($2::int)`, crashing with Postgres
+ * `invalid input syntax for type integer: "NaN"` (logged "Bot status error").
+ * The route must now reject a non-integer botId with 400 BEFORE touching the DB.
+ *
+ * Uses a real ephemeral express server + node http (no supertest dependency).
+ */
+const http = require('http');
+const express = require('express');
+
+jest.mock('../../idle_dispatch_handler', () => ({
+    smartDispatch: jest.fn(),
+    drainBotQueue: jest.fn(),
+    cleanupStuckQueue: jest.fn(),
+    getQueueStatus: jest.fn(),
+    isBotBusy: jest.fn().mockResolvedValue(false),
+}));
+
+const handler = require('../../idle_dispatch_handler');
+const router = require('../../api_idle_dispatch');
+
+function startServer() {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/mission/idle-dispatch', router);
+    return new Promise((resolve) => {
+        const server = app.listen(0, () => resolve(server));
+    });
+}
+
+function get(server, urlPath) {
+    const { port } = server.address();
+    return new Promise((resolve, reject) => {
+        http.get({ host: '127.0.0.1', port, path: urlPath }, (res) => {
+            let body = '';
+            res.on('data', (c) => { body += c; });
+            res.on('end', () => resolve({ status: res.statusCode, body: body ? JSON.parse(body) : {} }));
+        }).on('error', reject);
+    });
+}
+
+const AUTH = 'deviceId=dev1&entityId=2&botSecret=sec1';
+
+describe('GET /api/mission/idle-dispatch/bot-status/:botId — NaN guard (card_4e82263a)', () => {
+    let server;
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        handler.isBotBusy.mockResolvedValue(false);
+        server = await startServer();
+    });
+    afterEach((done) => { server.close(done); });
+
+    test('non-numeric "NaN" botId → 400 and never calls the DB layer', async () => {
+        const res = await get(server, `/api/mission/idle-dispatch/bot-status/NaN?${AUTH}`);
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(handler.isBotBusy).not.toHaveBeenCalled();
+    });
+
+    test('alphabetic botId → 400, no DB call', async () => {
+        const res = await get(server, `/api/mission/idle-dispatch/bot-status/abc?${AUTH}`);
+        expect(res.status).toBe(400);
+        expect(handler.isBotBusy).not.toHaveBeenCalled();
+    });
+
+    test('valid numeric botId → 200 and isBotBusy called with the parsed integer', async () => {
+        handler.isBotBusy.mockResolvedValue(true);
+        const res = await get(server, `/api/mission/idle-dispatch/bot-status/5?${AUTH}`);
+        expect(res.status).toBe(200);
+        expect(res.body.botEntityId).toBe(5);
+        expect(res.body.isBusy).toBe(true);
+        expect(handler.isBotBusy).toHaveBeenCalledWith('dev1', 5);
+    });
+
+    test('missing auth → 401 (guard order unchanged)', async () => {
+        const res = await get(server, '/api/mission/idle-dispatch/bot-status/5');
+        expect(res.status).toBe(401);
+        expect(handler.isBotBusy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Problem
`GET /api/mission/idle-dispatch/bot-status/:botId` called `parseInt(botId)` on the path param with no validation. A non-numeric `botId` (scanner / malformed request / `undefined`) → `NaN` → passed into `isBotBusy(deviceId, NaN)` → `to_jsonb($2::int)` → Postgres **`invalid input syntax for type integer: "NaN"`**, surfaced in Railway prod logs as `Bot status error` (card_4e82263a, caught by #5's 6h log monitor).

## Fix
Validate `botId` at the route boundary: parse with `Number.parseInt(botId, 10)` and return **400** if `!Number.isInteger(...)` — before any DB call. The validated integer is reused for both `isBotBusy` and the response `botEntityId`.

## Test
New `backend/tests/jest/idle-dispatch-botstatus-nan.test.js` (ephemeral express server + node http, mocked DB handler):
- non-numeric `"NaN"` botId → 400, `isBotBusy` never called
- alphabetic botId → 400, no DB call
- valid numeric botId → 200, `isBotBusy` called with the parsed integer
- missing auth → 401 (guard order unchanged)

All 4 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)