### PR TITLE
feat(action-requests): consensus type + real-time socket push (card_8151054f backend)

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -35,7 +35,12 @@ const pool = new Pool({
 
 const MAX_PROMPT_LEN = 2000;
 const MAX_LIST_LIMIT = 500;
-const VALID_TYPES = new Set(['decision', 'approval', 'input', 'credential', 'review', 'clarify']);
+// 'consensus' = 與其他實體討論取得共識 (added card_8151054f). NOTE: if you add a
+// type here you MUST also extend the aar_type_valid CHECK constraint — both in
+// agent_action_requests_schema.sql AND the idempotent migration in
+// initAgentActionRequestsDatabase() below (the prod table already exists, so a
+// plain schema re-run won't change the constraint).
+const VALID_TYPES = new Set(['decision', 'approval', 'input', 'credential', 'review', 'clarify', 'consensus']);
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 async function initAgentActionRequestsDatabase() {
@@ -61,6 +66,25 @@ async function initAgentActionRequestsDatabase() {
         console.log(`[AgentActionRequests] Database initialized: ${ok} OK, ${skipped} skipped, ${failed} failed`);
     } catch (error) {
         console.error('[AgentActionRequests] Failed to init database:', error.message);
+    }
+
+    // ── Idempotent constraint migration (card_8151054f) ──
+    // The table already exists in prod, so the CREATE TABLE above is a no-op and
+    // the freshened aar_type_valid CHECK (with 'consensus') in the schema file is
+    // NOT applied to the live table. Drop + recreate the constraint so the new
+    // 'consensus' type becomes insertable on the existing table. Best-effort: a
+    // failure here (e.g. an in-flight row violating the new IN-list, which cannot
+    // happen since the list only grows) must never crash init.
+    try {
+        await pool.query('ALTER TABLE agent_action_requests DROP CONSTRAINT IF EXISTS aar_type_valid');
+        await pool.query(
+            `ALTER TABLE agent_action_requests
+                ADD CONSTRAINT aar_type_valid
+                CHECK (type IN ('decision','approval','input','credential','review','clarify','consensus'))`
+        );
+        console.log('[AgentActionRequests] aar_type_valid constraint migrated (includes consensus)');
+    } catch (err) {
+        console.error('[AgentActionRequests] aar_type_valid migration skipped:', err.message);
     }
 }
 
@@ -88,13 +112,41 @@ function rowToApi(row) {
 /**
  * Factory. Matches the kanban/scheduled-messages module style so index.js wires it the same way.
  */
-module.exports = function (devices, { pushToBot, unifiedPush, serverLog } = {}) {
+module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io } = {}) {
     const router = express.Router();
 
     function log(level, msg, meta) {
         if (typeof serverLog === 'function') {
             try { serverLog(level, 'agent_action_requests', msg, meta || {}); } catch (_) {}
         }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // SOCKET EVENT CONTRACT (card_8151054f) — frontend integration point for #6
+    // ──────────────────────────────────────────────────────────────────────
+    // Event name : 'action_request:changed'
+    // Room       : 'device:<deviceId>'   (same room convention as chat:message)
+    // Payload    : { kind, requestId, fromEntityId }
+    //                kind         : 'emitted' | 'resolved' | 'dismissed'
+    //                requestId    : the agent_action_requests row UUID (string)
+    //                fromEntityId : the emitting entity id (integer)
+    // Semantics  : fired AFTER the DB write commits, best-effort. The frontend
+    //              "需要你" inbox listens on this event to live-refresh (it should
+    //              re-fetch GET /api/action-requests rather than trust the payload
+    //              as the full row). A socket failure here NEVER affects the HTTP
+    //              response. This name + shape is the stable contract — do not
+    //              rename without coordinating with the frontend.
+    // ══════════════════════════════════════════════════════════════════════
+    function emitChanged(deviceId, kind, requestId, fromEntityId) {
+        try {
+            if (io && deviceId) {
+                io.to(`device:${deviceId}`).emit('action_request:changed', {
+                    kind,
+                    requestId,
+                    fromEntityId,
+                });
+            }
+        } catch (_) { /* socket failure must never break the HTTP response */ }
     }
 
     // Best-effort: notify the emitting agent that its request was answered.
@@ -131,6 +183,9 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog } = {}) 
         if (result.rows.length === 0) return null;
         const row = result.rows[0];
         notifyAgentResolved(deviceId, device, row, answer);
+        // Live-refresh the inbox. Lives here (not only in the endpoint) so the
+        // /api/client/speak smart-quote auto-resolve path emits identically.
+        emitChanged(deviceId, 'resolved', row.id, row.from_entity_id);
         return row;
     }
 
@@ -199,6 +254,7 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog } = {}) 
             );
             const row = result.rows[0];
             log('info', `emit id=${row.id} from=${fromEntityId} type=${type}`, { deviceId });
