### PR TITLE
fix(action-requests): hardening — idempotent migration, bot resolve scoping, options cap, fromEntityId validation (PR#3732 follow-up)

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -68,21 +68,55 @@ async function initAgentActionRequestsDatabase() {
         console.error('[AgentActionRequests] Failed to init database:', error.message);
     }
 
-    // ── Idempotent constraint migration (card_8151054f) ──
+    // ── Idempotent, transactional constraint migration (card_8151054f; hardened) ──
     // The table already exists in prod, so the CREATE TABLE above is a no-op and
     // the freshened aar_type_valid CHECK (with 'consensus') in the schema file is
-    // NOT applied to the live table. Drop + recreate the constraint so the new
-    // 'consensus' type becomes insertable on the existing table. Best-effort: a
-    // failure here (e.g. an in-flight row violating the new IN-list, which cannot
-    // happen since the list only grows) must never crash init.
+    // NOT applied to the live table. We must drop + recreate the constraint so the
+    // new 'consensus' type becomes insertable on the existing table.
+    //
+    // Hardening (PR#3732 follow-up findings #1 + #2):
+    //   - GUARD first: if the live constraint already lists 'consensus', skip ALL
+    //     DDL. ACCESS EXCLUSIVE lock + full-table re-validation on every boot is
+    //     wasteful, and re-running on each restart is pointless once current.
+    //   - TRANSACTIONAL: when DDL is needed, run DROP+ADD inside a single
+    //     transaction on ONE pooled client, so there is never a *committed*
+    //     bare-constraint window (the old code committed the DROP, leaving the
+    //     table unconstrained until the separate ADD committed — and a multi-
+    //     instance race could DROP after a peer ADDed).
+    //   - ADVISORY LOCK: a transaction-scoped advisory lock serializes concurrent
+    //     instances doing the migration (cheap, auto-released on COMMIT/ROLLBACK).
+    // Best-effort throughout: any failure logs and never throws/crashes init.
     try {
-        await pool.query('ALTER TABLE agent_action_requests DROP CONSTRAINT IF EXISTS aar_type_valid');
-        await pool.query(
-            `ALTER TABLE agent_action_requests
-                ADD CONSTRAINT aar_type_valid
-                CHECK (type IN ('decision','approval','input','credential','review','clarify','consensus'))`
+        const existing = await pool.query(
+            `SELECT pg_get_constraintdef(oid) AS def
+               FROM pg_constraint
+              WHERE conname = 'aar_type_valid'
+                AND conrelid = 'agent_action_requests'::regclass`
         );
-        console.log('[AgentActionRequests] aar_type_valid constraint migrated (includes consensus)');
+        const curDef = existing.rows.length ? existing.rows[0].def : null;
+        if (curDef && curDef.includes('consensus')) {
+            console.log('[AgentActionRequests] aar_type_valid already current');
+        } else {
+            const client = await pool.connect();
+            try {
+                await client.query('BEGIN');
+                // 8151054f → numeric advisory-lock key (card id, transaction-scoped).
+                await client.query('SELECT pg_advisory_xact_lock(8151054)');
+                await client.query('ALTER TABLE agent_action_requests DROP CONSTRAINT IF EXISTS aar_type_valid');
+                await client.query(
+                    `ALTER TABLE agent_action_requests
+                        ADD CONSTRAINT aar_type_valid
+                        CHECK (type IN ('decision','approval','input','credential','review','clarify','consensus'))`
+                );
+                await client.query('COMMIT');
+                console.log('[AgentActionRequests] aar_type_valid constraint migrated (includes consensus)');
+            } catch (e) {
+                await client.query('ROLLBACK').catch(() => {});
+                throw e;
+            } finally {
+                client.release();
+            }
+        }
     } catch (err) {
         console.error('[AgentActionRequests] aar_type_valid migration skipped:', err.message);
     }
@@ -171,15 +205,25 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io } = 
     // Returns the resolved row, or null if nothing pending matched / id invalid.
     // Throws only on a DB error so the HTTP endpoint can 500; the speak path
     // wraps the call in try/catch and treats any failure as a no-op.
-    async function resolveActionRequest(deviceId, requestId, answer, device) {
+    //
+    // `restrictToEntityId` (PR#3732 follow-up finding #3): when non-null, the
+    // UPDATE also requires from_entity_id = that id, so a botSecret holder can
+    // only resolve a request IT emitted — never another entity's request on the
+    // same device (which would also forge a push-back to that other entity). The
+    // human/deviceSecret (isUser) path and the /api/client/speak USER auto-resolve
+    // path pass null (default) — the user owns the whole device inbox.
+    async function resolveActionRequest(deviceId, requestId, answer, device, restrictToEntityId = null) {
         if (!deviceId || !UUID_RE.test(String(requestId))) return null;
-        const result = await pool.query(
-            `UPDATE agent_action_requests
+        const params = [answer !== undefined ? JSON.stringify(answer) : null, requestId, deviceId];
+        let sql = `UPDATE agent_action_requests
                 SET status = 'resolved', answer = $1::jsonb, resolved_at = NOW()
-              WHERE id = $2 AND device_id = $3 AND status = 'pending'
-            RETURNING *`,
-            [answer !== undefined ? JSON.stringify(answer) : null, requestId, deviceId]
-        );
+              WHERE id = $2 AND device_id = $3 AND status = 'pending'`;
+        if (restrictToEntityId != null) {
+            params.push(restrictToEntityId);
+            sql += ` AND from_entity_id = $${params.length}`;
+        }
+        sql += ` RETURNING *`;
+        const result = await pool.query(sql, params);
         if (result.rows.length === 0) return null;
         const row = result.rows[0];
         notifyAgentResolved(deviceId, device, row, answer);
@@ -233,6 +277,20 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io } = 
         if (!Number.isInteger(fromEntityId) || fromEntityId < 0) {
             return res.status(400).json({ success: false, error: 'fromEntityId required (integer)' });
         }
+        // The bot path's auth.entityId is already vetted by authenticate(); only the
+        // user (deviceSecret) path names an arbitrary fromEntityId, so confirm it is
+        // a real bound entity on THIS device (finding #5). device.entities keys may
+        // be string- or int-typed — check both forms.
+        if (auth.isUser) {
+            const ents = auth.device && auth.device.entities;
+            const known = ents && (
+                Object.prototype.hasOwnProperty.call(ents, String(fromEntityId)) ||
+                Object.prototype.hasOwnProperty.call(ents, fromEntityId)
+            );
+            if (!known) {
+                return res.status(400).json({ success: false, error: 'fromEntityId is not a known entity on this device' });
+            }
+        }
         if (typeof type !== 'string' || !VALID_TYPES.has(type)) {
             return res.status(400).json({ success: false, error: `type must be one of: ${[...VALID_TYPES].join('|')}` });
         }
@@ -241,6 +299,12 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io } = 
         }
         if (options !== undefined && options !== null && !Array.isArray(options)) {
             return res.status(400).json({ success: false, error: 'options must be an array when provided' });
+        }
+        // Bound the options payload (finding #4). prompt is already capped at
+        // MAX_PROMPT_LEN; this mirrors that with a clearer error than the global
+        // body-parser cap. Defense-in-depth.
+        if (Array.isArray(options) && (options.length > 50 || JSON.stringify(options).length > 8192)) {
+            return res.status(400).json({ success: false, error: 'options too large (max 50 items / 8KB)' });
         }
         const anchor = normalizeAnchor(anchorMessageId);
 
@@ -310,7 +374,10 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io } = 
         const { answer } = req.body || {};
 
         try {
-            const row = await resolveActionRequest(deviceId, id, answer, device);
+            // A botSecret holder may only resolve its OWN emitted requests; the
+            // human (isUser/deviceSecret) owns the whole device inbox (finding #3).
+            const restrictToEntityId = auth.isUser ? null : auth.entityId;
+            const row = await resolveActionRequest(deviceId, id, answer, device, restrictToEntityId);
             if (!row) {
                 return res.status(404).json({ success: false, error: 'Not found or already resolved/dismissed' });
             }
@@ -334,13 +401,18 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io } = 
             return res.status(400).json({ success: false, error: 'Invalid id' });
         }
         try {
-            const result = await pool.query(
-                `UPDATE agent_action_requests
+            // A botSecret holder may only dismiss its OWN emitted requests; the
+            // human (isUser/deviceSecret) owns the whole device inbox (finding #3).
+            const params = [id, deviceId];
+            let sql = `UPDATE agent_action_requests
                     SET status = 'dismissed', resolved_at = NOW()
-                  WHERE id = $1 AND device_id = $2 AND status = 'pending'
-                RETURNING *`,
-                [id, deviceId]
-            );
+                  WHERE id = $1 AND device_id = $2 AND status = 'pending'`;
+            if (!auth.isUser) {
+                params.push(auth.entityId);
+                sql += ` AND from_entity_id = $${params.length}`;
+            }
+            sql += ` RETURNING *`;
+            const result = await pool.query(sql, params);
             if (result.rows.length === 0) {
                 return res.status(404).json({ success: false, error: 'Not found or already resolved/dismissed' });
             }

--- a/backend/tests/jest/action-request-hardening.test.js
+++ b/backend/tests/jest/action-request-hardening.test.js
@@ -1,0 +1,313 @@
+// Hardening tests for the "需要你" agent_action_requests API — PR#3732 follow-up.
+// Covers 5 LOW-severity findings from an adversarial multi-agent self-review:
+//   A — idempotent, transactional aar_type_valid migration (skip when current;
+//       DROP+ADD inside BEGIN/COMMIT when stale).
+//   B — bot resolve/dismiss scoped to the bot's OWN emitted requests; the user
+//       (deviceSecret) path stays unrestricted over the whole device inbox.
+//   C — bound the options payload (max 50 items / 8KB).
+//   D — user-path fromEntityId must be a real bound entity on the device.
+//
+// Same pg-mock + supertest style as action-request-consensus-realtime.test.js.
+
+// ── pg mock: one shared query fn for pool.query AND client.query, plus a
+//    pool.connect() that returns a client whose query is recorded too, so the
+//    Fix-A transaction (BEGIN/lock/DROP/ADD/COMMIT) is observable. ──
+const mockPoolQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+const mockClientQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+const mockClientRelease = jest.fn();
+const mockConnect = jest.fn().mockResolvedValue({ query: mockClientQuery, release: mockClientRelease });
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockPoolQuery,
+        connect: mockConnect,
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const express = require('express');
+const request = require('supertest');
+
+const deviceId = 'test-dev';
+const deviceSecret = 'dev-secret';
+const UUID = '11111111-2222-3333-4444-555555555555';
+
+let app;
+let emitToRoom;
+
+beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    const devices = {
+        [deviceId]: {
+            deviceSecret,
+            entities: {
+                2: { isBound: true, botSecret: 'bot-2' },
+                3: { isBound: true, botSecret: 'bot-3' },
+            },
+        },
+    };
+    emitToRoom = jest.fn();
+    const io = { to: jest.fn(() => ({ emit: emitToRoom })) };
+    const mod = require('../../agent-action-requests')(devices, { serverLog: () => {}, io });
+    app.use('/api/action-requests', mod.router);
+});
+
+afterEach(() => {
+    mockPoolQuery.mockClear();
+    mockClientQuery.mockClear();
+    mockClientRelease.mockClear();
+    mockConnect.mockClear();
+    emitToRoom.mockClear();
+});
+
+const post = (p) => request(app).post(p);
+
+function rowFixture(over = {}) {
+    return {
+        id: UUID, device_id: deviceId, from_entity_id: 2, anchor_message_id: null,
+        type: 'consensus', prompt: 'p', options: null,
+        status: 'pending', answer: null,
+        created_at: new Date('2026-06-25T00:00:00Z'), resolved_at: null, ...over,
+    };
+}
+
+// Find the resolve/dismiss UPDATE call among pool.query invocations.
+function findUpdate(verb) {
+    const calls = mockPoolQuery.mock.calls;
+    const re = new RegExp(`status = '${verb}'`);
+    return calls.find((c) => typeof c[0] === 'string' && re.test(c[0]));
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Fix B — bot resolve/dismiss scoped to OWN requests; user unrestricted
+// ════════════════════════════════════════════════════════════════════
+describe('Fix B — bot resolve/dismiss scoped to own emitted requests', () => {
+    describe('resolve', () => {
+        it("botSecret resolve of ANOTHER entity's request → UPDATE carries from_entity_id predicate, 0 rows → 404, no emit", async () => {
+            // entity 2 (bot-2) tries to resolve a request emitted by entity 3.
+            // Scoping appends `AND from_entity_id = $4`; mock returns 0 rows.
+            mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+            const res = await post(`/api/action-requests/${UUID}/resolve`).send({
+                deviceId, botSecret: 'bot-2', entityId: 2, answer: 'x',
+            });
+            expect(res.status).toBe(404);
+            const upd = findUpdate('resolved');
+            expect(upd).toBeTruthy();
+            expect(upd[0]).toMatch(/from_entity_id = \$\d+/);
+            // the restriction param is the bot's own entityId (2)
+            expect(upd[1]).toContain(2);
+            expect(emitToRoom).not.toHaveBeenCalled();
+        });
+
+        it('botSecret resolve of its OWN request → 200 + emit', async () => {
+            mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ status: 'resolved', from_entity_id: 2, answer: 'ok', resolved_at: new Date() })] });
+            const res = await post(`/api/action-requests/${UUID}/resolve`).send({
+                deviceId, botSecret: 'bot-2', entityId: 2, answer: 'ok',
+            });
+            expect(res.status).toBe(200);
+            expect(res.body.success).toBe(true);
+            const upd = findUpdate('resolved');
+            expect(upd[0]).toMatch(/from_entity_id = \$\d+/);
+            expect(emitToRoom).toHaveBeenCalledTimes(1);
+        });
+
+        it('deviceSecret (user) resolve → UPDATE has NO from_entity_id predicate → 200', async () => {
+            mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ status: 'resolved', from_entity_id: 3, answer: 'ok', resolved_at: new Date() })] });
+            const res = await post(`/api/action-requests/${UUID}/resolve`).send({
+                deviceId, deviceSecret, answer: 'ok',
+            });
+            expect(res.status).toBe(200);
+            const upd = findUpdate('resolved');
+            expect(upd).toBeTruthy();
+            expect(upd[0]).not.toMatch(/from_entity_id/);
+            // params for the user path: [answerJson, id, deviceId] only (no entity restriction)
+            expect(upd[1]).toHaveLength(3);
+        });
+    });
+
+    describe('dismiss', () => {
+        it("botSecret dismiss of ANOTHER entity's request → UPDATE carries from_entity_id predicate, 0 rows → 404, no emit", async () => {
+            mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+            const res = await post(`/api/action-requests/${UUID}/dismiss`).send({
+                deviceId, botSecret: 'bot-2', entityId: 2,
+            });
+            expect(res.status).toBe(404);
+            const upd = findUpdate('dismissed');
+            expect(upd).toBeTruthy();
+            expect(upd[0]).toMatch(/from_entity_id = \$\d+/);
+            expect(upd[1]).toContain(2);
+            expect(emitToRoom).not.toHaveBeenCalled();
+        });
+
+        it('botSecret dismiss of its OWN request → 200 + emit', async () => {
+            mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ status: 'dismissed', from_entity_id: 2, resolved_at: new Date() })] });
+            const res = await post(`/api/action-requests/${UUID}/dismiss`).send({
+                deviceId, botSecret: 'bot-2', entityId: 2,
+            });
+            expect(res.status).toBe(200);
+            const upd = findUpdate('dismissed');
+            expect(upd[0]).toMatch(/from_entity_id = \$\d+/);
+            expect(emitToRoom).toHaveBeenCalledTimes(1);
+        });
+
+        it('deviceSecret (user) dismiss → UPDATE has NO from_entity_id predicate → 200', async () => {
+            mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ status: 'dismissed', from_entity_id: 3, resolved_at: new Date() })] });
+            const res = await post(`/api/action-requests/${UUID}/dismiss`).send({
+                deviceId, deviceSecret,
+            });
+            expect(res.status).toBe(200);
+            const upd = findUpdate('dismissed');
+            expect(upd[0]).not.toMatch(/from_entity_id/);
+            expect(upd[1]).toHaveLength(2); // [id, deviceId] only
+        });
+    });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// Fix C — bound the options payload
+// ════════════════════════════════════════════════════════════════════
+describe('Fix C — options payload bound (max 50 items / 8KB)', () => {
+    it('options with 51 elements → 400', async () => {
+        const options = Array.from({ length: 51 }, (_, i) => `o${i}`);
+        const res = await post('/api/action-requests').send({
+            deviceId, botSecret: 'bot-2', entityId: 2, type: 'decision', prompt: 'p', options,
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/options too large/);
+    });
+
+    it('options whose JSON exceeds 8KB → 400', async () => {
+        // 10 items, each ~1KB → > 8192 bytes serialized, but only 10 items (< 50)
+        const options = Array.from({ length: 10 }, () => 'x'.repeat(1000));
+        expect(options.length).toBeLessThanOrEqual(50);
+        expect(JSON.stringify(options).length).toBeGreaterThan(8192);
+        const res = await post('/api/action-requests').send({
+            deviceId, botSecret: 'bot-2', entityId: 2, type: 'decision', prompt: 'p', options,
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/options too large/);
+    });
+
+    it('a small options array → 200 (not rejected)', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ options: ['a', 'b'] })] });
+        const res = await post('/api/action-requests').send({
+            deviceId, botSecret: 'bot-2', entityId: 2, type: 'decision', prompt: 'p', options: ['a', 'b'],
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// Fix D — user-path fromEntityId validated against device.entities
+// ════════════════════════════════════════════════════════════════════
+describe('Fix D — user-path fromEntityId validated against device.entities', () => {
+    it('user (deviceSecret) emit with fromEntityId NOT on device → 400', async () => {
+        const res = await post('/api/action-requests').send({
+            deviceId, deviceSecret, fromEntityId: 99, type: 'decision', prompt: 'p',
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/not a known entity on this device/);
+    });
+
+    it('user (deviceSecret) emit with a valid bound entity → 200', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ from_entity_id: 3 })] });
+        const res = await post('/api/action-requests').send({
+            deviceId, deviceSecret, fromEntityId: 3, type: 'decision', prompt: 'p',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        // INSERT received from_entity_id = 3
+        const insert = mockPoolQuery.mock.calls.find((c) => /INSERT INTO agent_action_requests/.test(c[0]));
+        expect(insert[1][1]).toBe(3);
+    });
+
+    it('bot (botSecret) emit still works — uses its own vetted entityId, no device.entities check', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ from_entity_id: 2 })] });
+        const res = await post('/api/action-requests').send({
+            deviceId, botSecret: 'bot-2', entityId: 2, type: 'decision', prompt: 'p',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════════
+// Fix A — idempotent, transactional aar_type_valid migration
+// ════════════════════════════════════════════════════════════════════
+describe('Fix A — idempotent transactional constraint migration', () => {
+    // initDatabase reads schema.sql then runs the guarded migration. We drive the
+    // pg mock to control what the `pg_get_constraintdef` SELECT returns. The
+    // schema.sql statements + the SELECT all go through pool.query; the DROP/ADD
+    // (only when stale) go through a connected client (pool.connect → client.query).
+    const { initAgentActionRequestsDatabase } = require('../../agent-action-requests');
+
+    function constraintDefSelectMock(def) {
+        // Make pool.query resolve schema statements as no-ops, but return the
+        // given constraint def for the pg_get_constraintdef SELECT.
+        mockPoolQuery.mockImplementation((sql) => {
+            if (typeof sql === 'string' && /pg_get_constraintdef/.test(sql)) {
+                return Promise.resolve({ rows: def === null ? [] : [{ def }] });
+            }
+            return Promise.resolve({ rows: [], rowCount: 0 });
+        });
+    }
+
+    afterEach(() => {
+        mockPoolQuery.mockReset();
+        mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+        mockClientQuery.mockReset();
+        mockClientQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    });
+
+    it('def already contains consensus → migration SKIPPED (no client connect, no ADD CONSTRAINT)', async () => {
+        constraintDefSelectMock("CHECK ((type)::text = ANY (ARRAY['decision','approval','input','credential','review','clarify','consensus']))");
+        await expect(initAgentActionRequestsDatabase()).resolves.toBeUndefined();
+        // No transaction client opened, no ADD CONSTRAINT issued anywhere.
+        expect(mockConnect).not.toHaveBeenCalled();
+        const addOnPool = mockPoolQuery.mock.calls.find((c) => /ADD CONSTRAINT aar_type_valid/.test(c[0]));
+        const addOnClient = mockClientQuery.mock.calls.find((c) => /ADD CONSTRAINT aar_type_valid/.test(c[0]));
+        expect(addOnPool).toBeUndefined();
+        expect(addOnClient).toBeUndefined();
+    });
+
+    it('def lacks consensus → DROP+ADD run inside BEGIN/COMMIT on a pooled client', async () => {
+        constraintDefSelectMock("CHECK ((type)::text = ANY (ARRAY['decision','approval','input','credential','review','clarify']))");
+        await expect(initAgentActionRequestsDatabase()).resolves.toBeUndefined();
+        expect(mockConnect).toHaveBeenCalledTimes(1);
+        const clientSql = mockClientQuery.mock.calls.map((c) => c[0]);
+        const joined = clientSql.join('\n');
+        expect(joined).toMatch(/BEGIN/);
+        expect(joined).toMatch(/DROP CONSTRAINT IF EXISTS aar_type_valid/);
+        expect(joined).toMatch(/ADD CONSTRAINT\s+aar_type_valid/);
+        expect(joined).toMatch(/COMMIT/);
+        // DROP+ADD must be committed (no bare-constraint window): COMMIT comes after both.
+        const iDrop = clientSql.findIndex((s) => /DROP CONSTRAINT/.test(s));
+        const iAdd = clientSql.findIndex((s) => /ADD CONSTRAINT/.test(s));
+        const iCommit = clientSql.findIndex((s) => /COMMIT/.test(s));
+        expect(iDrop).toBeGreaterThanOrEqual(0);
+        expect(iAdd).toBeGreaterThan(iDrop);
+        expect(iCommit).toBeGreaterThan(iAdd);
+        // released back to the pool
+        expect(mockClientRelease).toHaveBeenCalled();
+    });
+
+    it('no existing constraint row (fresh table) → DROP+ADD still run transactionally', async () => {
+        constraintDefSelectMock(null); // SELECT returns 0 rows
+        await expect(initAgentActionRequestsDatabase()).resolves.toBeUndefined();
+        expect(mockConnect).toHaveBeenCalledTimes(1);
+        const joined = mockClientQuery.mock.calls.map((c) => c[0]).join('\n');
+        expect(joined).toMatch(/ADD CONSTRAINT\s+aar_type_valid/);
+        expect(joined).toMatch(/COMMIT/);
+    });
+
+    it('init never throws even if the migration SELECT rejects', async () => {
+        mockPoolQuery.mockImplementation((sql) => {
+            if (typeof sql === 'string' && /pg_get_constraintdef/.test(sql)) {
+                return Promise.reject(new Error('boom'));
+            }
+            return Promise.resolve({ rows: [], rowCount: 0 });
+        });
+        await expect(initAgentActionRequestsDatabase()).resolves.toBeUndefined();
+    });
+});


### PR DESCRIPTION
Focused **hardening** follow-up to #3732 (action_action_requests). Five **LOW**-severity findings surfaced by an **adversarial multi-agent self-review** of the just-merged change; each confirmed real with exact line refs. All defense-in-depth — no behavior change for legitimate callers.

All changes are in `backend/agent-action-requests.js` + a new test file. `backend/index.js` is **unchanged** (the `/api/client/speak` USER auto-resolve call site stays a 4-arg call → new param defaults to `null` → unrestricted, as required).

### Fix A — idempotent, transactional constraint migration (findings #1 + #2)
`initAgentActionRequestsDatabase()` used to run an **unconditional** `DROP CONSTRAINT IF EXISTS aar_type_valid` then a separate `ADD CONSTRAINT … CHECK` on **every boot** — two autocommit queries. That meant an ACCESS EXCLUSIVE lock + full-table re-validation each restart, a **committed bare-constraint window**, and a multi-instance DROP-after-ADD race.
Now:
1. `SELECT pg_get_constraintdef(oid)` for the live constraint first.
2. If the def already contains `'consensus'` → **skip all DDL**, log `aar_type_valid already current`.
3. Otherwise run `DROP`+`ADD` inside a **single `BEGIN`/`COMMIT` on one pooled client** (`pool.connect()`), with `pg_advisory_xact_lock(8151054)` for multi-instance serialization, `ROLLBACK` on error. There is never a committed unconstrained window.

Stays best-effort: any failure logs and **never throws** from init. `schema.sql` CHECK left as-is (already includes `consensus`).

### Fix B — scope bot resolve/dismiss to the bot's OWN requests (finding #3)
resolve & dismiss UPDATEs were only `WHERE id=$ AND device_id=$ AND status='pending'`, so a botSecret holder for entity N could resolve/dismiss (and on resolve, forge a push-back for) a request emitted by a **different** entity M on the same device.
- `resolveActionRequest(deviceId, requestId, answer, device, restrictToEntityId = null)` — when non-null, appends `AND from_entity_id = $N` (parameterized).
- `POST /:id/resolve` calls with `auth.isUser ? null : auth.entityId`.
- `POST /:id/dismiss` appends `AND from_entity_id = $N` only when `!auth.isUser`.
- The **human (deviceSecret)** path and the **`/api/client/speak` USER** auto-resolve path stay **unrestricted** — the user owns the whole device inbox.
- Scoped-out → 0 rows → existing 404, and `emitChanged` does NOT fire.

### Fix C — bound the `options` payload (finding #4)
`POST /` now rejects `options` with `>50` items or `>8192` bytes serialized → `400 options too large (max 50 items / 8KB)`. Mirrors the existing 2000-char prompt cap; clearer than the global ~100kb body-parser cap.

### Fix D — validate user-path fromEntityId against device.entities (finding #5)
On the isUser emit path, `fromEntityId` was only range-checked, never confirmed to be a real entity. Now → `400 fromEntityId is not a known entity on this device` if it is not a bound entity on `device.entities` (handles string- or int-keyed). The **bot path** uses its `authenticate()`-vetted `auth.entityId`, untouched.

### Tests
New `backend/tests/jest/action-request-hardening.test.js` (16 cases, pg-mock + supertest, same style as `action-request-consensus-realtime.test.js`):
- **B**: bot resolve/dismiss of another entity's request → UPDATE carries `from_entity_id = $` predicate, 0 rows → 404, **no emit**; bot resolve/dismiss of OWN → 200 + emit; user resolve/dismiss → UPDATE has **no** `from_entity_id` predicate → 200.
- **C**: 51 items → 400; >8KB → 400; small array → 200.
- **D**: user emit with unknown fromEntityId → 400; valid bound entity → 200; bot emit still works.
- **A**: def already has `consensus` → migration **skipped** (no `pool.connect`, no `ADD CONSTRAINT`); def lacks `consensus` (and fresh-table no-row case) → `DROP`+`ADD` issued inside `BEGIN`…`COMMIT` on a client, ordered DROP→ADD→COMMIT, client released; init never throws on a SELECT reject.

### Verification
- `node --check backend/agent-action-requests.js backend/index.js` → OK
- jest (broad, pg mocked): `action-request-consensus-realtime`, `action-request-e2e-flow`, `action-request-speak-resolve`, `action-request-hardening`, `device-preferences*`, `kanban-nudge*` → **8 suites / 86 tests pass**; plus `agent-action-requests` + `chat-action-request-inbox` → **2 suites / 22 tests pass**.
- `node backend/scripts/i18n-check.js` → exit 0 (no i18n change in this PR).

Do not auto-merge — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)