### PR TITLE
feat(action-requests): PUT edit endpoint — cross-agent, audited (card_cd4f323c)

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -194,9 +194,12 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
     // Room       : 'device:<deviceId>'   (same room convention as chat:message)
     // Payload    : { kind, requestId, fromEntityId }
     //                kind         : 'emitted' | 'resolved' | 'dismissed'
-    //                               | 'consensus_triggered'
+    //                               | 'consensus_triggered' | 'edited'
     //                requestId    : the agent_action_requests row UUID (string)
     //                fromEntityId : the emitting entity id (integer)
+    //              NEW kind 'edited' (card_cd4f323c): an agent edited the
+    //              request's content (prompt/options/type) via PUT. The inbox
+    //              should re-fetch to show the updated text.
     //              NEW kind 'consensus_triggered' (card_ce0d685b): the timeout
     //              worker opened a bot-to-bot consensus round for a still-pending
     //              request (consensus policy). The request stays 'pending' until
@@ -604,6 +607,135 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
         } catch (err) {
             console.error('[AgentActionRequests] dismiss failed:', err.message);
             return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    // ════════════════════════════════════════
+    // PUT /:id — edit a pending request's CONTENT (card_cd4f323c)
+    // ──────────────────────────────────────────────────────────────────────
+    // Hank's decisions 2026-06-26:
+    //   opt1 編輯語意: an agent may edit the prompt text, options/choices, and
+    //                 type of an EXISTING request (partial — send any subset).
+    //   opt2 權限範圍: CROSS-AGENT. ANY valid agent on the device may edit ANY
+    //                 request — we deliberately do NOT restrict to from_entity_id
+    //                 (unlike resolve/dismiss, which gate botSecret holders to
+    //                 their own requests via restrictToEntityId). That cross-
+    //                 agent power is a tampering risk, so EVERY successful edit
+    //                 writes one agent_action_request_audit row (editorEntityId +
+    //                 per-field old→new) in the SAME transaction as the UPDATE.
+    // Only 'pending' requests are editable (mirrors the resolve/dismiss guard).
+    // Validation of each provided field reuses the create-path rules verbatim.
+    // ════════════════════════════════════════
+    router.put('/:id', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const { id } = req.params;
+        if (!UUID_RE.test(String(id))) {
+            return res.status(400).json({ success: false, error: 'Invalid id' });
+        }
+
+        const body = req.body || {};
+        const hasType = Object.prototype.hasOwnProperty.call(body, 'type');
+        const hasPrompt = Object.prototype.hasOwnProperty.call(body, 'prompt');
+        const hasOptions = Object.prototype.hasOwnProperty.call(body, 'options');
+        if (!hasType && !hasPrompt && !hasOptions) {
+            return res.status(400).json({ success: false, error: 'Provide at least one editable field: prompt, options, type' });
+        }
+        // Validate each PROVIDED field with the exact same rules as POST / (create).
+        if (hasType && (typeof body.type !== 'string' || !VALID_TYPES.has(body.type))) {
+            return res.status(400).json({ success: false, error: `type must be one of: ${[...VALID_TYPES].join('|')}` });
+        }
+        if (hasPrompt && (typeof body.prompt !== 'string' || body.prompt.length < 1 || body.prompt.length > MAX_PROMPT_LEN)) {
+            return res.status(400).json({ success: false, error: `prompt must be a string of length 1..${MAX_PROMPT_LEN}` });
+        }
+        if (hasOptions) {
+            if (body.options !== null && !Array.isArray(body.options)) {
+                return res.status(400).json({ success: false, error: 'options must be an array or null' });
+            }
+            if (Array.isArray(body.options) && (body.options.length > 50 || JSON.stringify(body.options).length > 8192)) {
+                return res.status(400).json({ success: false, error: 'options too large (max 50 items / 8KB)' });
+            }
+        }
+
+        const client = await pool.connect();
+        try {
+            await client.query('BEGIN');
+            // Lock the target row; device-scoped. Cross-agent (opt2): NO
+            // from_entity_id filter — any agent on the device may edit it.
+            const cur = await client.query(
+                `SELECT * FROM agent_action_requests
+                  WHERE id = $1 AND device_id = $2
+                  FOR UPDATE`,
+                [id, deviceId]
+            );
+            if (cur.rows.length === 0) {
+                await client.query('ROLLBACK');
+                return res.status(404).json({ success: false, error: 'Not found' });
+            }
+            const before = cur.rows[0];
+            if (before.status !== 'pending') {
+                await client.query('ROLLBACK');
+                return res.status(409).json({ success: false, error: 'Only pending requests can be edited' });
+            }
+
+            // Build the partial UPDATE + the per-field old→new change set. Only
+            // fields whose value ACTUALLY changes are written / audited.
+            const sets = [];
+            const params = [];
+            const changes = {};
+            if (hasType && body.type !== before.type) {
+                params.push(body.type); sets.push(`type = $${params.length}`);
+                changes.type = { old: before.type, new: body.type };
+            }
+            if (hasPrompt && body.prompt !== before.prompt) {
+                params.push(body.prompt); sets.push(`prompt = $${params.length}`);
+                changes.prompt = { old: before.prompt, new: body.prompt };
+            }
+            if (hasOptions) {
+                const newOpts = body.options != null ? JSON.stringify(body.options) : null;
+                const oldOpts = before.options != null ? JSON.stringify(before.options) : null;
+                if (newOpts !== oldOpts) {
+                    params.push(newOpts); sets.push(`options = $${params.length}::jsonb`);
+                    changes.options = { old: before.options ?? null, new: body.options ?? null };
+                }
+            }
+
+            // No effective change → 200 with the row, no audit row written.
+            if (sets.length === 0) {
+                await client.query('COMMIT');
+                return res.json({ success: true, request: rowToApi(before), changed: false });
+            }
+
+            params.push(id);
+            const upd = await client.query(
+                `UPDATE agent_action_requests SET ${sets.join(', ')}
+                  WHERE id = $${params.length}
+                RETURNING *`,
+                params
+            );
+            const after = upd.rows[0];
+
+            // Audit row — SAME transaction as the UPDATE (opt2 mitigation).
+            // editor_entity_id is the bot's entity id, or NULL for a human edit.
+            await client.query(
+                `INSERT INTO agent_action_request_audit
+                    (request_id, device_id, editor_entity_id, changes)
+                 VALUES ($1, $2, $3, $4::jsonb)`,
+                [id, deviceId, auth.entityId, JSON.stringify(changes)]
+            );
+            await client.query('COMMIT');
+
+            log('info', `edit id=${id} editor=${auth.entityId ?? 'user'} fields=${Object.keys(changes).join(',')}`, { deviceId });
+            emitChanged(deviceId, 'edited', after.id, after.from_entity_id);
+            return res.json({ success: true, request: rowToApi(after), changed: true });
+        } catch (err) {
+            await client.query('ROLLBACK').catch(() => {});
+            console.error('[AgentActionRequests] edit failed:', err.message);
+            log('error', `edit failed id=${id}: ${err.message}`, { deviceId });
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        } finally {
+            client.release();
         }
     });
 