+            emitChanged(deviceId, 'emitted', row.id, row.from_entity_id);
             return res.json({ success: true, request: rowToApi(row) });
         } catch (err) {
             console.error('[AgentActionRequests] POST failed:', err.message);
@@ -288,8 +344,10 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog } = {}) 
             if (result.rows.length === 0) {
                 return res.status(404).json({ success: false, error: 'Not found or already resolved/dismissed' });
             }
+            const row = result.rows[0];
             log('info', `dismiss id=${id}`, { deviceId });
-            return res.json({ success: true, request: rowToApi(result.rows[0]) });
+            emitChanged(deviceId, 'dismissed', row.id, row.from_entity_id);
+            return res.json({ success: true, request: rowToApi(row) });
         } catch (err) {
             console.error('[AgentActionRequests] dismiss failed:', err.message);
             return res.status(500).json({ success: false, error: 'Internal error' });

--- a/backend/agent_action_requests_schema.sql
+++ b/backend/agent_action_requests_schema.sql
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS agent_action_requests (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     resolved_at TIMESTAMPTZ DEFAULT NULL,
     CONSTRAINT aar_prompt_len CHECK (char_length(prompt) BETWEEN 1 AND 2000),
-    CONSTRAINT aar_type_valid CHECK (type IN ('decision','approval','input','credential','review','clarify')),
+    CONSTRAINT aar_type_valid CHECK (type IN ('decision','approval','input','credential','review','clarify','consensus')),
     CONSTRAINT aar_status_valid CHECK (status IN ('pending','resolved','dismissed'))
 );
 

--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -48,7 +48,16 @@ const DEFAULTS = {
     // Shape: { enabled: bool, threshold_5h_pct: 0-100, threshold_7d_pct: 0-100 }
     // Trigger logic: warn if (5h_remaining ≤ threshold_5h_pct) OR (7d_remaining ≤ threshold_7d_pct).
     usage_warning_config: { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5 },
+    // "需要你" HITL inbox (card_8151054f). Backend stub defaults only — the full
+    // settings UI is a separate PR (#6). The backend ALWAYS emits the
+    // 'action_request:changed' socket event; the frontend gates live-refresh
+    // display on this flag. timeout policy = what to do with an un-answered
+    // request after a deadline (consumed by a future settings/timeout PR).
+    action_request_realtime: true,
+    action_request_timeout_policy: 'keep', // 'keep' | 'auto_dismiss' | 'escalate'
 };
+
+const ACTION_REQUEST_TIMEOUT_POLICIES = new Set(['keep', 'auto_dismiss', 'escalate']);
 
 // Spec: docs/specs/kanban-nudge-spec.md §6 — restricted override key set.
 const NUDGE_ENTITY_OVERRIDE_KEYS = [
@@ -84,6 +93,9 @@ function coerceValue(key, raw) {
     }
     if (key === 'kanban_nudge_priority_mode') {
         return NUDGE_PRIORITY_MODES.has(raw) ? raw : def;
+    }
+    if (key === 'action_request_timeout_policy') {
+        return ACTION_REQUEST_TIMEOUT_POLICIES.has(raw) ? raw : def;
     }
     if (key === 'kanban_nudge_statuses') {
         if (!Array.isArray(raw)) return [...def];

--- a/backend/index.js
+++ b/backend/index.js
@@ -1938,6 +1938,7 @@ try {
         pushToBot,
         unifiedPush,
         serverLog,
+        io, // real-time inbox push: emits 'action_request:changed' to device:<id> (card_8151054f)
     });
     app.use('/api/action-requests', agentActionRequestsModule.router);
     console.log('[AgentActionRequests] Module loaded successfully');

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650360,6 +650360,7 @@ const TRANSLATIONS = {
         "action_request_type_credential": "Credential",
         "action_request_type_review": "Review",
         "action_request_type_clarify": "Clarify",
+        "action_request_type_consensus": "Consensus",
 
         "kb_toast_moved": "Moved to {col}",
         "kb_toast_archived": "Archived",
@@ -1235367,6 +1235368,7 @@ const TRANSLATIONS = {
         "action_request_type_credential": "憑證",
         "action_request_type_review": "審查",
         "action_request_type_clarify": "釐清",
+        "action_request_type_consensus": "協商共識",
 
         "kb_toast_moved": "已移到 {col}",
         "kb_toast_archived": "已封存",

--- a/backend/tests/jest/action-request-consensus-realtime.test.js
+++ b/backend/tests/jest/action-request-consensus-realtime.test.js
@@ -1,0 +1,167 @@
+// Tests for the consensus type + real-time socket push on the "需要你"
+// agent_action_requests API (card_8151054f).
+//   1. emitting type 'consensus' succeeds (now a VALID_TYPE);
+//   2. an unknown type still 400s;
+//   3. emit/resolve/dismiss best-effort emit 'action_request:changed' to
+//      device:<id> with the documented { kind, requestId, fromEntityId } payload.
+
+const mockPoolQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockPoolQuery,
+        connect: jest.fn().mockResolvedValue({ query: mockPoolQuery, release: jest.fn() }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const express = require('express');
+const request = require('supertest');
+
+const deviceId = 'test-dev';
+const deviceSecret = 'dev-secret';
+const UUID = '11111111-2222-3333-4444-555555555555';
+
+let app;
+let emitToRoom; // captures io.to(room).emit(...)
+let lastRoom;
+
+beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    const devices = {
+        [deviceId]: {
+            deviceSecret,
+            entities: {
+                2: { isBound: true, botSecret: 'bot-2' },
+            },
+        },
+    };
+    // Minimal io double: io.to(room) returns an object whose .emit is recorded.
+    emitToRoom = jest.fn();
+    const io = {
+        to: jest.fn((room) => {
+            lastRoom = room;
+            return { emit: emitToRoom };
+        }),
+    };
+    const mod = require('../../agent-action-requests')(devices, { serverLog: () => {}, io });
+    app.use('/api/action-requests', mod.router);
+});
+
+afterEach(() => {
+    mockPoolQuery.mockClear();
+    emitToRoom.mockClear();
+});
+
+const post = (p) => request(app).post(p);
+
+function rowFixture(over = {}) {
+    return {
+        id: UUID, device_id: deviceId, from_entity_id: 2, anchor_message_id: null,
+        type: 'consensus', prompt: 'align with #1 #5 on rollout', options: null,
+        status: 'pending', answer: null,
+        created_at: new Date('2026-06-25T00:00:00Z'), resolved_at: null, ...over,
+    };
+}
+
+describe('consensus type', () => {
+    it('emitting type=consensus succeeds (now a valid type)', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture()] });
+        const res = await post('/api/action-requests').send({
+            deviceId, botSecret: 'bot-2', entityId: 2,
+            type: 'consensus', prompt: 'align with #1 #5 on rollout',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.request.type).toBe('consensus');
+        // INSERT received type 'consensus'
+        const params = mockPoolQuery.mock.calls[0][1];
+        expect(params[3]).toBe('consensus');
+    });
+
+    it('an unknown type still 400s', async () => {
+        const res = await post('/api/action-requests').send({
+            deviceId, botSecret: 'bot-2', entityId: 2, type: 'bogus', prompt: 'x',
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/type must be/);
+        // error message lists the new type so callers can discover it
+        expect(res.body.error).toMatch(/consensus/);
+    });
+});
+
+describe("real-time 'action_request:changed' socket push", () => {
+    it('emit (POST /) pushes kind=emitted to device room', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture()] });
+        await post('/api/action-requests').send({
+            deviceId, botSecret: 'bot-2', entityId: 2, type: 'consensus', prompt: 'p',
+        });
+        expect(lastRoom).toBe(`device:${deviceId}`);
+        expect(emitToRoom).toHaveBeenCalledTimes(1);
+        const [event, payload] = emitToRoom.mock.calls[0];
+        expect(event).toBe('action_request:changed');
+        expect(payload).toEqual({ kind: 'emitted', requestId: UUID, fromEntityId: 2 });
+    });
+
+    it('resolve (POST /:id/resolve) pushes kind=resolved', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ status: 'resolved', answer: 'ok', resolved_at: new Date() })] });
+        await post(`/api/action-requests/${UUID}/resolve`).send({ deviceId, deviceSecret, answer: 'ok' });
+        expect(lastRoom).toBe(`device:${deviceId}`);
+        expect(emitToRoom).toHaveBeenCalledTimes(1);
+        const [event, payload] = emitToRoom.mock.calls[0];
+        expect(event).toBe('action_request:changed');
+        expect(payload).toEqual({ kind: 'resolved', requestId: UUID, fromEntityId: 2 });
+    });
+
+    it('dismiss (POST /:id/dismiss) pushes kind=dismissed', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ status: 'dismissed', resolved_at: new Date() })] });
+        await post(`/api/action-requests/${UUID}/dismiss`).send({ deviceId, deviceSecret });
+        expect(lastRoom).toBe(`device:${deviceId}`);
+        expect(emitToRoom).toHaveBeenCalledTimes(1);
+        const [event, payload] = emitToRoom.mock.calls[0];
+        expect(event).toBe('action_request:changed');
+        expect(payload).toEqual({ kind: 'dismissed', requestId: UUID, fromEntityId: 2 });
+    });
+
+    it('a 404 resolve (nothing pending matched) does NOT emit', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+        const res = await post(`/api/action-requests/${UUID}/resolve`).send({ deviceId, deviceSecret });
+        expect(res.status).toBe(404);
+        expect(emitToRoom).not.toHaveBeenCalled();
+    });
+});
+
+describe('resolveActionRequest helper (speak auto-resolve path) emits too', () => {
+    it('the shared helper emits kind=resolved (so /api/client/speak gets it identically)', async () => {
+        const devices = {
+            [deviceId]: { deviceSecret, entities: { 2: { isBound: true, botSecret: 'bot-2' } } },
+        };
+        const helperEmit = jest.fn();
+        const io = { to: jest.fn(() => ({ emit: helperEmit })) };
+        const mod = require('../../agent-action-requests')(devices, { serverLog: () => {}, io });
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ status: 'resolved', answer: { text: 'hi' }, resolved_at: new Date() })] });
+        const row = await mod.resolveActionRequest(deviceId, UUID, { text: 'hi' }, devices[deviceId]);
+        expect(row).toBeTruthy();
+        expect(io.to).toHaveBeenCalledWith(`device:${deviceId}`);
+        expect(helperEmit).toHaveBeenCalledWith('action_request:changed', {
+            kind: 'resolved', requestId: UUID, fromEntityId: 2,
+        });
+    });
+});
+
+describe('io absent → no crash (best-effort)', () => {
+    it('module wired without io still emits cleanly (no throw)', async () => {
+        const devices = {
+            [deviceId]: { deviceSecret, entities: { 2: { isBound: true, botSecret: 'bot-2' } } },
+        };
+        const mod = require('../../agent-action-requests')(devices, { serverLog: () => {} }); // no io
+        const noIoApp = express();
+        noIoApp.use(express.json());
+        noIoApp.use('/api/action-requests', mod.router);
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture()] });
+        const res = await request(noIoApp).post('/api/action-requests').send({
+            deviceId, botSecret: 'bot-2', entityId: 2, type: 'consensus', prompt: 'p',
+        });
+        expect(res.status).toBe(200);
+    });
+});


