### PR TITLE
fix(portal): QA/UIUX sweep — i18n fallback + a11y labels (card_4cafbf7e)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3775,9 +3775,9 @@
 
     <!-- Photo Lightbox -->
     <div class="lightbox" id="lightbox" onclick="if(event.target===this)closeLightbox()">
-        <button class="lightbox-arrow prev" onclick="event.stopPropagation();lightboxNav(-1)">&#8249;</button>
+        <button class="lightbox-arrow prev" aria-label="Previous image" onclick="event.stopPropagation();lightboxNav(-1)">&#8249;</button>
         <img id="lightboxImg" src="" alt="Enlarged chat image" onclick="event.stopPropagation();toggleLightboxZoom()">
-        <button class="lightbox-arrow next" onclick="event.stopPropagation();lightboxNav(1)">&#8250;</button>
+        <button class="lightbox-arrow next" aria-label="Next image" onclick="event.stopPropagation();lightboxNav(1)">&#8250;</button>
         <div class="lightbox-counter" id="lightboxCounter"></div>
     </div>
 
@@ -3837,7 +3837,7 @@
                 </div>
                 <div style="display:flex;gap:6px;align-items:flex-start">
                     <button class="entity-modal-close" id="entityModalRequoteBtn" data-i18n-title="chip_popover_requote" title="再引用到聊天" onclick="requoteFromEntityModal()" style="font-size:18px">📌</button>
-                    <button class="entity-modal-close" onclick="closeModal('entityPreviewModal')">&times;</button>
+                    <button class="entity-modal-close" aria-label="Close" onclick="closeModal('entityPreviewModal')">&times;</button>
                 </div>
             </div>
             <div class="entity-modal-body" id="entityModalBody">
@@ -3871,7 +3871,7 @@
                     <div class="note-modal-title" id="noteModalTitle">Note</div>
                     <div class="note-modal-id" id="noteModalId"></div>
                 </div>
-                <button class="note-modal-close" onclick="closeModal('notePreviewModal')">&times;</button>
+                <button class="note-modal-close" aria-label="Close" onclick="closeModal('notePreviewModal')">&times;</button>
             </div>
             <div class="note-modal-body" id="noteModalBody">
                 <div class="note-modal-loading">Loading...</div>

--- a/backend/public/portal/feedback.html
+++ b/backend/public/portal/feedback.html
@@ -760,7 +760,7 @@
         </div>
 
         <!-- Ask AI Banner -->
-        <div class="ask-ai-banner" onclick="openAiChat()">
+        <div class="ask-ai-banner" role="button" tabindex="0" aria-label="Ask AI for help" onclick="openAiChat()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();openAiChat();}">
             <span class="ask-ai-banner-icon">🤖</span>
             <div class="ask-ai-banner-text">
                 <div class="ask-ai-banner-title" data-i18n="feedback_ask_ai_title">Need quick help? Ask AI</div>

--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -453,7 +453,13 @@
 
     // i18n helper
     function t(key, fallback) {
-        return typeof i18n !== 'undefined' ? i18n.t(key) : fallback;
+        // i18n.t returns the bare key when it's missing; use our inline fallback in
+        // that case so users never see a raw key like "sc_send_failed" (card_4cafbf7e QA).
+        if (typeof i18n !== 'undefined' && i18n.t) {
+            const v = i18n.t(key);
+            if (v && v !== key) return v;
+        }
+        return fallback;
     }
 
     function shareLinkUrl() {

--- a/backend/public/portal/shared/reconnect-overlay.js
+++ b/backend/public/portal/shared/reconnect-overlay.js
@@ -32,7 +32,16 @@
         el.id = BANNER_ID;
         el.setAttribute('role', 'status');
         el.setAttribute('aria-live', 'polite');
-        const t = (k, fb) => (window.i18n && window.i18n.t) ? window.i18n.t(k, fb) : fb;
+        // i18n.t(key, params) treats the 2nd arg as {name}-substitution params, NOT a
+        // fallback, and returns the bare key string when the key is missing. So pass the
+        // inline fallback ourselves when i18n has no translation (card_4cafbf7e QA).
+        const t = (k, fb) => {
+            if (window.i18n && window.i18n.t) {
+                const v = window.i18n.t(k);
+                if (v && v !== k) return v;
+            }
+            return fb;
+        };
         el.innerHTML = '<span class="spinner" aria-hidden="true"></span>' +
             '<span>' + t('reconnect_overlay_text', '網路連線中斷，正在重新連線…') + '</span>';
         el.title = t('reconnect_overlay_help',


### PR DESCRIPTION
## Daily QA/UIUX regression sweep (card_4cafbf7e)
Covering #1's daily QA card while it's rate-limited. A 9-surface multi-agent audit (each finding adversarially verified vs origin/main + prod) found **0 P0, 1 P1, 14 P2** — no broken core flows. This PR fixes the confirmed user-visible ones (13 findings); 2 locale-stub findings filed as an issue.

### 🔴 i18n fallback — raw key shown to users (9 findings)
`reconnect-overlay.js` and `share-chat.html` each had a local `t(key, fallback)` that calls `i18n.t(key)` — but `i18n.t(key, params)` returns the **bare key** when the key is missing (its 2nd arg is `{name}`-substitution params, **not** a fallback; confirmed in i18n.js `t()` at the `if (str === undefined) str = key` line). Result:
- reconnect banner rendered the literal `reconnect_overlay_text`
- share-chat rendered raw keys like `sc_send_failed` / `sc_google_login_failed` on OAuth/SDK/send errors

Both helpers now return their **inline fallback** when i18n has no translation. **No change to the 7.7M-line i18n.js.**

### ♿ Accessibility — missing accessible names (4 findings)
- `chat.html`: lightbox prev/next arrows + entity/note modal close buttons used only glyph entities (‹ › ×) → added `aria-label`.
- `feedback.html`: Ask-AI banner was a `div` with `onclick` and no keyboard/role → added `role=button`, `tabindex=0`, `aria-label`, Enter/Space handler.

### Verify
- `node backend/scripts/i18n-check.js` ✅ (all referenced keys resolve in EN)
- portal jest **44 suites / 506 tests green**
- `node --check reconnect-overlay.js` ✅
- 4 files, +22/-7

### Out of scope (filed as issue)
`community_invite_guest_*` / `about_founder_*` keys missing in non-EN/ZH **stub** locales (en/zh fallback already works — these locales are intentional stubs per i18n-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)