### PR TITLE
fix(trust): drop non-IMMUTABLE NOW() from idx_blacklist_active predicate (card_8c83539b)

### DIFF
--- a/backend/trust_schema.sql
+++ b/backend/trust_schema.sql
@@ -103,8 +103,12 @@ CREATE TABLE IF NOT EXISTS user_blacklist (
 );
 
 CREATE INDEX IF NOT EXISTS idx_blacklist_user ON user_blacklist(user_id);
-CREATE INDEX IF NOT EXISTS idx_blacklist_active ON user_blacklist(expires_at)
-    WHERE expires_at IS NULL OR expires_at > NOW();
+-- Plain b-tree on expires_at: a partial predicate cannot reference NOW()
+-- (STABLE, not IMMUTABLE → Postgres rejects it: "functions in index predicate
+-- must be marked IMMUTABLE", so the index silently failed to create on prod).
+-- A full index on expires_at still serves the active-blacklist range filter
+-- (expires_at IS NULL OR expires_at > NOW()); user_id lookups use idx_blacklist_user.
+CREATE INDEX IF NOT EXISTS idx_blacklist_active ON user_blacklist(expires_at);
 
 -- ============================================
 -- rental_cooldowns — prevent repeat-rental abuse (P4)


### PR DESCRIPTION
## Problem
Prod log (ErrLog card_8c83539b, P2) recurring on every boot:
> `[Trust] Schema warning: functions in index predicate must be marked IMMUTABLE`

Root cause — `backend/trust_schema.sql` partial index:
```sql
CREATE INDEX IF NOT EXISTS idx_blacklist_active ON user_blacklist(expires_at)
    WHERE expires_at IS NULL OR expires_at > NOW();
```
`NOW()` is **STABLE, not IMMUTABLE**. Postgres forbids non-IMMUTABLE functions in an index predicate, so `trust.js:initTrustDatabase` (the `catch` at trust.js:77) swallows the failure as a warning and **`idx_blacklist_active` is never created** on prod. The active-blacklist lookup (`WHERE user_id=$1 AND (expires_at IS NULL OR expires_at > NOW())`) silently degrades to a seq scan.

## Fix
Make it a plain b-tree on `expires_at` (drop the time-relative predicate):
```sql
CREATE INDEX IF NOT EXISTS idx_blacklist_active ON user_blacklist(expires_at);
```
- A full index on `expires_at` still serves the `> NOW()` range filter at query time.
- `user_id` lookups already use `idx_blacklist_user`.
- Removes the recurring warning and actually creates the index.

## Scope
- 1 file, `backend/trust_schema.sql` (idempotent `CREATE INDEX IF NOT EXISTS`).
- No data migration needed; on next boot the index is created. Existing deploys that never had it simply gain it.

## Test plan
- Static: SQL parses; `IF NOT EXISTS` keeps it idempotent.
- Behavioral: after deploy, `[Trust] Schema warning` no longer logged; `\d user_blacklist` shows `idx_blacklist_active`.

## Out of scope
- The other partial indexes (`idx_disputes_status`, `idx_disputes_sla`) use a constant predicate (`status='open'`) which IS immutable-safe — left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)