### PR TITLE
feat(action-requests): timeout-policy worker — a/b/c/d enforcement + consensus auto-execute (card_ce0d685b)

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -28,6 +28,11 @@ const { Pool } = require('pg');
 const fs = require('fs');
 const path = require('path');
 const safeEqual = require('./safe-equal');
+// Singleton device-preferences module (its internal pool is wired once by
+// index.js via initTable). The timeout worker reads each device's policy +
+// timeout-minutes from here. Tests may inject a `getDevicePrefs` override on the
+// factory options to avoid touching it.
+const devicePrefs = require('./device-preferences');
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
@@ -42,6 +47,11 @@ const MAX_LIST_LIMIT = 500;
 // plain schema re-run won't change the constraint).
 const VALID_TYPES = new Set(['decision', 'approval', 'input', 'credential', 'review', 'clarify', 'consensus']);
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Timeout-policy worker (card_ce0d685b): sweep cadence + a process-level guard so
+// re-requiring / re-instantiating the factory never stacks intervals.
+const TIMEOUT_SWEEP_INTERVAL_MS = 5 * 60 * 1000; // every 5 minutes
+let timeoutSweepTimer = null;
 
 async function initAgentActionRequestsDatabase() {
     try {
@@ -120,6 +130,21 @@ async function initAgentActionRequestsDatabase() {
     } catch (err) {
         console.error('[AgentActionRequests] aar_type_valid migration skipped:', err.message);
     }
+
+    // ── Idempotent column migration: consensus_triggered_at (card_ce0d685b) ──
+    // The timeout worker's 'consensus' policy leaves a request 'pending' (the
+    // emitting agent resolves it after synthesis), so without a marker the worker
+    // would re-fire a consensus round every 5-min tick. This column is set once
+    // when a round is triggered. ADD COLUMN IF NOT EXISTS is a no-op on a table
+    // that already has it. Best-effort: never throws/crashes init.
+    try {
+        await pool.query(
+            `ALTER TABLE agent_action_requests
+                ADD COLUMN IF NOT EXISTS consensus_triggered_at TIMESTAMPTZ DEFAULT NULL`
+        );
+    } catch (err) {
+        console.error('[AgentActionRequests] consensus_triggered_at migration skipped:', err.message);
+    }
 }
 
 // ── Helpers ──
@@ -146,8 +171,15 @@ function rowToApi(row) {
 /**
  * Factory. Matches the kanban/scheduled-messages module style so index.js wires it the same way.
  */
-module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io } = {}) {
+module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, getDevicePrefs } = {}) {
     const router = express.Router();
+
+    // How the worker reads a device's timeout policy + minutes. Defaults to the
+    // singleton device-preferences module; tests inject a stub so they never
+    // touch real PG. Always returns an object (falls back to {} on error).
+    const readDevicePrefs = typeof getDevicePrefs === 'function'
+        ? getDevicePrefs
+        : (deviceId) => devicePrefs.getPrefs(deviceId);
 
     function log(level, msg, meta) {
         if (typeof serverLog === 'function') {
@@ -162,8 +194,14 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io } = 
     // Room       : 'device:<deviceId>'   (same room convention as chat:message)
     // Payload    : { kind, requestId, fromEntityId }
     //                kind         : 'emitted' | 'resolved' | 'dismissed'
+    //                               | 'consensus_triggered'
     //                requestId    : the agent_action_requests row UUID (string)
     //                fromEntityId : the emitting entity id (integer)
+    //              NEW kind 'consensus_triggered' (card_ce0d685b): the timeout
+    //              worker opened a bot-to-bot consensus round for a still-pending
+    //              request (consensus policy). The request stays 'pending' until
+    //              the emitting agent synthesizes + resolves it; the frontend can
+    //              render a "協商中 / In consensus" badge on this event.
     // Semantics  : fired AFTER the DB write commits, best-effort. The frontend
     //              "需要你" inbox listens on this event to live-refresh (it should
     //              re-fetch GET /api/action-requests rather than trust the payload
@@ -231,6 +269,149 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io } = 
         // /api/client/speak smart-quote auto-resolve path emits identically.
         emitChanged(deviceId, 'resolved', row.id, row.from_entity_id);
         return row;
+    }
+
+    // Best-effort: push a free-text message to one bound entity (channel or
+    // webhook). Mirrors notifyAgentResolved's transport selection. Never throws.
+    function pushTextToEntity(deviceId, entity, eventType, message, extra = {}) {
+        try {
+            if (!entity || !entity.isBound) return;
+            if (entity.bindingType === 'channel' && typeof unifiedPush === 'function') {
+                unifiedPush(entity, deviceId, eventType, { message, ...extra }, { event: 'message', from: 'action_request' }).catch(() => {});
+            } else if (entity.webhook && typeof pushToBot === 'function') {
+                pushToBot(entity, deviceId, eventType, { message, ...extra }).catch(() => {});
+            }
+        } catch (_) {}
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // TIMEOUT-POLICY WORKER (card_ce0d685b)
+    // ──────────────────────────────────────────────────────────────────────
+    // Periodically (every 5 min) enforces each device's
+    // `action_request_timeout_policy` on its pending "需要你" requests older than
+    // `action_request_timeout_minutes` (read from device-preferences):
+    //
+    //   keep         → no-op (device skipped entirely; this is the default).
+    //   auto_dismiss → mark the request dismissed + tell the emitting agent its
+    //                  request timed out and was auto-skipped; emit
+    //                  'action_request:changed' kind='dismissed'.
+    //   safe_default → call resolveActionRequest with a safe-default answer, so it
+    //                  resolves + notifies the emitter + emits kind='resolved'
+    //                  identically to a human answer; the agent continues.
+    //   consensus    → trigger ONE bot-to-bot consensus round (does NOT resolve):
+    //                    1. stamp consensus_triggered_at (so it never re-fires);
+    //                    2. broadcast a zh consensus prompt to every bound entity
+    //                       on the device (the emitter included);
+    //                    3. emit 'action_request:changed' kind='consensus_triggered'
+    //                       (a NEW socket kind — frontend shows "協商中").
+    //
+    // AUTO-EXECUTE CONTRACT (Hank's decision — no user confirmation):
+    //   The server worker's job is detect-timeout → trigger-round → mark. The
+    //   *synthesis + resolution* is the agent layer: the emitting agent
+    //   (#from_entity_id), on seeing the consensus prompt, collects the other
+    //   entities' replies, synthesizes the consensus decision, and calls
+    //   POST /api/action-requests/:id/resolve with that answer. Because resolve
+    //   has no user gate, that auto-executes the decision. The worker never
+    //   resolves a consensus request itself — it only opens the round once.
+    //
+    // Resilience: each device + each request is wrapped in try/catch so one bad
+    // row never aborts the sweep. Exported for direct test invocation. The
+    // periodic timer is registered once at module init (NODE_ENV !== 'test').
+    // ══════════════════════════════════════════════════════════════════════
+    async function enforceActionRequestTimeouts() {
+        let deviceIds = [];
+        try {
+            const r = await pool.query(
+                `SELECT DISTINCT device_id FROM agent_action_requests WHERE status = 'pending'`
+            );
+            deviceIds = r.rows.map(row => row.device_id).filter(Boolean);
+        } catch (err) {
+            console.error('[AgentActionRequests] timeout sweep: device scan failed:', err.message);
+            return;
+        }
+
+        for (const deviceId of deviceIds) {
+            try {
+                let prefs = {};
+                try { prefs = (await readDevicePrefs(deviceId)) || {}; } catch (_) { prefs = {}; }
+                const policy = prefs.action_request_timeout_policy || 'keep';
+                if (policy === 'keep') continue; // default: never auto-act
+                const minutesRaw = prefs.action_request_timeout_minutes;
+                const minutes = Number.isFinite(Number(minutesRaw)) ? Number(minutesRaw) : 1440;
+
+                // Pending requests older than the timeout. For consensus, also skip
+                // ones we've already opened a round for (consensus_triggered_at set).
+                let sql = `SELECT * FROM agent_action_requests
+                            WHERE device_id = $1 AND status = 'pending'
+                              AND created_at < NOW() - ($2 * interval '1 minute')`;
+                if (policy === 'consensus') sql += ` AND consensus_triggered_at IS NULL`;
+                sql += ` ORDER BY created_at ASC LIMIT ${MAX_LIST_LIMIT}`;
+                const res = await pool.query(sql, [deviceId, minutes]);
+                const rows = res.rows || [];
+                if (rows.length === 0) continue;
+
+                const device = devices && devices[deviceId];
+
+                for (const row of rows) {
+                    try {
+                        if (policy === 'auto_dismiss') {
+                            const upd = await pool.query(
+                                `UPDATE agent_action_requests
+                                    SET status = 'dismissed', resolved_at = NOW()
+                                  WHERE id = $1 AND status = 'pending'
+                                RETURNING *`,
+                                [row.id]
+                            );
+                            if (upd.rows.length === 0) continue; // raced/already acted
+                            emitChanged(deviceId, 'dismissed', row.id, row.from_entity_id);
+                            const emitter = device && device.entities && device.entities[row.from_entity_id];
+                            pushTextToEntity(
+                                deviceId, emitter, 'action_request_timeout_dismissed',
+                                `[逾時自動略過] 你的請求逾時未回覆，已自動略過：「${row.prompt}」(request ${row.id})`,
+                                { requestId: row.id }
+                            );
+                            log('info', `timeout auto_dismiss id=${row.id} from=${row.from_entity_id}`, { deviceId });
+                        } else if (policy === 'safe_default') {
+                            // Reuse the shared resolve path so it resolves + notifies
+                            // the emitter + emits kind='resolved' exactly like a human.
+                            await resolveActionRequest(
+                                deviceId, row.id,
+                                { text: '[安全預設] 逾時未回覆，agent 以安全預設續跑', auto: true, reason: 'timeout_safe_default' },
+                                device
+                            );
+                            log('info', `timeout safe_default id=${row.id} from=${row.from_entity_id}`, { deviceId });
+                        } else if (policy === 'consensus') {
+                            // 1. Stamp the marker first (guarded) so it never re-fires.
+                            const stamp = await pool.query(
+                                `UPDATE agent_action_requests
+                                    SET consensus_triggered_at = NOW()
+                                  WHERE id = $1 AND status = 'pending' AND consensus_triggered_at IS NULL
+                                RETURNING *`,
+                                [row.id]
+                            );
+                            if (stamp.rows.length === 0) continue; // raced / already opened
+                            // 2. Broadcast the consensus prompt to all bound entities.
+                            const consensusMsg =
+                                `[協商共識] 請求逾時需多方共識：「${row.prompt}」` +
+                                `(發起：#${row.from_entity_id})。請各實體表態，` +
+                                `由 #${row.from_entity_id} 綜合後直接 resolve 此請求` +
+                                `(requestId=${row.id}) 以自動執行決定。`;
+                            const entities = (device && device.entities) || {};
+                            for (const ent of Object.values(entities)) {
+                                pushTextToEntity(deviceId, ent, 'action_request_consensus', consensusMsg, { requestId: row.id });
+                            }
+                            // 3. New socket kind so the frontend can show "協商中".
+                            emitChanged(deviceId, 'consensus_triggered', row.id, row.from_entity_id);
+                            log('info', `timeout consensus_triggered id=${row.id} from=${row.from_entity_id}`, { deviceId });
+                        }
+                    } catch (rowErr) {
+                        console.error(`[AgentActionRequests] timeout enforce failed id=${row.id}:`, rowErr.message);
+                    }
+                }
+            } catch (devErr) {
+                console.error(`[AgentActionRequests] timeout sweep failed device=${deviceId}:`, devErr.message);
+            }
+        }
     }
 
     // ── Dual auth: deviceSecret (user) OR botSecret+entityId (agent) ──
@@ -426,6 +607,17 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io } = 
         }
     });
 
