### PR TITLE
fix(org-fwd): suppress #N_PERMISSION_HANDOFF + Codex heartbeat machine-noise in isLowSignalFwd

### DIFF
--- a/backend/org-fwd-filter.js
+++ b/backend/org-fwd-filter.js
@@ -52,6 +52,27 @@ const ORG_FWD_NOISE_PATTERNS = [
     /^\s*♻️?\s*Card reopened/iu,         // card reopened echo (kanban.js:2405/2408)
     // model-health FWD echoes (background traffic, by design): "[📢 FWD … MODEL_HEALTH/ACK]"
     /^\s*\[📢\s*FWD\b.*\b(MODEL_HEALTH|ACK)\b/i,
+
+    // ── Codex/openclaw runtime machine-noise forwards (card_77c4b9e2) ──
+    // #6's openclaw/codex runtime auto-emits these lifecycle templates:
+    //   • #N_PERMISSION_HANDOFF — a FALSE alarm fired when a benign post-exec
+    //     cleanup WARN ("Failed to terminate MCP process group N: Operation not
+    //     permitted") is misread as a real exec blocker; observed re-firing
+    //     ~1/min.
+    //   • "Codex #N status heartbeat" / bridge-lifecycle notices — periodic
+    //     keep-alive status, no decision content.
+    // The emitter is REMOTE (the process behind CODEX_COMMANDS_URL, not this
+    // repo) and re-evaluates per exec, stateless — so it cannot be silenced
+    // from chat and must be dropped HERE before the upward org-chart forward,
+    // exactly like the MODEL_HEALTH/ACK echoes above. The leading
+    // "[📢 FWD from #N]" wrapper is optional because the raw machine token can
+    // arrive already prefixed. Anchored at line start so a bot's OWN prose that
+    // merely mentions "heartbeat"/"handoff" in a sentence still forwards, and
+    // a genuine permission gate (different leading text) is never swallowed.
+    /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?#\d+_PERMISSION_HANDOFF\b/i,
+    /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?Codex\s+#?\d*\s*status heartbeat\b/i,
+    /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?Codex\s+(?:bridge error|watchdog|bridge status)\b/i,
+    /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?EClaw progress update\b/i,
 ];
 
 const ORG_FWD_MIN_BODY_LEN = 12;

--- a/backend/tests/jest/org-fwd-filter.test.js
+++ b/backend/tests/jest/org-fwd-filter.test.js
@@ -161,6 +161,49 @@ describe('isLowSignalFwd()', () => {
         });
     });
 
