### PR TITLE
fix(ios): send appVersion to /api/version so Settings update-chip can trigger (card_1771f826)

### DIFF
--- a/ios-app/app/(tabs)/settings.tsx
+++ b/ios-app/app/(tabs)/settings.tsx
@@ -98,7 +98,7 @@ export default function SettingsScreen() {
     let cancelled = false;
     (async () => {
       try {
-        const res = await miscApi.getVersion();
+        const res = await miscApi.getVersion(appVersion);
         const u = res?.data?.update;
         if (cancelled) return;
         if (shouldShowChip(u?.available, appVersion, u?.latestVersion)) {

--- a/ios-app/services/__tests__/miscApi.getVersion.test.ts
+++ b/ios-app/services/__tests__/miscApi.getVersion.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression for card_1771f826 — the iOS Settings "update-available" chip never
+ * triggered because `miscApi.getVersion()` called `/api/version` WITHOUT an
+ * `appVersion` query param. The backend only returns the `update` block (and
+ * thus `update.available`) when `?appVersion=` is present
+ * (backend/index.js app.get('/api/version')), so `res.data.update` was always
+ * undefined and `shouldShowChip` could never be true.
+ *
+ * This locks in that getVersion forwards the installed appVersion to the backend.
+ */
+
+// Mock axios so api.ts's `axios.create()` returns a stable stub instance we can
+// assert against. The request interceptor never runs here (get is stubbed), so
+// SecureStore is not exercised, but we mock it to keep the import graph clean.
+const mockGet = jest.fn(() => Promise.resolve({ data: {} }));
+const mockInstance = {
+  get: mockGet,
+  post: jest.fn(() => Promise.resolve({ data: {} })),
+  interceptors: {
+    request: { use: jest.fn() },
+    response: { use: jest.fn() },
+  },
+};
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { create: jest.fn(() => mockInstance) },
+  create: jest.fn(() => mockInstance),
+}));
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+  deleteItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+import { miscApi } from '../api';
+
+describe('miscApi.getVersion (card_1771f826)', () => {
+  beforeEach(() => {
+    mockGet.mockClear();
+  });
+
+  test('forwards the installed appVersion so backend returns the update block', async () => {
+    await miscApi.getVersion('1.0.0');
+    expect(mockGet).toHaveBeenCalledWith('/api/version', {
+      params: { appVersion: '1.0.0' },
+    });
+  });
+
+  test('omits appVersion (undefined) when none is supplied — no false param', async () => {
+    await miscApi.getVersion();
+    expect(mockGet).toHaveBeenCalledWith('/api/version', {
+      params: { appVersion: undefined },
+    });
+  });
+
+  test('null installed version is normalised to undefined, not sent as "null"', async () => {
+    await miscApi.getVersion(null);
+    expect(mockGet).toHaveBeenCalledWith('/api/version', {
+      params: { appVersion: undefined },
+    });
+  });
+});

--- a/ios-app/services/api.ts
+++ b/ios-app/services/api.ts
@@ -428,7 +428,12 @@ export const settingsManifestApi = {
 // ── Misc APIs ────────────────────────────────────────────────
 
 export const miscApi = {
-  getVersion: () => apiClient.get('/api/version'),
+  // Pass the installed appVersion so the backend returns the `update` block.
+  // /api/version only computes `update.available` when `?appVersion=` is present
+  // (backend/index.js app.get('/api/version')); without it res.data.update is
+  // undefined and the Settings update-chip can never trigger (card_1771f826).
+  getVersion: (appVersion?: string | null) =>
+    apiClient.get('/api/version', { params: { appVersion: appVersion ?? undefined } }),
   getFreeBotTos: () => apiClient.get('/api/free-bot-tos'),
   agreeFreeBotTos: () => apiClient.post('/api/free-bot-tos/agree'),
 };


### PR DESCRIPTION
## Problem
The iOS Settings **update-available chip** (card_1771f826) never appeared. Root cause: `miscApi.getVersion()` called `/api/version` **without** `?appVersion=`. The backend only returns the `update` block (`update.available`/`latestVersion`) when `appVersion` is present (`backend/index.js` `app.get('/api/version')`), so `res.data.update` was always `undefined` and `shouldShowChip()` could never be true.

Live confirmation: `/api/version` → no `update`; `/api/version?appVersion=1.0.0` → `update.available=true, latestVersion=1.0.96`.

## Fix (2 lines + test)
- `ios-app/services/api.ts`: `getVersion(appVersion?)` forwards `{ params: { appVersion } }` (mirrors sibling `settingsManifestApi.get`).
- `ios-app/app/(tabs)/settings.tsx`: passes installed `Constants.expoConfig.version`.
- New jest regression `miscApi.getVersion.test.ts`: asserts the param is forwarded + null/absent normalises to `undefined` (never the string `null`).

Downstream logic (`shouldShowChip` defensive cross-check, App Store redirect) was already correct — only the request was missing the param.

## Test
ts-jest: **3 suites / 30 tests green** (new + existing updateChip/settingsManifest). CI has no ios-app jest job (only ios-i18n) → validated locally.

## Credit / follow-up
Found by **#6** during iOS-simulator review — #6 correctly refused to fabricate the screenshot and re-blocked the card. Remaining after merge: iOS-simulator visual verification of the chip + App Store redirect → back to #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)