+    // Register the periodic timeout sweep ONCE per process (card_ce0d685b).
+    // Skipped under test (jest calls enforceActionRequestTimeouts directly). The
+    // module-level guard stops a re-`require` / multi-factory-call from stacking
+    // intervals. Failures are swallowed so the timer never crashes the process.
+    if (process.env.NODE_ENV !== 'test' && !timeoutSweepTimer) {
+        timeoutSweepTimer = setInterval(() => {
+            enforceActionRequestTimeouts().catch(() => {});
+        }, TIMEOUT_SWEEP_INTERVAL_MS);
+        if (typeof timeoutSweepTimer.unref === 'function') timeoutSweepTimer.unref();
+    }
+
     return {
         router,
         initDatabase: initAgentActionRequestsDatabase,
@@ -433,6 +625,9 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io } = 
         // smart-quote reply answers (card_b51598b7). Device-scoped, pending-only,
         // + best-effort agent push-back. Returns the row, or null on no-match.
         resolveActionRequest,
+        // Timeout-policy worker (card_ce0d685b). Exported so tests + an external
+        // scheduler can invoke a sweep directly.
+        enforceActionRequestTimeouts,
         _pool: pool,
     };
 };

--- a/backend/agent_action_requests_schema.sql
+++ b/backend/agent_action_requests_schema.sql
@@ -22,6 +22,10 @@ CREATE TABLE IF NOT EXISTS agent_action_requests (
     answer JSONB DEFAULT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     resolved_at TIMESTAMPTZ DEFAULT NULL,
+    -- Set once when the timeout worker fires a 'consensus' round for this still-
+    -- pending request, so the worker never re-triggers a round on each 5-min tick
+    -- (card_ce0d685b). NULL = no consensus round triggered yet.
+    consensus_triggered_at TIMESTAMPTZ DEFAULT NULL,
     CONSTRAINT aar_prompt_len CHECK (char_length(prompt) BETWEEN 1 AND 2000),
     CONSTRAINT aar_type_valid CHECK (type IN ('decision','approval','input','credential','review','clarify','consensus')),
     CONSTRAINT aar_status_valid CHECK (status IN ('pending','resolved','dismissed'))

--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -54,10 +54,25 @@ const DEFAULTS = {
     // display on this flag. timeout policy = what to do with an un-answered
     // request after a deadline (consumed by a future settings/timeout PR).
     action_request_realtime: true,
-    action_request_timeout_policy: 'keep', // 'keep' | 'auto_dismiss' | 'escalate'
+    // What to do with a "需要你" request the user never answers, once it is older
+    // than action_request_timeout_minutes. Consumed by the timeout worker in
+    // backend/agent-action-requests.js (card_ce0d685b):
+    //   'keep'         → never auto-act (device is a no-op for the worker)
+    //   'auto_dismiss' → mark dismissed + tell the emitter it was skipped
+    //   'safe_default' → resolve with a safe-default answer; agent continues
+    //   'consensus'    → trigger ONE bot-to-bot consensus round; the emitting
+    //                    agent synthesizes the entities' replies and resolves via
+    //                    the existing resolve API → auto-executes the decision
+    //                    (Hank's decision: no user confirmation gate).
+    action_request_timeout_policy: 'keep', // 'keep' | 'auto_dismiss' | 'safe_default' | 'consensus'
+    // Deadline (minutes) after which the policy above fires. Default 1440 (24h).
+    // Clamped to [5, 43200] (5 min .. 30 days).
+    action_request_timeout_minutes: 1440,
 };
 
-const ACTION_REQUEST_TIMEOUT_POLICIES = new Set(['keep', 'auto_dismiss', 'escalate']);
+const ACTION_REQUEST_TIMEOUT_POLICIES = new Set(['keep', 'auto_dismiss', 'safe_default', 'consensus']);
+const ACTION_REQUEST_TIMEOUT_MINUTES_MIN = 5;
+const ACTION_REQUEST_TIMEOUT_MINUTES_MAX = 43200; // 30 days
 
 // Spec: docs/specs/kanban-nudge-spec.md §6 — restricted override key set.
 const NUDGE_ENTITY_OVERRIDE_KEYS = [
@@ -84,6 +99,12 @@ function coerceValue(key, raw) {
         return raw === true || raw === 'true';
     }
     if (typeof def === 'boolean') return !!raw;
+    if (key === 'action_request_timeout_minutes') {
+        // parseInt-style coercion + clamp to [5, 43200]; invalid → default 1440.
+        const n = parseInt(raw, 10);
+        if (!Number.isFinite(n)) return def;
+        return Math.max(ACTION_REQUEST_TIMEOUT_MINUTES_MIN, Math.min(ACTION_REQUEST_TIMEOUT_MINUTES_MAX, n));
+    }
     if (typeof def === 'number') {
         const n = Number(raw);
         if (!Number.isFinite(n)) return def;

--- a/backend/tests/jest/action-request-timeout-worker.test.js
+++ b/backend/tests/jest/action-request-timeout-worker.test.js
@@ -1,0 +1,238 @@
+/**
+ * Tests for the "需要你" action-request TIMEOUT-POLICY worker (card_ce0d685b).
+ *
+ *  device-preferences:
+ *    - action_request_timeout_policy coerces to keep|auto_dismiss|safe_default|
+ *      consensus, default keep; the removed 'escalate' now coerces to keep.
+ *    - action_request_timeout_minutes clamps to [5, 43200] + defaults to 1440.
+ *
+ *  worker (enforceActionRequestTimeouts), pg mocked:
+ *    - auto_dismiss → dismiss UPDATE + emitChanged('dismissed') + emitter push.
+ *    - safe_default → resolveActionRequest(safe-default answer) → kind='resolved'.
+ *    - consensus    → stamp consensus_triggered_at + broadcast bot-to-bot prompt +
+ *      emitChanged('consensus_triggered'); does NOT resolve. A request that
+ *      already has consensus_triggered_at is skipped (WHERE excludes it).
+ *    - keep         → no DB writes (device skipped entirely).
+ *    - the SELECT carries the timeout-minutes interval + status='pending'.
+ */
+
+const mockPoolQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockPoolQuery,
+        connect: jest.fn().mockResolvedValue({ query: mockPoolQuery, release: jest.fn() }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const deviceId = 'dev-1';
+const UUID = '11111111-2222-3333-4444-555555555555';
+
+function buildModule({ prefs, devices } = {}) {
+    const emitToRoom = jest.fn();
+    const io = { to: jest.fn(() => ({ emit: emitToRoom })) };
+    const unifiedPush = jest.fn().mockResolvedValue({ pushed: true });
+    const pushToBot = jest.fn().mockResolvedValue({ pushed: true });
+    const getDevicePrefs = jest.fn().mockResolvedValue(prefs);
+    const factory = require('../../agent-action-requests');
+    const dev = devices || {
+        [deviceId]: {
+            deviceSecret: 'sek',
+            entities: {
+                1: { isBound: true, botSecret: 'bot-1', bindingType: 'channel' },
+                2: { isBound: true, botSecret: 'bot-2', bindingType: 'channel' },
+            },
+        },
+    };
+    const mod = factory(dev, { serverLog: () => {}, io, unifiedPush, pushToBot, getDevicePrefs });
+    return { mod, io, emitToRoom, unifiedPush, pushToBot, getDevicePrefs };
+}
+
+function pendingRow(over = {}) {
+    return {
+        id: UUID, device_id: deviceId, from_entity_id: 1, anchor_message_id: null,
+        type: 'decision', prompt: '要不要上線?', options: null,
+        status: 'pending', answer: null,
+        created_at: new Date('2026-06-01T00:00:00Z'), resolved_at: null,
+        consensus_triggered_at: null, ...over,
+    };
+}
+
+afterEach(() => { mockPoolQuery.mockReset(); mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 }); });
+
+// ───────────────────────────── device-preferences ─────────────────────────────
+describe('device-preferences: action_request_timeout_* coercion', () => {
+    const devicePrefs = require('../../device-preferences');
+
+    test('DEFAULTS: policy=keep, minutes=1440', () => {
+        expect(devicePrefs.DEFAULTS.action_request_timeout_policy).toBe('keep');
+        expect(devicePrefs.DEFAULTS.action_request_timeout_minutes).toBe(1440);
+    });
+
+    test('policy coerces to keep|auto_dismiss|safe_default|consensus; escalate→keep; junk→keep', async () => {
+        const written = [];
+        const stubPool = { query: jest.fn((sql, params) => { written.push({ sql, params }); return Promise.resolve({ rows: [] }); }) };
+        await devicePrefs.initTable(stubPool);
+
+        const readBack = () => JSON.parse(written[written.length - 1].params[1]);
+        const cases = [
+            ['keep', 'keep'],
+            ['auto_dismiss', 'auto_dismiss'],
+            ['safe_default', 'safe_default'],
+            ['consensus', 'consensus'],
+            ['escalate', 'keep'],   // removed value → default
+            ['nonsense', 'keep'],
+            [42, 'keep'],
+        ];
+        for (const [input, expected] of cases) {
+            written.length = 0;
+            await devicePrefs.updatePrefs(deviceId, { action_request_timeout_policy: input });
+            expect(readBack().action_request_timeout_policy).toBe(expected);
+        }
+    });
+
+    test('minutes clamps to [5,43200], parses ints, defaults invalid → 1440', async () => {
+        const written = [];
+        const stubPool = { query: jest.fn((sql, params) => { written.push({ sql, params }); return Promise.resolve({ rows: [] }); }) };
+        await devicePrefs.initTable(stubPool);
+        const readBack = () => JSON.parse(written[written.length - 1].params[1]);
+
+        const cases = [
+            [1, 5],            // below min → clamp up
+            [4, 5],
+            [5, 5],
+            [60, 60],
+            [43200, 43200],
+            [99999, 43200],    // above max → clamp down
+            ['120', 120],      // parseInt string
+            ['30abc', 30],     // parseInt-style
+            ['oops', 1440],    // NaN → default
+            [null, 1440],
+        ];
+        for (const [input, expected] of cases) {
+            written.length = 0;
+            await devicePrefs.updatePrefs(deviceId, { action_request_timeout_minutes: input });
+            expect(readBack().action_request_timeout_minutes).toBe(expected);
+        }
+    });
+});
+
+// ───────────────────────────── worker ─────────────────────────────
+describe('enforceActionRequestTimeouts', () => {
+    test('policy=keep → device skipped, NO pending-request SELECT/UPDATE', async () => {
+        const { mod } = buildModule({ prefs: { action_request_timeout_policy: 'keep', action_request_timeout_minutes: 1440 } });
+        // call 0 = DISTINCT device scan
+        mockPoolQuery.mockResolvedValueOnce({ rows: [{ device_id: deviceId }] });
+        await mod.enforceActionRequestTimeouts();
+        // Only the device-scan query ran; no per-device SELECT or any write.
+        expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+        expect(mockPoolQuery.mock.calls[0][0]).toMatch(/SELECT DISTINCT device_id/);
+    });
+
+    test('the pending SELECT carries the timeout-minutes interval + status=pending', async () => {
+        const { mod } = buildModule({ prefs: { action_request_timeout_policy: 'auto_dismiss', action_request_timeout_minutes: 90 } });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }] }) // scan
+            .mockResolvedValueOnce({ rows: [] });                       // pending SELECT → none
+        await mod.enforceActionRequestTimeouts();
+        const selectCall = mockPoolQuery.mock.calls[1];
+        expect(selectCall[0]).toMatch(/status = 'pending'/);
+        expect(selectCall[0]).toMatch(/created_at < NOW\(\) - \(\$2 \* interval '1 minute'\)/);
+        expect(selectCall[1]).toEqual([deviceId, 90]);
+    });
+
+    test('auto_dismiss → dismiss UPDATE + emitChanged(dismissed) + emitter push', async () => {
+        const { mod, emitToRoom, unifiedPush } = buildModule({ prefs: { action_request_timeout_policy: 'auto_dismiss', action_request_timeout_minutes: 1440 } });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }] })       // scan
+            .mockResolvedValueOnce({ rows: [pendingRow()] })                  // pending SELECT
+            .mockResolvedValueOnce({ rows: [pendingRow({ status: 'dismissed', resolved_at: new Date() })] }); // dismiss UPDATE
+        await mod.enforceActionRequestTimeouts();
+
+        const updateCall = mockPoolQuery.mock.calls[2];
+        expect(updateCall[0]).toMatch(/SET status = 'dismissed'/);
+        expect(updateCall[0]).toMatch(/WHERE id = \$1 AND status = 'pending'/);
+        expect(updateCall[1]).toEqual([UUID]);
+
+        expect(emitToRoom).toHaveBeenCalledWith('action_request:changed', { kind: 'dismissed', requestId: UUID, fromEntityId: 1 });
+        // emitter (#1) was told it timed out
+        const pushed = unifiedPush.mock.calls.find(c => /逾時自動略過/.test(c[3].message));
+        expect(pushed).toBeTruthy();
+    });
+
+    test('safe_default → resolveActionRequest path: resolve UPDATE + emitChanged(resolved)', async () => {
+        const { mod, emitToRoom, unifiedPush } = buildModule({ prefs: { action_request_timeout_policy: 'safe_default', action_request_timeout_minutes: 1440 } });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }] })       // scan
+            .mockResolvedValueOnce({ rows: [pendingRow()] })                  // pending SELECT
+            .mockResolvedValueOnce({ rows: [pendingRow({ status: 'resolved', resolved_at: new Date() })] }); // resolve UPDATE
+        await mod.enforceActionRequestTimeouts();
+
+        const resolveCall = mockPoolQuery.mock.calls[2];
+        expect(resolveCall[0]).toMatch(/SET status = 'resolved'/);
+        // safe-default answer payload was passed as the jsonb param
+        const answerJson = JSON.parse(resolveCall[1][0]);
+        expect(answerJson.reason).toBe('timeout_safe_default');
+        expect(answerJson.auto).toBe(true);
+
+        expect(emitToRoom).toHaveBeenCalledWith('action_request:changed', { kind: 'resolved', requestId: UUID, fromEntityId: 1 });
+        // emitter notified via the RESOLVED push-back (resolveActionRequest)
+        const pushed = unifiedPush.mock.calls.find(c => /RESOLVED/.test(c[3].message));
+        expect(pushed).toBeTruthy();
+    });
+
+    test('consensus → stamp consensus_triggered_at + broadcast prompt + emitChanged(consensus_triggered); NO resolve', async () => {
+        const { mod, emitToRoom, unifiedPush } = buildModule({ prefs: { action_request_timeout_policy: 'consensus', action_request_timeout_minutes: 1440 } });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }] })       // scan
+            .mockResolvedValueOnce({ rows: [pendingRow()] })                  // pending SELECT
+            .mockResolvedValueOnce({ rows: [pendingRow({ consensus_triggered_at: new Date() })] }); // stamp UPDATE
+        await mod.enforceActionRequestTimeouts();
+
+        // pending SELECT excluded already-triggered rows
+        expect(mockPoolQuery.mock.calls[1][0]).toMatch(/consensus_triggered_at IS NULL/);
+
+        const stampCall = mockPoolQuery.mock.calls[2];
+        expect(stampCall[0]).toMatch(/SET consensus_triggered_at = NOW\(\)/);
+        expect(stampCall[0]).toMatch(/consensus_triggered_at IS NULL/);
+        expect(stampCall[1]).toEqual([UUID]);
+
+        // exactly 3 queries → no resolve/dismiss UPDATE fired
+        expect(mockPoolQuery).toHaveBeenCalledTimes(3);
+
+        expect(emitToRoom).toHaveBeenCalledWith('action_request:changed', { kind: 'consensus_triggered', requestId: UUID, fromEntityId: 1 });
+
+        // bot-to-bot consensus prompt broadcast to BOTH bound entities
+        const consensusPushes = unifiedPush.mock.calls.filter(c => /協商共識/.test(c[3].message));
+        expect(consensusPushes.length).toBe(2);
+        const msg = consensusPushes[0][3].message;
+        expect(msg).toMatch(/requestId=11111111-2222-3333-4444-555555555555/);
+        expect(msg).toMatch(/發起：#1/);
+    });
+
+    test('consensus: a request already stamped (consensus_triggered_at set) is not re-fired', async () => {
+        // The SELECT filters consensus_triggered_at IS NULL, so a stamped row never
+        // returns → the worker performs no UPDATE for it.
+        const { mod, emitToRoom, unifiedPush } = buildModule({ prefs: { action_request_timeout_policy: 'consensus', action_request_timeout_minutes: 1440 } });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }] }) // scan
+            .mockResolvedValueOnce({ rows: [] });                       // SELECT excludes stamped → empty
+        await mod.enforceActionRequestTimeouts();
+        expect(mockPoolQuery).toHaveBeenCalledTimes(2);          // scan + empty SELECT only
+        expect(emitToRoom).not.toHaveBeenCalled();
+        expect(unifiedPush).not.toHaveBeenCalled();
+    });
+
+    test('one bad row does not abort the sweep (best-effort per request)', async () => {
+        const row2 = pendingRow({ id: '22222222-2222-3333-4444-555555555555', from_entity_id: 2 });
+        const { mod, emitToRoom } = buildModule({ prefs: { action_request_timeout_policy: 'auto_dismiss', action_request_timeout_minutes: 1440 } });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }] })   // scan
+            .mockResolvedValueOnce({ rows: [pendingRow(), row2] })        // two pending
+            .mockRejectedValueOnce(new Error('boom'))                     // first dismiss throws
+            .mockResolvedValueOnce({ rows: [row2] });                     // second dismiss ok
+        await mod.enforceActionRequestTimeouts();
+        // second row still emitted despite first throwing
+        expect(emitToRoom).toHaveBeenCalledWith('action_request:changed', { kind: 'dismissed', requestId: row2.id, fromEntityId: 2 });
+    });
+});


