### PR TITLE
feat(action-requests): auto-resolve on smart-quote reply via /api/client/speak (card_b51598b7)

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -97,6 +97,43 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog } = {}) 
         }
     }
 
+    // Best-effort: notify the emitting agent that its request was answered.
+    // Extracted so both POST /:id/resolve and the /api/client/speak smart-quote
+    // auto-resolve path push back identically (card_b51598b7). Never throws.
+    function notifyAgentResolved(deviceId, device, row, answer) {
+        try {
+            const entity = device && device.entities && device.entities[row.from_entity_id];
+            if (!entity || !entity.isBound) return;
+            const note = `[需要你 RESOLVED] "${row.prompt}" → ${JSON.stringify(answer ?? null)} (request ${row.id}${row.anchor_message_id ? `, anchor ${row.anchor_message_id}` : ''})`;
+            if (entity.bindingType === 'channel' && typeof unifiedPush === 'function') {
+                unifiedPush(entity, deviceId, 'action_request_resolved', { message: note, requestId: row.id, anchorMessageId: row.anchor_message_id, answer: answer ?? null }, { event: 'message', from: 'action_request' }).catch(() => {});
+            } else if (entity.webhook && typeof pushToBot === 'function') {
+                pushToBot(entity, deviceId, 'action_request_resolved', { message: note }).catch(() => {});
+            }
+        } catch (_) {}
+    }
+
+    // Core resolve: guarded UPDATE (pending-only, device-scoped) + best-effort
+    // agent push-back. Shared by POST /:id/resolve and the /api/client/speak
+    // smart-quote auto-resolve loop (card_b51598b7).
+    // Returns the resolved row, or null if nothing pending matched / id invalid.
+    // Throws only on a DB error so the HTTP endpoint can 500; the speak path
+    // wraps the call in try/catch and treats any failure as a no-op.
+    async function resolveActionRequest(deviceId, requestId, answer, device) {
+        if (!deviceId || !UUID_RE.test(String(requestId))) return null;
+        const result = await pool.query(
+            `UPDATE agent_action_requests
+                SET status = 'resolved', answer = $1::jsonb, resolved_at = NOW()
+              WHERE id = $2 AND device_id = $3 AND status = 'pending'
+            RETURNING *`,
+            [answer !== undefined ? JSON.stringify(answer) : null, requestId, deviceId]
+        );
+        if (result.rows.length === 0) return null;
+        const row = result.rows[0];
+        notifyAgentResolved(deviceId, device, row, answer);
+        return row;
+    }
+
     // ── Dual auth: deviceSecret (user) OR botSecret+entityId (agent) ──
     // Returns { device, deviceId, entityId|null, isUser } or null (after sending the error response).
     function authenticate(req, res) {
@@ -217,30 +254,10 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog } = {}) 
         const { answer } = req.body || {};
 
         try {
-            const result = await pool.query(
-                `UPDATE agent_action_requests
-                    SET status = 'resolved', answer = $1::jsonb, resolved_at = NOW()
-                  WHERE id = $2 AND device_id = $3 AND status = 'pending'
-                RETURNING *`,
-                [answer !== undefined ? JSON.stringify(answer) : null, id, deviceId]
-            );
-            if (result.rows.length === 0) {
+            const row = await resolveActionRequest(deviceId, id, answer, device);
+            if (!row) {
                 return res.status(404).json({ success: false, error: 'Not found or already resolved/dismissed' });
             }
-            const row = result.rows[0];
-            // Best-effort notify the emitting agent that its request was answered.
-            // Full smart-quote/anchor routing is child card_b51598b7.
-            try {
-                const entity = device.entities && device.entities[row.from_entity_id];
-                if (entity && entity.isBound) {
-                    const note = `[需要你 RESOLVED] "${row.prompt}" → ${JSON.stringify(answer ?? null)} (request ${row.id}${row.anchor_message_id ? `, anchor ${row.anchor_message_id}` : ''})`;
-                    if (entity.bindingType === 'channel' && typeof unifiedPush === 'function') {
-                        unifiedPush(entity, deviceId, 'action_request_resolved', { message: note, requestId: row.id, anchorMessageId: row.anchor_message_id, answer: answer ?? null }, { event: 'message', from: 'action_request' }).catch(() => {});
-                    } else if (entity.webhook && typeof pushToBot === 'function') {
-                        pushToBot(entity, deviceId, 'action_request_resolved', { message: note }).catch(() => {});
-                    }
-                }
-            } catch (_) {}
             log('info', `resolve id=${row.id} from=${row.from_entity_id}`, { deviceId });
             return res.json({ success: true, request: rowToApi(row) });
         } catch (err) {
@@ -282,6 +299,10 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog } = {}) 
     return {
         router,
         initDatabase: initAgentActionRequestsDatabase,
+        // Shared resolve so /api/client/speak can auto-resolve a request a
+        // smart-quote reply answers (card_b51598b7). Device-scoped, pending-only,
+        // + best-effort agent push-back. Returns the row, or null on no-match.
+        resolveActionRequest,
         _pool: pool,
     };
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -12206,6 +12206,26 @@ app.post('/api/client/speak', idempotencyMiddleware, clientSpeakDedupeMiddleware
     if (mentionWarnings.length > 0) {
         clientSpeakResponse.warnings = (clientSpeakResponse.warnings || []).concat(mentionWarnings);
     }
+
+    // ── "需要你" smart-quote auto-resolve (card_b51598b7) ──
+    // A freeform quoted reply to a pending action-request carries
+    // actionRequest:{ requestId } (the inbox 回覆 button anchored it). The
+    // message above is already saved; now mark that request resolved with the
+    // user's reply text as the answer. Device-scoped + pending-only inside the
+    // helper. Best-effort: a failure here must NEVER break the speak response.
+    try {
+        const arReqId = req.body && req.body.actionRequest && req.body.actionRequest.requestId;
+        if (arReqId && agentActionRequestsModule && typeof agentActionRequestsModule.resolveActionRequest === 'function') {
+            const row = await agentActionRequestsModule.resolveActionRequest(deviceId, arReqId, { text: text || '' }, device);
+            if (row) {
+                clientSpeakResponse.actionRequestResolved = { requestId: row.id };
+                serverLog('info', 'agent_action_requests', `auto-resolve via speak id=${row.id} from=${row.from_entity_id}`, { deviceId });
+            }
+        }
+    } catch (arErr) {
+        console.error('[AgentActionRequests] speak auto-resolve failed:', arErr.message);
+    }
+
     res.json(clientSpeakResponse);
 });
 

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -7482,6 +7482,14 @@
             body.replyContext = replyContextsPayload.length === 1
                 ? replyContextsPayload[0]
                 : { requests: replyContextsPayload };
