### PR TITLE
feat(inbox): server-side owner-decision classifier auto-surfaces owner-only review/blocked child cards to 需要你 inbox

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -159,6 +159,21 @@ async function initAgentActionRequestsDatabase() {
     } catch (err) {
         console.error('[AgentActionRequests] related_card_id migration skipped:', err.message);
     }
+
+    // ── Idempotent column migration: decision_context (owner-decision classifier) ──
+    // JSONB blob the server attaches when it auto-surfaces an owner-only
+    // review/blocked child card: {whatWasDone, recommendation, evidence, recommended
+    // OptionIndex}. The prod table already exists, so the CREATE TABLE above is a
+    // no-op; this ALTER adds the column to the live table. ADD COLUMN IF NOT EXISTS
+    // is a no-op once present. Best-effort: never throws/crashes init.
+    try {
+        await pool.query(
+            `ALTER TABLE agent_action_requests
+                ADD COLUMN IF NOT EXISTS decision_context JSONB DEFAULT NULL`
+        );
+    } catch (err) {
+        console.error('[AgentActionRequests] decision_context migration skipped:', err.message);
+    }
 }
 
 // ── Helpers ──
@@ -179,6 +194,23 @@ function validateRelatedCardId(value) {
     return { ok: true, value: value.trim() || null };
 }
 