### PR DESCRIPTION
Backend for the **\"需要你\" action-request timeout-policy worker** (card_ce0d685b). Frontend settings dropdown is #6's — this PR is backend-only with tests and clean contracts.

## The 4 timeout policies (`action_request_timeout_policy`)
Realigned the device-pref enum to **`keep | auto_dismiss | safe_default | consensus`** (removed `escalate`), default `keep`. When a device's pending request is older than `action_request_timeout_minutes`, the worker applies:

| policy | worker action |
| --- | --- |
| **keep** | no-op — device is skipped entirely (default). |
| **auto_dismiss** | `UPDATE … status='dismissed'`, emit `action_request:changed` kind=`dismissed`, push `[逾時自動略過]…` to the emitting agent. |
| **safe_default** | `resolveActionRequest(…, { text:'[安全預設]…', auto:true, reason:'timeout_safe_default' })` → resolves + notifies emitter + emits kind=`resolved`, agent continues. |
| **consensus** | opens ONE bot-to-bot consensus round (does **not** resolve): stamps `consensus_triggered_at`, broadcasts a zh consensus prompt to all bound entities, emits new kind=`consensus_triggered`. |

Each device + each request is wrapped in try/catch so one failure never aborts the sweep.

## Timeout-minutes default
New pref **`action_request_timeout_minutes`**, default **1440** (24h). Coerce = `parseInt` + clamp to **[5, 43200]** (5 min .. 30 days); invalid → 1440.