+            // Smart-quote → auto-resolve loop (card_b51598b7): forward the FIRST
+            // pending action-request so the /api/client/speak handler can resolve
+            // it server-side with the reply text as the answer. Server-authoritative
+            // — works even if the client-side resolve call below is dropped/offline.
+            const first = replyContextsPayload[0];
+            if (first && first.requestId) {
+                body.actionRequest = { requestId: first.requestId, anchorMessageId: first.anchorMessageId || null };
+            }
             return body;
         }
 

--- a/backend/tests/jest/action-request-speak-resolve.test.js
+++ b/backend/tests/jest/action-request-speak-resolve.test.js
@@ -1,0 +1,185 @@
+/**
+ * Smart-quote → auto-resolve loop (card_b51598b7).
+ *
+ * Closes the "需要你" HITL inbox loop: a freeform quoted reply to a pending
+ * action-request, sent via POST /api/client/speak, must mark that request
+ * resolved (answer = the reply text), device-scoped + pending-only, best-effort.
+ *
+ * Two layers:
+ *   1. Unit — resolveActionRequest() helper extracted from agent-action-requests.js
+ *      (the load-bearing UPDATE + guards), mocked pg.
+ *   2. Integration — /api/client/speak against the real index.js: a body carrying
+ *      actionRequest.requestId triggers the resolve; a body WITHOUT it does not.
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+
+// ──────────────────────────────────────────────────────────────────────────
+// Layer 1: resolveActionRequest() helper, unit-tested directly
+// ──────────────────────────────────────────────────────────────────────────
+describe('resolveActionRequest() helper', () => {
+    const deviceId = 'dev-helper';
+    const UUID = '11111111-2222-3333-4444-555555555555';
+
+    // agent-action-requests.js creates ONE module-scope pool (new Pool() at load).
+    // The pg mock from mock-setup gives that pool its own query fn; grab it via
+    // the factory's _pool (same singleton on every invocation).
+    const mod = require('../../agent-action-requests')({}, { serverLog: () => {} });
+    const poolQuery = mod._pool.query;
+
+    function rowFixture(over = {}) {
+        return {
+            id: UUID, device_id: deviceId, from_entity_id: 2, anchor_message_id: null,
+            type: 'clarify', prompt: 'which one?', options: null,
+            status: 'resolved', answer: { text: 'option B' },
+            created_at: new Date('2026-06-25T00:00:00Z'), resolved_at: new Date(), ...over,
+        };
+    }
+
+    afterEach(() => poolQuery.mockReset());
+
+    it('runs a device-scoped, pending-only UPDATE with the answer and returns the row', async () => {
+        poolQuery.mockResolvedValueOnce({ rows: [rowFixture()] });
+        const row = await mod.resolveActionRequest(deviceId, UUID, { text: 'option B' }, { entities: {} });
+        expect(row).not.toBeNull();
+        expect(row.status).toBe('resolved');
+        const [sql, params] = poolQuery.mock.calls[0];
+        expect(sql).toMatch(/status = 'resolved'/);
+        expect(sql).toMatch(/AND status = 'pending'/);   // pending-only
+        expect(sql).toMatch(/device_id = \$3/);          // device-scoped
+        expect(params[0]).toBe(JSON.stringify({ text: 'option B' })); // answer jsonb
+        expect(params[1]).toBe(UUID);
+        expect(params[2]).toBe(deviceId);
+    });
+
+    it('returns null (no throw) when nothing pending matches', async () => {
+        poolQuery.mockResolvedValueOnce({ rows: [] });
+        const row = await mod.resolveActionRequest(deviceId, UUID, { text: 'x' }, { entities: {} });
+        expect(row).toBeNull();
+    });
+
+    it('skips a malformed requestId without touching the DB', async () => {
+        const row = await mod.resolveActionRequest(deviceId, 'not-a-uuid', { text: 'x' }, { entities: {} });
+        expect(row).toBeNull();
+        expect(poolQuery).not.toHaveBeenCalled();
+    });
+
+    it('skips a missing deviceId without touching the DB', async () => {
+        const row = await mod.resolveActionRequest(null, UUID, { text: 'x' }, { entities: {} });
+        expect(row).toBeNull();
+        expect(poolQuery).not.toHaveBeenCalled();
+    });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Layer 2: /api/client/speak auto-resolve, integration against index.js
+// ──────────────────────────────────────────────────────────────────────────
+describe('POST /api/client/speak — smart-quote auto-resolve', () => {
+    let app;
+    let arPool;
+    const UUID = '99999999-8888-7777-6666-555555555555';
+    const post = (p) => request(app).post(p).set('Host', 'localhost');
+    const get = (p) => request(app).get(p).set('Host', 'localhost');
+
+    async function registerDevice(id) {
+        const secret = `secret-${id}`;
+        await post('/api/device/register').send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+        return secret;
+    }
+
+    beforeAll(async () => {
+        app = require('../../index');
+        // Same module-scope singleton pool the speak handler resolves against.
+        arPool = require('../../agent-action-requests')({}, {})._pool;
+    });
+
+    afterAll(async () => {
+        const { httpServer } = require('../../index');
+        await new Promise((resolve) => httpServer.close(resolve));
+    });
+
+    beforeEach(() => {
+        // Default: resolve UPDATE matches nothing (rows:[]); individual tests override.
+        arPool.query.mockReset();
+        arPool.query.mockResolvedValue({ rows: [], rowCount: 0 });
+    });
+
+    function lastResolveCall() {
+        // The auto-resolve UPDATE is the only call the speak path makes through
+        // the agent-action-requests pool. Find it by its SQL signature.
+        return arPool.query.mock.calls.find(
+            ([sql]) => typeof sql === 'string' && /UPDATE agent_action_requests/.test(sql) && /status = 'resolved'/.test(sql)
+        );
+    }
+
+    it('body WITH actionRequest.requestId triggers a device-scoped, pending-only resolve (answer = reply text)', async () => {
+        const deviceId = 'speak-ar-yes';
+        const secret = await registerDevice(deviceId);
+        await post('/api/bind').send({ deviceId, entityId: 0, name: 'Bot', character: '🤖', webhook: '' });
+
+        arPool.query.mockResolvedValueOnce({
+            rows: [{
+                id: UUID, device_id: deviceId, from_entity_id: 0, anchor_message_id: null,
+                prompt: 'pick one', status: 'resolved', answer: { text: 'my freeform answer' },
+                created_at: new Date(), resolved_at: new Date(),
+            }],
+        });
+
+        const res = await post('/api/client/speak').send({
+            deviceId, deviceSecret: secret, entityId: 0, source: 'web_chat',
+            text: 'my freeform answer',
+            actionRequest: { requestId: UUID, anchorMessageId: null },
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+
+        const call = lastResolveCall();
+        expect(call).toBeDefined();
+        const [sql, params] = call;
+        expect(sql).toMatch(/AND status = 'pending'/);   // pending-only
+        expect(sql).toMatch(/device_id = \$3/);          // device-scoped
+        expect(params[1]).toBe(UUID);                    // the requestId
+        expect(params[2]).toBe(deviceId);                // the SAME device
+        // answer = the user's freeform reply text, wrapped { text }
+        expect(JSON.parse(params[0])).toEqual({ text: 'my freeform answer' });
+        // Response surfaces the resolved request id
+        expect(res.body.actionRequestResolved).toEqual({ requestId: UUID });
+    });
+
+    it('body WITHOUT actionRequest does NOT resolve anything', async () => {
+        const deviceId = 'speak-ar-no';
+        const secret = await registerDevice(deviceId);
+        await post('/api/bind').send({ deviceId, entityId: 0, name: 'Bot', character: '🤖', webhook: '' });
+
+        const res = await post('/api/client/speak').send({
+            deviceId, deviceSecret: secret, entityId: 0, source: 'web_chat',
+            text: 'just a normal message',
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(lastResolveCall()).toBeUndefined();           // no resolve UPDATE fired
+        expect(res.body.actionRequestResolved).toBeUndefined();
+    });
+
+    it('a resolve failure (DB throw) never breaks the speak response', async () => {
+        const deviceId = 'speak-ar-throws';
+        const secret = await registerDevice(deviceId);
+        await post('/api/bind').send({ deviceId, entityId: 0, name: 'Bot', character: '🤖', webhook: '' });
+
+        arPool.query.mockRejectedValueOnce(new Error('boom'));
+
+        const res = await post('/api/client/speak').send({
+            deviceId, deviceSecret: secret, entityId: 0, source: 'web_chat',
+            text: 'reply that will fail to resolve',
+            actionRequest: { requestId: UUID },
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.actionRequestResolved).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Completes the **"需要你" HITL inbox smart-quote loop** (card_b51598b7). Backend model+API (#3726) and inbox UI (#3728) are already on main; this closes the last gap: a freeform **quoted reply** to a pending action-request now resolves that request **server-side** via `/api/client/speak`.

## The gap
The inbox's inline buttons resolve directly, and the freeform 回覆 button puts the request into the reply context (`{requestId, anchorMessageId}` meta). But when the user SENT that reply, `sendMessage()` only forwarded `replyContext`/`replyContexts` — the backend `/api/client/speak` handler never read it, so a freeform quoted reply did not resolve the request (it relied solely on a separate client-side resolve call that can be dropped/offline).

## Changes
**Frontend — `backend/public/portal/chat.html`** (`attachReplyContextPayload`, +8 lines)
- Now also sets `body.actionRequest = { requestId, anchorMessageId }` for the FIRST pending action-request in the reply contexts, forwarded to `/api/client/speak`. All existing speak call sites already route through `attachReplyContextPayload`, so every send path (local, file, cross-device) carries it.
- Optimistic inbox refresh after a successful send is already covered by the existing `resolveActionRequestReplyContexts` → `loadActionRequests` path (reused, no change needed).

**Backend — `backend/agent-action-requests.js`** (extracted helper)
- Extracted `resolveActionRequest(deviceId, requestId, answer, device)`: the device-scoped, **pending-only** guarded UPDATE (`status='resolved', answer=$1::jsonb, resolved_at=NOW() WHERE id=$2 AND device_id=$3 AND status='pending'`) + best-effort agent push-back (channel `unifiedPush` / webhook `pushToBot`). Returns the row, or `null` on no-match / malformed-or-missing id (no throw).
- `POST /:id/resolve` now calls the helper instead of duplicating the SQL + push-back.
- Helper exported from the factory return so `index.js` can reuse it.

**Backend — `backend/index.js`** (`/api/client/speak`, +20 lines)
- After the message is saved, if `req.body.actionRequest.requestId` is present, calls `resolveActionRequest(deviceId, requestId, { text }, device)` with `answer` = the user's freeform reply text. Wrapped in try/catch — a resolve failure NEVER breaks the speak response. On success the response includes `actionRequestResolved: { requestId }`.

## Anti-abuse / correctness
- Only a request with `status='pending'` belonging to the **same `deviceId`** as the speak call is resolved.
- Malformed/missing `requestId` → skipped (logged), no throw, no DB call.

## Tests
New `backend/tests/jest/action-request-speak-resolve.test.js` (7 tests):
- **Unit** `resolveActionRequest()`: device-scoped + pending-only UPDATE with the answer; returns null on no-match; skips malformed UUID and missing deviceId without touching the DB.
- **Integration** `/api/client/speak` (real index.js): body WITH `actionRequest.requestId` fires the resolve (answer = reply text, device-scoped, pending-only, response surfaces `actionRequestResolved`); body WITHOUT does NOT; a DB-throw never breaks the speak response.

### Suites run (all green)
- `action-request-speak-resolve.test.js` — **7/7** (new)
- `agent-action-requests.test.js` + `chat-action-request-inbox.test.js` — **22/22**
- `chat.test.js` + `client-speak-payload-dedupe.test.js` — **33/33** (main `/api/client/speak` integration)
- `cross-speak.test.js` + `speak-to-delivery.test.js` + `chat-multiquote.test.js` + `chat-quote-photo.test.js` — **39/39**
- `node --check backend/index.js` ✅ · `node --check backend/agent-action-requests.js` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)