+// Optional decision_context (owner-decision classifier): a JSONB blob the server
+// attaches when it auto-surfaces an owner-only review/blocked card. Shape:
+//   {whatWasDone, recommendation, evidence:[{label,url,kind}], recommendedOptionIndex}
+// Shared by the create (POST /) and edit (PUT /:id) paths. Returns { ok, value }
+// where `value` is a JSON STRING (ready for a ::jsonb cast) or null:
+//   undefined | null              → { ok: true,  value: null }   (none / clear)
+//   plain object, JSON ≤ 8192     → { ok: true,  value: <json-string> }
+//   non-object | JSON > 8192      → { ok: false }
+function validateDecisionContext(value) {
+    if (value === undefined || value === null) return { ok: true, value: null };
+    if (typeof value !== 'object' || Array.isArray(value)) return { ok: false, value: null };
+    let json;
+    try { json = JSON.stringify(value); } catch (_) { return { ok: false, value: null }; }
+    if (json == null || json.length > 8192) return { ok: false, value: null };
+    return { ok: true, value: json };
+}
+
 function rowToApi(row) {
     return {
         id: row.id,
@@ -188,6 +220,7 @@ function rowToApi(row) {
         prompt: row.prompt,
         options: row.options || null,
         relatedCardId: row.related_card_id || null,
+        decisionContext: row.decision_context || null,
         status: row.status,
         answer: row.answer || null,
         createdAt: new Date(row.created_at).getTime(),
@@ -314,6 +347,59 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
         } catch (_) {}
     }
 
+    // Core create: insert ONE request row + emit 'emitted'. Shared by the HTTP
+    // POST / route AND the kanban owner-decision auto-surface hook (子3/子4) so
+    // there is exactly one INSERT code path. INPUT VALIDATION IS THE CALLER'S
+    // JOB: the HTTP route validates + caps every field; the kanban hook passes
+    // already-shaped server-built values. `options`/`decisionContext` may be a
+    // JS value (stringified here) or an already-serialized JSON string.
+    // Returns the created row in rowToApi() shape. Throws only on DB error.
+    async function createActionRequest({
+        deviceId, fromEntityId, type, prompt, options,
+        anchorMessageId, relatedCardId, decisionContext,
+    } = {}) {
+        const anchor = normalizeAnchor(anchorMessageId);
+        const optionsJson = options != null
+            ? (typeof options === 'string' ? options : JSON.stringify(options))
+            : null;
+        const decisionJson = decisionContext != null
+            ? (typeof decisionContext === 'string' ? decisionContext : JSON.stringify(decisionContext))
+            : null;
+        const result = await pool.query(
+            `INSERT INTO agent_action_requests
+                (device_id, from_entity_id, anchor_message_id, type, prompt, options, related_card_id, decision_context)
+             VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::jsonb)
+             RETURNING *`,
+            [deviceId, fromEntityId, anchor, type, prompt, optionsJson, relatedCardId != null ? relatedCardId : null, decisionJson]
+        );
+        const row = result.rows[0];
+        emitChanged(deviceId, 'emitted', row.id, row.from_entity_id);
+        return rowToApi(row);
+    }
+
+    // Owner-decision lifecycle (子6a): when a kanban card leaves review/blocked,
+    // dismiss any still-pending OWNER-DECISION request(s) for it. We only touch
+    // rows the move-hook created — decision_context IS NOT NULL — so an agent's
+    // ordinary request that merely references the same card is left untouched.
+    // Device-scoped; emits 'dismissed' per row on the SAME socket contract as the
+    // HTTP dismiss so the inbox live-refreshes. Returns the dismissed rows.
+    // Throws only on a DB error (the kanban hook wraps the call in try/catch).
+    async function dismissActionRequestsForCard(deviceId, cardId) {
+        if (!deviceId || !cardId) return [];
+        const upd = await pool.query(
+            `UPDATE agent_action_requests
+                SET status = 'dismissed', resolved_at = NOW()
+              WHERE device_id = $1 AND related_card_id = $2
+                AND status = 'pending' AND decision_context IS NOT NULL
+            RETURNING *`,
+            [deviceId, cardId]
+        );
+        for (const row of (upd.rows || [])) {
+            emitChanged(deviceId, 'dismissed', row.id, row.from_entity_id);
+        }
+        return upd.rows || [];
+    }
+
     // ══════════════════════════════════════════════════════════════════════
     // TIMEOUT-POLICY WORKER (card_ce0d685b)
     // ──────────────────────────────────────────────────────────────────────
@@ -384,6 +470,11 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
 
                 for (const row of rows) {
                     try {
+                        // 子6(b): owner-decision items (decision_context non-null) are
+                        // PINNED to 'keep' semantics — they wait for Hank and must
+                        // NEVER be auto_dismissed / safe_defaulted / consensus-routed
+                        // by the timeout worker, regardless of the device's policy.
+                        if (row.decision_context != null) continue;
                         if (policy === 'auto_dismiss') {
                             const upd = await pool.query(
                                 `UPDATE agent_action_requests
@@ -522,20 +613,28 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
         if (!relCard.ok) {
             return res.status(400).json({ success: false, error: 'relatedCardId must be a string of max 64 chars or null' });
         }
-        const anchor = normalizeAnchor(anchorMessageId);
+        // Optional owner-decision context: a plain object whose JSON is ≤8192
+        // bytes, or null (mirrors the related_card_id validation + the 8KB cap on
+        // options). Returns a ready-to-cast JSON string or null.
+        const decCtx = validateDecisionContext(req.body.decisionContext);
+        if (!decCtx.ok) {
+            return res.status(400).json({ success: false, error: 'decisionContext must be an object whose JSON is at most 8192 bytes, or null' });
+        }
 
         try {
-            const result = await pool.query(
-                `INSERT INTO agent_action_requests
-                    (device_id, from_entity_id, anchor_message_id, type, prompt, options, related_card_id)
-                 VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)
-                 RETURNING *`,
-                [deviceId, fromEntityId, anchor, type, prompt, options != null ? JSON.stringify(options) : null, relCard.value]
-            );
-            const row = result.rows[0];
-            log('info', `emit id=${row.id} from=${fromEntityId} type=${type}`, { deviceId });
-            emitChanged(deviceId, 'emitted', row.id, row.from_entity_id);
-            return res.json({ success: true, request: rowToApi(row) });
+            // Shared INSERT path (子3) — same code the kanban hook calls.
+            const apiRow = await createActionRequest({
+                deviceId,
+                fromEntityId,
+                type,
+                prompt,
+                options: options != null ? options : null,
+                anchorMessageId,
+                relatedCardId: relCard.value,
+                decisionContext: decCtx.value,
+            });
+            log('info', `emit id=${apiRow.id} from=${fromEntityId} type=${type}`, { deviceId });
+            return res.json({ success: true, request: apiRow });
         } catch (err) {
             console.error('[AgentActionRequests] POST failed:', err.message);
             log('error', `POST failed: ${err.message}`, { deviceId });
@@ -672,8 +771,9 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
         const hasPrompt = Object.prototype.hasOwnProperty.call(body, 'prompt');
         const hasOptions = Object.prototype.hasOwnProperty.call(body, 'options');
         const hasRelatedCardId = Object.prototype.hasOwnProperty.call(body, 'relatedCardId');
-        if (!hasType && !hasPrompt && !hasOptions && !hasRelatedCardId) {
-            return res.status(400).json({ success: false, error: 'Provide at least one editable field: prompt, options, type, relatedCardId' });
+        const hasDecisionContext = Object.prototype.hasOwnProperty.call(body, 'decisionContext');
+        if (!hasType && !hasPrompt && !hasOptions && !hasRelatedCardId && !hasDecisionContext) {
+            return res.status(400).json({ success: false, error: 'Provide at least one editable field: prompt, options, type, relatedCardId, decisionContext' });
         }
         // Validate each PROVIDED field with the exact same rules as POST / (create).
         if (hasType && (typeof body.type !== 'string' || !VALID_TYPES.has(body.type))) {
@@ -698,6 +798,16 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
                 return res.status(400).json({ success: false, error: 'relatedCardId must be a string of max 64 chars or null' });
             }
             relatedCardIdNew = relCard.value;
+        }
+        // decision_context (owner-decision classifier): object ≤8192 JSON or null
+        // (null clears it). Lets the commander refine the surfaced context.
+        let decisionContextNew = null; // JSON string or null
+        if (hasDecisionContext) {
+            const decCtx = validateDecisionContext(body.decisionContext);
+            if (!decCtx.ok) {
+                return res.status(400).json({ success: false, error: 'decisionContext must be an object whose JSON is at most 8192 bytes, or null' });
+            }
+            decisionContextNew = decCtx.value;
         }
 
         const client = await pool.connect();
@@ -747,6 +857,16 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
                 if (relatedCardIdNew !== oldRel) {
                     params.push(relatedCardIdNew); sets.push(`related_card_id = $${params.length}`);
                     changes.relatedCardId = { old: oldRel, new: relatedCardIdNew };
+                }
+            }
+            if (hasDecisionContext) {
+                const oldDc = before.decision_context != null ? JSON.stringify(before.decision_context) : null;
+                if (decisionContextNew !== oldDc) {
+                    params.push(decisionContextNew); sets.push(`decision_context = $${params.length}::jsonb`);
+                    changes.decisionContext = {
+                        old: before.decision_context ?? null,
+                        new: decisionContextNew != null ? JSON.parse(decisionContextNew) : null,
+                    };
                 }
             }
 
@@ -809,6 +929,14 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
         // Timeout-policy worker (card_ce0d685b). Exported so tests + an external
         // scheduler can invoke a sweep directly.
         enforceActionRequestTimeouts,
+        // Shared create path (子3) so the kanban move-hook can auto-surface an
+        // owner-only review/blocked card into this inbox via the SAME INSERT +
+        // 'emitted' socket emit the HTTP route uses. Caller validates inputs.
+        createActionRequest,
+        // Owner-decision lifecycle (子6a): kanban calls this when a card leaves
+        // review/blocked to auto-dismiss its pending owner-decision request(s) +
+        // emit the 'dismissed' socket event.
+        dismissActionRequestsForCard,
         _pool: pool,
     };
 };

--- a/backend/agent-improvement/owner-decision-classifier.js
+++ b/backend/agent-improvement/owner-decision-classifier.js
@@ -1,0 +1,152 @@
+// Owner-decision classifier — decides whether a piece of work is genuinely
+// OWNER-ONLY (only Hank can decide) versus bot-resolvable, so the kanban
+// move-hook only auto-surfaces real owner decisions into the "需要你"
+// (action-request) inbox instead of flooding it.
+//
+// Pure functions, NO deps (mirrors agent-improvement/classifier.js so both the
+// kanban hook and tests can import it without a circular dependency). Keyword
+// matching is case-insensitive and covers EN + 繁體中文.
+//
+// DEFAULT is ownerOnly=false: a card is bot-resolvable unless it trips one of
+// the owner-only category keyword sets OR carries an explicit owner flag.
+
+'use strict';
+
+// ── Owner-only categories ──
+// Each entry: { category, kws: [substring matches], res: [optional RegExp] }.
+// A category fires if ANY of its keywords is a (case-insensitive) substring of
+// the text, or any of its regexes matches.
+const OWNER_ONLY_CATEGORIES = Object.freeze([
+    {
+        category: 'irreversible_data',
+        kws: ['drop table', 'truncate', 'purge', 'delete account', 'wipe', 'irreversible',
+            '刪除帳號', '不可逆', '清庫', '抹除'],
+        res: [],
+    },
+    {
+        category: 'spend_cost',
+        kws: ['provision', 'paid plan', 'budget', 'spend', 'quota raise', 'subscription',
+            'billing', '$', '付費', '訂閱', '花錢', '加預算'],
+        res: [],
+    },
+    {
+        category: 'product_direction',
+        kws: ['product direction', 'roadmap', '要不要做', '產品方向', '策略方向'],
+        res: [/prioriti[sz]e\s+roadmap/i],
+    },
+    {
+        category: 'legal_pii',
+        kws: ['legal', '法務', 'pii', '個資', 'retention policy', 'gdpr', '隱私', '保留期', '合規'],
+        res: [],
+    },
+    {
+        category: 'security_policy',
+        kws: ['security policy', 'auth policy', 'permission policy', 'secret rotation',
+            '資安政策', '權限政策', '金鑰輪換'],
+        res: [],
+    },
+    {
+        category: 'strategic_tradeoff',
+        kws: ['tradeoff', 'trade-off', '取捨', '權衡', '兩難', 'ambiguous strategic'],
+        res: [],
+    },
+]);
+
+// Explicit owner flag — an author/gate that literally marks the work as
+// owner-only / un-authorizable / legal-hold / 需要你. Always forces ownerOnly.
+const EXPLICIT_FLAG_RE = /owner[-_ ]?only|需要你|un-?authoriz|不可授權|legal-hold/i;
+
+// painTags (OODA-R taxonomy) that represent pure front-end / appearance work.
+// A screenshot-review card whose pain is ONLY these is a UI vision-check (a
+// separate concern routed to the UI reviewer), not an owner decision.
+const UI_ONLY_TAGS = Object.freeze(new Set(['ux_feedback', 'redirect_deeplink']));
+
+/**
+ * Classify free-form text for owner-only signals.
+ * @param {string} text
+ * @returns {{ ownerOnly: boolean, categories: string[], reasons: string[] }}
+ */
+function classifyOwnerDecision(text) {
+    const raw = typeof text === 'string' ? text : '';
+    const hay = raw.toLowerCase();
+    const categories = [];
+    const reasons = [];
+
+    for (const { category, kws, res } of OWNER_ONLY_CATEGORIES) {
+        let hit = null;
+        for (const kw of kws) {
+            if (hay.includes(kw.toLowerCase())) { hit = kw; break; }
+        }
+        if (!hit && res && res.length) {
+            for (const re of res) {
+                if (re.test(raw)) { hit = re.source; break; }
+            }
+        }
+        if (hit) {
+            categories.push(category);
+            reasons.push(`${category}: matched "${hit}"`);
+        }
+    }
+
+    if (EXPLICIT_FLAG_RE.test(raw) && !categories.includes('explicit_flag')) {
+        categories.push('explicit_flag');
+        reasons.push('explicit_flag: text carries an owner-only / 需要你 / legal-hold marker');
+    }
+
+    return { ownerOnly: categories.length > 0, categories, reasons };
+}
+
+/**
+ * Card-level helper: decide whether a kanban card is an owner-only decision.
+ *
+ * Short-circuits to ownerOnly=false for a pure UI vision-check card
+ * (requiresScreenshotReview === true and the card's painTags are all UI-only) —
+ * that is a separate front-end-review concern, not an owner decision.
+ *
+ * Otherwise runs classifyOwnerDecision on the concatenated
+ * title+description+latestComment+gateReason and ORs an explicit-flag check on
+ * gateReason (so an auto-block / gate reason that itself names an owner flag
+ * still surfaces).
+ *
+ * @param {object} args
+ * @param {string} [args.title]
+ * @param {string} [args.description]
+ * @param {string} [args.latestComment]
+ * @param {string} [args.gateReason]
+ * @param {boolean} [args.requiresScreenshotReview]
+ * @param {string[]} [args.painTags]
+ * @returns {{ ownerOnly: boolean, categories: string[], reasons: string[] }}
+ */
+function classifyCardOwnerDecision({ title, description, latestComment, gateReason, requiresScreenshotReview, painTags } = {}) {
+    const tags = Array.isArray(painTags) ? painTags : [];
+    const onlyUi = tags.length > 0 && tags.every(t => UI_ONLY_TAGS.has(t));
+    if (requiresScreenshotReview === true && onlyUi) {
+        return {
+            ownerOnly: false,
+            categories: [],
+            reasons: ['short_circuit: UI vision-check card (requiresScreenshotReview + UI-only painTags) is not an owner decision'],
+        };
+    }
+
+    const text = [title, description, latestComment, gateReason].filter(Boolean).join('\n\n');
+    const result = classifyOwnerDecision(text);
+
+    // OR the gateReason explicit-flag check (defensive — gateReason is already in
+    // `text`, but state the intent: a gate/auto-block reason naming an owner flag
+    // is itself an owner decision).
+    if (typeof gateReason === 'string' && EXPLICIT_FLAG_RE.test(gateReason) && !result.categories.includes('explicit_flag')) {
+        result.categories.push('explicit_flag');
+        result.reasons.push('explicit_flag: gateReason names an owner-only / legal-hold marker');
+        result.ownerOnly = true;
+    }
+
+    return result;
+}
+
+module.exports = {
+    OWNER_ONLY_CATEGORIES,
+    EXPLICIT_FLAG_RE,
+    UI_ONLY_TAGS,
+    classifyOwnerDecision,
+    classifyCardOwnerDecision,
+};

--- a/backend/agent_action_requests_schema.sql
+++ b/backend/agent_action_requests_schema.sql
@@ -29,6 +29,14 @@ CREATE TABLE IF NOT EXISTS agent_action_requests (
     -- Optional kanban-card reference (計畫D, card_df646877). When set, the inbox
     -- item renders a "🗂 任務卡" chip that deep-links to this card. NULL = no card.
     related_card_id VARCHAR(64) DEFAULT NULL,
+    -- Optional owner-decision context (owner-decision inbox classifier). When the
+    -- server auto-surfaces an owner-only review/blocked child card, it attaches a
+    -- JSONB blob: {whatWasDone, recommendation, evidence:[{label,url,kind}],
+    -- recommendedOptionIndex} so the inbox can render the decision with evidence.
+    -- NULL = an ordinary agent-emitted request (not an owner-decision item). The
+    -- timeout worker pins rows with a non-null decision_context to 'keep' (they
+    -- wait for the owner and are never auto-dismissed/safe-defaulted/consensus'd).
+    decision_context JSONB DEFAULT NULL,
     CONSTRAINT aar_prompt_len CHECK (char_length(prompt) BETWEEN 1 AND 2000),
     CONSTRAINT aar_type_valid CHECK (type IN ('decision','approval','input','credential','review','clarify','consensus')),
     CONSTRAINT aar_status_valid CHECK (status IN ('pending','resolved','dismissed'))

--- a/backend/index.js
+++ b/backend/index.js
@@ -1824,6 +1824,23 @@ try {
         emitDevicePreferences: (deviceId, prefs) => {
             io.to(`device:${deviceId}`).emit('device:preferences', { deviceId, prefs });
         },
+        // Owner-decision inbox auto-surface (子3/子4): late-bound thunk because the
+        // action-requests module is constructed AFTER kanban below. By the time a
+        // /card/:id/move request runs, agentActionRequestsModule is wired. Returns
+        // a resolved null when the module is unavailable so the hook stays a no-op.
+        createActionRequest: (...args) => (
+            agentActionRequestsModule && typeof agentActionRequestsModule.createActionRequest === 'function'
+                ? agentActionRequestsModule.createActionRequest(...args)
+                : Promise.resolve(null)
+        ),
+        // Owner-decision lifecycle (子6a): auto-dismiss a card's pending owner-
+        // decision request(s) when it leaves review/blocked. Late-bound thunk for
+        // the same construction-order reason as createActionRequest above.
+        dismissActionRequestsForCard: (...args) => (
+            agentActionRequestsModule && typeof agentActionRequestsModule.dismissActionRequestsForCard === 'function'
+                ? agentActionRequestsModule.dismissActionRequestsForCard(...args)
+                : Promise.resolve([])
+        ),
     });
     app.use('/api/mission', kanbanModule.router);
     console.log('[Kanban] Module loaded successfully');

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -442,7 +442,7 @@ async function initKanbanDatabase() {
 /**
  * Factory: receives in-memory devices object from index.js
  */
-function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, pushToChannelCallback, saveChatMessage, getMissionApiHints, pushToBot, orgChart, notifyDevice, emitDevicePreferences } = {}) {
+function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, pushToChannelCallback, saveChatMessage, getMissionApiHints, pushToBot, orgChart, notifyDevice, emitDevicePreferences, createActionRequest, dismissActionRequestsForCard } = {}) {
     const router = express.Router();
 
     // Health check
@@ -2529,6 +2529,126 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     from: statusLabel(lang, oldStatus)
                 });
                 notifyEntities(deviceId, [updatedCard.reviewerEntityId], reviewerMsg, { description: card.description, cardId, role: 'reviewer' });
+            }
+
+            // ── Owner-decision inbox auto-surface (子4) — failure-isolated ──
+            // A parent-child card moving INTO review/blocked is classified for
+            // genuine OWNER-ONLY signals (irreversible data / spend / product
+            // direction / legal-PII / security policy / strategic tradeoff /
+            // explicit flag). If owner-only AND not already surfaced, ONE
+            // record-only「需要你決策」item is opened in the 需要你 inbox with the
+            // commander's last comment as whatWasDone + PR/screenshot evidence.
+            // The option set RECORDS Hank's choice only — NO auto-execute. Mirrors
+            // the OODA-R preflight hook below: self-invoking async IIFE wrapped in
+            // try/catch; a classifier or DB error NEVER blocks or fails the move.
+            if (card.parent_card_id != null && ['review', 'blocked'].includes(newStatus) && oldStatus !== newStatus) {
+                (async () => {
+                    try {
+                        if (typeof createActionRequest !== 'function') return;
+
+                        // Latest non-system (commander) comment + all comment texts.
+                        const cmtRes = await pool.query(
+                            `SELECT text, is_system AS "isSystem", created_at AS "createdAt"
+                             FROM kanban_comments
+                             WHERE card_id = $1 AND device_id = $2
+                             ORDER BY created_at ASC`,
+                            [cardId, deviceId]
+                        );
+                        const comments = cmtRes.rows || [];
+                        const lastHuman = [...comments].reverse().find(c => !c.isSystem);
+                        const whatWasDone = (lastHuman && typeof lastHuman.text === 'string' ? lastHuman.text : '').slice(0, 1000);
+
+                        // Evidence: PR URLs from any comment + image files on the card.
+                        const evidence = [];
+                        const seenPr = new Set();
+                        const PR_RE = /https?:\/\/github\.com\/[^\s)]+\/pull\/\d+/gi;
+                        for (const c of comments) {
+                            const txt = typeof c.text === 'string' ? c.text : '';
+                            let m;
+                            while ((m = PR_RE.exec(txt)) !== null) {
+                                if (!seenPr.has(m[0])) { seenPr.add(m[0]); evidence.push({ label: 'PR', url: m[0], kind: 'pr' }); }
+                            }
+                        }
+                        const filesRes = await pool.query(
+                            `SELECT url, filename FROM kanban_files
+                             WHERE card_id = $1 AND device_id = $2 AND mime_type LIKE 'image/%'
+                             ORDER BY created_at ASC`,
+                            [cardId, deviceId]
+                        );
+                        for (const f of (filesRes.rows || [])) {
+                            evidence.push({ label: f.filename || 'screenshot', url: f.url || null, kind: 'image' });
+                        }
+
+                        // painTags (best-effort) so the classifier can short-circuit
+                        // a pure UI vision-check card.
+                        let painTags = [];
+                        try {
+                            const classifier = require('./agent-improvement/classifier');
+                            painTags = classifier.classifyPainTags(`${card.title || ''}\n\n${card.description || ''}`, undefined);
+                        } catch (_) { /* classifier optional */ }
+
+                        const { classifyCardOwnerDecision } = require('./agent-improvement/owner-decision-classifier');
+                        const verdict = classifyCardOwnerDecision({
+                            title: card.title || '',
+                            description: card.description || '',
+                            latestComment: whatWasDone,
+                            gateReason: card.gate_reason || '',
+                            requiresScreenshotReview: card.requires_screenshot_review === true,
+                            painTags,
+                        });
+                        if (!verdict.ownerOnly) return;
+
+                        // Dedup: skip if a pending request already references this card.
+                        const dup = await pool.query(
+                            `SELECT 1 FROM agent_action_requests
+                             WHERE device_id = $1 AND related_card_id = $2 AND status = 'pending'
+                             LIMIT 1`,
+                            [deviceId, cardId]
+                        );
+                        if (dup.rows.length > 0) return;
+
+                        // from_entity_id: the card's owner/assignee, else the mover, else 0.
+                        const moverId = parseInt(req.body.entityId, 10);
+                        const ownerId = (Array.isArray(bots) && bots.length && Number.isInteger(bots[0]))
+                            ? bots[0]
+                            : (Number.isInteger(moverId) && moverId >= 0 ? moverId : 0);
+
+                        const headline = `需要你決策：「${card.title || cardId}」(${verdict.categories.join(', ') || 'owner-only'})`.slice(0, 2000);
+                        await createActionRequest({
+                            deviceId,
+                            fromEntityId: ownerId,
+                            type: 'decision',
+                            prompt: headline,
+                            options: ['核可', '退回', '延後'], // RECORD-ONLY — no auto-execute
+                            relatedCardId: cardId,
+                            decisionContext: {
+                                whatWasDone,
+                                recommendation: whatWasDone,
+                                evidence,
+                                recommendedOptionIndex: 0,
+                            },
+                        });
+                        console.log(`[Kanban] owner-decision surfaced card=${cardId} cats=${verdict.categories.join(',')}`);
+                    } catch (e) {
+                        console.error('[Kanban] owner-decision hook error (non-blocking):', e.message);
+                    }
+                })();
+            }
+
+            // ── Owner-decision lifecycle (子6a) — failure-isolated ──
+            // When a card LEAVES review/blocked, the surfaced decision is moot:
+            // auto-dismiss any pending owner-decision request(s) for it (+ emit the
+            // 'dismissed' socket event via the injected helper). Never blocks the move.
+            if (typeof dismissActionRequestsForCard === 'function'
+                && ['review', 'blocked'].includes(oldStatus)
+                && !['review', 'blocked'].includes(newStatus)) {
+                (async () => {
+                    try {
+                        await dismissActionRequestsForCard(deviceId, cardId);
+                    } catch (e) {
+                        console.error('[Kanban] owner-decision auto-dismiss error (non-blocking):', e.message);
+                    }
+                })();
             }
 
             await bumpVersion(deviceId);

--- a/backend/tests/jest/owner-decision-action-request.test.js
+++ b/backend/tests/jest/owner-decision-action-request.test.js
@@ -1,0 +1,145 @@
+// Owner-decision additions to the agent_action_requests module:
+//   子1  decision_context create-validation + rowToApi emit + PUT edit
+//   子3  shared createActionRequest()
+//   子6a dismissActionRequestsForCard()
+//   子6b timeout worker pins decision_context rows to 'keep'
+//
+// Mocks pg so the module's Pool() is captured (mirrors agent-action-requests.test.js).
+
+const mockPoolQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockPoolQuery,
+        connect: jest.fn().mockResolvedValue({ query: mockPoolQuery, release: jest.fn() }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const express = require('express');
+const request = require('supertest');
+
+const deviceId = 'test-dev';
+const deviceSecret = 'dev-secret';
+const UUID = '11111111-2222-3333-4444-555555555555';
+const CARD = 'card_abc123';
+
+let app;
+let mod;
+const devices = {
+    [deviceId]: {
+        deviceSecret,
+        entities: { 2: { isBound: true, botSecret: 'bot-2' } },
+    },
+};
+
+beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    // Inject getDevicePrefs so the timeout worker never touches device-preferences.
+    mod = require('../../agent-action-requests')(devices, {
+        serverLog: () => {},
+        getDevicePrefs: () => ({ action_request_timeout_policy: 'auto_dismiss', action_request_timeout_minutes: 1 }),
+    });
+    app.use('/api/action-requests', mod.router);
+});
+
+afterEach(() => mockPoolQuery.mockReset());
+
+const post = (p) => request(app).post(p);
+
+function rowFixture(over = {}) {
+    return {
+        id: UUID, device_id: deviceId, from_entity_id: 2, anchor_message_id: null,
+        type: 'decision', prompt: 'pick', options: ['A', 'B'],
+        related_card_id: null, decision_context: null,
+        status: 'pending', answer: null,
+        created_at: new Date('2026-06-25T00:00:00Z'), resolved_at: null, ...over,
+    };
+}
+
+describe('子1 decision_context — create validation + rowToApi', () => {
+    it('accepts a decisionContext object and rowToApi emits decisionContext', async () => {
+        const dc = { whatWasDone: 'merged PR', recommendation: 'approve', evidence: [], recommendedOptionIndex: 0 };
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ decision_context: dc })] }); // INSERT RETURNING *
+        const res = await post('/api/action-requests').send({
+            deviceId, deviceSecret, fromEntityId: 2, type: 'decision', prompt: 'decide', decisionContext: dc,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.request.decisionContext).toEqual(dc);
+        // INSERT must include the decision_context column.
+        const insert = mockPoolQuery.mock.calls.find(c => /INSERT INTO agent_action_requests/.test(c[0]));
+        expect(insert[0]).toMatch(/decision_context/);
+    });
+
+    it('rejects a decisionContext whose JSON exceeds 8192 bytes → 400, no DB write', async () => {
+        const dc = { whatWasDone: 'x'.repeat(9000) };
+        const res = await post('/api/action-requests').send({
+            deviceId, deviceSecret, fromEntityId: 2, type: 'decision', prompt: 'decide', decisionContext: dc,
+        });
+        expect(res.status).toBe(400);
+        expect(mockPoolQuery).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-object decisionContext → 400', async () => {
+        const res = await post('/api/action-requests').send({
+            deviceId, deviceSecret, fromEntityId: 2, type: 'decision', prompt: 'decide', decisionContext: 'not-an-object',
+        });
+        expect(res.status).toBe(400);
+    });
+});
+
+describe('子3 createActionRequest() shared path', () => {
+    it('inserts the row (with decision_context) and returns rowToApi shape', async () => {
+        const dc = { whatWasDone: 'did X', recommendation: 'approve', evidence: [{ label: 'PR', url: 'u', kind: 'pr' }], recommendedOptionIndex: 0 };
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ decision_context: dc, related_card_id: CARD })] });
+        const api = await mod.createActionRequest({
+            deviceId, fromEntityId: 2, type: 'decision', prompt: 'decide', options: ['核可', '退回'], relatedCardId: CARD, decisionContext: dc,
+        });
+        expect(api.id).toBe(UUID);
+        expect(api.decisionContext).toEqual(dc);
+        expect(api.relatedCardId).toBe(CARD);
+        const insert = mockPoolQuery.mock.calls.find(c => /INSERT INTO agent_action_requests/.test(c[0]));
+        expect(insert[0]).toMatch(/decision_context/);
+    });
+});
+
+describe('子6a dismissActionRequestsForCard()', () => {
+    it('dismisses only pending owner-decision rows for the card (decision_context IS NOT NULL)', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ status: 'dismissed' })] }); // UPDATE RETURNING *
+        const rows = await mod.dismissActionRequestsForCard(deviceId, CARD);
+        expect(rows).toHaveLength(1);
+        const upd = mockPoolQuery.mock.calls.find(c => /UPDATE agent_action_requests/.test(c[0]));
+        expect(upd[0]).toMatch(/status = 'dismissed'/);
+        expect(upd[0]).toMatch(/decision_context IS NOT NULL/);
+        expect(upd[1]).toEqual([deviceId, CARD]);
+    });
+
+    it('is a no-op on missing args', async () => {
+        const rows = await mod.dismissActionRequestsForCard(null, CARD);
+        expect(rows).toEqual([]);
+        expect(mockPoolQuery).not.toHaveBeenCalled();
+    });
+});
+
+describe('子6b timeout worker pins owner-decision rows to keep', () => {
+    it('never auto_dismisses a pending row whose decision_context is non-null', async () => {
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }] })                       // SELECT DISTINCT device_id
+            .mockResolvedValueOnce({ rows: [rowFixture({ decision_context: { whatWasDone: 'x' } })] }); // candidate SELECT
+        await mod.enforceActionRequestTimeouts();
+        // The per-row guard must have skipped it → NO UPDATE ... dismissed call.
+        const dismissUpdate = mockPoolQuery.mock.calls.find(c => /UPDATE agent_action_requests/.test(c[0]) && /dismissed/.test(c[0]));
+        expect(dismissUpdate).toBeUndefined();
+    });
+
+    it('still auto_dismisses an ordinary pending row (decision_context null)', async () => {
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }] })          // SELECT DISTINCT device_id
+            .mockResolvedValueOnce({ rows: [rowFixture({ decision_context: null })] }) // candidate SELECT
+            .mockResolvedValueOnce({ rows: [rowFixture({ status: 'dismissed' })] });   // UPDATE ... dismissed RETURNING *
+        await mod.enforceActionRequestTimeouts();
+        const dismissUpdate = mockPoolQuery.mock.calls.find(c => /UPDATE agent_action_requests/.test(c[0]) && /dismissed/.test(c[0]));
+        expect(dismissUpdate).toBeDefined();
+    });
+});

--- a/backend/tests/jest/owner-decision-classifier.test.js
+++ b/backend/tests/jest/owner-decision-classifier.test.js
@@ -1,0 +1,141 @@
+/**
+ * Owner-decision classifier — unit tests.
+ *
+ * Card: server-side owner-decision inbox classifier (子2).
+ *
+ * jest.config.js uses testEnvironment: 'node'. The classifier is a pure,
+ * dependency-free module, so this lives in tests/jest (the testMatch dir) and
+ * imports it by relative path, mirroring agent-improvement-episode-schema.test.js.
+ */
+'use strict';
+
+const {
+    classifyOwnerDecision,
+    classifyCardOwnerDecision,
+    OWNER_ONLY_CATEGORIES,
+} = require('../../agent-improvement/owner-decision-classifier');
+
+describe('classifyOwnerDecision — owner-only positives (1 per category)', () => {
+    const POSITIVES = [
+        ['irreversible_data', 'We need to DROP TABLE chat_orders to reclaim space'],
+        ['spend_cost', 'Upgrade to the paid plan, this will cost $200/month'],
+        ['product_direction', 'Should we prioritize the roadmap item for avatars?'],
+        ['legal_pii', 'This touches PII retention policy and GDPR compliance'],
+        ['security_policy', 'This changes the auth policy and requires secret rotation'],
+        ['strategic_tradeoff', 'This is a strategic tradeoff between speed and quality'],
+    ];
+
+    test.each(POSITIVES)('category %s → ownerOnly=true and category present', (category, text) => {
+        const r = classifyOwnerDecision(text);
+        expect(r.ownerOnly).toBe(true);
+        expect(r.categories).toContain(category);
+        expect(Array.isArray(r.reasons)).toBe(true);
+        expect(r.reasons.length).toBeGreaterThan(0);
+    });
+
+    test('explicit flag → ownerOnly=true, category explicit_flag', () => {
+        const r = classifyOwnerDecision('owner-only decision required before we proceed');
+        expect(r.ownerOnly).toBe(true);
+        expect(r.categories).toContain('explicit_flag');
+    });
+
+    test('每個分類都覆蓋繁中關鍵字', () => {
+        expect(classifyOwnerDecision('這個操作不可逆，會抹除資料').categories).toContain('irreversible_data');
+        expect(classifyOwnerDecision('要加預算改用付費方案').categories).toContain('spend_cost');
+        expect(classifyOwnerDecision('這關係到產品方向要不要做').categories).toContain('product_direction');
+        expect(classifyOwnerDecision('涉及個資與保留期合規').categories).toContain('legal_pii');
+        expect(classifyOwnerDecision('需要調整權限政策與金鑰輪換').categories).toContain('security_policy');
+        expect(classifyOwnerDecision('這是速度與品質的取捨權衡').categories).toContain('strategic_tradeoff');
+        expect(classifyOwnerDecision('這是不可授權的決定').categories).toContain('explicit_flag');
+    });
+});
+
+describe('classifyOwnerDecision — bot-resolvable negatives (ownerOnly=false)', () => {
+    const NEGATIVES = [
+        ['CI-green reversible PR', 'fix typo, tests green, merge'],
+        ['UX vision-check', 'Please vision-check the new settings card layout on mobile and desktop, screenshot attached'],
+        ['bugfix', 'Fix null pointer in renderer, add a guard, tests pass'],
+        ['dep bump', 'Bump lodash from 4.17.20 to 4.17.21 via dependabot'],
+        ['doc update', 'Update the README with local setup steps'],
+        ['staleness auto-block', '⏰ 此卡片閒置超過 12 小時，自動移至 blocked 欄，等待認領'],
+    ];
+
+    test.each(NEGATIVES)('%s → ownerOnly=false', (_label, text) => {
+        const r = classifyOwnerDecision(text);
+        expect(r.ownerOnly).toBe(false);
+        expect(r.categories).toEqual([]);
+    });
+
+    test('empty / non-string is safe and not owner-only', () => {
+        expect(classifyOwnerDecision('').ownerOnly).toBe(false);
+        expect(classifyOwnerDecision(undefined).ownerOnly).toBe(false);
+        expect(classifyOwnerDecision(null).ownerOnly).toBe(false);
+    });
+});
+
+describe('classifyCardOwnerDecision — card-level helper', () => {
+    test('UI vision-check card short-circuits to ownerOnly=false', () => {
+        const r = classifyCardOwnerDecision({
+            title: 'Polish the settings card spacing',
+            description: 'Tighten the avatar layout on mobile',
+            requiresScreenshotReview: true,
+            painTags: ['ux_feedback'],
+        });
+        expect(r.ownerOnly).toBe(false);
+    });
+
+    test('owner-only work is NOT short-circuited even with screenshot review off', () => {
+        const r = classifyCardOwnerDecision({
+            title: 'Purge deleted-account PII tables',
+            description: 'DROP TABLE on the residual device-scoped tables',
+            requiresScreenshotReview: false,
+            painTags: ['scope_completeness'],
+        });
+        expect(r.ownerOnly).toBe(true);
+        expect(r.categories).toContain('irreversible_data');
+    });
+
+    test('gateReason explicit flag forces ownerOnly even if title/body are benign', () => {
+        const r = classifyCardOwnerDecision({
+            title: 'Routine cleanup',
+            description: 'small refactor',
+            gateReason: 'legal-hold: do not auto-resolve',
+        });
+        expect(r.ownerOnly).toBe(true);
+        expect(r.categories).toContain('explicit_flag');
+    });
+
+    test('concatenates fields — a keyword only in latestComment still fires', () => {
+        const r = classifyCardOwnerDecision({
+            title: 'Investigate option',
+            description: 'see comment',
+            latestComment: 'Recommend we move to the paid plan, budget impact noted',
+        });
+        expect(r.ownerOnly).toBe(true);
+        expect(r.categories).toContain('spend_cost');
+    });
+
+    test('a UI card that ALSO requires screenshot but has non-UI painTags is NOT short-circuited', () => {
+        const r = classifyCardOwnerDecision({
+            title: 'Delete account flow',
+            description: 'wipe user data irreversibly',
+            requiresScreenshotReview: true,
+            painTags: ['scope_completeness'],
+        });
+        expect(r.ownerOnly).toBe(true);
+    });
+});
+
+describe('classifier shape invariants', () => {
+    test('exposes the enumerated owner-only categories', () => {
+        const names = OWNER_ONLY_CATEGORIES.map(c => c.category);
+        expect(names).toEqual([
+            'irreversible_data',
+            'spend_cost',
+            'product_direction',
+            'legal_pii',
+            'security_policy',
+            'strategic_tradeoff',
+        ]);
+    });
+});


### PR DESCRIPTION
## What & why

Auto-surface **only genuinely owner-only** kanban child-cards into the 需要你
(action-request) inbox when they reach `review`/`blocked`, instead of flooding
the inbox with every bot-resolvable card. **Backend only** — no `chat.html` /
`i18n.js` / UI changes (that is a separate card). No app build.

## Sub-tasks

### 子1 — schema + API (`agent-action-requests.js`, `agent_action_requests_schema.sql`)
- New nullable JSONB column `decision_context`:
  `{whatWasDone, recommendation, evidence:[{label,url,kind}], recommendedOptionIndex}`.
  Added to `CREATE TABLE` **and** an idempotent
  `ALTER TABLE ... ADD COLUMN IF NOT EXISTS decision_context JSONB` at boot
  (mirrors the existing `related_card_id` migration so the live prod table picks it up).
- `rowToApi()` emits `decisionContext`.
- `POST /` create and `PUT /:id` edit accept `decisionContext`, validated as
  object-or-null with `JSON.stringify` length **≤ 8192** (else `400`), mirroring
  the `related_card_id` / options caps.

### 子2 — classifier (`agent-improvement/owner-decision-classifier.js`)
- Pure, dependency-free `classifyOwnerDecision(text) -> {ownerOnly, categories, reasons}`.
- **Rule:** `ownerOnly` is true iff the text trips one of **6 owner-only
  categories** (keyword sets matching EN + 繁中, case-insensitive) — `irreversible_data`,
  `spend_cost`, `product_direction`, `legal_pii`, `security_policy`,
  `strategic_tradeoff` — **or** an explicit-flag signal
  (`/owner[-_ ]?only|需要你|un-?authoriz|不可授權|legal-hold/i`). **Default is
  `ownerOnly=false` (bot-resolvable).**
- `classifyCardOwnerDecision({title, description, latestComment, gateReason,
  requiresScreenshotReview, painTags})` short-circuits to `false` for a pure UI
  vision-check card (`requiresScreenshotReview===true` + UI-only painTags),
  otherwise classifies the concatenated text and ORs the `gateReason` explicit-flag check.

### 子3 — shared `createActionRequest` (`agent-action-requests.js`)
- The HTTP `POST /` route and a new exported
  `createActionRequest({deviceId, fromEntityId, type, prompt, options,
  anchorMessageId, relatedCardId, decisionContext})` now share **one** INSERT
  code path (insert row + `emitChanged('emitted')`), returning the `rowToApi` shape.

### 子4 — hook (CORE) (`kanban.js POST /card/:id/move` + `index.js` injection)
- A new **failure-isolated self-invoking async block**, structured exactly like
  the existing OODA-R preflight hook, inserted **after the reviewer-notify block
  and before `bumpVersion`**.
- Gate: `card.parent_card_id != null && ['review','blocked'].includes(newStatus)
  && oldStatus !== newStatus`.
- Builds `whatWasDone` (latest non-system commander comment) + `evidence`
  (`github.com/.../pull/\d+` URLs from comments + `image/*` files on the card),
  runs `classifyCardOwnerDecision`, and — if `ownerOnly` **and** no pending
  request already references the card (dedup) — opens **one** `type:'decision'`
  「需要你決策」item with a **record-only** option set `['核可','退回','延後']`
  (**NO auto-execute**), `relatedCardId`, and `decisionContext`.
- `createActionRequest` is injected into kanban via a **late-bound thunk** in
  `index.js` (kanban is constructed before the action-requests module, so a
  direct reference would be `undefined`; the thunk resolves at request time).

### 子6 — lifecycle / dedup (`agent-action-requests.js` + `kanban.js`)
- **(a)** When a card **leaves** `review`/`blocked`, `dismissActionRequestsForCard`
  auto-dismisses its pending owner-decision row(s) (`decision_context IS NOT NULL`
  only, so an agent's ordinary request that merely references the card is left
  alone) + `emitChanged('dismissed')`. Called from the move handler, failure-isolated.
- **(b)** The timeout worker (`enforceActionRequestTimeouts`) **pins** rows whose
  `decision_context` is non-null to `keep` semantics — they are **never**
  `auto_dismissed` / `safe_defaulted` / consensus-routed regardless of device
  policy (they wait for Hank).

## Failure-isolation guarantee
Both move-handler hooks are self-invoking `async` IIFEs wrapped in `try/catch`
(modelled on the OODA-R preflight hook). A classifier or DB error inside them can
**never** block or fail the card move — it only logs `[Kanban] ... (non-blocking)`.
`type` stays `'decision'`; `VALID_TYPES` and the `aar_type_valid` CHECK are untouched.

## Test plan
- `cd backend && npx jest tests/jest/owner-decision-classifier.test.js
  tests/jest/owner-decision-action-request.test.js` → **29 pass**.
  - classifier: 1 positive per category + explicit flag (EN + 繁中); negatives
    that must be `ownerOnly=false` (CI-green PR, UX vision-check, bugfix, dep bump,
    doc update, staleness auto-block); card-helper short-circuit + gate-flag OR.
  - AR module: `decision_context` create-validation + `rowToApi` emit, shared
    `createActionRequest`, `dismissActionRequestsForCard`, timeout keep-pin (±).
- Existing `agent-action-requests*` + `kanban` move/gate/preflight suites stay
  green: **199 tests / 12 suites locally**.
- `npx eslint` on the 4 touched/added source files → **0 errors** (the single
  remaining warning, `kanban.js:4685 entityId unused`, pre-exists on `origin/main`
  in the unrelated `/card/:id/messages` route).

## Reviewer please check
- **fromEntityId choice** in the hook: card's first assignee (`bots[0]`), else the
  mover's `entityId`, else `0`.
- **Dedup scope**: a pending request with `related_card_id = cardId` (any type)
  blocks re-surfacing; auto-dismiss is narrower (`decision_context IS NOT NULL` only).
- **"8 categories" spec wording**: the spec text says "8 owner-only categories"
  but enumerates only 6 keyword categories + the explicit-flag signal. I
  implemented exactly the 6 enumerated categories + `explicit_flag` (7 signal
  labels) and did not invent extra categories. Easy to add more if intended.
- **Test location**: jest only discovers `backend/tests/jest/**/*.test.js`
  (`jest.config.js testMatch`), so the classifier test lives there (not
  `agent-improvement/__tests__/`, which is not on the test path) per the
  "match the repo convention" allowance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