### PR DESCRIPTION
Backend foundation for **card_8151054f**, extending the already-live "需要你" HITL inbox (`agent_action_requests`). Frontend (inbox live-refresh + settings UI) is handled separately by **#6** — this PR is BACKEND only and defines the contract.

## 1. New request type: `consensus` (與其他實體討論取得共識)
- Added `'consensus'` to `VALID_TYPES` in `backend/agent-action-requests.js`.
- Added `consensus` to the `aar_type_valid` CHECK in `backend/agent_action_requests_schema.sql`.
- **Constraint migration (prod table already exists):** `CREATE TABLE IF NOT EXISTS` is a no-op on prod, so the freshened CHECK in the schema file is NOT applied to the live table. `initAgentActionRequestsDatabase()` now runs an idempotent migration after the schema replay:
  ```sql
  ALTER TABLE agent_action_requests DROP CONSTRAINT IF EXISTS aar_type_valid;
  ALTER TABLE agent_action_requests ADD CONSTRAINT aar_type_valid
    CHECK (type IN ('decision','approval','input','credential','review','clarify','consensus'));
  ```
  Wrapped in try/catch (best-effort) so a failure never crashes init. The IN-list only grows, so the recreate can't fail on existing rows.

## 2. i18n
- `action_request_type_consensus` added to `backend/public/shared/i18n.js` in BOTH `en` ("Consensus") and `zh` ("協商共識"), matching the existing `action_request_type_*` key style/location.