+    describe('Codex/openclaw runtime machine-noise forwards (card_77c4b9e2)', () => {
+        // Repro (2026-06-26): #6's codex runtime auto-emitted #6_PERMISSION_HANDOFF
+        // every ~1min from a benign post-exec cleanup WARN, plus periodic status
+        // heartbeats. These were org-forwarded up to #2 and flooded the user's
+        // chat because ORG_FWD_NOISE_PATTERNS had no matching entry.
+        const HANDOFF = `#6_PERMISSION_HANDOFF
+- Blocker: Codex runtime output reported permission_or_login: WARN codex_rmcp_client::stdio_server_launcher: Failed to terminate MCP process group 64526: Operation not permitted (os error 1)
+- Next step: grant the required permission/login through an approved channel`;
+        const HEARTBEAT = `Codex #6 status heartbeat
+- Task: [task in progress - preview redacted to prevent secret leak]
+- Elapsed: 30s
+- Progress: bridge is still alive, codex exec is still running`;
+
+        it('suppresses raw #N_PERMISSION_HANDOFF (pre-prefix, as orgChartForward sees it)', () => {
+            expect(isLowSignalFwd(HANDOFF)).toBe(true);
+            expect(isLowSignalFwd('#1_PERMISSION_HANDOFF\n- Next step: grant')).toBe(true);
+        });
+
+        it('suppresses the already-wrapped "[📢 FWD from #N] #N_PERMISSION_HANDOFF" variant', () => {
+            expect(isLowSignalFwd(`[📢 FWD from #6] ${HANDOFF}`)).toBe(true);
+        });
+
+        it('suppresses "Codex #N status heartbeat" (with and without the entity number)', () => {
+            expect(isLowSignalFwd(HEARTBEAT)).toBe(true);
+            expect(isLowSignalFwd(`[📢 FWD from #6] ${HEARTBEAT}`)).toBe(true);
+            expect(isLowSignalFwd('Codex status heartbeat\n- Elapsed: 30s\n- Progress: still running')).toBe(true);
+        });
+
+        it('suppresses Codex bridge error / watchdog / bridge status + EClaw progress update', () => {
+            expect(isLowSignalFwd('Codex bridge error: socket closed unexpectedly, retrying')).toBe(true);
+            expect(isLowSignalFwd('Codex watchdog recovery window is 45m 0s only if heartbeats stop')).toBe(true);
+            expect(isLowSignalFwd('Codex bridge status: reconnected after transient drop')).toBe(true);
+            expect(isLowSignalFwd('EClaw progress update — still polling, nothing new')).toBe(true);
+        });
+
+        it('does NOT suppress a real permission request or prose that merely mentions handoff/heartbeat', () => {
+            // Critical false-positive guard: a genuine gate / real work forwards.
+            expect(isLowSignalFwd('Need you to grant GitHub repo scope for the private mirror before I can push')).toBe(false);
+            expect(isLowSignalFwd('I finished the permission-handoff refactor PR #3120, ready for review')).toBe(false);
+            expect(isLowSignalFwd('Heartbeat metrics dashboard shipped — p99 latency down 40%')).toBe(false);
+        });
+    });
+
     describe('real messages must pass through (no false positives)', () => {
         it('lets normal status reports through', () => {
             expect(isLowSignalFwd('Card 7a03c4 moved to in_progress, ETA 2h')).toBe(false);


### PR DESCRIPTION
## Problem (Hank, 2026-06-26 live session)
`#6`'s codex/openclaw runtime auto-emits `#6_PERMISSION_HANDOFF` ~once/min (a FALSE alarm: a benign post-exec cleanup WARN `Failed to terminate MCP process group N: Operation not permitted` misread as an exec blocker), plus periodic `Codex #N status heartbeat` lines. These flood the user's chat.

## Why the existing suppressors didn't stop it
- **Bridge `FLEET_NOISE_RE`** (channel repo, PR #23): routing-target hygiene **only** — by design it NEVER suppresses delivery.
- **b2b token-bucket** (`index.js:1147`): a content-blind **throttle** (regen 1/min) that **every human `/api/client/speak` resets** → the user debugging the flood refills the emitter's quota.
- **`org-fwd-filter.js` `isLowSignalFwd()`** — the *real* backend b2b noise suppressor, applied in `orgChartForward()` (`index.js:19274`) before a bot's output is forwarded up to its supervisor. It already drops MODEL_HEALTH/ACK echoes, kanban system-template echoes, JSON crashes, timeout markers — but had **no pattern** for `#N_PERMISSION_HANDOFF` / `Codex #N status heartbeat`, so they were forwarded up to `#2` and into the user's chat.

## Fix
Add 4 patterns to `ORG_FWD_NOISE_PATTERNS` (the existing, already-safe chokepoint):
- `#\d+_PERMISSION_HANDOFF`
- `Codex #?\d* status heartbeat`
- `Codex (bridge error|watchdog|bridge status)`
- `EClaw progress update`

Optional leading `[📢 FWD from #N]` wrapper (raw token may arrive pre-prefixed). Anchored at line start so:
- a bot's **own prose** that mentions "handoff"/"heartbeat" still forwards,
- a **genuine permission gate** (different leading text) is never swallowed,
- **user messages** (`/api/client/speak`) are never touched.

The remote emitter (`CODEX_COMMANDS_URL`, not this repo) can't be silenced from chat, so receiver-side suppression is correct; root-cause fix stays upstream in #6's runtime (separate).

## Tests
`backend/tests/jest/org-fwd-filter.test.js` +5 tests incl. false-positive guards. **jest: 35/35 pass.** `node --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)