### PR TITLE
feat(action-requests): backend model + API for 需要你 HITL inbox (card_edeb190b)

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -1,0 +1,289 @@
+/**
+ * Agent Action Requests — the "需要你" Human-in-the-Loop inbox.
+ *
+ * Mounted at: /api/action-requests
+ *
+ * An autonomous agent (entity) that gets blocked needing the user EMITS a
+ * request here. The chat-page "需要你" inbox LISTS pending requests; the user
+ * RESOLVES or DISMISSES them, and (if dispatch callbacks are wired) the answer
+ * is pushed back to the emitting agent so it can unblock and continue.
+ *
+ * Endpoints:
+ *   POST   /            — emit a request        (agent action → botSecret+entityId, or deviceSecret+fromEntityId)
+ *   GET    /            — list requests          (deviceSecret OR botSecret; default status=pending)
+ *   POST   /:id/resolve — answer a request       (user action → deviceSecret, or botSecret)
+ *   POST   /:id/dismiss — drop a request         (user action → deviceSecret, or botSecret)
+ *
+ * `anchorMessageId` pins the originating chat message (a chat_messages UUID,
+ * surfaced in chat as his_<uuid>) so the inbox item routes back to that
+ * message and a smart-quote reply can be correlated to the exact request.
+ * The full smart-quote round-trip wiring lives in child card_b51598b7; this
+ * module is the model + emit/list/resolve API (child card_edeb190b).
+ *
+ * Parent spec: card_a03d9d09.
+ */
+
+const express = require('express');
+const { Pool } = require('pg');
+const fs = require('fs');
+const path = require('path');
+const safeEqual = require('./safe-equal');
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
+});
+
+const MAX_PROMPT_LEN = 2000;
+const MAX_LIST_LIMIT = 500;
+const VALID_TYPES = new Set(['decision', 'approval', 'input', 'credential', 'review', 'clarify']);
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+async function initAgentActionRequestsDatabase() {
+    try {
+        const schemaPath = path.join(__dirname, 'agent_action_requests_schema.sql');
+        const schema = fs.readFileSync(schemaPath, 'utf8');
+        const cleaned = schema.replace(/--[^\n]*/g, '').replace(/\n\s*\n/g, '\n');
+        const statements = cleaned.split(';').map(s => s.trim()).filter(s => s.length > 5);
+        let ok = 0, skipped = 0, failed = 0;
+        for (const stmt of statements) {
+            try {
+                await pool.query(stmt);
+                ok++;
+            } catch (err) {
+                if (err.message.includes('already exists') || err.message.includes('duplicate key')) {
+                    skipped++;
+                } else {
+                    failed++;
+                    console.error('[AgentActionRequests] Schema failed:', err.message, '\n  stmt:', stmt.slice(0, 80));
+                }
+            }
+        }
+        console.log(`[AgentActionRequests] Database initialized: ${ok} OK, ${skipped} skipped, ${failed} failed`);
+    } catch (error) {
+        console.error('[AgentActionRequests] Failed to init database:', error.message);
+    }
+}
+
+// ── Helpers ──
+function normalizeAnchor(value) {
+    if (typeof value === 'string' && UUID_RE.test(value.trim())) return value.trim();
+    return null;
+}
+
+function rowToApi(row) {
+    return {
+        id: row.id,
+        fromEntityId: row.from_entity_id,
+        anchorMessageId: row.anchor_message_id || null,
+        type: row.type,
+        prompt: row.prompt,
+        options: row.options || null,
+        status: row.status,
+        answer: row.answer || null,
+        createdAt: new Date(row.created_at).getTime(),
+        resolvedAt: row.resolved_at ? new Date(row.resolved_at).getTime() : null,
+    };
+}
+
+/**
+ * Factory. Matches the kanban/scheduled-messages module style so index.js wires it the same way.
+ */
+module.exports = function (devices, { pushToBot, unifiedPush, serverLog } = {}) {
+    const router = express.Router();
+
+    function log(level, msg, meta) {
+        if (typeof serverLog === 'function') {
+            try { serverLog(level, 'agent_action_requests', msg, meta || {}); } catch (_) {}
+        }
+    }
+
+    // ── Dual auth: deviceSecret (user) OR botSecret+entityId (agent) ──
+    // Returns { device, deviceId, entityId|null, isUser } or null (after sending the error response).
+    function authenticate(req, res) {
+        const params = { ...req.query, ...req.body };
+        const { deviceId, deviceSecret, botSecret, entityId } = params;
+        if (!deviceId) {
+            res.status(400).json({ success: false, error: 'Missing deviceId' });
+            return null;
+        }
+        const device = devices && devices[deviceId];
+        if (deviceSecret) {
+            if (device && safeEqual(device.deviceSecret, deviceSecret)) {
+                return { device, deviceId, entityId: null, isUser: true };
+            }
+            res.status(401).json({ success: false, error: 'Invalid credentials' });
+            return null;
+        }
+        if (botSecret) {
+            const eid = parseInt(entityId, 10);
+            const entity = device && device.entities && device.entities[eid];
+            if (entity && entity.isBound && safeEqual(entity.botSecret, botSecret)) {
+                return { device, deviceId, entityId: eid, isUser: false };
+            }
+            res.status(401).json({ success: false, error: 'Invalid credentials' });
+            return null;
+        }
+        res.status(400).json({ success: false, error: 'Missing deviceSecret or botSecret' });
+        return null;
+    }
+
+    // ════════════════════════════════════════
+    // POST / — emit an action request
+    // ════════════════════════════════════════
+    router.post('/', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const { type, prompt, options, anchorMessageId } = req.body || {};
+
+        // from_entity_id: a bot emits as itself; a user (deviceSecret) must name the agent.
+        let fromEntityId = auth.isUser ? parseInt(req.body.fromEntityId, 10) : auth.entityId;
+        if (!Number.isInteger(fromEntityId) || fromEntityId < 0) {
+            return res.status(400).json({ success: false, error: 'fromEntityId required (integer)' });
+        }
+        if (typeof type !== 'string' || !VALID_TYPES.has(type)) {
+            return res.status(400).json({ success: false, error: `type must be one of: ${[...VALID_TYPES].join('|')}` });
+        }
+        if (typeof prompt !== 'string' || prompt.length < 1 || prompt.length > MAX_PROMPT_LEN) {
+            return res.status(400).json({ success: false, error: `prompt must be a string of length 1..${MAX_PROMPT_LEN}` });
+        }
+        if (options !== undefined && options !== null && !Array.isArray(options)) {
+            return res.status(400).json({ success: false, error: 'options must be an array when provided' });
+        }
+        const anchor = normalizeAnchor(anchorMessageId);
+
+        try {
+            const result = await pool.query(
+                `INSERT INTO agent_action_requests
+                    (device_id, from_entity_id, anchor_message_id, type, prompt, options)
+                 VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                 RETURNING *`,
+                [deviceId, fromEntityId, anchor, type, prompt, options != null ? JSON.stringify(options) : null]
+            );
+            const row = result.rows[0];
+            log('info', `emit id=${row.id} from=${fromEntityId} type=${type}`, { deviceId });
+            return res.json({ success: true, request: rowToApi(row) });
+        } catch (err) {
+            console.error('[AgentActionRequests] POST failed:', err.message);
+            log('error', `POST failed: ${err.message}`, { deviceId });
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    // ════════════════════════════════════════
+    // GET / — list requests (default pending) for the device
+    // ════════════════════════════════════════
+    router.get('/', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const statusFilter = (req.query.status || 'pending');
+        if (!['pending', 'resolved', 'dismissed', 'all'].includes(statusFilter)) {
+            return res.status(400).json({ success: false, error: 'status must be pending|resolved|dismissed|all' });
+        }
+        const fromEntityId = req.query.fromEntityId;
+
+        try {
+            const params = [deviceId];
+            let sql = `SELECT * FROM agent_action_requests WHERE device_id = $1`;
+            if (statusFilter !== 'all') {
+                params.push(statusFilter);
+                sql += ` AND status = $${params.length}`;
+            }
+            if (fromEntityId != null && fromEntityId !== '') {
+                params.push(parseInt(fromEntityId, 10));
+                sql += ` AND from_entity_id = $${params.length}`;
+            }
+            sql += ` ORDER BY created_at ASC LIMIT ${MAX_LIST_LIMIT}`;
+            const result = await pool.query(sql, params);
+            return res.json({ success: true, requests: result.rows.map(rowToApi) });
+        } catch (err) {
+            console.error('[AgentActionRequests] GET failed:', err.message);
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    // ════════════════════════════════════════
+    // POST /:id/resolve — answer a pending request (notifies the agent if wired)
+    // ════════════════════════════════════════
+    router.post('/:id/resolve', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { device, deviceId } = auth;
+        const { id } = req.params;
+        if (!UUID_RE.test(String(id))) {
+            return res.status(400).json({ success: false, error: 'Invalid id' });
+        }
+        const { answer } = req.body || {};
+
+        try {
+            const result = await pool.query(
+                `UPDATE agent_action_requests
+                    SET status = 'resolved', answer = $1::jsonb, resolved_at = NOW()
+                  WHERE id = $2 AND device_id = $3 AND status = 'pending'
+                RETURNING *`,
+                [answer !== undefined ? JSON.stringify(answer) : null, id, deviceId]
+            );
+            if (result.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Not found or already resolved/dismissed' });
+            }
+            const row = result.rows[0];
+            // Best-effort notify the emitting agent that its request was answered.
+            // Full smart-quote/anchor routing is child card_b51598b7.
+            try {
+                const entity = device.entities && device.entities[row.from_entity_id];
+                if (entity && entity.isBound) {
+                    const note = `[需要你 RESOLVED] "${row.prompt}" → ${JSON.stringify(answer ?? null)} (request ${row.id}${row.anchor_message_id ? `, anchor ${row.anchor_message_id}` : ''})`;
+                    if (entity.bindingType === 'channel' && typeof unifiedPush === 'function') {
+                        unifiedPush(entity, deviceId, 'action_request_resolved', { message: note, requestId: row.id, anchorMessageId: row.anchor_message_id, answer: answer ?? null }, { event: 'message', from: 'action_request' }).catch(() => {});
+                    } else if (entity.webhook && typeof pushToBot === 'function') {
+                        pushToBot(entity, deviceId, 'action_request_resolved', { message: note }).catch(() => {});
+                    }
+                }
+            } catch (_) {}
+            log('info', `resolve id=${row.id} from=${row.from_entity_id}`, { deviceId });
+            return res.json({ success: true, request: rowToApi(row) });
+        } catch (err) {
+            console.error('[AgentActionRequests] resolve failed:', err.message);
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    // ════════════════════════════════════════
+    // POST /:id/dismiss — drop a pending request without answering
+    // ════════════════════════════════════════
+    router.post('/:id/dismiss', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const { id } = req.params;
+        if (!UUID_RE.test(String(id))) {
+            return res.status(400).json({ success: false, error: 'Invalid id' });
+        }
+        try {
+            const result = await pool.query(
+                `UPDATE agent_action_requests
+                    SET status = 'dismissed', resolved_at = NOW()
+                  WHERE id = $1 AND device_id = $2 AND status = 'pending'
+                RETURNING *`,
+                [id, deviceId]
+            );
+            if (result.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Not found or already resolved/dismissed' });
+            }
+            log('info', `dismiss id=${id}`, { deviceId });
+            return res.json({ success: true, request: rowToApi(result.rows[0]) });
+        } catch (err) {
+            console.error('[AgentActionRequests] dismiss failed:', err.message);
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    return {
+        router,
+        initDatabase: initAgentActionRequestsDatabase,
+        _pool: pool,
+    };
+};
+
+module.exports.initAgentActionRequestsDatabase = initAgentActionRequestsDatabase;

--- a/backend/agent_action_requests_schema.sql
+++ b/backend/agent_action_requests_schema.sql
@@ -1,0 +1,31 @@
+-- agent_action_requests — Human-in-the-Loop "需要你" inbox.
+--
+-- An autonomous agent (entity) that gets blocked needing the user emits a
+-- row here ("I need you to decide / approve / fill in X"). The chat-page
+-- "需要你" inbox lists pending rows; the user resolves/dismisses them, and
+-- the answer routes back to the agent so it can unblock and continue.
+--
+-- anchor_message_id pins the originating chat message (the his_<uuid> /
+-- chat_messages UUID) so the inbox item can route back to that message and
+-- the user's smart-quote reply can be correlated to the exact request.
+-- Parent spec: card_a03d9d09 (child card_edeb190b).
+
+CREATE TABLE IF NOT EXISTS agent_action_requests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    device_id VARCHAR(64) NOT NULL,
+    from_entity_id INTEGER NOT NULL,
+    anchor_message_id UUID DEFAULT NULL,
+    type VARCHAR(16) NOT NULL,
+    prompt TEXT NOT NULL,
+    options JSONB DEFAULT NULL,
+    status VARCHAR(16) NOT NULL DEFAULT 'pending',
+    answer JSONB DEFAULT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolved_at TIMESTAMPTZ DEFAULT NULL,
+    CONSTRAINT aar_prompt_len CHECK (char_length(prompt) BETWEEN 1 AND 2000),
+    CONSTRAINT aar_type_valid CHECK (type IN ('decision','approval','input','credential','review','clarify')),
+    CONSTRAINT aar_status_valid CHECK (status IN ('pending','resolved','dismissed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_aar_device_status ON agent_action_requests(device_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_aar_anchor ON agent_action_requests(anchor_message_id);

--- a/backend/index.js
+++ b/backend/index.js
@@ -1931,6 +1931,21 @@ try {
     scheduledMessagesModule = { initDatabase: () => {}, startPoller: () => {}, stopPoller: () => {} };
 }
 
+// Agent Action Requests — the "需要你" HITL inbox (card_a03d9d09 / card_edeb190b)
+let agentActionRequestsModule;
+try {
+    agentActionRequestsModule = require('./agent-action-requests')(devices, {
+        pushToBot,
+        unifiedPush,
+        serverLog,
+    });
+    app.use('/api/action-requests', agentActionRequestsModule.router);
+    console.log('[AgentActionRequests] Module loaded successfully');
+} catch (err) {
+    console.error('[AgentActionRequests] Failed to load module:', err.message);
+    agentActionRequestsModule = { initDatabase: () => {} };
+}
+
 // ============================================
 // PAGE VIEW TRACKING (fire-and-forget)
 // ============================================
@@ -2527,6 +2542,9 @@ if (scheduledMessagesModule && scheduledMessagesModule.initDatabase) {
     if (process.env.NODE_ENV !== 'test' && scheduledMessagesModule.startPoller) {
         scheduledMessagesModule.startPoller();
     }
+}
+if (agentActionRequestsModule && agentActionRequestsModule.initDatabase) {
+    agentActionRequestsModule.initDatabase();
 }
 // Wire notification callback (notifyDevice defined later, uses closure)
 missionModule.setNotifyCallback((deviceId, notif) => notifyDevice(deviceId, notif));

--- a/backend/tests/jest/agent-action-requests.test.js
+++ b/backend/tests/jest/agent-action-requests.test.js
@@ -1,0 +1,164 @@
+// Tests for the "需要你" agent_action_requests API (card_edeb190b).
+// Mocks pg so the module's Pool() is captured; uses supertest against the router.
+
+const mockPoolQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockPoolQuery,
+        connect: jest.fn().mockResolvedValue({ query: mockPoolQuery, release: jest.fn() }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const express = require('express');
+const request = require('supertest');
+
+const deviceId = 'test-dev';
+const deviceSecret = 'dev-secret';
+const UUID = '11111111-2222-3333-4444-555555555555';
+const ANCHOR = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+let app;
+
+beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    const devices = {
+        [deviceId]: {
+            deviceSecret,
+            entities: {
+                2: { isBound: true, botSecret: 'bot-2' },
+                6: { isBound: true, botSecret: 'bot-6' },
+                3: { isBound: false, botSecret: null },
+            },
+        },
+    };
+    const mod = require('../../agent-action-requests')(devices, { serverLog: () => {} });
+    app.use('/api/action-requests', mod.router);
+});
+
+afterEach(() => mockPoolQuery.mockClear());
+
+const post = (p) => request(app).post(p);
+const get = (p) => request(app).get(p);
+
+function rowFixture(over = {}) {
+    return {
+        id: UUID, device_id: deviceId, from_entity_id: 2, anchor_message_id: null,
+        type: 'decision', prompt: 'pick A or B', options: ['A', 'B'],
+        status: 'pending', answer: null,
+        created_at: new Date('2026-06-25T00:00:00Z'), resolved_at: null, ...over,
+    };
+}
+
+describe('auth', () => {
+    it('missing deviceId → 400', async () => {
+        const res = await post('/api/action-requests').send({ type: 'decision', prompt: 'x' });
+        expect(res.status).toBe(400);
+    });
+    it('bad deviceSecret → 401', async () => {
+        const res = await get('/api/action-requests?deviceId=' + deviceId + '&deviceSecret=wrong');
+        expect(res.status).toBe(401);
+    });
+    it('bad botSecret → 401', async () => {
+        const res = await post('/api/action-requests').send({ deviceId, botSecret: 'nope', entityId: 2, type: 'decision', prompt: 'x' });
+        expect(res.status).toBe(401);
+    });
+    it('unbound entity botSecret → 401', async () => {
+        const res = await post('/api/action-requests').send({ deviceId, botSecret: 'bot-3', entityId: 3, type: 'decision', prompt: 'x' });
+        expect(res.status).toBe(401);
+    });
+});
+
+describe('POST / (emit)', () => {
+    it('agent emits as itself (from_entity_id = authed entity)', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture()] });
+        const res = await post('/api/action-requests').send({
+            deviceId, botSecret: 'bot-2', entityId: 2,
+            type: 'decision', prompt: 'pick A or B', options: ['A', 'B'], anchorMessageId: ANCHOR,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.request.fromEntityId).toBe(2);
+        // INSERT params: from_entity_id is the authed entity (2), not from body
+        const params = mockPoolQuery.mock.calls[0][1];
+        expect(params[1]).toBe(2);
+    });
+    it('rejects invalid type', async () => {
+        const res = await post('/api/action-requests').send({ deviceId, botSecret: 'bot-2', entityId: 2, type: 'bogus', prompt: 'x' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/type must be/);
+    });
+    it('rejects empty prompt', async () => {
+        const res = await post('/api/action-requests').send({ deviceId, botSecret: 'bot-2', entityId: 2, type: 'approval', prompt: '' });
+        expect(res.status).toBe(400);
+    });
+    it('rejects non-array options', async () => {
+        const res = await post('/api/action-requests').send({ deviceId, botSecret: 'bot-2', entityId: 2, type: 'decision', prompt: 'x', options: 'A,B' });
+        expect(res.status).toBe(400);
+    });
+    it('drops a non-UUID anchorMessageId to null', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ anchor_message_id: null })] });
+        const res = await post('/api/action-requests').send({ deviceId, botSecret: 'bot-2', entityId: 2, type: 'clarify', prompt: 'which?', anchorMessageId: 'not-a-uuid' });
+        expect(res.status).toBe(200);
+        const params = mockPoolQuery.mock.calls[0][1];
+        expect(params[2]).toBeNull(); // anchor param
+    });
+    it('user (deviceSecret) must name fromEntityId', async () => {
+        const res = await post('/api/action-requests').send({ deviceId, deviceSecret, type: 'decision', prompt: 'x' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/fromEntityId/);
+    });
+});
+
+describe('GET / (list)', () => {
+    it('defaults to status=pending, scoped to device', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture(), rowFixture({ id: ANCHOR, from_entity_id: 6 })] });
+        const res = await get('/api/action-requests?deviceId=' + deviceId + '&deviceSecret=' + deviceSecret);
+        expect(res.status).toBe(200);
+        expect(res.body.requests).toHaveLength(2);
+        const [sql, params] = mockPoolQuery.mock.calls[0];
+        expect(sql).toMatch(/device_id = \$1/);
+        expect(sql).toMatch(/status = \$2/);
+        expect(params).toEqual([deviceId, 'pending']);
+    });
+    it('rejects bad status filter', async () => {
+        const res = await get('/api/action-requests?deviceId=' + deviceId + '&deviceSecret=' + deviceSecret + '&status=weird');
+        expect(res.status).toBe(400);
+    });
+});
+
+describe('POST /:id/resolve', () => {
+    it('resolves a pending request by id+device, returns updated row', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ status: 'resolved', answer: 'A', resolved_at: new Date() })] });
+        const res = await post(`/api/action-requests/${UUID}/resolve`).send({ deviceId, deviceSecret, answer: 'A' });
+        expect(res.status).toBe(200);
+        expect(res.body.request.status).toBe('resolved');
+        const [sql, params] = mockPoolQuery.mock.calls[0];
+        expect(sql).toMatch(/status = 'resolved'/);
+        expect(sql).toMatch(/AND status = 'pending'/); // only resolves pending
+        expect(params).toContain(UUID);
+        expect(params).toContain(deviceId);
+    });
+    it('404 when nothing pending matches', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+        const res = await post(`/api/action-requests/${UUID}/resolve`).send({ deviceId, deviceSecret, answer: 'A' });
+        expect(res.status).toBe(404);
+    });
+    it('rejects non-UUID id', async () => {
+        const res = await post('/api/action-requests/not-a-uuid/resolve').send({ deviceId, deviceSecret });
+        expect(res.status).toBe(400);
+    });
+});
+
+describe('POST /:id/dismiss', () => {
+    it('dismisses a pending request', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ status: 'dismissed', resolved_at: new Date() })] });
+        const res = await post(`/api/action-requests/${UUID}/dismiss`).send({ deviceId, deviceSecret });
+        expect(res.status).toBe(200);
+        expect(res.body.request.status).toBe('dismissed');
+        const [sql] = mockPoolQuery.mock.calls[0];
+        expect(sql).toMatch(/status = 'dismissed'/);
+        expect(sql).toMatch(/AND status = 'pending'/);
+    });
+});