## 3. Real-time socket push — **CONTRACT FOR #6's FRONTEND**
Threaded the socket.io `io` instance into the module factory (added `io` to the options param in `agent-action-requests.js`; passed from the `require('./agent-action-requests')(devices, {...})` registration in `index.js`). After each successful DB write the module emits, best-effort:

| field | value |
|---|---|
| **event name** | `action_request:changed` |
| **room** | `device:<deviceId>` (same room convention as `chat:message`) |
| **payload** | `{ kind, requestId, fromEntityId }` |
| `kind` | `'emitted'` \| `'resolved'` \| `'dismissed'` |
| `requestId` | the `agent_action_requests` row UUID (string) |
| `fromEntityId` | emitting entity id (integer) |

**#6 frontend integration:** listen on `action_request:changed`; on receipt, re-fetch `GET /api/action-requests` to live-refresh the "需要你" inbox (treat the payload as a change signal, not the full row). Fired AFTER the DB commit; a socket failure NEVER affects the HTTP response (try/catch). The event name + payload shape are the stable contract — documented in a block comment above the `emitChanged()` helper.

Emit points:
- **emit** — POST `/` → `kind: 'emitted'`
- **resolve** — POST `/:id/resolve` AND the shared `resolveActionRequest` helper (so the `/api/client/speak` smart-quote auto-resolve path emits identically) → `kind: 'resolved'`
- **dismiss** — POST `/:id/dismiss` → `kind: 'dismissed'`

