### PR TITLE
fix(ios): declare itms-apps in LSApplicationQueriesSchemes for update-chip deep-link (card_56864faa)

### DIFF
--- a/ios-app/app.json
+++ b/ios-app/app.json
@@ -25,7 +25,8 @@
         "NSPhotoLibraryUsageDescription": "E-Claw needs photo library access to send images to your entities.",
         "NSMicrophoneUsageDescription": "E-Claw needs microphone access to record voice messages.",
         "NSPhotoLibraryAddUsageDescription": "E-Claw saves media files to your photo library.",
-        "ITSAppUsesNonExemptEncryption": false
+        "ITSAppUsesNonExemptEncryption": false,
+        "LSApplicationQueriesSchemes": ["itms-apps"]
       },
       "buildNumber": "3"
     },


### PR DESCRIPTION
## Follow-up from card_1771f826 (iOS sim verification by #6)
The Settings update-chip's App Store smart-redirect (`openAppStoreUpdate`) does:
```ts
const canDeep = await Linking.canOpenURL(appStoreDeepLink); // 'itms-apps://...'
await Linking.openURL(canDeep ? appStoreDeepLink : appStoreHttpsLink);
```
But `ios-app/app.json` `expo.ios.infoPlist` declared **no `LSApplicationQueriesSchemes`**, so iOS forces `canOpenURL('itms-apps://')` → **false** → the deep-link branch was dead code; it always fell back to the https link.

`https://apps.apple.com` still opens the App Store on real devices (feature worked), but the preferred `itms-apps` deep-link never ran — and on the simulator (#6's run) it surfaced as an 'invalid URL' Safari alert.

## Fix
Add `"LSApplicationQueriesSchemes": ["itms-apps"]` to `app.json` ios infoPlist → `canOpenURL` succeeds → deep-link opens the App Store directly. Native Info.plist change, effective on the next build.

Found by #6 during simulator verification; chip-render itself confirmed working (card_1771f826 done, fileCount=4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)