### PR DESCRIPTION
## What
Backend data layer for the chat-page **「需要你」** Human-in-the-Loop inbox (parent spec card_a03d9d09, child **card_edeb190b**). An autonomous agent blocked needing the user emits a request here; the user lists/resolves/dismisses it and the answer routes back so the agent unblocks.

## Files
- **agent_action_requests_schema.sql** — new table: `id` (uuid), `device_id`, `from_entity_id`, `anchor_message_id` (uuid → the `his_<uuid>` chat message that triggered the need), `type` (decision|approval|input|credential|review|clarify), `prompt`, `options` (jsonb), `status` (pending|resolved|dismissed), `answer` (jsonb), `created_at`, `resolved_at`. CHECK constraints + device/status/anchor indexes.
- **agent-action-requests.js** — factory module (mirrors `scheduled-messages.js`). **Dual auth**: agents emit via `botSecret`+`entityId` (`from_entity_id` = the authed entity); users list/resolve/dismiss via `deviceSecret`.
  - `POST /` emit (validates type/prompt/options, normalizes anchor to a real UUID or null)
  - `GET /` list (default `status=pending`, device-scoped)
  - `POST /:id/resolve` answer + best-effort push-back to the emitting agent
  - `POST /:id/dismiss`
- **index.js** — mount `/api/action-requests` + `initDatabase` on boot (mirrors scheduled-messages wiring).
- **jest** — 16 tests (auth, emit validation, anchor normalization, list scoping, resolve/dismiss pending-only guards), all green locally.

## Scope / follow-ups
This is the **model + emit/list/resolve API** only. The smart-quote anchor round-trip (card_b51598b7) and the chat.html inbox UI (card_a7602133, delegated to #6 for UI/UX design) build on top. No frontend change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)