A no-op resolve/dismiss (nothing pending matched → 404) does NOT emit.

## Settings (backend stub only — NOT the full settings UI)
Socket emit is always-on; the frontend gates display on a client setting (#6). Added two trivial defaults to the existing `backend/device-preferences.js` store for the future settings PR to consume:
- `action_request_realtime: true`
- `action_request_timeout_policy: 'keep'` (`'keep'` \| `'auto_dismiss'` \| `'escalate'`, enum-coerced)

No timeout-policy enforcement logic is implemented here — that's the settings/timeout PR's job.

## Tests
New `backend/tests/jest/action-request-consensus-realtime.test.js`:
- emitting `consensus` succeeds (now valid); unknown type still 400s (and the error lists `consensus`);
- emit/resolve/dismiss each call `io.to('device:<id>').emit('action_request:changed', {kind, requestId, fromEntityId})` with the right payload (mocked `io`);
- a 404 resolve does NOT emit;
- the shared `resolveActionRequest` helper (speak path) emits too;
- module wired without `io` still responds 200 (best-effort no-crash).

**Local results (all green):**
- `jest agent-action-requests.test.js action-request-speak-resolve.test.js action-request-e2e-flow.test.js action-request-consensus-realtime.test.js` → **4 suites, 58 tests passed**
- `jest device-preferences*.test.js` → **2 suites, 16 tests passed** (defaults additions safe)
- `node --check` on `index.js`, `agent-action-requests.js`, `device-preferences.js` → OK
- `node backend/scripts/i18n-check.js` → ✅ all referenced keys resolve in EN

Only intended files staged; CRLF-churn on untouched `test_*.js` files left unstaged. **Do not merge** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)