### PR TITLE
fix(chat): restore staged reply on send-abort paths, not just on catch (card_2625ae06)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -8486,6 +8486,18 @@
             // restore them (and their action-request binding) instead of orphaning
             // the request (card_b176c435).
             const replyContextsSnapshot = replyContexts.slice();
+            // Restore the optimistically-cleared quote chips + their action-request
+            // binding on ANY abort path — the early-return guards below (uploads still
+            // pending / no routing target) as well as the catch. Without this a send
+            // that never leaves the client silently orphans the staged reply with no
+            // feedback (card_2625ae06; extends the catch-only restore of card_b176c435).
+            const restoreReplyContextsOnAbort = () => {
+                if (replyContextsSnapshot.length && replyContexts.length === 0) {
+                    replyContexts = replyContextsSnapshot.slice();
+                    renderReplyPreviews();
+                    recomputeAutoReceivers();
+                }
+            };
             let finalText = text;
             if (replyContexts.length) {
                 // One "↩ …" line per quote so the recipient entity receives EVERY
@@ -8519,6 +8531,7 @@
             // Check if any files still uploading
             if (pendingFiles.some(f => f.status === 'uploading')) {
                 showToast(i18n.t('chat_wait_upload') || 'Please wait for uploads to finish', 'error');
+                restoreReplyContextsOnAbort();
                 return;
             }
 
@@ -8557,6 +8570,7 @@
 
             if (targets.local.length === 0 && targets.contacts.length === 0) {
                 showToast(i18n.t('chat_select_entity'), 'error');
+                restoreReplyContextsOnAbort();
                 return;
             }
 
@@ -8733,11 +8747,7 @@
                 // Send failed — the request was never resolved server-side, so
                 // restore the quote chips (incl. the action-request binding) the
                 // optimistic clear removed, letting the user retry (card_b176c435).
-                if (replyContextsSnapshot.length && replyContexts.length === 0) {
-                    replyContexts = replyContextsSnapshot.slice();
-                    renderReplyPreviews();
-                    recomputeAutoReceivers();
-                }
+                restoreReplyContextsOnAbort();
             } finally {
                 btn.disabled = false;
                 input.focus();

--- a/backend/tests/jest/chat-action-request-inbox.test.js
+++ b/backend/tests/jest/chat-action-request-inbox.test.js
@@ -164,4 +164,18 @@ describe('需要你 inbox collapse + lifecycle hardening (card_b176c435)', () =>
         expect(chatHtml).toContain('if (replyContextsSnapshot.length && replyContexts.length === 0) {');
         expect(chatHtml).toMatch(/function removeReplyContextForRequest\(requestId\)/);
     });
+
+    test('every send abort path (uploads-pending / no-target / catch) restores the staged reply, not just the catch (card_2625ae06)', () => {
+        // clearReplyContext() runs optimistically BEFORE the early-return guards, so
+        // each abort must restore the snapshot or the staged quote + action-request
+        // binding is silently orphaned with no user feedback. One DRY helper covers all.
+        const fn = chatHtml.slice(chatHtml.indexOf('async function sendMessage('), chatHtml.indexOf('async function uploadVoice('));
+        expect(fn).toContain('const restoreReplyContextsOnAbort = () => {');
+        // uploads-still-pending guard restores before returning
+        expect(fn).toMatch(/chat_wait_upload[\s\S]{0,180}restoreReplyContextsOnAbort\(\);\s*\n\s*return;/);
+        // no-routing-target guard restores before returning
+        expect(fn).toMatch(/chat_select_entity[\s\S]{0,140}restoreReplyContextsOnAbort\(\);\s*\n\s*return;/);
+        // invoked on all three abort paths: 2 early-return guards + the catch
+        expect((fn.match(/restoreReplyContextsOnAbort\(\)/g) || []).length).toBeGreaterThanOrEqual(3);
+    });
 });

--- a/backend/tests/jest/chat-targets-static.test.js
+++ b/backend/tests/jest/chat-targets-static.test.js
@@ -21,10 +21,14 @@ describe('chat target selection safety', () => {
     test('sendMessage surfaces the existing select-entity error when no targets are selected', () => {
         const start = chatHtml.indexOf('async function sendMessage()');
         expect(start).toBeGreaterThan(0);
-        // Window widened 5000 -> 6000 (card_277c80f5): the multi-quote block added
-        // ~lines to the top of sendMessage, pushing the (intact) no-target guard to
-        // ~offset 5100. The guard itself is unchanged; only its position moved.
-        const body = chatHtml.slice(start, start + 6000);
+        // Slice to the semantic end-marker (the send-button lookup that immediately
+        // follows the no-target guard) instead of a fixed byte window. A fixed window
+        // kept breaking when top-of-function code was added (5000->6000 for the
+        // multi-quote block card_277c80f5; then the card_2625ae06 abort-restore helper
+        // pushed the intact guard past 6000). A semantic marker is shift-proof.
+        const end = chatHtml.indexOf("const btn = document.getElementById('btnSend')", start);
+        expect(end).toBeGreaterThan(start);
+        const body = chatHtml.slice(start, end);
 
         expect(body).toContain('const targets = getSelectedTargets();');
         expect(body).toMatch(/targets\.local\.length\s*===\s*0\s*&&\s*targets\.contacts\.length\s*===\s*0/);


### PR DESCRIPTION
## What
`sendMessage()` runs `clearReplyContext()` **optimistically** before two early-return guards:
1. uploads-still-pending (`chat_wait_upload`)
2. no routing target selected (`chat_select_entity`)

The snapshot-restore that puts the quote chips back lived **only in the `catch` block**, which those two `return`s never reach. So a send aborted on either path **silently discarded** the user's staged quote chips **and** their action-request reply binding — the message never sent and the linkage to the「需要你」inbox item was orphaned, with no feedback.

## Fix
- Extract the catch-block restore into a DRY `restoreReplyContextsOnAbort()` closure (defined right after the existing `replyContextsSnapshot`).
- Invoke it on **both** early-return guards, and reuse it in the `catch` (no behavior change to the catch path).
- Net: every abort path now restores the staged reply; the happy path is untouched (`clearReplyContext()` still consumes the quotes on a real send).

## How found
Daily QA/UIUX regression sweep (card_2625ae06), run while covering rate-limited #1. Med-Low severity, narrow blast radius (needs uploads-pending OR no-target while a quote/action-request is staged) but it's silent data loss.

## Test hardening (same PR)
`chat-targets-static.test.js` sliced `sendMessage` with a **fixed 6000-byte window** to assert the no-target guard. The new helper (~780 chars near the top of the function) pushed the **intact** guard past 6000 — the exact fragility that previously forced a 5000→6000 widen (card_277c80f5). Switched the slice to a **semantic end-marker** (`btnSend` lookup immediately after the guard) so the assertion is shift-proof and won't recur.

## Tests
- `chat-action-request-inbox.test.js` — added an assertion that all three abort paths (uploads / no-target / catch) restore via the helper.
- `chat-action-request-inbox` + `chat-targets-static`: **19/19 green** locally.
- (Local full-suite run was in a deps-less worktree; authoritative full green is this PR's CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)