--- a/backend/agent_action_requests_schema.sql
+++ b/backend/agent_action_requests_schema.sql
@@ -33,3 +33,23 @@ CREATE TABLE IF NOT EXISTS agent_action_requests (
 
 CREATE INDEX IF NOT EXISTS idx_aar_device_status ON agent_action_requests(device_id, status, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_aar_anchor ON agent_action_requests(anchor_message_id);
+
+-- agent_action_request_audit — tamper-evident edit trail for the PUT edit
+-- endpoint (card_cd4f323c). Hank's decision opt2: ANY agent on the device may
+-- edit ANY request's content (prompt/options/type), not just the creator. That
+-- cross-agent power carries a tampering risk, so EVERY content edit writes one
+-- row here in the SAME transaction as the UPDATE. `changes` holds only the
+-- fields that actually changed, each as {old,new}. editor_entity_id is the
+-- editing agent's entity id, or NULL when a human (deviceSecret) made the edit.
+-- Append-only: no edit/resolve/dismiss ever rewrites a row here.
+CREATE TABLE IF NOT EXISTS agent_action_request_audit (
+    id BIGSERIAL PRIMARY KEY,
+    request_id UUID NOT NULL,
+    device_id VARCHAR(64) NOT NULL,
+    editor_entity_id INTEGER DEFAULT NULL,
+    changes JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_aar_audit_request ON agent_action_request_audit(request_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_aar_audit_editor ON agent_action_request_audit(device_id, editor_entity_id, created_at DESC);

--- a/backend/index.js
+++ b/backend/index.js
@@ -1568,7 +1568,8 @@ app.get('/api/help', (req, res) => {
         vault:      ['vault','device-vars','devicevars','secret','api key','apikey','金鑰','密鑰','秘密','保險箱','audit','審計','variables','環境變數','환경 변수','보관소','감사','シークレット','金庫','監査','bí mật','kho','giám sát','rahasia','brankas','audit log'],
         analytics:  ['analytics','growth','metrics','signup','retention','kpi','viral','k-value','成長','指標','留存','分析','회귀','분석','지표','メトリクス','分析','指標'],
         usage:      ['usage','spend','token spend','token','claude usage','codex usage','snapshot','timeline','daemon','widget','usage widget','dashboard widget','dashboard usage widget','5h','5-hour','five hour','gauge','用量','花費','token 花費','token 用量','使用量','消費','儀表板用量','用量小工具','5小時','コスト','使用量','使用ウィジェット','사용량','비용','사용량 위젯'],
-        remote_control: ['remote control','screen control','screen capture','screen image','device control','tap','swipe','long press','launch app','stop app','mobile-use','mobile use','minitap','遠端控制','螢幕控制','畫面控制','點擊','滑動','長按','啟動 app','關閉 app','操作 app','遥控','屏幕控制','リモート制御','画面制御','タップ','スワイプ','長押し','앱 실행','앱 종료','원격 제어','화면 제어','탭']
+        remote_control: ['remote control','screen control','screen capture','screen image','device control','tap','swipe','long press','launch app','stop app','mobile-use','mobile use','minitap','遠端控制','螢幕控制','畫面控制','點擊','滑動','長按','啟動 app','關閉 app','操作 app','遥控','屏幕控制','リモート制御','画面制御','タップ','スワイプ','長押し','앱 실행','앱 종료','원격 제어','화면 제어','탭'],
+        action_requests: ['action request','action-request','actionrequest','action_request','需要你','hitl','human in the loop','human-in-the-loop','ask user','ask the user','詢問使用者','需要決定','需要你決定','需要協助','編輯請求','edit request','edit action request','resolve request','dismiss request','inbox','需要你 inbox','請求收件匣']
     };
 
     const matched = Object.entries(INTENT_MAP).find(([category, kws]) =>
@@ -1650,6 +1651,13 @@ app.get('/api/help', (req, res) => {
             { title: 'GET channel repair log (public; filter channel/kind/limit)', curl: `curl -s "${apiBase}/api/channel-repair-log?limit=50"  # &channel=openclaw-channel-eclaw&kind=fix` },
             { title: 'POST a repair record (auth: deviceSecret OR entityId+botSecret; never include secrets)', curl: `curl -s -X POST "${apiBase}/api/channel-repair-log" -H "Content-Type: application/json" -d ${d},"channel_type":"openclaw-channel-eclaw","entity_refs":"#1","kind":"fix","title":"...","detail":"...","status":"mitigated","occurred_at":"2026-06-08T05:33:00Z","source":"monitor"}'` }
         ],
+        action_requests: [
+            { title: 'Emit a 需要你 request (ask the user/agent to decide/approve/fill-in)', curl: `curl -s -X POST "${apiBase}/api/action-requests" -H "Content-Type: application/json" -d ${d},"type":"decision","prompt":"QUESTION_TEXT","options":["A","B"]}'` },
+            { title: 'List requests for this device (status: pending|resolved|dismissed|all)', curl: `curl -s "${apiBase}/api/action-requests?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}&status=pending"` },
+            { title: 'Edit an existing request — prompt/options/type (cross-agent, audited; send any subset)', curl: `curl -s -X PUT "${apiBase}/api/action-requests/REQUEST_ID" -H "Content-Type: application/json" -d ${d},"prompt":"NEW_QUESTION_TEXT","options":["A","B","C"],"type":"approval"}'` },
+            { title: 'Resolve (answer) a pending request', curl: `curl -s -X POST "${apiBase}/api/action-requests/REQUEST_ID/resolve" -H "Content-Type: application/json" -d ${d},"answer":"YOUR_ANSWER"}'` },
+            { title: 'Dismiss a pending request', curl: `curl -s -X POST "${apiBase}/api/action-requests/REQUEST_ID/dismiss" -H "Content-Type: application/json" -d ${d}}'` }
+        ],
         remote_control: [
             { title: 'Screen capture (UI tree, long-poll ≤5s)', curl: `curl -s -X POST "${apiBase}/api/device/screen-capture" -H "Content-Type: application/json" -d ${d}}'` },
             { title: 'Send tap', curl: `curl -s -X POST "${apiBase}/api/device/control" -H "Content-Type: application/json" -d ${d},"command":"tap","params":{"x":100,"y":200}}'` },
@@ -1671,7 +1679,7 @@ app.get('/api/help', (req, res) => {
     res.json({
         intent,
         matched_category: matched,
-        tip: `Use ?intent=KEYWORD to discover APIs. Categories: messaging, kanban, schedule, notes, search, files, entities, vault, analytics, usage, remote_control`,
+        tip: `Use ?intent=KEYWORD to discover APIs. Categories: messaging, kanban, schedule, notes, search, files, entities, vault, analytics, usage, remote_control, action_requests`,
         curl_examples: curlBlock
     });
 });

--- a/backend/migrations/20260626_action_request_audit.down.sql
+++ b/backend/migrations/20260626_action_request_audit.down.sql
@@ -1,0 +1,6 @@
+-- Down: 20260626_action_request_audit
+-- Drop the action-request edit audit trail in reverse order.
+
+DROP INDEX IF EXISTS idx_aar_audit_editor;
+DROP INDEX IF EXISTS idx_aar_audit_request;
+DROP TABLE IF EXISTS agent_action_request_audit;

--- a/backend/migrations/20260626_action_request_audit.up.sql
+++ b/backend/migrations/20260626_action_request_audit.up.sql
@@ -1,0 +1,41 @@
+-- Migration: 20260626_action_request_audit
+-- Card: card_cd4f323c2fc2552d85ee15c4 (Plan B — edit "需要你" action-request content)
+--
+-- Hank's decisions 2026-06-26:
+--   opt1 編輯語意: agents may EDIT an existing action-request's content
+--                 (prompt text, options/choices, type) via PUT /api/action-requests/:id.
+--   opt2 權限範圍: ANY agent on the device may edit ANY request (cross-agent),
+--                 not just the creator. That tampering risk is mitigated by a
+--                 MANDATORY audit record written on every edit.
+--
+-- This audit table is also created at boot by agent-action-requests.js'
+-- initAgentActionRequestsDatabase() (it runs agent_action_requests_schema.sql,
+-- which carries the same DDL). This migration file is the ops/SoT mirror — both
+-- use IF NOT EXISTS so they are idempotent and never conflict.
+--
+-- `changes` stores only the fields that actually changed on a given edit, each
+-- as {"old": <prev>, "new": <next>}, e.g.
+--   {"prompt": {"old": "pick A", "new": "pick A or B"},
+--    "options": {"old": ["A"], "new": ["A","B"]}}
+-- editor_entity_id = the editing agent's entity id, or NULL for a human edit.
+
+CREATE TABLE IF NOT EXISTS agent_action_request_audit (
+    id BIGSERIAL PRIMARY KEY,
+    request_id UUID NOT NULL,
+    device_id VARCHAR(64) NOT NULL,
+    editor_entity_id INTEGER DEFAULT NULL,
+    changes JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_aar_audit_request
+    ON agent_action_request_audit(request_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_aar_audit_editor
+    ON agent_action_request_audit(device_id, editor_entity_id, created_at DESC);
+
+COMMENT ON TABLE agent_action_request_audit IS
+    'Append-only audit trail of content edits to agent_action_requests (PUT '
+    '/api/action-requests/:id, card_cd4f323c). One row per edit; cross-agent '
+    'edits are permitted (opt2) so this table is the tampering-risk mitigation. '
+    'changes holds only the {old,new} of fields that actually changed.';

--- a/backend/tests/jest/agent-action-requests.test.js
+++ b/backend/tests/jest/agent-action-requests.test.js
@@ -41,6 +41,19 @@ afterEach(() => mockPoolQuery.mockClear());
 
 const post = (p) => request(app).post(p);
 const get = (p) => request(app).get(p);
+const put = (p) => request(app).put(p);
+
+// Queue the exact pg call sequence the transactional PUT /:id edit runs:
+//   BEGIN → SELECT ... FOR UPDATE → UPDATE ... RETURNING * → INSERT audit → COMMIT
+function queueEditTxn(before, after) {
+    mockPoolQuery
+        .mockResolvedValueOnce({ rows: [] })        // BEGIN
+        .mockResolvedValueOnce({ rows: [before] })  // SELECT ... FOR UPDATE
+        .mockResolvedValueOnce({ rows: [after] })   // UPDATE ... RETURNING *
+        .mockResolvedValueOnce({ rows: [] })        // INSERT agent_action_request_audit
+        .mockResolvedValueOnce({ rows: [] });       // COMMIT
+}
+const auditCall = () => mockPoolQuery.mock.calls.find(c => /agent_action_request_audit/.test(c[0]));
 
 function rowFixture(over = {}) {
     return {
@@ -160,5 +173,140 @@ describe('POST /:id/dismiss', () => {
         const [sql] = mockPoolQuery.mock.calls[0];
         expect(sql).toMatch(/status = 'dismissed'/);
         expect(sql).toMatch(/AND status = 'pending'/);
+    });
+});
+
+// ════════════════════════════════════════
+// PUT /:id — edit content (card_cd4f323c): opt1 edit prompt/options/type,
+// opt2 cross-agent + mandatory audit.
+// ════════════════════════════════════════
+describe('PUT /:id (edit)', () => {
+    it('(a) edits prompt + options + type, returns updated row + changed:true', async () => {
+        const before = rowFixture(); // type=decision, prompt='pick A or B', options=['A','B'], from #2
+        const after = rowFixture({ type: 'approval', prompt: 'pick A, B or C', options: ['A', 'B', 'C'] });
+        queueEditTxn(before, after);
+        const res = await put(`/api/action-requests/${UUID}`).send({
+            deviceId, botSecret: 'bot-2', entityId: 2,
+            type: 'approval', prompt: 'pick A, B or C', options: ['A', 'B', 'C'],
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.changed).toBe(true);
+        expect(res.body.request.type).toBe('approval');
+        expect(res.body.request.prompt).toBe('pick A, B or C');
+        expect(res.body.request.options).toEqual(['A', 'B', 'C']);
+        // The UPDATE writes all three columns.
+        const updCall = mockPoolQuery.mock.calls.find(c => /UPDATE agent_action_requests SET/.test(c[0]));
+        expect(updCall[0]).toMatch(/type = /);
+        expect(updCall[0]).toMatch(/prompt = /);
+        expect(updCall[0]).toMatch(/options = /);
+    });
+
+    it('(b) cross-agent: editor entity 6 edits a request created by entity 2 → 200 (no creator restriction)', async () => {
+        const before = rowFixture({ from_entity_id: 2 });
+        const after = rowFixture({ from_entity_id: 2, prompt: 'edited by #6' });
+        queueEditTxn(before, after);
+        const res = await put(`/api/action-requests/${UUID}`).send({
+            deviceId, botSecret: 'bot-6', entityId: 6, prompt: 'edited by #6',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.changed).toBe(true);
+        // The row-lock SELECT is device-scoped but NOT restricted to from_entity_id.
+        const selCall = mockPoolQuery.mock.calls.find(c => /FOR UPDATE/.test(c[0]));
+        expect(selCall[0]).toMatch(/device_id = \$2/);
+        expect(selCall[0]).not.toMatch(/from_entity_id/);
+    });
+
+    it('(c) writes an audit row with editorEntityId + correct old→new', async () => {
+        const before = rowFixture({ from_entity_id: 2, prompt: 'pick A or B', options: ['A', 'B'], type: 'decision' });
+        const after = rowFixture({ from_entity_id: 2, prompt: 'pick A, B or C', options: ['A', 'B', 'C'], type: 'approval' });
+        queueEditTxn(before, after);
+        const res = await put(`/api/action-requests/${UUID}`).send({
+            deviceId, botSecret: 'bot-6', entityId: 6,
+            prompt: 'pick A, B or C', options: ['A', 'B', 'C'], type: 'approval',
+        });
+        expect(res.status).toBe(200);
+        const ac = auditCall();
+        expect(ac).toBeTruthy();
+        const params = ac[1]; // [request_id, device_id, editor_entity_id, changesJson]
+        expect(params[0]).toBe(UUID);
+        expect(params[1]).toBe(deviceId);
+        expect(params[2]).toBe(6); // editor = the cross-agent editor, not the creator (#2)
+        const changes = JSON.parse(params[3]);
+        expect(changes.prompt).toEqual({ old: 'pick A or B', new: 'pick A, B or C' });
+        expect(changes.options).toEqual({ old: ['A', 'B'], new: ['A', 'B', 'C'] });
+        expect(changes.type).toEqual({ old: 'decision', new: 'approval' });
+    });
+
+    it('(c2) human (deviceSecret) edit records editorEntityId = null', async () => {
+        const before = rowFixture({ prompt: 'old' });
+        const after = rowFixture({ prompt: 'new' });
+        queueEditTxn(before, after);
+        const res = await put(`/api/action-requests/${UUID}`).send({ deviceId, deviceSecret, prompt: 'new' });
+        expect(res.status).toBe(200);
+        expect(auditCall()[1][2]).toBeNull();
+    });
+
+    it('(d) rejects invalid type with 400 (no DB write)', async () => {
+        const res = await put(`/api/action-requests/${UUID}`).send({ deviceId, botSecret: 'bot-2', entityId: 2, type: 'bogus' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/type must be/);
+        expect(mockPoolQuery).not.toHaveBeenCalled();
+    });
+
+    it('(d) rejects empty prompt with 400', async () => {
+        const res = await put(`/api/action-requests/${UUID}`).send({ deviceId, botSecret: 'bot-2', entityId: 2, prompt: '' });
+        expect(res.status).toBe(400);
+    });
+
+    it('(d) rejects non-array options with 400', async () => {
+        const res = await put(`/api/action-requests/${UUID}`).send({ deviceId, botSecret: 'bot-2', entityId: 2, options: 'A,B' });
+        expect(res.status).toBe(400);
+    });
+
+    it('(d) rejects when no editable field supplied with 400', async () => {
+        const res = await put(`/api/action-requests/${UUID}`).send({ deviceId, botSecret: 'bot-2', entityId: 2 });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/at least one editable field/);
+        expect(mockPoolQuery).not.toHaveBeenCalled();
+    });
+
+    it('(d) rejects non-UUID id with 400', async () => {
+        const res = await put('/api/action-requests/not-a-uuid').send({ deviceId, botSecret: 'bot-2', entityId: 2, prompt: 'x' });
+        expect(res.status).toBe(400);
+    });
+
+    it('(d) editing an already-resolved request → 409, no audit row', async () => {
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [] })                                    // BEGIN
+            .mockResolvedValueOnce({ rows: [rowFixture({ status: 'resolved' })] })  // SELECT FOR UPDATE
+            .mockResolvedValueOnce({ rows: [] });                                   // ROLLBACK
+        const res = await put(`/api/action-requests/${UUID}`).send({ deviceId, botSecret: 'bot-2', entityId: 2, prompt: 'x' });
+        expect(res.status).toBe(409);
+        expect(res.body.error).toMatch(/pending/);
+        expect(auditCall()).toBeUndefined();
+    });
+
+    it('(d) editing a non-existent request → 404', async () => {
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [] })  // BEGIN
+            .mockResolvedValueOnce({ rows: [] })  // SELECT FOR UPDATE (none)
+            .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+        const res = await put(`/api/action-requests/${UUID}`).send({ deviceId, botSecret: 'bot-2', entityId: 2, prompt: 'x' });
+        expect(res.status).toBe(404);
+    });
+
+    it('no-op edit (same values) → changed:false, no audit row', async () => {
+        const before = rowFixture({ prompt: 'pick A or B', options: ['A', 'B'], type: 'decision' });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [] })        // BEGIN
+            .mockResolvedValueOnce({ rows: [before] })  // SELECT FOR UPDATE
+            .mockResolvedValueOnce({ rows: [] });       // COMMIT (no UPDATE / no audit)
+        const res = await put(`/api/action-requests/${UUID}`).send({
+            deviceId, botSecret: 'bot-2', entityId: 2,
+            prompt: 'pick A or B', options: ['A', 'B'], type: 'decision',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.changed).toBe(false);
+        expect(auditCall()).toBeUndefined();
     });
 });


### PR DESCRIPTION
## What
Implements Hank's 2026-06-26 decisions on card_cd4f323c2fc2552d85ee15c4 for the "需要你" / action-request inbox:

- **opt1 編輯語意** — agents can now EDIT an existing request's CONTENT: prompt text, options/choices, and type. New endpoint `PUT /api/action-requests/:id` (partial — send any subset of `prompt` / `options` / `type`).
- **opt2 權限範圍** — CROSS-AGENT: ANY valid agent on the device may edit ANY request, not just the creator. Unlike `resolve`/`dismiss` (which gate a botSecret holder to their own requests via `restrictToEntityId`), the edit path deliberately does NOT restrict by `from_entity_id`. The tampering risk this introduces is mitigated by a **mandatory audit record** written on every edit, in the SAME DB transaction as the UPDATE.

## Endpoint
`PUT /api/action-requests/:id` — auth identical to the rest of the module (deviceSecret OR botSecret+entityId).

Body (any subset, ≥1 required): `{ prompt?, options?, type? }` — validated with the exact create-path rules (type ∈ decision|approval|input|credential|review|clarify|consensus; prompt 1..2000; options array ≤50 / ≤8KB or null).

Response: `{ success, request, changed }`. `changed:false` when supplied values equal current (no audit row written). Guards: `400` invalid id/field/none-supplied, `404` not found, `409` request not pending (mirrors resolve guard).

Fires a new `action_request:changed` socket kind `'edited'` (documented in the contract comment) so the inbox live-refreshes.

## Audit schema (new)
`agent_action_request_audit` (append-only) — created at boot via the module's `agent_action_requests_schema.sql` init path, with a mirror ops migration `migrations/20260626_action_request_audit.{up,down}.sql` (both `IF NOT EXISTS`, idempotent):

| col | type | note |
|---|---|---|
| id | BIGSERIAL PK | |
| request_id | UUID NOT NULL | |
| device_id | VARCHAR(64) NOT NULL | |
| editor_entity_id | INTEGER NULL | editing agent's entity id; NULL = human/deviceSecret edit |
| changes | JSONB NOT NULL | only fields that changed, each `{old,new}` |
| created_at | TIMESTAMPTZ | |

## Bot tool surface
Added a new `?intent=action_requests` category to `/api/help` (INTENT_MAP + curl_examples + the categories tip) covering emit/list/**edit**/resolve/dismiss.

## Tests
`backend/tests/jest/agent-action-requests.test.js` — 28/28 green (12 new): (a) edit prompt+options+type, (b) cross-agent edit (editor ≠ creator) succeeds with no creator restriction, (c) audit row has correct editorEntityId + per-field old→new, (c2) human edit → null editor, (d) 400/404/409 + no-op `changed:false`. Full backend jest suite green (396 suites / 5431 passed / 0 fail).

## Reviewer please double-check
- The deliberate cross-agent semantics (no `from_entity_id` gate on edit) vs resolve/dismiss — intended per opt2, audit is the mitigation.
- Audit DDL lives in BOTH the module schema file (runtime creation) and a migrations/ pair (ops SoT) — by design, both idempotent.

needs #2 review. Do not merge / card stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBmn5NeYXxoWMYX6QPx2mt