### PR TITLE
feat(kanban): notify agents on (re)assign + @-mentioned comment, include latest comment (card_cc20541e)

### DIFF
--- a/backend/i18n/kanban-notifications.js
+++ b/backend/i18n/kanban-notifications.js
@@ -14,7 +14,9 @@ const TRANSLATIONS = {
         scheduleRecurringWithStatus: '🗓️ Schedule triggered: [{title}]\nStatus: {from} → {to}, please continue this task',
         reviewerNotify: '🔍 Task completed, awaiting review: [{title}]\nBot #{entityId} reported: {reply}\nIf there are issues, please create a new card.',
         reviewerMovedToReview: '🔍 Pending review: [{title}]\nMoved from {from} to Review. Please review.',
-        reviewerNoReply: '(no reply content)'
+        reviewerNoReply: '(no reply content)',
+        assignedToYou: '📌 Assigned to you: [{title}]\nPlease begin this task.',
+        commentMention: '💬 You were @-mentioned on: [{title}]\nPlease check the latest comment below.'
     },
     zh: {
         statusLabels: { backlog: '待辦池', todo: '待辦', in_progress: '進行中', review: '審查', done: '完成', blocked: '已封鎖' },
@@ -27,7 +29,9 @@ const TRANSLATIONS = {
         scheduleRecurringWithStatus: '🗓️ 排程觸發：[{title}]\n狀態: {from} → {to}，請繼續推進此任務',
         reviewerNotify: '🔍 任務完成待審：[{title}]\nBot #{entityId} 已完成並回報：{reply}\n如有問題請重新建卡指派。',
         reviewerMovedToReview: '🔍 待審：[{title}]\n已從 {from} 移到審查階段，請審。',
-        reviewerNoReply: '（無回覆內容）'
+        reviewerNoReply: '（無回覆內容）',
+        assignedToYou: '📌 指派給你：[{title}]\n請開始執行此任務。',
+        commentMention: '💬 有人在留言 @ 你：[{title}]\n請查看下方最新留言。'
     },
     'zh-CN': {
         statusLabels: { backlog: '待办池', todo: '待办', in_progress: '进行中', review: '审查', done: '完成', blocked: '已封锁' },

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -46,6 +46,7 @@ const { tKanban, statusLabel } = require('./i18n/kanban-notifications');
 const devicePrefs = require('./device-preferences');
 const { emit: emitKanbanEvent } = require('./lib/kanban-events');
 const { resolveEntityHostDevice } = require('./lib/per-device-cron');
+const mentionParser = require('./mention-parser');
 
 // Cache device→language to avoid repeated lookups
 const deviceLangCache = new Map();
@@ -609,6 +610,36 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         const API_BASE = 'https://eclawbot.com';
         const SOURCE_TAG = 'kanban_notify';
 
+        // ── Latest-comment enrichment (card_cc20541e) ──
+        // Assignment/@-mention notifications carry the most actionable context
+        // when they include the latest留言. Prefer an explicitly-passed
+        // latestComment (the @-mention path already has the text in hand); else,
+        // when a cardId is given, fetch the newest non-system comment row so the
+        // push always reflects the current discussion. Bounded to keep the push
+        // payload sane. Best-effort: a failed fetch must never block the push.
+        const LATEST_COMMENT_MAX = 1500;
+        let latestComment = typeof options.latestComment === 'string' ? options.latestComment : null;
+        if (!latestComment && cardId) {
+            try {
+                const c = await pool.query(
+                    `SELECT text FROM kanban_comments
+                      WHERE card_id = $1 AND is_system = false
+                      ORDER BY created_at DESC
+                      LIMIT 1`,
+                    [cardId]
+                );
+                if (c.rows[0]?.text) latestComment = c.rows[0].text;
+            } catch (e) {
+                console.warn(`[Kanban] latest-comment fetch failed for card ${cardId}:`, e.message);
+            }
+        }
+        if (latestComment && latestComment.length > LATEST_COMMENT_MAX) {
+            latestComment = latestComment.slice(0, LATEST_COMMENT_MAX) + '…';
+        }
+        const commentBlock = latestComment
+            ? `\n\n[LATEST COMMENT]\n${latestComment}\n[/LATEST COMMENT]`
+            : '';
+
         for (const eid of entityIds) {
             try {
                 // ── Per-device host resolution ──
@@ -710,7 +741,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     const result = await pushToChannelCallback(pushDeviceId, pushEid, {
                         event: 'kanban_notification',
                         from: 'kanban',
-                        text: message + descBlock,
+                        text: message + descBlock + commentBlock,
                         eclaw_context: {
                             expectsReply: true,
                             silentToken: '[SILENT]',
@@ -724,6 +755,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     const pushMsg = [
                         `[KANBAN NOTIFICATION] ${message}`,
                         descBlock,
+                        commentBlock,
                         `[NOTIFICATION — NO REPLY EXPECTED] This is a Kanban task notification. Take action on the card as needed.`,
                         missionBlock,
                     ].filter(Boolean).join('\n');
@@ -739,7 +771,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
 
                 } else if (pushToEntity) {
                     // Legacy fallback
-                    const pushMsg = `[KANBAN NOTIFICATION] ${message}${descBlock}${missionBlock}`;
+                    const pushMsg = `[KANBAN NOTIFICATION] ${message}${descBlock}${commentBlock}${missionBlock}`;
                     await pushToEntity(pushDeviceId, pushEid, pushMsg);
                     console.log(`[Kanban] Legacy push to entity ${pushEid}@${pushDeviceId}`);
                 }
@@ -748,6 +780,49 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 console.error(`[Kanban] Failed to push to entity ${eid}:`, e.message);
             }
         }
+    }
+
+    // ── @-mention resolution for card comments (card_cc20541e) ──
+    // Reuse the platform's canonical mention parser (backend/mention-parser.js)
+    // so card comments accept the exact same token forms as chat: @#N / @N
+    // (same-device entityId), <@N>, @xxxxxx / <@xxxxxx> (6-char publicCode),
+    // and same-device display names. The parser needs a publicCodeIndex to
+    // resolve publicCode tokens; the kanban module is same-device only, so we
+    // synthesize a minimal index from the card's own device bindings rather
+    // than threading the global index through the factory. Returns an array of
+    // same-device entityIds that were @-mentioned.
+    function resolveCommentMentions(deviceId, text) {
+        if (!text || typeof text !== 'string') return [];
+        const device = devices[deviceId];
+        const entities = device?.entities || {};
+        // Per-device publicCode → { deviceId, entityId } so @xxxxxx resolves
+        // without the global publicCodeIndex (cross-device mentions are out of
+        // scope for kanban notifications — same device only).
+        const localPublicCodeIndex = {};
+        for (const [eidRaw, entity] of Object.entries(entities)) {
+            if (entity?.isBound && entity?.publicCode) {
+                localPublicCodeIndex[entity.publicCode] = { deviceId, entityId: parseInt(eidRaw, 10) };
+            }
+        }
+        let parsed;
+        try {
+            parsed = mentionParser.parseMentions(text, {
+                senderDeviceId: deviceId,
+                devices,
+                publicCodeIndex: localPublicCodeIndex,
+            });
+        } catch (e) {
+            console.warn('[Kanban] mention parse failed:', e.message);
+            return [];
+        }
+        const ids = new Set();
+        for (const m of (parsed.mentions || [])) {
+            // Same-device, bound entity only.
+            if (m && !m.isCrossDevice && m.deviceId === deviceId && Number.isFinite(m.entityId)) {
+                ids.add(Number(m.entityId));
+            }
+        }
+        return [...ids];
     }
 
     // ── Smart-queue notify helpers (card_dfe3b8df Phase 2 + #2307 hotfix) ──
@@ -2165,6 +2240,37 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             }
 
             await bumpVersion(deviceId);
+
+            // ── A. Notify on (re)assignment (card_cc20541e) ──
+            // When this PUT ADDS new entity ids to assigned_bots, ping ONLY the
+            // newly-added ids (not the whole assigned set — that would re-spam
+            // unchanged assignees on every edit). Best-effort, fire-and-forget:
+            // a notify failure must never break the 200 response. Mirrors the
+            // create-path notify (line ~1234) so a card assigned via edit gets
+            // the same task brief the create flow would have delivered.
+            if (assignedBots !== undefined && Array.isArray(assignedBots)) {
+                try {
+                    const before = existing.rows[0];
+                    const updated = result.rows[0];
+                    const prevSet = new Set(
+                        (Array.isArray(before.assigned_bots) ? before.assigned_bots : []).map(Number)
+                    );
+                    const newlyAdded = (Array.isArray(updated.assigned_bots) ? updated.assigned_bots : [])
+                        .map(Number)
+                        .filter(id => Number.isFinite(id) && !prevSet.has(id));
+                    if (newlyAdded.length > 0) {
+                        const lang = await getDeviceLanguage(deviceId);
+                        const msg = tKanban(lang, 'assignedToYou', { title: updated.title });
+                        notifyEntities(deviceId, newlyAdded, msg, {
+                            description: updated.description,
+                            cardId: updated.id,
+                        });
+                    }
+                } catch (notifyErr) {
+                    console.error('[Kanban] assign-notify failed:', notifyErr.message);
+                }
+            }
+
             res.json({ success: true, card: serializeCard(result.rows[0]) });
         } catch (err) {
             console.error('[Kanban] Update card error:', err);
@@ -2730,7 +2836,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
 
         try {
             const cardCheck = await pool.query(
-                `SELECT id, assigned_bots FROM kanban_cards WHERE id = $1 AND device_id = $2`,
+                `SELECT id, title, assigned_bots FROM kanban_cards WHERE id = $1 AND device_id = $2`,
                 [cardId, deviceId]
             );
             if (cardCheck.rows.length === 0) {
@@ -2761,6 +2867,32 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             await bumpVersion(deviceId);
 
             res.json({ success: true, comment });
+
+            // ── B. Notify @-mentioned entities (card_cc20541e) ──
+            // ANTI-SPAM: only an @-mention triggers a push — a plain comment
+            // notifies nobody (the create/move/reopen paths already cover
+            // assignment-time pings). Fired AFTER res.json so notify latency
+            // never delays the comment response; wrapped so a failure can't
+            // surface as an unhandled rejection. The mentioned entity gets the
+            // comment text itself as the actionable brief (latestComment).
+            try {
+                const commentText = result.rows[0].text;
+                const mentionedIds = resolveCommentMentions(deviceId, commentText)
+                    // Don't ping a bot for its OWN comment.
+                    .filter(id => id !== eId);
+                if (mentionedIds.length > 0) {
+                    const lang = await getDeviceLanguage(deviceId);
+                    const msg = tKanban(lang, 'commentMention', { title: cardCheck.rows[0].title });
+                    for (const mentionedId of mentionedIds) {
+                        notifyEntities(deviceId, [mentionedId], msg, {
+                            cardId,
+                            latestComment: commentText,
+                        });
+                    }
+                }
+            } catch (notifyErr) {
+                console.error('[Kanban] comment-mention notify failed:', notifyErr.message);
+            }
         } catch (err) {
             console.error('[Kanban] Add comment error:', err);
             res.status(500).json({ success: false, error: err.message });

--- a/backend/tests/jest/kanban-notify-on-assign-comment.test.js
+++ b/backend/tests/jest/kanban-notify-on-assign-comment.test.js
@@ -1,0 +1,290 @@
+'use strict';
+
+/**
+ * card_cc20541e — Kanban notify on (re)assignment + @-mentioned comment,
+ * with latest-comment enrichment.
+ *
+ * Root cause (verified by file:line on origin/main backend/kanban.js):
+ *   - notifyEntities() was ONLY wired into create / move / reopen / cron-spawn.
+ *   - PUT /card/:id changed assigned_bots WITHOUT notifying the new assignee.
+ *   - POST /card/:id/comment inserted a留言 WITHOUT notifying anyone — so an
+ *     @-mention in a comment never reached the mentioned agent.
+ *
+ * This suite drives the real router (supertest) over a mocked pg pool and a
+ * captured pushToChannelCallback, asserting the three new behaviours plus the
+ * anti-spam rules (no notify on unchanged assignment / plain comment / own @).
+ *
+ * Mock-ordering note: notifyEntities is fire-and-forget (NOT awaited inside the
+ * handlers), so the HTTP response resolves before the push runs. Each test
+ * awaits flushAsync() to let the microtask + I/O queue drain before asserting
+ * on the push spy.
+ */
+
+const mockQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockQuery,
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../safe-equal', () => (a, b) => a === b);
+
+const express = require('express');
+const request = require('supertest');
+
+let app;
+let pushSpy;
+
+// Channel-bound entities so notifyEntities() takes the pushToChannelCallback
+// path and parseMentions() can resolve @<publicCode> tokens.
+const mockDevices = {
+    'test-dev': {
+        deviceSecret: 'test-secret',
+        entities: {
+            0: { isBound: true, bindingType: 'channel', channelAccountId: 'acct0', botSecret: 'sec0', publicCode: 'aaaaaa', name: 'Bot0', character: 'Bot0' },
+            1: { isBound: true, bindingType: 'channel', channelAccountId: 'acct1', botSecret: 'sec1', publicCode: 'bbbbbb', name: 'Bot1', character: 'Bot1' },
+            3: { isBound: true, bindingType: 'channel', channelAccountId: 'acct3', botSecret: 'sec3', publicCode: 'cccccc', name: 'Bot3', character: 'Bot3' },
+        },
+    },
+};
+
+beforeAll(() => {
+    app = express();
+    app.use(express.json());
+
+    pushSpy = jest.fn().mockResolvedValue({ pushed: true });
+
+    const kanbanModule = require('../../kanban')(mockDevices, {
+        pushToChannelCallback: (...args) => pushSpy(...args),
+    });
+    app.use('/api/mission', kanbanModule.router);
+});
+
+beforeEach(() => {
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    pushSpy.mockReset();
+    pushSpy.mockResolvedValue({ pushed: true });
+});
+
+const put = (path) => request(app).put(path);
+const post = (path) => request(app).post(path);
+const AUTH = { deviceId: 'test-dev', deviceSecret: 'test-secret' };
+
+// Let the fire-and-forget notifyEntities() chain settle before asserting.
+const flushAsync = () => new Promise((resolve) => setImmediate(resolve));
+
+// Pull the text of every captured channel push.
+const pushedTexts = () => pushSpy.mock.calls.map((c) => c[2] && c[2].text);
+// Which entityIds received a push (2nd positional arg of pushToChannelCallback).
+const pushedEntityIds = () => pushSpy.mock.calls.map((c) => c[1]);
+
+function updatedCardRow(overrides = {}) {
+    return {
+        id: 'card_x', device_id: 'test-dev', title: 'My task',
+        description: 'do the thing', priority: 'P2', status: 'todo',
+        assigned_bots: [0], created_by: 0,
+        created_at: new Date(), updated_at: new Date(),
+        status_changed_at: new Date(), archived: false,
+        ...overrides,
+    };
+}
+
+// ════════════════════════════════════════════════════════════════
+// A. PUT /card/:id — notify newly-added assignees
+// ════════════════════════════════════════════════════════════════
+describe('A. PUT /card/:id assignment notify', () => {
+    it('notifies ONLY the newly-added entity with the description', async () => {
+        mockQuery
+            // existing SELECT *  (was assigned to [0])
+            .mockResolvedValueOnce({ rows: [updatedCardRow({ assigned_bots: [0] })] })
+            // UPDATE RETURNING * (now assigned to [0, 3])
+            .mockResolvedValueOnce({ rows: [updatedCardRow({ assigned_bots: [0, 3] })] })
+            // bumpVersion
+            .mockResolvedValueOnce({ rows: [] });
+        // getDeviceLanguage user_accounts SELECT + latest-comment fetch fall
+        // through to the default empty resolve.
+
+        const res = await put('/api/mission/card/card_x').send({ ...AUTH, assignedBots: [0, 3] });
+        expect(res.status).toBe(200);
+
+        await flushAsync();
+
+        // Only the new id (3) is pinged; the unchanged assignee (0) is not.
+        expect(pushedEntityIds()).toEqual([3]);
+        const texts = pushedTexts();
+        expect(texts).toHaveLength(1);
+        expect(texts[0]).toMatch(/Assigned to you|指派給你/);
+        expect(texts[0]).toMatch(/\[TASK DESCRIPTION\]\ndo the thing/);
+    });
+
+    it('does NOT notify when assigned_bots is unchanged', async () => {
+        mockQuery
+            .mockResolvedValueOnce({ rows: [updatedCardRow({ assigned_bots: [0] })] })
+            .mockResolvedValueOnce({ rows: [updatedCardRow({ assigned_bots: [0] })] })
+            .mockResolvedValueOnce({ rows: [] });
+
+        const res = await put('/api/mission/card/card_x').send({ ...AUTH, assignedBots: [0] });
+        expect(res.status).toBe(200);
+
+        await flushAsync();
+        expect(pushSpy).not.toHaveBeenCalled();
+    });
+
+    it('does NOT notify when the PUT does not touch assigned_bots at all', async () => {
+        mockQuery
+            .mockResolvedValueOnce({ rows: [updatedCardRow({ assigned_bots: [0] })] })
+            .mockResolvedValueOnce({ rows: [updatedCardRow({ assigned_bots: [0], title: 'Renamed' })] })
+            .mockResolvedValueOnce({ rows: [] });
+
+        const res = await put('/api/mission/card/card_x').send({ ...AUTH, title: 'Renamed' });
+        expect(res.status).toBe(200);
+
+        await flushAsync();
+        expect(pushSpy).not.toHaveBeenCalled();
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// B. POST /card/:id/comment — notify @-mentioned entities
+// ════════════════════════════════════════════════════════════════
+describe('B. POST /card/:id/comment mention notify', () => {
+    function commentRow(text, fromEntityId = 0) {
+        return {
+            id: 'cmt1', card_id: 'card_x', device_id: 'test-dev',
+            from_entity_id: fromEntityId, text, is_system: false,
+            created_at: new Date(),
+        };
+    }
+
+    // cardCheck SELECT → INSERT comment RETURNING → UPDATE updated_at → bumpVersion
+    function primeCommentMocks(text, fromEntityId = 0) {
+        mockQuery
+            .mockResolvedValueOnce({ rows: [{ id: 'card_x', title: 'My task', assigned_bots: [0] }] })
+            .mockResolvedValueOnce({ rows: [commentRow(text, fromEntityId)] })
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [] });
+    }
+
+    it('@#3 in a comment → pushes to entity 3 with the comment text as the brief', async () => {
+        primeCommentMocks('hey @#3 please look at this', 0);
+
+        const res = await post('/api/mission/card/card_x/comment')
+            .send({ ...AUTH, entityId: 0, text: 'hey @#3 please look at this' });
+        expect(res.status).toBe(200);
+
+        await flushAsync();
+        expect(pushedEntityIds()).toEqual([3]);
+        const texts = pushedTexts();
+        expect(texts[0]).toMatch(/@-mentioned|@ 你/);
+        expect(texts[0]).toMatch(/\[LATEST COMMENT\]\nhey @#3 please look at this/);
+    });
+
+    it('@<publicCode> resolves to the bound entity', async () => {
+        primeCommentMocks('ping @cccccc take over', 0);
+
+        const res = await post('/api/mission/card/card_x/comment')
+            .send({ ...AUTH, entityId: 0, text: 'ping @cccccc take over' });
+        expect(res.status).toBe(200);
+
+        await flushAsync();
+        expect(pushedEntityIds()).toEqual([3]);
+    });
+
+    it('plain comment with NO @-mention notifies nobody (anti-spam)', async () => {
+        primeCommentMocks('just a status note, no mention', 0);
+
+        const res = await post('/api/mission/card/card_x/comment')
+            .send({ ...AUTH, entityId: 0, text: 'just a status note, no mention' });
+        expect(res.status).toBe(200);
+
+        await flushAsync();
+        expect(pushSpy).not.toHaveBeenCalled();
+    });
+
+    it('does NOT notify a commenter who @-mentions themselves', async () => {
+        // Entity 3 comments and @-mentions @#3 (itself) → no self-ping.
+        primeCommentMocks('noting @#3 for myself', 3);
+
+        const res = await post('/api/mission/card/card_x/comment')
+            .send({ ...AUTH, entityId: 3, text: 'noting @#3 for myself' });
+        expect(res.status).toBe(200);
+
+        await flushAsync();
+        expect(pushSpy).not.toHaveBeenCalled();
+    });
+
+    it('mentioning multiple entities pings each one (but not the commenter)', async () => {
+        // Commenter is entity 0, mentions @#1 and @#3 and @#0 (self) → only 1 & 3.
+        primeCommentMocks('@#1 @#3 and me @#0 sync up', 0);
+
+        const res = await post('/api/mission/card/card_x/comment')
+            .send({ ...AUTH, entityId: 0, text: '@#1 @#3 and me @#0 sync up' });
+        expect(res.status).toBe(200);
+
+        await flushAsync();
+        expect(pushedEntityIds().sort()).toEqual([1, 3]);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// C. notifyEntities — latest-comment block enrichment
+// ════════════════════════════════════════════════════════════════
+describe('C. latest-comment enrichment', () => {
+    // The comment-mention path passes latestComment explicitly (covered in B).
+    // Here we assert the OTHER half: when only cardId is given (assignment
+    // path), notifyEntities fetches the newest non-system comment and appends
+    // the [LATEST COMMENT] block.
+    // getDeviceLanguage() caches per-device, and notifyEntities issues its
+    // latest-comment SELECT out of band, so positional mockResolvedValueOnce
+    // ordering is brittle here. Drive the mock by SQL shape instead: the
+    // newest-comment lookup is the only query that hits kanban_comments with
+    // `is_system = false ... ORDER BY created_at DESC`.
+    function sqlAwareMock(latestText) {
+        mockQuery.mockImplementation((sql) => {
+            if (/FROM kanban_comments[\s\S]*ORDER BY created_at DESC/.test(sql)) {
+                return Promise.resolve({ rows: [{ text: latestText }] });
+            }
+            if (/UPDATE kanban_cards SET[\s\S]*RETURNING/.test(sql)) {
+                return Promise.resolve({ rows: [updatedCardRow({ assigned_bots: [0, 3] })] });
+            }
+            if (/^\s*SELECT \* FROM kanban_cards/.test(sql)) {
+                return Promise.resolve({ rows: [updatedCardRow({ assigned_bots: [0] })] });
+            }
+            return Promise.resolve({ rows: [], rowCount: 0 });
+        });
+    }
+
+    it('PUT assignment notify appends the latest留言 fetched by cardId', async () => {
+        sqlAwareMock('latest discussion line');
+
+        const res = await put('/api/mission/card/card_x').send({ ...AUTH, assignedBots: [0, 3] });
+        expect(res.status).toBe(200);
+
+        await flushAsync();
+        const texts = pushedTexts();
+        expect(texts).toHaveLength(1);
+        expect(texts[0]).toMatch(/\[LATEST COMMENT\]\nlatest discussion line\n\[\/LATEST COMMENT\]/);
+    });
+
+    it('caps an over-long latest comment to ~1500 chars', async () => {
+        sqlAwareMock('x'.repeat(5000));
+
+        const res = await put('/api/mission/card/card_x').send({ ...AUTH, assignedBots: [0, 3] });
+        expect(res.status).toBe(200);
+
+        await flushAsync();
+        const text = pushedTexts()[0];
+        const m = text.match(/\[LATEST COMMENT\]\n([\s\S]*?)\n\[\/LATEST COMMENT\]/);
+        expect(m).toBeTruthy();
+        // 1500 sliced chars + the truncation ellipsis.
+        expect(m[1].length).toBeLessThanOrEqual(1501);
+        expect(m[1].endsWith('…')).toBe(true);
+    });
+});

--- a/backend/tests/jest/kanban-nudge-lifecycle-directive.test.js
+++ b/backend/tests/jest/kanban-nudge-lifecycle-directive.test.js
@@ -55,10 +55,10 @@ describe('kanban notify → task-lifecycle directive (card_c0819f4e)', () => {
         // channel path
         expect(kanbanSrc).toMatch(/missionHints: missionBlock,/);
         // webhook path: missionBlock is an element of the pushMsg array
-        const webhookBlock = kanbanSrc.slice(kanbanSrc.indexOf('Non-channel: build full push message')).slice(0, 400);
+        const webhookBlock = kanbanSrc.slice(kanbanSrc.indexOf('Non-channel: build full push message')).slice(0, 600);
         expect(webhookBlock).toMatch(/missionBlock,/);
-        // legacy path
-        expect(kanbanSrc).toMatch(/\$\{descBlock\}\$\{missionBlock\}/);
+        // legacy path (card_cc20541e inserts ${commentBlock} between descBlock and missionBlock)
+        expect(kanbanSrc).toMatch(/\$\{descBlock\}\$\{commentBlock\}\$\{missionBlock\}/);
 
         // Guard: no push path may still emit the bare kanbanHints variable —
         // every consumer must go through missionBlock so the directive travels.


### PR DESCRIPTION
## Summary (card_cc20541e)

Wires the existing `notifyEntities()` push helper into two paths it previously skipped, so agents actually get pinged when work is handed to them or when someone @-mentions them on a card.

### A. Notify on (re)assignment — `PUT /card/:id`
When the update **adds** new entity ids to `assigned_bots`, notify **only the newly-added ids** (compared against the card's previous `assigned_bots`) with the task description — not the whole assigned set (that would re-spam unchanged assignees on every edit). Mirrors the create-path notify (`cardCreated`) so an edit-time assignment behaves like a create-time one.

### B. Notify on @-mentioned comment — `POST /card/:id/comment`
When the comment text @-mentions an entity, notify each mentioned, **bound, same-device** entity with the comment text itself as the actionable brief. Reuses the platform's canonical `backend/mention-parser.js` (`parseMentions`), so card comments accept the exact same token forms as chat: `@#N` / `@N` / `<@N>` / `@<publicCode>` / `<@publicCode>` / same-device `@name`. A small local same-device `publicCodeIndex` is synthesized from the card device's bindings so `@<publicCode>` resolves without threading the global index through the kanban factory.

### C. Latest-comment enrichment — `notifyEntities()`
Appends a bounded `[LATEST COMMENT]` block (after the existing `[TASK DESCRIPTION]` block) in every push path (channel / webhook / legacy). The @-mention path passes the comment text directly via `latestComment`; other callers that pass a `cardId` get the newest **non-system** comment fetched from `kanban_comments` and attached. Sliced to ~1500 chars with an ellipsis.

## Verified root cause
`origin/main backend/kanban.js`: `notifyEntities()` was only invoked on **create** (~1234), **move** (~2413), **reopen** (~2645) and **cron-spawn** paths. `PUT /card/:id` updated `assigned_bots` without notifying, and `POST /card/:id/comment` inserted a留言 without notifying anyone — so reassign-by-edit and @-mentions in comments reached no agent.

## Anti-spam / correctness
- Only **"assignment added"** and **"@-mentioned comment"** trigger new notifications — a plain `PUT` or a mention-free comment notifies nobody.
- A bot is **never pinged for its own** @-mention (commenter entityId is filtered out of the mentioned set).
- All notifies are **fire-and-forget** and wrapped in `try/catch` (the comment-mention path fires after `res.json`), so a push failure can never break the HTTP response — matching the prevailing pattern for the existing notify calls.

## i18n
New keys `assignedToYou` + `commentMention` added in **EN + ZH** (`backend/i18n/kanban-notifications.js`); all other locales fall back to EN via `tKanban`'s `dict[key] || TRANSLATIONS.en[key]` chain.

## Test coverage
`backend/tests/jest/kanban-notify-on-assign-comment.test.js` — **10 cases, all green** (supertest over mocked `pg` + captured `pushToChannelCallback`):
1. PUT adds a new entity → push fires for **only** the new id, with the description block.
2. PUT with unchanged `assigned_bots` → no notify.
3. PUT that doesn't touch `assigned_bots` → no notify.
4. Comment `@#3` → push to entity 3 with the comment text in `[LATEST COMMENT]`.
5. Comment `@<publicCode>` → resolves to the bound entity.
6. Plain comment (no mention) → no notify.
7. Commenter @-mentions **itself** → no self-ping.
8. Multi-mention `@#1 @#3 @#0(self)` → pings 1 & 3 only.
9. Assignment notify fetches + appends the latest留言 by `cardId`.
10. Over-long latest comment capped to ~1500 chars + ellipsis.

Existing `kanban-card.test.js` (40) and related kanban suites (`i18n-zh-tw-alias`, `done-device-push-wiring`, `smart-notify-queue`, `chat-card-ref`) stay green. `node --check backend/kanban.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)