### PR TITLE
feat(android): Stage 3 native Rotate Secret + Switch Device (card_c3b13f64)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -353,6 +353,17 @@ class SettingsActivity : AppCompatActivity() {
             WebViewActivity.launch(this, "https://eclawbot.com/portal/settings.html?focus=kanban-nudge", getString(R.string.kanban_nudge_settings_title))
         }
 
+        // Stage 3 native — Rotate Secret + Switch Device (card_c3b13f64)
+        findViewById<MaterialButton>(R.id.rowRotateSecret).setOnClickListener {
+            TelemetryHelper.trackAction("settings_rotate_secret")
+            showRotateSecretDialog()
+        }
+
+        findViewById<MaterialButton>(R.id.rowSwitchDevice).setOnClickListener {
+            TelemetryHelper.trackAction("settings_switch_device")
+            showSwitchDeviceDialog()
+        }
+
         findViewById<MaterialButton>(R.id.btnWallet).setOnClickListener {
             TelemetryHelper.trackAction("settings_wallet")
             WebViewActivity.launch(this, "https://eclawbot.com/portal/wallet.html", getString(R.string.settings_wallet))
@@ -1011,6 +1022,199 @@ class SettingsActivity : AppCompatActivity() {
                     Toast.makeText(this@SettingsActivity, errorMsg ?: getString(R.string.unknown_error), Toast.LENGTH_SHORT).show()
                     dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = true
                     dialog.getButton(AlertDialog.BUTTON_POSITIVE).text = getString(R.string.account_login_btn)
+                }
+            }
+        }
+    }
+
+    // ============================================
+    // STAGE 3 NATIVE: ROTATE SECRET + SWITCH DEVICE (card_c3b13f64)
+    // ============================================
+
+    /**
+     * Rotate the device secret. Destructive: the current secret is invalidated and a
+     * new one is issued (manifest field `validation.confirm = true`), so other
+     * sessions must re-enter the new value to sign in. On success the new secret
+     * returned ONCE is persisted locally via [DeviceManager.setCredentials] (keeping
+     * the same deviceId). Never logs the secret in plaintext.
+     */
+    private fun showRotateSecretDialog() {
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.settings_rotate_secret_confirm_title))
+            .setMessage(getString(R.string.settings_rotate_device_secret_hint))
+            .setNegativeButton(R.string.cancel, null)
+            .setPositiveButton(getString(R.string.settings_rotate_secret_confirm_btn)) { _, _ ->
+                lifecycleScope.launch {
+                    try {
+                        val response = NetworkModule.api.rotateDeviceSecret(
+                            com.hank.clawlive.data.remote.RotateSecretRequest(
+                                deviceId = deviceManager.deviceId,
+                                deviceSecret = deviceManager.deviceSecret
+                            )
+                        )
+                        if (response.success && !response.newDeviceSecret.isNullOrBlank()) {
+                            // Persist the new secret ONCE (returned only here); keep the
+                            // same deviceId. Mirrors the account-login persistence seam.
+                            deviceManager.setCredentials(deviceManager.deviceId, response.newDeviceSecret)
+                            TelemetryHelper.trackAction("settings_rotate_secret_success")
+                            Toast.makeText(
+                                this@SettingsActivity,
+                                getString(R.string.settings_rotate_secret_success),
+                                Toast.LENGTH_LONG
+                            ).show()
+                        } else {
+                            Toast.makeText(
+                                this@SettingsActivity,
+                                response.error ?: getString(R.string.unknown_error),
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    } catch (e: Exception) {
+                        Timber.e(e, "Rotate device secret failed")
+                        TelemetryHelper.trackError(e, mapOf("action" to "rotate_secret"))
+                        val errorMsg = try {
+                            val errorBody = (e as? retrofit2.HttpException)?.response()?.errorBody()?.string()
+                            val json = com.google.gson.JsonParser.parseString(errorBody ?: "").asJsonObject
+                            json.get("error")?.asString ?: e.message
+                        } catch (_: Exception) { e.message }
+                        Toast.makeText(
+                            this@SettingsActivity,
+                            errorMsg ?: getString(R.string.settings_rotate_secret_failed),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+            }
+            .show()
+    }
+
+    /**
+     * Sign this device into a different Device ID / Device Secret pair via
+     * POST /api/auth/device-login. On success the canonical creds from the response
+     * are persisted via [DeviceManager.setCredentials] and the app is restarted to
+     * pick them up — mirroring [showAccountLoginDialog]'s post-login restart. The
+     * secret field uses a password input and is never logged in plaintext.
+     */
+    private fun showSwitchDeviceDialog() {
+        val layout = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dpToPx(24), dpToPx(16), dpToPx(24), dpToPx(8))
+        }
+
+        val deviceIdInput = TextInputLayout(this).apply {
+            hint = getString(R.string.settings_device_id)
+            boxBackgroundMode = TextInputLayout.BOX_BACKGROUND_OUTLINE
+        }
+        val deviceIdEdit = TextInputEditText(this)
+        deviceIdEdit.inputType = android.text.InputType.TYPE_CLASS_TEXT
+        deviceIdInput.addView(deviceIdEdit)
+        layout.addView(deviceIdInput)
+
+        val deviceSecretInput = TextInputLayout(this).apply {
+            hint = getString(R.string.settings_device_secret)
+            boxBackgroundMode = TextInputLayout.BOX_BACKGROUND_OUTLINE
+            endIconMode = TextInputLayout.END_ICON_PASSWORD_TOGGLE
+            val lp = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            )
+            lp.topMargin = dpToPx(12)
+            layoutParams = lp
+        }
+        val deviceSecretEdit = TextInputEditText(this)
+        deviceSecretEdit.inputType = android.text.InputType.TYPE_CLASS_TEXT or android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD
+        deviceSecretInput.addView(deviceSecretEdit)
+        layout.addView(deviceSecretInput)
+
+        val hintText = TextView(this).apply {
+            text = getString(R.string.settings_switch_device_hint)
+            setTextColor(0x99FFFFFF.toInt())
+            textSize = 12f
+            val lp = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            )
+            lp.topMargin = dpToPx(8)
+            layoutParams = lp
+        }
+        layout.addView(hintText)
+
+        val dialog = AlertDialog.Builder(this)
+            .setTitle(getString(R.string.settings_switch_device))
+            .setView(layout)
+            .setPositiveButton(getString(R.string.settings_switch_device_confirm), null)
+            .setNegativeButton(R.string.cancel, null)
+            .create()
+
+        dialog.show()
+
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+            val deviceId = deviceIdEdit.text?.toString()?.trim() ?: ""
+            val deviceSecret = deviceSecretEdit.text?.toString()?.trim() ?: ""
+
+            if (deviceId.isEmpty() || deviceSecret.isEmpty()) {
+                Toast.makeText(this, getString(R.string.bind_email_fill_all), Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = false
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).text = getString(R.string.account_login_logging_in)
+
+            lifecycleScope.launch {
+                try {
+                    val response = NetworkModule.api.deviceLogin(
+                        com.hank.clawlive.data.remote.DeviceLoginRequest(
+                            deviceId = deviceId,
+                            deviceSecret = deviceSecret
+                        )
+                    )
+                    val user = response.user
+                    if (response.success && user?.deviceId != null && user.deviceSecret != null) {
+                        // Overwrite local credentials with the switched device's creds.
+                        deviceManager.setCredentials(user.deviceId, user.deviceSecret)
+                        // Restore language preference from server, if provided.
+                        user.language?.let { lang ->
+                            val localeTag = when (lang) {
+                                "zh" -> "zh-TW"
+                                "zh-CN" -> "zh-CN"
+                                "id" -> "in"
+                                else -> lang
+                            }
+                            AppCompatDelegate.setApplicationLocales(
+                                LocaleListCompat.forLanguageTags(localeTag)
+                            )
+                        }
+                        dialog.dismiss()
+                        TelemetryHelper.trackAction("settings_switch_device_success")
+
+                        // Show success and prompt restart (same mechanism as account login).
+                        AlertDialog.Builder(this@SettingsActivity)
+                            .setTitle(getString(R.string.settings_switch_device_success_title))
+                            .setMessage(getString(R.string.settings_switch_device_success_msg, user.email ?: user.deviceId))
+                            .setPositiveButton(getString(R.string.account_login_restart)) { _, _ ->
+                                val intent = packageManager.getLaunchIntentForPackage(packageName)
+                                intent?.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                                startActivity(intent)
+                                Runtime.getRuntime().exit(0)
+                            }
+                            .setCancelable(false)
+                            .show()
+                    } else {
+                        Toast.makeText(this@SettingsActivity, response.error ?: getString(R.string.unknown_error), Toast.LENGTH_SHORT).show()
+                        dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = true
+                        dialog.getButton(AlertDialog.BUTTON_POSITIVE).text = getString(R.string.settings_switch_device_confirm)
+                    }
+                } catch (e: Exception) {
+                    Timber.e(e, "Switch device failed")
+                    TelemetryHelper.trackError(e, mapOf("action" to "switch_device"))
+                    val errorMsg = try {
+                        val errorBody = (e as? retrofit2.HttpException)?.response()?.errorBody()?.string()
+                        val json = com.google.gson.JsonParser.parseString(errorBody ?: "").asJsonObject
+                        json.get("error")?.asString ?: e.message
+                    } catch (_: Exception) { e.message }
+                    Toast.makeText(this@SettingsActivity, errorMsg ?: getString(R.string.unknown_error), Toast.LENGTH_SHORT).show()
+                    dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = true
+                    dialog.getButton(AlertDialog.BUTTON_POSITIVE).text = getString(R.string.settings_switch_device_confirm)
                 }
             }
         }

--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -414,6 +414,19 @@ interface ClawApiService {
     @POST("api/auth/app-login")
     suspend fun appLogin(@Body body: Map<String, String>): AppLoginResponse
 
+    // ── Settings Stage 3 native: Rotate Secret + Switch Device (card_c3b13f64) ──
+
+    // Rotate the device secret. The new secret is returned ONCE in the response and
+    // MUST be persisted locally (overwrite the stored deviceSecret) — the old secret
+    // is invalidated server-side. 401 Invalid credentials on mismatch; rate-limited.
+    @POST("api/device/rotate-secret")
+    suspend fun rotateDeviceSecret(@Body request: RotateSecretRequest): RotateSecretResponse
+
+    // Sign this device into a different deviceId/deviceSecret pair. On success the
+    // returned user object carries the canonical creds to persist before restart.
+    @POST("api/auth/device-login")
+    suspend fun deviceLogin(@Body request: DeviceLoginRequest): DeviceLoginResponse
+
     @PATCH("api/auth/language")
     suspend fun updateLanguage(@Body body: Map<String, String>): ApiResponse
 
@@ -802,6 +815,42 @@ data class AppLoginResponse(
     val email: String? = null,
     val language: String? = null,
     val error: String? = null
+)
+
+// ── Settings Stage 3 native: Rotate Secret + Switch Device (card_c3b13f64) ──
+
+data class RotateSecretRequest(
+    val deviceId: String,
+    val deviceSecret: String
+)
+
+data class RotateSecretResponse(
+    val success: Boolean,
+    val deviceId: String? = null,
+    val newDeviceSecret: String? = null,
+    val rotatedAt: String? = null,
+    val error: String? = null
+)
+
+data class DeviceLoginRequest(
+    val deviceId: String,
+    val deviceSecret: String
+)
+
+data class DeviceLoginResponse(
+    val success: Boolean,
+    val authToken: String? = null,
+    val user: DeviceLoginUser? = null,
+    val error: String? = null
+)
+
+data class DeviceLoginUser(
+    val id: String? = null,
+    val email: String? = null,
+    val deviceId: String? = null,
+    val deviceSecret: String? = null,
+    val language: String? = null,
+    val subscriptionStatus: String? = null
 )
 
 data class OAuthLoginResponse(

--- a/app/src/main/java/com/hank/clawlive/settings/SettingsManifestSync.kt
+++ b/app/src/main/java/com/hank/clawlive/settings/SettingsManifestSync.kt
@@ -69,6 +69,8 @@ object SettingsManifestSync {
         "feedback",
         "account_identity",
         "channel_api",
+        "rotate_secret",
+        "switch_device",
         "logout"
     )
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -623,6 +623,38 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- Rotate Device Secret (Stage 3 native — card_c3b13f64) -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/rowRotateSecret"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_rotate_device_secret"
+                android:textColor="@color/text_white_80"
+                app:backgroundTint="@color/surface_input"
+                android:layout_marginTop="16dp"
+                app:cornerRadius="12dp"
+                app:icon="@drawable/ic_refresh"
+                app:iconTint="@color/text_white_80"
+                app:strokeColor="@color/text_dark"
+                app:strokeWidth="1dp"
+                style="@style/Widget.Material3.Button.TonalButton"/>
+
+            <!-- Switch Device (Stage 3 native — card_c3b13f64) -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/rowSwitchDevice"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_switch_device"
+                android:textColor="@color/text_white_80"
+                app:backgroundTint="@color/surface_input"
+                android:layout_marginTop="8dp"
+                app:cornerRadius="12dp"
+                app:icon="@drawable/ic_devices"
+                app:iconTint="@color/text_white_80"
+                app:strokeColor="@color/text_dark"
+                app:strokeWidth="1dp"
+                style="@style/Widget.Material3.Button.TonalButton"/>
+
             <!-- Kanban Nudge Settings Button — opens WebView deep-linked to the Kanban Nudge card -->
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnKanbanNudge"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -867,6 +867,20 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="settings_feature_web_help">此设置会在网页视图中打开，因为此 App 版本尚未内置原生界面。更新 App 即可获得原生界面，或现在直接在网页中使用。</string>
     <string name="settings_feature_gated_help">此设置的原生版本需要较新的 App 版本。更新 App 即可获得原生界面，或现在直接在网页中打开。</string>
     <string name="settings_feature_gated_badge">更新 App 以使用原生版</string>
+    <!-- 设置第三阶段原生：更换密钥 + 切换设备 (card_c3b13f64) -->
+    <string name="settings_rotate_device_secret">更换设备密钥</string>
+    <string name="settings_rotate_device_secret_hint">若当前的设备密钥已泄露，可重新生成一组新密钥。其他会话需使用新密钥才能登录。</string>
+    <string name="settings_rotate_secret_confirm_title">确定要更换设备密钥？</string>
+    <string name="settings_rotate_secret_confirm_btn">更换</string>
+    <string name="settings_rotate_secret_success">设备密钥已更换，新密钥已保存在此设备。</string>
+    <string name="settings_rotate_secret_failed">无法更换设备密钥，请重试。</string>
+    <string name="settings_switch_device">切换设备</string>
+    <string name="settings_switch_device_confirm">切换</string>
+    <string name="settings_switch_device_hint">将此 App 登录到另一个设备 ID。若您有第二个拥有自己实体的管理员账号，此功能很有用。</string>
+    <string name="settings_device_id">设备 ID</string>
+    <string name="settings_device_secret">设备密钥</string>
+    <string name="settings_switch_device_success_title">已切换设备</string>
+    <string name="settings_switch_device_success_msg">当前登录身份：%s\nApp 将重新启动以载入此设备。</string>
     <string name="settings_invite">邀请好友</string>
     <string name="settings_my_rentals">我的租借</string>
     <string name="settings_wallet">钱包</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -702,6 +702,20 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="settings_feature_web_help">此設定會在網頁檢視中開啟，因為此 App 版本尚未內建原生畫面。更新 App 即可取得原生畫面，或現在直接在網頁中使用。</string>
     <string name="settings_feature_gated_help">此設定的原生版本需要較新的 App 版本。更新 App 即可取得原生畫面，或現在直接在網頁中開啟。</string>
     <string name="settings_feature_gated_badge">更新 App 以使用原生版</string>
+    <!-- 設定第三階段原生：更換密鑰 + 切換裝置 (card_c3b13f64) -->
+    <string name="settings_rotate_device_secret">更換裝置密鑰</string>
+    <string name="settings_rotate_device_secret_hint">若目前的裝置密鑰已外洩，可重新產生一組新密鑰。其他工作階段需使用新密鑰才能登入。</string>
+    <string name="settings_rotate_secret_confirm_title">確定要更換裝置密鑰？</string>
+    <string name="settings_rotate_secret_confirm_btn">更換</string>
+    <string name="settings_rotate_secret_success">裝置密鑰已更換，新密鑰已儲存於此裝置。</string>
+    <string name="settings_rotate_secret_failed">無法更換裝置密鑰，請再試一次。</string>
+    <string name="settings_switch_device">切換裝置</string>
+    <string name="settings_switch_device_confirm">切換</string>
+    <string name="settings_switch_device_hint">將此 App 登入到另一個裝置 ID。若您有第二個擁有自己實體的管理員帳號，此功能很有用。</string>
+    <string name="settings_device_id">裝置 ID</string>
+    <string name="settings_device_secret">裝置密鑰</string>
+    <string name="settings_switch_device_success_title">已切換裝置</string>
+    <string name="settings_switch_device_success_msg">目前登入身分：%s\nApp 將重新啟動以載入此裝置。</string>
     <string name="show_label">顯示</string>
     <string name="sign_in_facebook">使用 Facebook 登入</string>
     <string name="sign_in_google">使用 Google 登入</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -619,6 +619,22 @@
     <string name="account_login_success_msg">Account restored: %s\nThe app will restart to load your data.</string>
     <string name="account_login_restart">Restart Now</string>
 
+    <!-- Settings Stage 3 native: Rotate Secret + Switch Device (card_c3b13f64) -->
+    <!-- i18n keys mirror the settings-manifest schema field i18n names. -->
+    <string name="settings_rotate_device_secret">Rotate Device Secret</string>
+    <string name="settings_rotate_device_secret_hint">Generate a new Device Secret if the current one has leaked. Other sessions will need the new value to sign in.</string>
+    <string name="settings_rotate_secret_confirm_title">Rotate Device Secret?</string>
+    <string name="settings_rotate_secret_confirm_btn">Rotate</string>
+    <string name="settings_rotate_secret_success">Device Secret rotated. The new secret has been saved on this device.</string>
+    <string name="settings_rotate_secret_failed">Could not rotate Device Secret. Please try again.</string>
+    <string name="settings_switch_device">Switch Device</string>
+    <string name="settings_switch_device_confirm">Switch</string>
+    <string name="settings_switch_device_hint">Sign this app into a different Device ID. Useful if you have a second admin account with its own entities.</string>
+    <string name="settings_device_id">Device ID</string>
+    <string name="settings_device_secret">Device Secret</string>
+    <string name="settings_switch_device_success_title">Device Switched</string>
+    <string name="settings_switch_device_success_msg">Now signed in as: %s\nThe app will restart to load this device.</string>
+
     <!-- Privacy Policy -->
     <string name="privacy_policy_title">Privacy Policy</string>
     <string name="delete_account">Delete Account</string>

--- a/app/src/test/java/com/hank/clawlive/settings/SettingsManifestSyncTest.kt
+++ b/app/src/test/java/com/hank/clawlive/settings/SettingsManifestSyncTest.kt
@@ -40,18 +40,36 @@ class SettingsManifestSyncTest {
 
     @Test
     fun planDynamicRows_newWebOnlyFeature_emitsWebRow() {
-        // rotate_secret / switch_device: native:false, no static row.
+        // rental_management: native:false, no static native row → dynamic web row.
         val rows = SettingsManifestSync.planDynamicRows(
-            manifest(feature("rotate_secret", native = false)),
+            manifest(feature("rental_management", native = false)),
             "1.0.94"
         )
         assertEquals(1, rows.size)
-        assertEquals("rotate_secret", rows[0].key)
+        assertEquals("rental_management", rows[0].key)
         assertFalse("plain web-only feature is not version-gated", rows[0].gated)
         assertEquals(
-            "https://eclawbot.com/portal/settings.html?focus=rotate_secret",
+            "https://eclawbot.com/portal/settings.html?focus=rental_management",
             rows[0].webFallback
         )
+    }
+
+    // ── Stage 3 native (card_c3b13f64): rotate_secret / switch_device are now ──
+    // ── handled by native dialogs, so even though the manifest declares them   ──
+    // ── web-only (native:false) the planner must NOT emit a duplicate web row. ──
+
+    @Test
+    fun planDynamicRows_stage3NativeRows_areCoveredNatively() {
+        assertTrue("rotate_secret is a native static row", "rotate_secret" in SettingsManifestSync.nativeRowKeys)
+        assertTrue("switch_device is a native static row", "switch_device" in SettingsManifestSync.nativeRowKeys)
+        val rows = SettingsManifestSync.planDynamicRows(
+            manifest(
+                feature("rotate_secret", native = false),
+                feature("switch_device", native = false)
+            ),
+            "1.0.94"
+        )
+        assertTrue("native-handled features emit no dynamic web row", rows.isEmpty())
     }
 
     // ── feature the static screen already renders natively → no dynamic row ──
@@ -162,13 +180,15 @@ class SettingsManifestSyncTest {
                 feature("rental_management", native = false),      // NEW web-only → row
                 feature("agent_policy", native = false),           // NEW web-only → row
                 feature("passive_health", native = false),         // NEW web-only → row
-                feature("rotate_secret", native = false),          // NEW web-only → row
-                feature("switch_device", native = false)           // NEW web-only → row
+                feature("rotate_secret", native = false),          // Stage 3 native → no row
+                feature("switch_device", native = false)           // Stage 3 native → no row
             ),
             "1.0.94"
         )
         assertEquals(
-            listOf("rental_management", "agent_policy", "passive_health", "rotate_secret", "switch_device"),
+            // rotate_secret/switch_device are now native static rows (Stage 3) so they
+            // are statically covered — only the genuinely web-only features surface.
+            listOf("rental_management", "agent_policy", "passive_health"),
             rows.map { it.key }
         )
         assertTrue("all are plain web-only, none gated", rows.none { it.gated })


### PR DESCRIPTION
## Why
Stage 3-native (Android half) of the settings→APP auto-sync seam. The two HIGH-drift features `rotate_secret` + `switch_device` were missing from BOTH apps (web-fallback only). This adds them as **native Android screens**.

(Backend field-registry + Stage 2 manifest consumption already shipped; iOS/Expo half tracked separately. iOS release + the manifest `native:false→true` version-flip are deliberately NOT in this PR — they happen at release time, gated on Apple/Play signing.)

## What
- **Rotate Secret**: destructive confirm dialog → `POST /api/device/rotate-secret {deviceId,deviceSecret}` → persists the once-returned `newDeviceSecret` via `DeviceManager.setCredentials` (same deviceId). 
- **Switch Device**: dialog with Device ID + password-masked Device Secret → `POST /api/auth/device-login` → persists returned creds + restarts app (mirrors the account-login flow).
- Retrofit: `rotateDeviceSecret` + `deviceLogin` methods + data classes (`ClawApiService.kt`).
- `activity_settings.xml`: two native rows (`rowRotateSecret`, `rowSwitchDevice`).
- `SettingsManifestSync.kt`: added both keys to `nativeRowKeys` so the manifest WebView dynamic-row path doesn't duplicate them.
- i18n: EN + zh-rTW + zh-rCN.
- Secret never logged in plaintext; HttpException error-body surfaced to the user.

## Verification
- `./gradlew :app:testDebugUnitTest --tests SettingsManifestSyncTest` → **10/10 green** (full `compileDebugKotlin` ran).
- `./gradlew :app:assembleDebug` → **BUILD SUCCESSFUL**, APK packaged (resources + strings link clean).
- No backend change, no version bump.

## ⚠️ Draft — blocked on
1. **#6 emulator/simulator vision-check** of the two rows + dialogs (UIUX gate).
2. Release decision (Hank): when shipping, flip `rotate_secret`/`switch_device` `native:false→true` + set `minAppVersion` in `backend/lib/settings-manifest.js`, bump `versionCode/versionName`, and sign/upload — needs Apple/Play signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwUSDu6mYWNTVYiCGYWA8L