## New column + migration (`consensus_triggered_at`)
The consensus policy leaves the request `pending` until the agent resolves it, so the worker would re-fire every 5-min tick. Added `consensus_triggered_at TIMESTAMPTZ DEFAULT NULL`:
- in `agent_action_requests_schema.sql` CREATE TABLE,
- idempotent `ALTER TABLE … ADD COLUMN IF NOT EXISTS …` in `initAgentActionRequestsDatabase()` (best-effort try/catch, never crashes init).

The consensus SELECT excludes `consensus_triggered_at IS NOT NULL`, and the stamp UPDATE is guarded `… AND consensus_triggered_at IS NULL`, so a round opens at most once.

## New socket kind: `consensus_triggered`
Emitted on `action_request:changed` to room `device:<id>` with `{ kind:'consensus_triggered', requestId, fromEntityId }`. **Frontend (#6):** render a \"協商中 / In consensus\" badge on this event; the request stays `pending` until the agent resolves it. Documented in the SOCKET EVENT CONTRACT comment block.

## Auto-execute contract (Hank's decision — no user gate)
The **server worker** only does: detect-timeout → trigger-round → mark. The **agent layer** does synthesis + resolution: the emitting agent (`#from_entity_id`), on seeing the consensus prompt, collects the other entities' replies, synthesizes the consensus decision, and calls `POST /api/action-requests/:id/resolve` with that answer. Because resolve has no user confirmation, that **auto-executes** the decision. The worker never resolves a consensus request itself.

Consensus prompt frame (zh):
> `[協商共識] 請求逾時需多方共識：「<prompt>」(發起：#<from>)。請各實體表態，由 #<from> 綜合後直接 resolve 此請求(requestId=<id>) 以自動執行決定。`

## Scheduling
`setInterval(enforceActionRequestTimeouts, 5*60*1000)` registered once per process (module-level guard, skipped under `NODE_ENV=test`, `.unref()`'d). Exported `enforceActionRequestTimeouts` for direct invocation/tests.

## Frontend follow-up for #6
`backend/lib/settings-manifest.js` + `settings.html` still list the old `escalate` option (untouched — frontend scope). #6 should update the dropdown to `keep | auto_dismiss | safe_default | consensus` to match the backend coerce contract. (Selecting `escalate` now safely coerces back to `keep`.)

## Verify
- `node --check` ✅ on agent-action-requests.js, device-preferences.js, index.js.
- jest (pg mocked): new suite **10/10**; related suites (action-request*, agent-action-requests, device-preferences*, settings-action-request-prefs, chat-action-request-inbox) **10 suites / 115 tests all green**.
- `node backend/scripts/i18n-check.js` ✅ (no i18n change from this PR; EN keys all resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwUSDu6mYWNTVYiCGYWA8L