### PR TITLE
fix(chat): 需要你 inbox — default-collapsed summary + lifecycle hardening (card_b176c435)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -327,6 +327,7 @@
             background: var(--card, #1A1A2E); border: 1px solid var(--card-border, #333355);
             color: var(--text, #ffffff);
             font-size: 14px; line-height: 1.5; display: flex; flex-direction: column; gap: 8px;
+            flex-shrink: 0; /* never starve the chat history; the inbox body caps+scrolls itself */
         }
         body.dark .greet-banner { background: #23262f; border-color: #3a3f4d; }
         .greet-banner-text { display: block; overflow-wrap: anywhere; }
@@ -338,8 +339,33 @@
         }
         .greet-chip:hover { background: rgba(91,108,255,0.1); }
         .greet-chip.greet-chip-dismiss { border-color: var(--card-border, #333355); color: var(--text-secondary, #AAAAAA); }
-        .action-request-inbox { display: flex; flex-direction: column; gap: 10px; }
-        .action-request-inbox-head { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+        /* 需要你 inbox — default-collapsed one-line summary 「🔔 需要你 N 件 ▼」,
+           expands to a viewport-capped, self-scrolling list so a burst of
+           requests can never cover the chat (card_b176c435). */
+        .action-request-inbox { display: flex; flex-direction: column; gap: 0; }
+        .action-request-inbox-summary {
+            display: flex; align-items: center; gap: 8px; width: 100%;
+            min-height: 36px; padding: 6px 6px; background: transparent; border: none;
+            color: var(--text, #ffffff); font-size: 14px; font-weight: 700;
+            cursor: pointer; text-align: left; border-radius: 8px;
+        }
+        .action-request-inbox-summary:hover { background: rgba(91,108,255,0.06); }
+        .action-request-inbox-summary .ar-bell { flex-shrink: 0; }
+        .action-request-inbox-summary .ar-summary-label { flex: 0 0 auto; }
+        .ar-chevron {
+            margin-left: auto; flex-shrink: 0; color: var(--text-secondary, #AAAAAA);
+            transition: transform .18s ease;
+        }
+        .action-request-inbox.is-open .ar-chevron { transform: rotate(180deg); }
+        .action-request-inbox-body {
+            display: none; flex-direction: column; gap: 10px; margin-top: 8px;
+            max-height: 40vh; overflow-y: auto; overscroll-behavior: contain;
+            -webkit-overflow-scrolling: touch;
+        }
+        .action-request-inbox.is-open .action-request-inbox-body { display: flex; }
+        @media (max-width: 640px) { .action-request-inbox-body { max-height: 38vh; } }
+        @media (prefers-reduced-motion: reduce) { .ar-chevron { transition: none; } }
+        .action-request-inbox-head { display: flex; align-items: center; justify-content: flex-end; flex-wrap: wrap; gap: 10px; }
         .action-request-inbox-title { font-weight: 700; color: var(--text, #ffffff); }
         .action-request-inbox-status { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 6px; }
         .action-request-inbox-count {
@@ -368,7 +394,10 @@
             display: inline-flex; align-items: center; border-radius: 999px; padding: 2px 8px;
             border: 1px solid rgba(45,212,191,0.65); color: #2dd4bf; background: rgba(20,184,166,0.12);
         }
-        .action-request-prompt { color: var(--text, #ffffff); overflow-wrap: anywhere; }
+        .action-request-prompt {
+            color: var(--text, #ffffff); overflow-wrap: anywhere;
+            display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden;
+        }
         .action-request-type-hint { color: var(--text-secondary, #AAAAAA); font-size: 12px; line-height: 1.45; }
         .action-request-options, .action-request-actions { display: flex; flex-wrap: wrap; gap: 6px; }
         .action-request-option, .action-request-action {
@@ -4049,6 +4078,17 @@
         let actionRequestTimeoutPolicy = 'keep';
         const actionRequestConsensusTriggeredIds = new Set();
         let actionRequestRefreshTimer = null;
+        // Inbox is collapsed by default so a burst of "需要你" requests never
+        // covers the chat (card_b176c435); the user's open/closed choice persists.
+        const ACTION_REQUEST_INBOX_OPEN_KEY = 'action_request_inbox_open';
+        let actionRequestInboxOpen = (() => {
+            try { return localStorage.getItem(ACTION_REQUEST_INBOX_OPEN_KEY) === '1'; } catch (_) { return false; }
+        })();
+        // Coalesce a refresh that arrives while one is already in flight, so the
+        // post-resolve/socket refetch is never silently dropped (card_b176c435).
+        let actionRequestsRefreshPending = false;
+        let actionRequestsRefreshPendingRender = false;
+        let actionRequestsRefreshPendingForce = false;
 
         // ── System-message smart filter (spec chat-smart-filter-system-messages.md) ──
         // Active set of 5 categories from ChatSourceCategory. Default per spec:
@@ -7401,7 +7441,16 @@
                 if (renderGreeting && window.EclawGreeting) window.EclawGreeting.maybeShow({ force: forceGreeting });
                 return actionRequests;
             }
-            if (actionRequestsLoading) return actionRequests;
+            // A refresh requested mid-flight (e.g. socket 'resolved' lands while the
+            // post-send refetch is running) must not be dropped — record it and
+            // re-run once the in-flight load finishes, carrying the strongest
+            // render flags forward so the emptied/updated inbox always repaints.
+            if (actionRequestsLoading) {
+                actionRequestsRefreshPending = true;
+                if (renderGreeting) actionRequestsRefreshPendingRender = true;
+                if (forceGreeting) actionRequestsRefreshPendingForce = true;
+                return actionRequests;
+            }
             actionRequestsLoading = true;
             try {
                 const qs = new URLSearchParams({
@@ -7425,6 +7474,15 @@
                 actionRequestsLoaded = true;
                 actionRequestsLoading = false;
                 if (renderGreeting && window.EclawGreeting) window.EclawGreeting.maybeShow({ force: forceGreeting });
+            }
+            // Run the coalesced refresh that arrived mid-flight, if any.
+            if (actionRequestsRefreshPending) {
+                actionRequestsRefreshPending = false;
+                const nextRender = actionRequestsRefreshPendingRender;
+                const nextForce = actionRequestsRefreshPendingForce;
+                actionRequestsRefreshPendingRender = false;
+                actionRequestsRefreshPendingForce = false;
+                await loadActionRequests({ renderGreeting: nextRender, forceGreeting: nextForce });
             }
             return actionRequests;
         }
@@ -7500,6 +7558,12 @@
         async function dismissActionRequest(requestId) {
             const id = normalizeChatMessageId(requestId);
             if (!id || !currentUser?.deviceId || !currentUser?.deviceSecret) return;
+            // Optimistically drop the item + any pending reply binding so 略過 feels
+            // instant and a lingering/already-resolved card can always be cleared.
+            actionRequests = actionRequests.filter(r => normalizeChatMessageId(r && r.id) !== id);
+            clearActionRequestConsensusTriggered(id);
+            removeReplyContextForRequest(id);
+            if (window.EclawGreeting) { try { EclawGreeting.maybeShow({ force: true }); } catch (_) {} }
             try {
                 await apiCall('POST', `/api/action-requests/${id}/dismiss`, {
                     deviceId: currentUser.deviceId,
@@ -7507,10 +7571,23 @@
                 });
                 if (typeof showToast === 'function') showToast(i18n.t('action_request_dismissed') || 'Request dismissed', 'success');
             } catch (err) {
-                if (typeof showToast === 'function') showToast((i18n.t('chat_send_failed') || 'Failed') + ': ' + (err.message || err), 'error');
+                // A request already resolved/dismissed server-side (404/409/410) is the
+                // expected state after a reply — treat it as success, not an error
+                // (card_b176c435: "回覆後按略過跳紅字關不掉").
+                const st = err && err.status;
+                if (st === 404 || st === 409 || st === 410) {
+                    if (typeof showToast === 'function') showToast(i18n.t('action_request_dismissed') || 'Request dismissed', 'success');
+                } else if (typeof showToast === 'function') {
+                    showToast((i18n.t('chat_send_failed') || 'Failed') + ': ' + (err.message || err), 'error');
+                }
             } finally {
                 await loadActionRequests({ renderGreeting: true, forceGreeting: true });
             }
+        }
+
+        function setActionRequestInboxOpen(open) {
+            actionRequestInboxOpen = !!open;
+            try { localStorage.setItem(ACTION_REQUEST_INBOX_OPEN_KEY, open ? '1' : '0'); } catch (_) {}
         }
 
         function renderActionRequestInbox(banner) {
@@ -7518,27 +7595,60 @@
             const t = actionRequestT;
             banner.textContent = '';
             const wrap = document.createElement('div');
-            wrap.className = 'action-request-inbox';
-            const head = document.createElement('div');
-            head.className = 'action-request-inbox-head';
-            const title = document.createElement('span');
-            title.className = 'action-request-inbox-title';
-            title.textContent = t('action_request_inbox_title', 'Needs you');
+            wrap.className = 'action-request-inbox' + (actionRequestInboxOpen ? ' is-open' : '');
+            // Suppress whole-inbox screen-reader re-announcement on every poll/socket
+            // refresh; only the count below is a live region (card_b176c435).
+            wrap.setAttribute('aria-live', 'off');
+
+            const bodyId = 'actionRequestInboxBody';
+
+            // Always-visible, collapsed-by-default one-line summary 「🔔 需要你 N 件 ▼」.
+            const summary = document.createElement('button');
+            summary.type = 'button';
+            summary.className = 'action-request-inbox-summary';
+            summary.setAttribute('aria-expanded', actionRequestInboxOpen ? 'true' : 'false');
+            summary.setAttribute('aria-controls', bodyId);
+            const bell = document.createElement('span');
+            bell.className = 'ar-bell';
+            bell.setAttribute('aria-hidden', 'true');
+            bell.textContent = '🔔';
+            const summaryLabel = document.createElement('span');
+            summaryLabel.className = 'ar-summary-label';
+            summaryLabel.textContent = t('action_request_inbox_title', 'Needs you');
             const count = document.createElement('span');
             count.className = 'action-request-inbox-count';
+            count.setAttribute('aria-live', 'polite');
+            count.setAttribute('aria-atomic', 'true');
             count.textContent = t('action_request_inbox_count', '{count} pending', { count: actionRequests.length });
+            const chevron = document.createElement('span');
+            chevron.className = 'ar-chevron';
+            chevron.setAttribute('aria-hidden', 'true');
+            chevron.textContent = '▼';
+            summary.appendChild(bell);
+            summary.appendChild(summaryLabel);
+            summary.appendChild(count);
+            summary.appendChild(chevron);
+            summary.addEventListener('click', () => {
+                const next = !wrap.classList.contains('is-open');
+                wrap.classList.toggle('is-open', next);
+                summary.setAttribute('aria-expanded', next ? 'true' : 'false');
+                setActionRequestInboxOpen(next);
+            });
+            wrap.appendChild(summary);
+
+            // Expandable body: live-state badge + the request list (caps + scrolls).
+            const body = document.createElement('div');
+            body.className = 'action-request-inbox-body';
+            body.id = bodyId;
+            const head = document.createElement('div');
+            head.className = 'action-request-inbox-head';
             const live = document.createElement('span');
             live.className = 'action-request-live-state' + (actionRequestRealtimeEnabled ? ' on' : '');
             live.textContent = actionRequestRealtimeEnabled
                 ? t('action_request_realtime_on', 'Live')
                 : t('action_request_realtime_off', 'Manual refresh');
-            const status = document.createElement('span');
-            status.className = 'action-request-inbox-status';
-            status.appendChild(live);
-            status.appendChild(count);
-            head.appendChild(title);
-            head.appendChild(status);
-            wrap.appendChild(head);
+            head.appendChild(live);
+            body.appendChild(head);
 
             actionRequests.forEach(request => {
                 const typeMeta = actionRequestTypeMeta(request.type);
@@ -7614,8 +7724,9 @@
                 dismiss.addEventListener('click', () => dismissActionRequest(request.id));
                 actions.appendChild(dismiss);
                 item.appendChild(actions);
-                wrap.appendChild(item);
+                body.appendChild(item);
             });
+            wrap.appendChild(body);
             banner.appendChild(wrap);
             banner.style.display = '';
         }
@@ -7733,6 +7844,20 @@
             replyContexts.splice(idx, 1);
             renderReplyPreviews();
             recomputeAutoReceivers();
+        }
+
+        // Drop any pending reply-context chip bound to a given action-request id
+        // (used when that request is dismissed/resolved so the composer's quote
+        // can't outlive the inbox item it pointed at — card_b176c435).
+        function removeReplyContextForRequest(requestId) {
+            const id = normalizeChatMessageId(requestId);
+            if (!id) return;
+            const before = replyContexts.length;
+            replyContexts = replyContexts.filter(rc => rc._key !== ('request:' + id));
+            if (replyContexts.length !== before) {
+                renderReplyPreviews();
+                recomputeAutoReceivers();
+            }
         }
 
         // Rebuild the reply bar as N removable chips. Empty → hide the bar.
@@ -8270,6 +8395,13 @@
                     this._shown = true;
                     return;
                 }
+                // The last request just cleared. Tear down any stale inbox DOM NOW,
+                // before the greeting logic's guarded/_shown early-returns can leave a
+                // phantom "需要你" card mounted (card_b176c435 empty-state leak).
+                if (banner.querySelector('.action-request-inbox')) {
+                    banner.textContent = '';
+                    banner.style.display = 'none';
+                }
                 if (!ACTION_REQUEST_INBOX_EMPTY_FALLBACK_TO_GREETING) {
                     banner.style.display = 'none';
                     this._shown = true;
@@ -8350,6 +8482,10 @@
             if (!text && !hasFiles && !hasR2Refs) return;
 
             const actionRequestReplyContexts = collectActionRequestReplyContexts();
+            // Snapshot quotes BEFORE the optimistic clear so a failed send can
+            // restore them (and their action-request binding) instead of orphaning
+            // the request (card_b176c435).
+            const replyContextsSnapshot = replyContexts.slice();
             let finalText = text;
             if (replyContexts.length) {
                 // One "↩ …" line per quote so the recipient entity receives EVERY
@@ -8594,6 +8730,14 @@
                 input.value = savedContent;
                 input.style.height = 'auto';
                 input.style.height = Math.min(input.scrollHeight, 120) + 'px';
+                // Send failed — the request was never resolved server-side, so
+                // restore the quote chips (incl. the action-request binding) the
+                // optimistic clear removed, letting the user retry (card_b176c435).
+                if (replyContextsSnapshot.length && replyContexts.length === 0) {
+                    replyContexts = replyContextsSnapshot.slice();
+                    renderReplyPreviews();
+                    recomputeAutoReceivers();
+                }
             } finally {
                 btn.disabled = false;
                 input.focus();

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -4080,7 +4080,7 @@
         let actionRequestRefreshTimer = null;
         // Inbox is collapsed by default so a burst of "需要你" requests never
         // covers the chat (card_b176c435); the user's open/closed choice persists.
-        const ACTION_REQUEST_INBOX_OPEN_KEY = 'action_request_inbox_open';
+        const ACTION_REQUEST_INBOX_OPEN_KEY = 'needsyou_inbox_open';
         let actionRequestInboxOpen = (() => {
             try { return localStorage.getItem(ACTION_REQUEST_INBOX_OPEN_KEY) === '1'; } catch (_) { return false; }
         })();

--- a/backend/tests/jest/chat-action-request-inbox.test.js
+++ b/backend/tests/jest/chat-action-request-inbox.test.js
@@ -108,7 +108,7 @@ describe('chat action request inbox (card_b51598b7 frontend)', () => {
 
 describe('需要你 inbox collapse + lifecycle hardening (card_b176c435)', () => {
     test('inbox is collapsed by default with a persisted open/closed state', () => {
-        expect(chatHtml).toContain("const ACTION_REQUEST_INBOX_OPEN_KEY = 'action_request_inbox_open';");
+        expect(chatHtml).toContain("const ACTION_REQUEST_INBOX_OPEN_KEY = 'needsyou_inbox_open';");
         // default closed: only an explicit '1' opens it
         expect(chatHtml).toContain("return localStorage.getItem(ACTION_REQUEST_INBOX_OPEN_KEY) === '1';");
         expect(chatHtml).toMatch(/function setActionRequestInboxOpen\(open\)/);

--- a/backend/tests/jest/chat-action-request-inbox.test.js
+++ b/backend/tests/jest/chat-action-request-inbox.test.js
@@ -105,3 +105,63 @@ describe('chat action request inbox (card_b51598b7 frontend)', () => {
         expect(i18nJs).toContain('"action_request_consensus_triggered": "協商中"');
     });
 });
+
+describe('需要你 inbox collapse + lifecycle hardening (card_b176c435)', () => {
+    test('inbox is collapsed by default with a persisted open/closed state', () => {
+        expect(chatHtml).toContain("const ACTION_REQUEST_INBOX_OPEN_KEY = 'action_request_inbox_open';");
+        // default closed: only an explicit '1' opens it
+        expect(chatHtml).toContain("return localStorage.getItem(ACTION_REQUEST_INBOX_OPEN_KEY) === '1';");
+        expect(chatHtml).toMatch(/function setActionRequestInboxOpen\(open\)/);
+        expect(chatHtml).toContain("localStorage.setItem(ACTION_REQUEST_INBOX_OPEN_KEY, open ? '1' : '0');");
+    });
+
+    test('renders a one-line summary 「🔔 + title + count + chevron」 that toggles the body', () => {
+        expect(chatHtml).toContain("summary.className = 'action-request-inbox-summary';");
+        expect(chatHtml).toContain("bell.textContent = '🔔';");
+        expect(chatHtml).toContain("chevron.textContent = '▼';");
+        expect(chatHtml).toContain("summary.setAttribute('aria-expanded', actionRequestInboxOpen ? 'true' : 'false');");
+        expect(chatHtml).toContain("summary.setAttribute('aria-controls', bodyId);");
+        // the request list lives in the collapsible body, not directly in wrap
+        expect(chatHtml).toContain("body.className = 'action-request-inbox-body';");
+        expect(chatHtml).toContain('body.appendChild(item);');
+        expect(chatHtml).toContain('wrap.appendChild(body);');
+    });
+
+    test('CSS caps the expanded body so a burst of requests cannot cover the chat', () => {
+        expect(chatHtml).toMatch(/\.action-request-inbox-body\s*\{[^}]*max-height:\s*40vh/);
+        expect(chatHtml).toMatch(/\.action-request-inbox-body\s*\{[^}]*overflow-y:\s*auto/);
+        expect(chatHtml).toContain('.action-request-inbox.is-open .action-request-inbox-body { display: flex; }');
+        // the banner must not shrink the message list to absorb the inbox
+        expect(chatHtml).toMatch(/\.greet-banner\s*\{[^}]*flex-shrink:\s*0/);
+    });
+
+    test('whole inbox is not a live region; only the count announces changes', () => {
+        expect(chatHtml).toContain("wrap.setAttribute('aria-live', 'off');");
+        expect(chatHtml).toContain("count.setAttribute('aria-live', 'polite');");
+    });
+
+    test('dismiss is optimistic and idempotent for already-resolved requests', () => {
+        const fn = chatHtml.slice(chatHtml.indexOf('async function dismissActionRequest('), chatHtml.indexOf('function renderActionRequestInbox('));
+        expect(fn).toContain('actionRequests = actionRequests.filter(r => normalizeChatMessageId(r && r.id) !== id);');
+        expect(fn).toContain('removeReplyContextForRequest(id);');
+        expect(fn).toContain('const st = err && err.status;');
+        expect(fn).toContain('if (st === 404 || st === 409 || st === 410) {');
+    });
+
+    test('a mid-flight refresh is coalesced, never dropped', () => {
+        const fn = chatHtml.slice(chatHtml.indexOf('async function loadActionRequests('), chatHtml.indexOf('function scheduleActionRequestRefresh('));
+        expect(fn).toContain('actionRequestsRefreshPending = true;');
+        expect(fn).toContain('if (actionRequestsRefreshPending) {');
+        expect(fn).toContain('await loadActionRequests({ renderGreeting: nextRender, forceGreeting: nextForce });');
+    });
+
+    test('emptied inbox tears down stale DOM before greeting early-returns', () => {
+        expect(chatHtml).toContain("if (banner.querySelector('.action-request-inbox')) {");
+    });
+
+    test('failed send restores the quote chips it optimistically cleared', () => {
+        expect(chatHtml).toContain('const replyContextsSnapshot = replyContexts.slice();');
+        expect(chatHtml).toContain('if (replyContextsSnapshot.length && replyContexts.length === 0) {');
+        expect(chatHtml).toMatch(/function removeReplyContextForRequest\(requestId\)/);
+    });
+});


### PR DESCRIPTION
## Why
Hank live-tested the new "需要你" (action-request) inbox and hit two blockers:
1. **連發遮擋畫面** — a burst of pending requests covered the whole chat.
2. **回覆後關不掉** — after replying to a request you couldn't dismiss it.

A 3-dimension adversarial audit (state/race · layout/mobile · correctness/i18n/a11y) surfaced **7 real bugs**. This PR fixes all of them.

## What
**UX — Hank's original design**
- Inbox now defaults to **collapsed**: one sticky row 「🔔 需要你 N 件 ▼」. Click to expand. The body caps at `40vh` (`38vh` mobile) and scrolls — a burst can never cover the chat. `.greet-banner` gets `flex-shrink:0` so it no longer starves the message list. Open/closed state persists per device.

**Lifecycle (the "can't dismiss after reply" root causes)**
- `loadActionRequests` **coalesces** a refresh that arrives mid-flight (the socket `resolved` that lands while the post-send refetch runs) instead of dropping it via the loading guard → resolved items no longer linger.
- `dismissActionRequest` is **optimistic** (drops item + reply binding instantly) and **idempotent** — a `404/409/410` (already resolved server-side after a reply) is treated as success, not a red error toast.
- `maybeShow` tears down stale inbox DOM the moment the list empties, before the greeting guard's early-returns could leave a phantom card mounted.
- A **failed send restores** the quote chips (+ action-request binding) the optimistic clear removed, so the request isn't orphaned.

**A11y**
- Inbox is no longer a blanket `aria-live` region (no whole-list re-announce on every poll); only the count is `polite`-live. Summary is a real `<button>` with `aria-expanded`/`aria-controls`. Prompt clamps to 5 lines.

## Test plan
- `chat-action-request-inbox.test.js`: **+8 assertions, 16/16 green** (collapse default/persist, summary structure, 40vh cap, aria, idempotent dismiss, refresh coalescing, empty-state teardown, send-failure restore).
- Inline-script parse ✓ · portal-smoke ✓ · existing inbox/consensus tests ✓.
- Post-deploy: desktop + mobile prod vision-check (collapsed default, expand, 5-item burst doesn't cover chat, reply→auto-remove, 略過 idempotent).

## Out of scope
- `recomputeAutoReceivers` reply-target auto-select (existing smart-receiver behavior; left intact to avoid routing regressions).
- Singular/plural count copy (zh needs none; en cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwUSDu6mYWNTVYiCGYWA8L