### PR TITLE
feat(ios): Stage 3 native Rotate Secret + Switch Device (card_c3b13f64)

### DIFF
--- a/ios-app/app/(tabs)/settings.tsx
+++ b/ios-app/app/(tabs)/settings.tsx
@@ -31,12 +31,25 @@ import { shouldShowChip, appStoreDeepLink, appStoreHttpsLink } from '../../servi
 import { Alert, Linking } from 'react-native';
 import { SUPPORTED_LANGUAGES } from '../../i18n';
 import Constants from 'expo-constants';
+import * as Updates from 'expo-updates';
+import type { AuthUser } from '../../store/authStore';
 
 export default function SettingsScreen() {
   const { t } = useTranslation();
   const theme = useTheme();
   const router = useRouter();
-  const { deviceId, user, authToken, clearUserSession, clearAll, language, setLanguage } = useAuthStore();
+  const {
+    deviceId,
+    deviceSecret,
+    user,
+    authToken,
+    clearUserSession,
+    clearAll,
+    language,
+    setLanguage,
+    setDeviceCredentials,
+    setUserSession,
+  } = useAuthStore();
 
   const [langDialogVisible, setLangDialogVisible] = useState(false);
   const [emailDialogVisible, setEmailDialogVisible] = useState(false);
@@ -48,6 +61,14 @@ export default function SettingsScreen() {
   const [snack, setSnack] = useState('');
   const [notifBotReply, setNotifBotReply] = useState(true);
   const [notifBroadcast, setNotifBroadcast] = useState(true);
+
+  // ── Stage-3 native: Rotate Secret + Switch Device (card_c3b13f64) ──────────
+  const [rotateDialogVisible, setRotateDialogVisible] = useState(false);
+  const [rotateLoading, setRotateLoading] = useState(false);
+  const [switchDialogVisible, setSwitchDialogVisible] = useState(false);
+  const [switchDeviceId, setSwitchDeviceId] = useState('');
+  const [switchDeviceSecret, setSwitchDeviceSecret] = useState('');
+  const [switchLoading, setSwitchLoading] = useState(false);
 
   const appVersion = Constants.expoConfig?.version ?? '1.0.0';
 
@@ -221,6 +242,116 @@ export default function SettingsScreen() {
     );
   };
 
+  // ── Rotate Device Secret (Stage-3 native, card_c3b13f64) ───────────────────
+  // Mirrors Android SettingsActivity.showRotateSecretDialog(): destructive
+  // confirm → POST /api/device/rotate-secret. The new secret is returned ONCE in
+  // `newDeviceSecret`; on success it is persisted via setDeviceCredentials with
+  // the SAME deviceId (the credential store seam login.tsx uses). The secret is
+  // never surfaced or logged in plaintext — only success/failure is shown.
+  const handleRotateSecret = async () => {
+    if (!deviceId || !deviceSecret) {
+      setSnack(t('settings.rotate_secret_failed', 'Could not rotate Device Secret. Please try again.'));
+      return;
+    }
+    setRotateLoading(true);
+    try {
+      const res = await authApi.rotateDeviceSecret(deviceId, deviceSecret);
+      const newSecret = res.data?.newDeviceSecret;
+      if (res.data?.success && newSecret) {
+        // Persist the once-returned secret locally, keeping the same deviceId.
+        await setDeviceCredentials(deviceId, newSecret);
+        setRotateDialogVisible(false);
+        setSnack(t('settings.rotate_secret_success', 'Device Secret rotated. The new secret has been saved on this device.'));
+      } else {
+        setSnack(
+          res.data?.error ||
+            res.data?.message ||
+            t('settings.rotate_secret_failed', 'Could not rotate Device Secret. Please try again.')
+        );
+      }
+    } catch (err: any) {
+      // The interceptor already strips to a message; never echo the secret.
+      setSnack(err?.message || t('settings.rotate_secret_failed', 'Could not rotate Device Secret. Please try again.'));
+    } finally {
+      setRotateLoading(false);
+    }
+  };
+
+  // ── Switch Device (Stage-3 native, card_c3b13f64) ──────────────────────────
+  // Mirrors Android SettingsActivity.showSwitchDeviceDialog() + login.tsx's
+  // handleDeviceLogin: two inputs (Device ID + masked Device Secret) → the
+  // EXISTING authApi.deviceLogin (POST /api/auth/device-login). On success the
+  // returned creds are persisted the same way the login screen does
+  // (setDeviceCredentials + setUserSession) and the app is reloaded so every
+  // screen picks up the new device — the iOS equivalent of Android's
+  // launch-intent restart.
+  const handleSwitchDevice = async () => {
+    const id = switchDeviceId.trim();
+    const secret = switchDeviceSecret.trim();
+    if (!id || !secret) {
+      setSnack(t('auth.fill_required_fields', 'Please fill in all fields'));
+      return;
+    }
+    setSwitchLoading(true);
+    try {
+      const res = await authApi.deviceLogin(id, secret);
+      const data = res.data;
+      if (!data?.success && data?.success !== undefined) {
+        setSnack(data?.error || data?.message || t('settings.rotate_secret_failed', 'Failed'));
+        return;
+      }
+      // Persist the new device credentials (the entered pair is canonical; prefer
+      // any backend-echoed values when present), exactly like login.tsx.
+      const respUser = data?.user;
+      await setDeviceCredentials(respUser?.deviceId || id, respUser?.deviceSecret || secret);
+      const token = data?.authToken || data?.token;
+      if (token && respUser) {
+        const authUser: AuthUser = {
+          id: respUser.id,
+          email: respUser.email ?? null,
+          displayName: respUser.displayName ?? null,
+          avatarUrl: respUser.avatarUrl ?? null,
+          provider: 'device',
+          subscriptionStatus: respUser.subscriptionStatus,
+          googleLinked: respUser.googleLinked,
+          facebookLinked: respUser.facebookLinked,
+          appleLinked: respUser.appleLinked,
+        };
+        await setUserSession(token, authUser);
+      }
+      setSwitchDialogVisible(false);
+      setSwitchDeviceId('');
+      setSwitchDeviceSecret('');
+      // Restart so the whole app reloads under the new device — mirrors the
+      // Android post-login restart. In dev/Expo Go reloadAsync may be a no-op;
+      // fall back to navigating to the tabs root.
+      Alert.alert(
+        t('settings.switch_device_success_title', 'Device Switched'),
+        t('settings.switch_device_success_msg', {
+          account: respUser?.email || respUser?.deviceId || id,
+          defaultValue: 'Now signed in as: {{account}}\nThe app will restart to load this device.',
+        }),
+        [
+          {
+            text: t('settings.switch_device_restart', 'Restart'),
+            onPress: async () => {
+              try {
+                await Updates.reloadAsync();
+              } catch {
+                // Not in an OTA-updatable build (e.g. dev client) — soft reload.
+                router.replace('/(tabs)');
+              }
+            },
+          },
+        ]
+      );
+    } catch (err: any) {
+      setSnack(err?.message || String(err));
+    } finally {
+      setSwitchLoading(false);
+    }
+  };
+
   const providerLabel = () => {
     if (!user) return t('auth.current_provider_device', 'Device-only authentication');
     switch (user.provider) {
@@ -253,6 +384,28 @@ export default function SettingsScreen() {
               onPress={() => router.push('/bind-email')}
             />
           )}
+        </List.Section>
+
+        <Divider />
+
+        {/* Security & Device (Stage-3 native, card_c3b13f64) — Rotate Secret +
+            Switch Device rendered natively instead of via the manifest WebView
+            fallback. Both gated behind a device identity (deviceId/deviceSecret). */}
+        <List.Section title={t('settings.security_device', 'Security & Device')}>
+          <List.Item
+            title={t('settings.rotate_device_secret', 'Rotate Device Secret')}
+            description={t('settings.rotate_device_secret_hint', 'Generate a new Device Secret if the current one has leaked. Other sessions will need the new value to sign in.')}
+            left={(props) => <List.Icon {...props} icon="key-change" />}
+            disabled={!deviceId || !deviceSecret}
+            onPress={() => setRotateDialogVisible(true)}
+          />
+          <List.Item
+            title={t('settings.switch_device', 'Switch Device')}
+            description={t('settings.switch_device_hint', 'Sign this app into a different Device ID. Useful if you have a second admin account with its own entities.')}
+            left={(props) => <List.Icon {...props} icon="account-switch" />}
+            right={(props) => <List.Icon {...props} icon="chevron-right" />}
+            onPress={() => setSwitchDialogVisible(true)}
+          />
         </List.Section>
 
         <Divider />
@@ -510,6 +663,82 @@ export default function SettingsScreen() {
               disabled={emailLoading}
             >
               {t('settings.bind_email_confirm', 'Bind')}
+            </Button>
+          </Dialog.Actions>
+        </Dialog>
+      </Portal>
+
+      {/* Rotate Device Secret confirm (Stage-3 native, card_c3b13f64) —
+          destructive; manifest schema marks validation.confirm:true. */}
+      <Portal>
+        <Dialog visible={rotateDialogVisible} onDismiss={() => !rotateLoading && setRotateDialogVisible(false)}>
+          <Dialog.Title>
+            {t('settings.rotate_secret_confirm_title', 'Rotate Device Secret?')}
+          </Dialog.Title>
+          <Dialog.Content>
+            <Text variant="bodyMedium">
+              {t('settings.rotate_device_secret_hint', 'Generate a new Device Secret if the current one has leaked. Other sessions will need the new value to sign in.')}
+            </Text>
+          </Dialog.Content>
+          <Dialog.Actions>
+            <Button onPress={() => setRotateDialogVisible(false)} disabled={rotateLoading}>
+              {t('common.cancel', 'Cancel')}
+            </Button>
+            <Button
+              mode="contained"
+              onPress={handleRotateSecret}
+              loading={rotateLoading}
+              disabled={rotateLoading}
+              textColor={theme.colors.onError}
+              buttonColor={theme.colors.error}
+            >
+              {t('settings.rotate_secret_confirm_btn', 'Rotate')}
+            </Button>
+          </Dialog.Actions>
+        </Dialog>
+      </Portal>
+
+      {/* Switch Device dialog (Stage-3 native, card_c3b13f64) — Device ID +
+          masked Device Secret → authApi.deviceLogin, then persist + restart. */}
+      <Portal>
+        <Dialog visible={switchDialogVisible} onDismiss={() => !switchLoading && setSwitchDialogVisible(false)}>
+          <Dialog.Title>{t('settings.switch_device', 'Switch Device')}</Dialog.Title>
+          <Dialog.Content>
+            <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 12 }}>
+              {t('settings.switch_device_hint', 'Sign this app into a different Device ID. Useful if you have a second admin account with its own entities.')}
+            </Text>
+            <TextInput
+              label={t('settings.device_id', 'Device ID')}
+              value={switchDeviceId}
+              onChangeText={setSwitchDeviceId}
+              autoCapitalize="none"
+              autoCorrect={false}
+              mode="outlined"
+              style={{ marginBottom: 12 }}
+              disabled={switchLoading}
+            />
+            <TextInput
+              label={t('settings.device_secret', 'Device Secret')}
+              value={switchDeviceSecret}
+              onChangeText={setSwitchDeviceSecret}
+              secureTextEntry
+              autoCapitalize="none"
+              autoCorrect={false}
+              mode="outlined"
+              disabled={switchLoading}
+            />
+          </Dialog.Content>
+          <Dialog.Actions>
+            <Button onPress={() => setSwitchDialogVisible(false)} disabled={switchLoading}>
+              {t('common.cancel', 'Cancel')}
+            </Button>
+            <Button
+              mode="contained"
+              onPress={handleSwitchDevice}
+              loading={switchLoading}
+              disabled={switchLoading}
+            >
+              {t('settings.switch_device_confirm', 'Switch')}
             </Button>
           </Dialog.Actions>
         </Dialog>

--- a/ios-app/i18n/en.json
+++ b/ios-app/i18n/en.json
@@ -268,7 +268,22 @@
     "open_on_web": "Open on web",
     "update_available": "Update available · v{{latest}}",
     "update_help_title": "App update available",
-    "update_help_body": "A newer version (v{{latest}}) is available; you are on v{{current}}. Tap Update to open the App Store, then tap Update there to install — Apple does not allow in-app installs."
+    "update_help_body": "A newer version (v{{latest}}) is available; you are on v{{current}}. Tap Update to open the App Store, then tap Update there to install — Apple does not allow in-app installs.",
+    "security_device": "Security & Device",
+    "rotate_device_secret": "Rotate Device Secret",
+    "rotate_device_secret_hint": "Generate a new Device Secret if the current one has leaked. Other sessions will need the new value to sign in.",
+    "rotate_secret_confirm_title": "Rotate Device Secret?",
+    "rotate_secret_confirm_btn": "Rotate",
+    "rotate_secret_success": "Device Secret rotated. The new secret has been saved on this device.",
+    "rotate_secret_failed": "Could not rotate Device Secret. Please try again.",
+    "switch_device": "Switch Device",
+    "switch_device_confirm": "Switch",
+    "switch_device_hint": "Sign this app into a different Device ID. Useful if you have a second admin account with its own entities.",
+    "device_id": "Device ID",
+    "device_secret": "Device Secret",
+    "switch_device_success_title": "Device Switched",
+    "switch_device_success_msg": "Now signed in as: {{account}}\nThe app will restart to load this device.",
+    "switch_device_restart": "Restart"
   },
   "entity": {
     "rename": "Rename Entity",

--- a/ios-app/i18n/zh-CN.json
+++ b/ios-app/i18n/zh-CN.json
@@ -268,7 +268,22 @@
     "open_on_web": "在网页打开",
     "update_available": "有可用更新 · v{{latest}}",
     "update_help_title": "有 App 更新",
-    "update_help_body": "有新版本(v{{latest}}),你当前是 v{{current}}。点“更新”打开 App Store,在那里点 Update 安装 — Apple 不允许 App 内直接安装。"
+    "update_help_body": "有新版本(v{{latest}}),你当前是 v{{current}}。点“更新”打开 App Store,在那里点 Update 安装 — Apple 不允许 App 内直接安装。",
+    "security_device": "安全与设备",
+    "rotate_device_secret": "更换设备密钥",
+    "rotate_device_secret_hint": "若当前的设备密钥已泄露,可重新生成一组新密钥。其他会话需使用新密钥才能登录。",
+    "rotate_secret_confirm_title": "确定要更换设备密钥?",
+    "rotate_secret_confirm_btn": "更换",
+    "rotate_secret_success": "设备密钥已更换,新密钥已保存在此设备。",
+    "rotate_secret_failed": "无法更换设备密钥,请重试。",
+    "switch_device": "切换设备",
+    "switch_device_confirm": "切换",
+    "switch_device_hint": "将此 App 登录到另一个设备 ID。若您有第二个拥有自己实体的管理员账号,此功能很有用。",
+    "device_id": "设备 ID",
+    "device_secret": "设备密钥",
+    "switch_device_success_title": "已切换设备",
+    "switch_device_success_msg": "当前登录身份:{{account}}\nApp 将重新启动以载入此设备。",
+    "switch_device_restart": "立即重启"
   },
   "entity": {
     "rename": "重命名实体",

--- a/ios-app/i18n/zh-TW.json
+++ b/ios-app/i18n/zh-TW.json
@@ -268,7 +268,22 @@
     "open_on_web": "在網頁開啟",
     "update_available": "有可用更新 · v{{latest}}",
     "update_help_title": "有 App 更新",
-    "update_help_body": "有新版本(v{{latest}}),你目前是 v{{current}}。點「更新」開啟 App Store,在那裡點 Update 安裝 — Apple 不允許 App 內直接安裝。"
+    "update_help_body": "有新版本(v{{latest}}),你目前是 v{{current}}。點「更新」開啟 App Store,在那裡點 Update 安裝 — Apple 不允許 App 內直接安裝。",
+    "security_device": "安全與裝置",
+    "rotate_device_secret": "更換裝置密鑰",
+    "rotate_device_secret_hint": "若目前的裝置密鑰已外洩,可重新產生一組新密鑰。其他工作階段需使用新密鑰才能登入。",
+    "rotate_secret_confirm_title": "確定要更換裝置密鑰?",
+    "rotate_secret_confirm_btn": "更換",
+    "rotate_secret_success": "裝置密鑰已更換,新密鑰已儲存於此裝置。",
+    "rotate_secret_failed": "無法更換裝置密鑰,請再試一次。",
+    "switch_device": "切換裝置",
+    "switch_device_confirm": "切換",
+    "switch_device_hint": "將此 App 登入到另一個裝置 ID。若您有第二個擁有自己實體的管理員帳號,此功能很有用。",
+    "device_id": "裝置 ID",
+    "device_secret": "裝置密鑰",
+    "switch_device_success_title": "已切換裝置",
+    "switch_device_success_msg": "目前登入身分:{{account}}\nApp 將重新啟動以載入此裝置。",
+    "switch_device_restart": "立即重啟"
   },
   "entity": {
     "rename": "重新命名實體",

--- a/ios-app/services/__tests__/settingsManifest.test.ts
+++ b/ios-app/services/__tests__/settingsManifest.test.ts
@@ -179,12 +179,15 @@ function manifest(...features: SettingsManifestFeature[]): SettingsManifest {
 
 describe('planDynamicRows — Stage-2 auto-sync delta', () => {
   test('NEW web-only feature with no native row -> emits web row (the payoff)', () => {
-    const rows = planDynamicRows(manifest(f('rotate_secret', false)), '1.0.94');
+    // passive_health: still web-only (not in the iOS static screen nor a Stage-3
+    // native row), so it is exactly the auto-sync payoff. rotate_secret/
+    // switch_device used to live here but are now native (card_c3b13f64).
+    const rows = planDynamicRows(manifest(f('passive_health', false)), '1.0.94');
     expect(rows.length).toBe(1);
-    expect(rows[0].key).toBe('rotate_secret');
+    expect(rows[0].key).toBe('passive_health');
     expect(rows[0].gated).toBe(false);
     expect(rows[0].webFallback).toBe(
-      'https://eclawbot.com/portal/settings.html?focus=rotate_secret'
+      'https://eclawbot.com/portal/settings.html?focus=passive_health'
     );
   });
 
@@ -250,9 +253,11 @@ describe('planDynamicRows — Stage-2 auto-sync delta', () => {
   test('live-like iOS manifest -> only the features iOS does not render natively surface', () => {
     // Reflects the iOS static screen: account/subscription/language/notifications/
     // invite/wallet/my_rentals/files/feedback render natively; kanban_nudge is a
-    // web-backed static row. channel_api / display / chat_prefs /
-    // developer_broadcast / companion_petdx are NOT in the iOS static screen, so
-    // the manifest auto-surfaces them (the drift-fix the seam exists for).
+    // web-backed static row; rotate_secret/switch_device are Stage-3 native rows
+    // (card_c3b13f64) so they no longer auto-surface as web rows. channel_api /
+    // display / chat_prefs / developer_broadcast / companion_petdx are NOT in the
+    // iOS static screen, so the manifest auto-surfaces them (the drift-fix the
+    // seam exists for).
     const rows = planDynamicRows(
       manifest(
         f('account_identity', true, { minVer: '1.0.0' }),
@@ -273,8 +278,8 @@ describe('planDynamicRows — Stage-2 auto-sync delta', () => {
         f('files', true, { minVer: '1.0.0' }),
         f('companion_petdx', true, { minVer: '1.0.0' }), // not in iOS static -> web row
         f('feedback', true, { minVer: '1.0.0' }),
-        f('rotate_secret', false), // NEW web-only -> row
-        f('switch_device', false) // NEW web-only -> row
+        f('rotate_secret', false), // Stage-3 native row -> skip
+        f('switch_device', false) // Stage-3 native row -> skip
       ),
       '1.0.94'
     );
@@ -287,9 +292,19 @@ describe('planDynamicRows — Stage-2 auto-sync delta', () => {
       'agent_policy',
       'passive_health',
       'companion_petdx',
-      'rotate_secret',
-      'switch_device',
     ]);
     expect(rows.some((r) => r.gated)).toBe(false);
+  });
+
+  test('Stage-3 native rows (rotate_secret + switch_device) are covered natively -> no web rows', () => {
+    // card_c3b13f64: both are native:false in the manifest (no WebView surface to
+    // gate) but the iOS app now renders them as native settings rows, so the
+    // auto-sync planner must NOT emit duplicate web rows for them. Mirrors the
+    // Android SettingsManifestSyncTest.planDynamicRows_stage3NativeRows_areCoveredNatively.
+    const rows = planDynamicRows(
+      manifest(f('rotate_secret', false), f('switch_device', false)),
+      '1.0.94'
+    );
+    expect(rows).toEqual([]);
   });
 });

--- a/ios-app/services/api.ts
+++ b/ios-app/services/api.ts
@@ -257,6 +257,17 @@ export const feedbackApi = {
 
 // ── Auth APIs ────────────────────────────────────────────────
 
+/** Response shape of POST /api/device/rotate-secret. `newDeviceSecret` is the
+ *  rotated secret, returned exactly ONCE — persist it immediately on success. */
+export interface RotateSecretResponse {
+  success: boolean;
+  deviceId?: string;
+  newDeviceSecret?: string;
+  rotatedAt?: string;
+  error?: string;
+  message?: string;
+}
+
 export const authApi = {
   /** Email + password login */
   login: (email: string, password: string) =>
@@ -269,6 +280,15 @@ export const authApi = {
   /** Login with device credentials (returns JWT) */
   deviceLogin: (deviceId: string, deviceSecret: string) =>
     apiClient.post('/api/auth/device-login', { deviceId, deviceSecret }),
+
+  /**
+   * Rotate this device's secret (Stage-3 native; mirrors the manifest
+   * rotate_secret feature → POST /api/device/rotate-secret). The backend returns
+   * the new secret ONCE in `newDeviceSecret`; the caller must persist it locally
+   * (overwriting the stored deviceSecret, same deviceId). 401 on mismatch.
+   */
+  rotateDeviceSecret: (deviceId: string, deviceSecret: string) =>
+    apiClient.post<RotateSecretResponse>('/api/device/rotate-secret', { deviceId, deviceSecret }),
 
   /** Forgot password — sends reset email */
   forgotPassword: (email: string) =>

--- a/ios-app/services/settingsManifest.ts
+++ b/ios-app/services/settingsManifest.ts
@@ -242,6 +242,12 @@ export const nativeRowKeys: ReadonlySet<string> = new Set([
   'my_rentals',
   'files',
   'feedback',
+  // Stage-3 native (card_c3b13f64): Rotate Secret + Switch Device are now
+  // rendered as native settings rows (see ios-app/app/(tabs)/settings.tsx), so
+  // the manifest auto-sync path must NOT also emit duplicate web rows for them.
+  // Mirrors the Android SettingsManifestSync.nativeRowKeys addition (PR #3742).
+  'rotate_secret',
+  'switch_device',
   'logout',
 ]);
 


### PR DESCRIPTION
## Why
Stage 3-native (iOS/Expo half) of the settings→APP auto-sync seam — companion to the Android half in #3742. Adds native **Rotate Secret** + **Switch Device** to the React Native/Expo settings screen (the two HIGH-drift features that were web-fallback only).

(Backend field-registry + Stage 2 manifest consumption already shipped. The manifest `native:false→true` version-flip + version bump are deliberately NOT here — they happen at release time, gated on EAS/Apple signing.)

## What
- **Rotate Secret**: destructive confirm dialog → `POST /api/device/rotate-secret` → persists the once-returned `newDeviceSecret` via `authStore.setDeviceCredentials` (same deviceId — the SecureStore seam `login.tsx` uses).
- **Switch Device**: dialog with Device ID + `secureTextEntry` Device Secret → existing `authApi.deviceLogin` → persists creds (`setDeviceCredentials` + `setUserSession`) → `Updates.reloadAsync()` restart (iOS analog of Android's launch-intent restart; `router.replace` fallback for dev clients).
- `services/api.ts`: `authApi.rotateDeviceSecret()` + `RotateSecretResponse` type (deviceLogin reused).
- `services/settingsManifest.ts`: `rotate_secret`/`switch_device` added to `nativeRowKeys` (no duplicate WebView rows).
- i18n: EN + zh-TW + zh-CN under `settings.` (wording matches the Android half for parity).
- Secret never logged; only success/error Snackbar/Alert text shown.

## Verification
- **ts-jest 21/21 PASS** (+1 new Stage-3 "covered natively → no web rows" test).
- `tsc --noEmit`: **0 new type errors** (22 pre-existing in unrelated files, identical with changes stashed vs applied).
- No backend change, no `app.json` version bump.

## ⚠️ Draft — blocked on
1. **#6 simulator vision-check** of the two rows + dialogs (UIUX gate).
2. Release decision (Hank): at ship time, flip `native:false→true` + `minAppVersion` in `backend/lib/settings-manifest.js`, bump `app.json` version/buildNumber, and EAS build/submit — needs Apple/EAS signing.

Pairs with #3742 (Android). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwUSDu6mYWNTVYiCGYWA8L