### PR TITLE
feat(org-fwd): suppression transparency + b2b quota countdown (card_59f41e5b)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -18,7 +18,7 @@ const sitePageviews = require('./site-pageviews');
 const feedbackModule = require('./device-feedback');
 const chatIntegrity = require('./chat-integrity');
 const communitySsr = require('./community-ssr');
-const { isLowSignalFwd } = require('./org-fwd-filter');
+const { isLowSignalFwd, classifyLowSignalFwd } = require('./org-fwd-filter');
 const orgFwdEscalation = require('./org-fwd-escalation');
 const { buildOrgEntitySessionKey, isOrgEntitySessionKey } = require('./session-scope');
 const { assignDefaultCompanionIfMissing } = require('./petdx-phase0-hook');
@@ -1204,6 +1204,20 @@ function getBotToBotRemaining(deviceId, entityId) {
     return Math.max(0, BOT2BOT_MAX_MESSAGES - botToBotCounter[key].count);
 }
 
+// Time (ms) until this entity's bucket regenerates its NEXT token — feeds the
+// front-end b2b quota countdown chip (card_59f41e5b). Returns 0 when there is
+// nothing pending to regenerate (no bucket, or a full bucket at count 0). The
+// bucket is regenerated first so the value reflects the current moment; if the
+// regen drained it back to full we again return 0 (no pending countdown).
+function getBotToBotNextRegenMs(deviceId, entityId) {
+    const key = `${deviceId}:${entityId}`;
+    const bucket = botToBotCounter[key];
+    if (!bucket || bucket.count === 0) return 0;
+    _regenBotToBotTokens(bucket);
+    if (bucket.count === 0) return 0;
+    return Math.max(0, BOT2BOT_REGEN_INTERVAL_MS - (Date.now() - bucket.lastRegenAt));
+}
+
 // Reset bot-to-bot counter when human sends a message (called from /api/client/speak)
 function resetBotToBotCounter(deviceId) {
     const prefix = `${deviceId}:`;
@@ -1215,6 +1229,33 @@ function resetBotToBotCounter(deviceId) {
     }
     // Also clear broadcast dedup cache for this device so human-initiated broadcasts work fresh
     delete recentBroadcasts[deviceId];
+}
+
+// ── Suppression transparency ring buffer (card_59f41e5b) ──
+// orgChartForward() drops low-signal machine noise (ack/heartbeat echoes, JSON
+// crash fragments, kanban-notice echoes — see org-fwd-filter.js) before it can
+// flood the user's channel. Instead of dropping SILENTLY, each suppressed
+// forward is recorded here and pushed live to the dashboard, so the user can
+// see WHAT was filtered and WHY ("drop-but-surface"). In-memory only (not
+// persisted); per-device array capped at SUPPRESSION_LOG_CAP, oldest dropped.
+// Shape: suppressionLog[deviceId] = [{ ts, fromEntityId, reason, snippet }] (oldest-first).
+const suppressionLog = {};
+const SUPPRESSION_LOG_CAP = 50;
+
+function recordSuppressedForward(deviceId, item) {
+    if (!deviceId) return null;
+    const rec = {
+        ts: Date.now(),
+        fromEntityId: item && item.fromEntityId != null ? item.fromEntityId : null,
+        reason: (item && item.reason) || 'low_signal',
+        snippet: String((item && item.snippet) || '').slice(0, 80),
+    };
+    const arr = suppressionLog[deviceId] || (suppressionLog[deviceId] = []);
+    arr.push(rec);
+    if (arr.length > SUPPRESSION_LOG_CAP) arr.splice(0, arr.length - SUPPRESSION_LOG_CAP);
+    // Live UI: notify the dashboard suppression-transparency drawer.
+    if (io) io.to(deviceId).emit('suppression:logged', { deviceId, item: rec, count: arr.length });
+    return rec;
 }
 
 function checkCrossSpeakRateLimit(deviceId, entityId) {
@@ -8480,6 +8521,66 @@ app.get('/api/status', (req, res) => {
         rental_contract_id: entity.rental_contract_id || null,
         versionInfo: getVersionInfo(appVersion || entity.appVersion)
     });
+});
+
+// Shared read-auth for the transparency GETs below (card_59f41e5b): authorize
+// with the SAME credentials the other mission/status GETs accept —
+// deviceId+deviceSecret (owner) OR deviceId+botSecret+entityId (a bound bot).
+// Returns { ok, status, error } and never leaks which factor failed.
+function authDeviceRead(query) {
+    const { deviceId, deviceSecret, botSecret } = query;
+    const eId = parseInt(query.entityId);
+    if (!deviceId) return { ok: false, status: 400, error: 'deviceId required' };
+    const device = devices[deviceId];
+    if (!device) return { ok: false, status: 404, error: 'Device not found' };
+    const deviceAuthed = !!(deviceSecret && device.deviceSecret && safeEqual(device.deviceSecret, deviceSecret));
+    const botEntity = (botSecret && Number.isInteger(eId) && isValidEntityId(device, eId)) ? device.entities[eId] : null;
+    const botAuthed = !!(botEntity && botEntity.isBound && botEntity.botSecret && safeEqual(botEntity.botSecret, botSecret));
+    if (!deviceAuthed && !botAuthed) return { ok: false, status: 403, error: 'Invalid credentials' };
+    return { ok: true, deviceId, device };
+}
+
+/**
+ * GET /api/suppression-log — "drop-but-surface" transparency feed (card_59f41e5b)
+ * Returns the in-memory ring buffer of low-signal org-chart forwards that were
+ * suppressed for this device (see orgChartForward / org-fwd-filter.js).
+ * Query: deviceId, botSecret, entityId  (or deviceId, deviceSecret)
+ * Response: { success:true, count, items:[{ ts, fromEntityId, reason, snippet }] }
+ *   items are OLDEST-FIRST (append order); `count` === items.length (cap 50).
+ */
+app.get('/api/suppression-log', (req, res) => {
+    const auth = authDeviceRead(req.query);
+    if (!auth.ok) return res.status(auth.status).json({ success: false, message: auth.error });
+    const items = suppressionLog[auth.deviceId] || [];
+    res.json({ success: true, count: items.length, items });
+});
+
+/**
+ * GET /api/b2b-status — bot-to-bot quota + regen countdown (card_59f41e5b)
+ * Feeds the front-end b2b quota countdown chip. Reports, per BOUND entity on
+ * the device (or just the one named by entityId), the remaining b2b tokens, the
+ * bucket capacity, and ms until the next token regenerates.
+ * Query: deviceId, botSecret, entityId  (entityId also scopes the result to one
+ *        entity; omit deviceSecret form to report the whole device)
+ * Response: { success:true, max, entities:[{ entityId, remaining, max, nextRegenMs }] }
+ */
+app.get('/api/b2b-status', (req, res) => {
+    const auth = authDeviceRead(req.query);
+    if (!auth.ok) return res.status(auth.status).json({ success: false, message: auth.error });
+    const { deviceId, device } = auth;
+    const scopeId = parseInt(req.query.entityId);
+    // When deviceSecret-authed and an entityId is given, scope to that one;
+    // bot-authed callers may also pass entityId to scope to themselves.
+    const ids = (Number.isInteger(scopeId) && isValidEntityId(device, scopeId))
+        ? [scopeId]
+        : Object.keys(device.entities).map(Number).filter(id => device.entities[id] && device.entities[id].isBound);
+    const entities = ids.map(id => ({
+        entityId: id,
+        remaining: getBotToBotRemaining(deviceId, id),
+        max: BOT2BOT_MAX_MESSAGES,
+        nextRegenMs: getBotToBotNextRegenMs(deviceId, id),
+    }));
+    res.json({ success: true, max: BOT2BOT_MAX_MESSAGES, entities });
 });
 
 /**
@@ -19317,8 +19418,17 @@ const ORG_TASK_FWD_PREFIX = '[📋 TASK FWD';
 
 async function orgChartForward(entity, deviceId, message, opts = {}) {
     if (!message || message.startsWith(ORG_TASK_FWD_PREFIX) || message.startsWith(ORG_FWD_PREFIX)) return;
-    if (isLowSignalFwd(message)) {
-        serverLog('info', 'org_forward_skip', `#${entity.entityId} suppressed low-signal fwd: "${String(message).trim().slice(0, 60)}"`, { deviceId, entityId: entity.entityId });
+    // card_59f41e5b: "drop-but-surface" — classify WHY it's low-signal, drop the
+    // upward forward as before, but ALSO record it + push a live event so the
+    // dashboard can show the user what was filtered (instead of a silent drop).
+    const lowSignalReason = classifyLowSignalFwd(message);
+    if (lowSignalReason) {
+        serverLog('info', 'org_forward_skip', `#${entity.entityId} suppressed low-signal fwd (${lowSignalReason}): "${String(message).trim().slice(0, 60)}"`, { deviceId, entityId: entity.entityId });
+        recordSuppressedForward(deviceId, {
+            fromEntityId: opts.fromEntityId != null ? opts.fromEntityId : (entity.entityId != null ? entity.entityId : null),
+            reason: lowSignalReason,
+            snippet: String(message).trim().slice(0, 80),
+        });
         return;
     }
 
@@ -24219,3 +24329,12 @@ module.exports._officialBorrowTest = {
 };
 module.exports._buildBindFailurePayload = buildBindFailurePayload;
 module.exports._getSilentTransformSuppressionReason = getSilentTransformSuppressionReason;
+// card_59f41e5b — b2b quota countdown + suppression-transparency internals
+module.exports._checkBotToBotRateLimit = checkBotToBotRateLimit;
+module.exports._getBotToBotRemaining = getBotToBotRemaining;
+module.exports._getBotToBotNextRegenMs = getBotToBotNextRegenMs;
+module.exports._BOT2BOT_MAX_MESSAGES = BOT2BOT_MAX_MESSAGES;
+module.exports._BOT2BOT_REGEN_INTERVAL_MS = BOT2BOT_REGEN_INTERVAL_MS;
+module.exports._recordSuppressedForward = recordSuppressedForward;
+module.exports._suppressionLog = suppressionLog;
+module.exports._SUPPRESSION_LOG_CAP = SUPPRESSION_LOG_CAP;

--- a/backend/org-fwd-filter.js
+++ b/backend/org-fwd-filter.js
@@ -7,30 +7,52 @@
  * or that ack-the-ack with one-word replies, were flooding the user's
  * channel with low-signal noise. This filter drops those before the silent
  * push happens.
+ *
+ * The patterns are grouped by KIND so callers can not only decide *whether* to
+ * suppress (isLowSignalFwd) but also *why* (classifyLowSignalFwd) — the latter
+ * feeds the "drop-but-surface" suppression-transparency log (card_59f41e5b) so
+ * the dashboard can show the user what was filtered and which category it was.
  */
 
-const ORG_FWD_NOISE_PATTERNS = [
-    /^\s*Unexpected (non-whitespace character after JSON|token .* in JSON|end of JSON)/i,
-    /^\s*SyntaxError: Unexpected/i,
-    /^\s*at position \d+/i,
-    /^\s*line \d+ column \d+/i,
-    /^\s*\[[^\]]{1,40}回應超時\]\s*$/,
-    /^\s*\[[^\]]{1,40}response timeout\]\s*$/i,
+// Each entry: [reasonLabel, regex]. Order matters only for classification (the
+// first matching group wins); isLowSignalFwd is order-independent (any match →
+// true). The flat ORG_FWD_NOISE_PATTERNS below is derived from this list so the
+// boolean filter and the classifier can never drift apart.
+const ORG_FWD_NOISE_GROUPS = [
+    // ── JSON parse / stack-trace crash fragments (the original Mac_E flood) ──
+    ['json_crash', /^\s*Unexpected (non-whitespace character after JSON|token .* in JSON|end of JSON)/i],
+    ['json_crash', /^\s*SyntaxError: Unexpected/i],
+    ['json_crash', /^\s*at position \d+/i],
+    ['json_crash', /^\s*line \d+ column \d+/i],
+
+    // ── Bare timeout markers (the Hermes empty-FWD loop) ──
+    ['timeout_marker', /^\s*\[[^\]]{1,40}回應超時\]\s*$/],
+    ['timeout_marker', /^\s*\[[^\]]{1,40}response timeout\]\s*$/i],
+
+    // ── One-word / control acks (the ack-of-ack loop) ──
     // [SILENT] is optional here so that getSilentTransformSuppressionReason
     // can pre-strip the token before evaluating the trailer (test:
     // `@#6 [SILENT] #6 sign-off FWD echo` → strip mention + [SILENT] →
     // `#6 sign-off FWD echo` should still classify as low-signal).
-    /^\s*(?:\[SILENT\]\s*)?#?\d+\s+sign[- ]off\s+FWD\s+echo\b/i,
-    /^\s*(ping|pong|ack|ok|received|noted)\s*[.!]*\s*$/i,
+    ['ack', /^\s*(?:\[SILENT\]\s*)?#?\d+\s+sign[- ]off\s+FWD\s+echo\b/i],
+    ['ack', /^\s*(ping|pong|ack|ok|received|noted)\s*[.!]*\s*$/i],
     // ACK / FWD-ACK nonce responses — these are no-op acknowledgements
-    /^\s*ACK\s+<\/?nonce>\s*$/i,
-    /^\s*\[📢\s*FWD\s+from\s+#\d+\]\s+ACK\s+<\/?nonce>\s*$/i,
+    ['ack', /^\s*ACK\s+<\/?nonce>\s*$/i],
+    ['ack', /^\s*\[📢\s*FWD\s+from\s+#\d+\]\s+ACK\s+<\/?nonce>\s*$/i],
+    // Chinese bot-to-bot pure ack (card_59f41e5b). The optional [📢 FWD from #N]
+    // wrapper mirrors the PERMISSION_HANDOFF pattern; the trailing class only
+    // allows whitespace/punctuation + an optional 🦞 mascot, so a *real* status
+    // report that merely STARTS with 收到 but carries content ("收到，正在處理
+    // card_…，預計 30 分鐘內回報") fails the `$` anchor and still forwards.
+    // NB: 🦞 is wrapped as (?:🦞)? — a bare `🦞?` (no /u flag) would quantify
+    // only the low surrogate and wrongly REQUIRE the high surrogate.
+    ['ack', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?(?:收到|已收到|了解|好的|OK|okay)[\s，,。.!！~]*(?:🦞)?\s*$/i],
 
     // ── System / automation / kanban notification echoes (card_ef4f729385089025431ea8f1) ──
     // The kanban notify path (backend/kanban.js notifyEntities) pushes
     // platform-generated status/automation notices to the *assigned* bot. When
     // that bot's agent echoes / acks the notice back, the echo travels up the
-    // org chart (index.js:9807 orgChartForward) and floods the supervisor.
+    // org chart (index.js orgChartForward) and floods the supervisor.
     // These are NOT decision-needing content — they're system status noise, so
     // suppress them before the upward forward. Matched by the stable
     // leading-emoji + template markers used across every locale in
@@ -42,16 +64,18 @@ const ORG_FWD_NOISE_PATTERNS = [
     // Anchored to the leading icon so a bot's *own* free-text status report
     // ("Card 7a03c4 moved to in_progress, ETA 2h") still forwards normally —
     // only the verbatim system-template strings are dropped.
-    /^\s*📌\s*狀態更新/,                       // in-card system comment echo (kanban.js:2170)
-    /^\s*(?:➡️?|⬅️?)️?\s/u,             // statusChanged: leading "{➡️|⬅️} Task status changed …"
-    /^\s*📋\s/,                               // cardCreated  ("📋 New task assigned / 新任務指派 / …")
-    /^\s*🗓️?\s/u,                       // schedule*/automationTrigger ("🗓️ Schedule/Automation triggered …")
-    /^\s*⏰\s/,                               // staleNudge   ("⏰ Task nudge / 任務催促 / …")
-    /^\s*🔍\s/,                               // reviewerNotify / reviewerMovedToReview ("🔍 …")
-    /^\s*⏸️?\s/u,                        // screenshot-gate auto-close hold notice (kanban.js:3996/4001)
-    /^\s*♻️?\s*Card reopened/iu,         // card reopened echo (kanban.js:2405/2408)
-    // model-health FWD echoes (background traffic, by design): "[📢 FWD … MODEL_HEALTH/ACK]"
-    /^\s*\[📢\s*FWD\b.*\b(MODEL_HEALTH|ACK)\b/i,
+    ['kanban_echo', /^\s*📌\s*狀態更新/],                       // in-card system comment echo (kanban.js:2170)
+    ['kanban_echo', /^\s*(?:➡️?|⬅️?)️?\s/u],             // statusChanged: leading "{➡️|⬅️} Task status changed …"
+    ['kanban_echo', /^\s*📋\s/],                               // cardCreated  ("📋 New task assigned / 新任務指派 / …")
+    ['kanban_echo', /^\s*🗓️?\s/u],                       // schedule*/automationTrigger ("🗓️ Schedule/Automation triggered …")
+    ['kanban_echo', /^\s*⏰\s/],                               // staleNudge   ("⏰ Task nudge / 任務催促 / …")
+    ['kanban_echo', /^\s*🔍\s/],                               // reviewerNotify / reviewerMovedToReview ("🔍 …")
+    ['kanban_echo', /^\s*⏸️?\s/u],                        // screenshot-gate auto-close hold notice (kanban.js:3996/4001)
+    ['kanban_echo', /^\s*♻️?\s*Card reopened/iu],         // card reopened echo (kanban.js:2405/2408)
+
+    // ── Model-health FWD echoes (background traffic, by design) ──
+    // "[📢 FWD … MODEL_HEALTH/ACK]"
+    ['model_health', /^\s*\[📢\s*FWD\b.*\b(MODEL_HEALTH|ACK)\b/i],
 
     // ── Codex/openclaw runtime machine-noise forwards (card_77c4b9e2) ──
     // #6's openclaw/codex runtime auto-emits these lifecycle templates:
@@ -69,23 +93,68 @@ const ORG_FWD_NOISE_PATTERNS = [
     // arrive already prefixed. Anchored at line start so a bot's OWN prose that
     // merely mentions "heartbeat"/"handoff" in a sentence still forwards, and
     // a genuine permission gate (different leading text) is never swallowed.
-    /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?#\d+_PERMISSION_HANDOFF\b/i,
-    /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?Codex\s+#?\d*\s*status heartbeat\b/i,
-    /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?Codex\s+(?:bridge error|watchdog|bridge status)\b/i,
-    /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?EClaw progress update\b/i,
+    ['permission_handoff', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?#\d+_PERMISSION_HANDOFF\b/i],
+    ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?Codex\s+#?\d*\s*status heartbeat\b/i],
+    ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?Codex\s+(?:bridge error|watchdog|bridge status)\b/i],
+    ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?EClaw progress update\b/i],
+    // Chinese peer heartbeat / status-echo ack (card_59f41e5b). These are the
+    // "收到，#6 仍在跑 / last output 9m29s 前 / watchdog 35m 餘量。🦞" keep-alive
+    // echoes peers bounce back. Two safety properties make this false-positive
+    // safe (the whole feature hinges on never eating a real escalation):
+    //   1. a lookahead REQUIRES at least one keep-alive keyword, so a bare
+    //      "收到，#6" never matches; and
+    //   2. it is END-ANCHORED to a whitelist of heartbeat tokens (separators,
+    //      entity refs #N, time numbers like 9m29s/35m, 前/後, 🦞, and the
+    //      keep-alive keywords). The instant any real prose appears (e.g.
+    //      "…但我發現 card_123 卡住了，需要你決定") a non-whitelist char breaks
+    //      the `$` anchor and the message FORWARDS. A peer never appends an
+    //      escalation to a heartbeat echo — those arrive as separate messages.
+    ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?(?:收到|已收到)(?=(?:[，,。.\s]|#?\d+(?:[mhsd]|分|秒|時|天)?|前|後|🦞|仍在跑|還在跑|在線|餘量|窗口|仍可守|bridge|alive|last|output|watchdog)*?(?:仍在跑|還在跑|在線|餘量|窗口|仍可守|watchdog|bridge|output))(?:[，,。.\s]|#?\d+(?:[mhsd]|分|秒|時|天)?|前|後|🦞|仍在跑|還在跑|在線|餘量|窗口|仍可守|bridge|alive|last|output|watchdog)*$/i],
+
+    // ── Standalone lobster mascot ping (card_59f41e5b) ──
+    // A bare 🦞 (optionally FWD-wrapped) carries no information.
+    ['lobster', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?🦞\s*$/],
 ];
+
+// Flat list preserved for backward compatibility (and existing imports).
+const ORG_FWD_NOISE_PATTERNS = ORG_FWD_NOISE_GROUPS.map(([, re]) => re);
 
 const ORG_FWD_MIN_BODY_LEN = 12;
 
-function isLowSignalFwd(message) {
-    if (!message) return true;
+/**
+ * Classify a candidate org-chart forward into a low-signal reason label, or
+ * return null if it carries real signal and should forward.
+ *
+ * Reason labels: 'json_crash' | 'timeout_marker' | 'ack' | 'kanban_echo' |
+ * 'model_health' | 'permission_handoff' | 'heartbeat' | 'lobster' |
+ * 'low_signal'. The last ('low_signal') is the catch-all for empty / too-short
+ * bodies that match no specific pattern.
+ *
+ * isLowSignalFwd(message) === (classifyLowSignalFwd(message) != null), by
+ * construction — the boolean filter and the classifier share one source of
+ * truth so they can never disagree.
+ */
+function classifyLowSignalFwd(message) {
+    if (!message) return 'low_signal';
     const trimmed = String(message).trim();
-    if (trimmed.length < ORG_FWD_MIN_BODY_LEN) return true;
-    return ORG_FWD_NOISE_PATTERNS.some(re => re.test(trimmed));
+    // Specific patterns first, so even a short body gets a meaningful label
+    // (e.g. '已收到。' → 'ack' rather than the generic 'low_signal').
+    for (const [reason, re] of ORG_FWD_NOISE_GROUPS) {
+        if (re.test(trimmed)) return reason;
+    }
+    // Catch-all: anything too short to be actionable.
+    if (trimmed.length < ORG_FWD_MIN_BODY_LEN) return 'low_signal';
+    return null;
+}
+
+function isLowSignalFwd(message) {
+    return classifyLowSignalFwd(message) != null;
 }
 
 module.exports = {
     isLowSignalFwd,
+    classifyLowSignalFwd,
     ORG_FWD_NOISE_PATTERNS,
+    ORG_FWD_NOISE_GROUPS,
     ORG_FWD_MIN_BODY_LEN,
 };

--- a/backend/tests/jest/org-fwd-filter.test.js
+++ b/backend/tests/jest/org-fwd-filter.test.js
@@ -4,7 +4,7 @@
  * acks) up the org chart and into the user's channel.
  */
 
-const { isLowSignalFwd, ORG_FWD_MIN_BODY_LEN } = require('../../org-fwd-filter');
+const { isLowSignalFwd, classifyLowSignalFwd, ORG_FWD_MIN_BODY_LEN } = require('../../org-fwd-filter');
 const { tKanban, statusLabel, TRANSLATIONS } = require('../../i18n/kanban-notifications');
 
 describe('isLowSignalFwd()', () => {
@@ -201,6 +201,80 @@ describe('isLowSignalFwd()', () => {
             expect(isLowSignalFwd('Need you to grant GitHub repo scope for the private mirror before I can push')).toBe(false);
             expect(isLowSignalFwd('I finished the permission-handoff refactor PR #3120, ready for review')).toBe(false);
             expect(isLowSignalFwd('Heartbeat metrics dashboard shipped — p99 latency down 40%')).toBe(false);
+        });
+    });
+
+    describe('Chinese bot-to-bot ack / peer-heartbeat-echo noise (card_59f41e5b)', () => {
+        // Repro: peers bounce "[📢 FWD from #N] 收到 🦞" / "已收到。" /
+        // "收到，#6 仍在跑 …" keep-alive echoes that org-forward up and flood the
+        // user's chat. These are pure acks / status echoes with no decision
+        // content and must be suppressed before the upward forward.
+        it('suppresses the peer-status-echo "[📢 FWD from #5] 收到，#6 仍在跑。🦞"', () => {
+            expect(isLowSignalFwd('[📢 FWD from #5] 收到，#6 仍在跑。🦞')).toBe(true);
+        });
+
+        it('suppresses pure acks "[📢 FWD from #6] 收到 🦞" / "已收到。"', () => {
+            expect(isLowSignalFwd('[📢 FWD from #6] 收到 🦞')).toBe(true);
+            expect(isLowSignalFwd('[📢 FWD from #6] 已收到。')).toBe(true);
+            expect(isLowSignalFwd('已收到。')).toBe(true);
+            expect(isLowSignalFwd('收到，了解。')).toBe(true);
+            expect(isLowSignalFwd('好的 🦞')).toBe(true);
+        });
+
+        it('suppresses the watchdog/last-output peer heartbeat echo', () => {
+            expect(isLowSignalFwd('收到，#6 last output 9m29s 前，watchdog 35m 餘量。🦞')).toBe(true);
+            expect(isLowSignalFwd('[📢 FWD from #6] 收到，#5 bridge alive，窗口 40m 仍可守')).toBe(true);
+            expect(isLowSignalFwd('已收到，#1 還在跑')).toBe(true);
+        });
+
+        it('suppresses a standalone lobster mascot 🦞 (with and without FWD wrapper)', () => {
+            expect(isLowSignalFwd('🦞')).toBe(true);
+            expect(isLowSignalFwd('[📢 FWD from #5] 🦞')).toBe(true);
+            expect(isLowSignalFwd('   🦞   ')).toBe(true);
+        });
+
+        it('CRITICAL false-positive guard: a real "收到 + actionable" report still forwards', () => {
+            // The existing guard the whole feature hinges on — a status report
+            // that begins with 收到 but carries a card id + ETA must NOT be eaten.
+            expect(isLowSignalFwd('收到，正在處理 card_a60568c，預計 30 分鐘內回報')).toBe(false);
+            expect(isLowSignalFwd('收到你的 PR #3758，我來 review')).toBe(false);
+            expect(isLowSignalFwd('了解了，這個 bug 根因是 X，我修')).toBe(false);
+            expect(isLowSignalFwd('收到，#6 仍在跑，但我發現 card_123 卡住了，需要你決定')).toBe(false);
+            expect(isLowSignalFwd('好的，我先把 deploy 跑起來再回報結果')).toBe(false);
+        });
+    });
+
+    describe('classifyLowSignalFwd() reason labels (card_59f41e5b)', () => {
+        it('labels each noise category for the suppression-transparency log', () => {
+            expect(classifyLowSignalFwd('Unexpected end of JSON input')).toBe('json_crash');
+            expect(classifyLowSignalFwd('[Hermes 回應超時]')).toBe('timeout_marker');
+            expect(classifyLowSignalFwd('[📢 FWD from #6] 收到 🦞')).toBe('ack');
+            expect(classifyLowSignalFwd('已收到。')).toBe('ack');
+            expect(classifyLowSignalFwd('📌 狀態更新：待辦 → 進行中')).toBe('kanban_echo');
+            expect(classifyLowSignalFwd('[📢 FWD from #1] MODEL_HEALTH/ACK ok')).toBe('model_health');
+            expect(classifyLowSignalFwd('#6_PERMISSION_HANDOFF\n- Next step: grant')).toBe('permission_handoff');
+            expect(classifyLowSignalFwd('Codex #6 status heartbeat\n- Elapsed: 30s')).toBe('heartbeat');
+            expect(classifyLowSignalFwd('收到，#6 仍在跑。🦞')).toBe('heartbeat');
+            expect(classifyLowSignalFwd('🦞')).toBe('lobster');
+            expect(classifyLowSignalFwd('short')).toBe('low_signal');
+        });
+
+        it('returns null for real signal (forwards)', () => {
+            expect(classifyLowSignalFwd('收到，正在處理 card_a60568c，預計 30 分鐘內回報')).toBeNull();
+            expect(classifyLowSignalFwd('Card 7a03c4 moved to in_progress, ETA 2h')).toBeNull();
+        });
+
+        it('isLowSignalFwd === (classifyLowSignalFwd != null) for a spread of inputs', () => {
+            const samples = [
+                null, '', '   ', 'ack', '🦞', '已收到。',
+                '收到，正在處理 card_a60568c，預計 30 分鐘內回報',
+                'Card 7a03c4 moved to in_progress, ETA 2h',
+                '#6_PERMISSION_HANDOFF\n- Next step: grant',
+                'meaningful !',
+            ];
+            for (const s of samples) {
+                expect(isLowSignalFwd(s)).toBe(classifyLowSignalFwd(s) != null);
+            }
         });
     });
 

--- a/backend/tests/jest/suppression-transparency-b2b.test.js
+++ b/backend/tests/jest/suppression-transparency-b2b.test.js
@@ -1,0 +1,188 @@
+/**
+ * Suppression-transparency + b2b quota countdown (card_59f41e5b).
+ *
+ * Covers the backend contract the front-end (#6) builds against:
+ *   - recordSuppressedForward() ring buffer (cap 50, oldest dropped)
+ *   - getBotToBotNextRegenMs() countdown semantics
+ *   - GET /api/suppression-log   (auth + shape)
+ *   - GET /api/b2b-status        (auth + shape)
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+let app, indexModule;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+const get = (path) => request(app).get(path).set('Host', 'localhost');
+
+async function bindEntity(deviceId, deviceSecret, entityId = 0) {
+    if (entityId > 0) {
+        await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+    }
+    const regRes = await post('/api/device/register').send({ deviceId, deviceSecret, entityId });
+    const code = regRes.body.bindingCode;
+    if (!code) return undefined;
+    const bindRes = await post('/api/bind').send({ code });
+    return bindRes.body.botSecret;
+}
+
+beforeAll(() => {
+    indexModule = require('../../index');
+    app = indexModule;
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+describe('recordSuppressedForward() ring buffer', () => {
+    const recordSuppressedForward = () => indexModule._recordSuppressedForward;
+    const suppressionLog = () => indexModule._suppressionLog;
+    const CAP = () => indexModule._SUPPRESSION_LOG_CAP;
+    const deviceId = 'supp-ring-dev';
+
+    beforeEach(() => { delete suppressionLog()[deviceId]; });
+
+    it('records {ts, fromEntityId, reason, snippet} and clamps snippet to 80 chars', () => {
+        const long = 'x'.repeat(200);
+        const rec = recordSuppressedForward()(deviceId, { fromEntityId: 5, reason: 'ack', snippet: long });
+        expect(rec).toMatchObject({ fromEntityId: 5, reason: 'ack' });
+        expect(typeof rec.ts).toBe('number');
+        expect(rec.snippet.length).toBe(80);
+        expect(suppressionLog()[deviceId]).toHaveLength(1);
+    });
+
+    it('defaults reason to "low_signal" and fromEntityId to null', () => {
+        const rec = recordSuppressedForward()(deviceId, { snippet: 'hi' });
+        expect(rec.reason).toBe('low_signal');
+        expect(rec.fromEntityId).toBeNull();
+    });
+
+    it('caps the per-device buffer at SUPPRESSION_LOG_CAP, dropping oldest (oldest-first order)', () => {
+        const cap = CAP();
+        for (let i = 0; i < cap + 10; i++) {
+            recordSuppressedForward()(deviceId, { fromEntityId: 1, reason: 'ack', snippet: `m${i}` });
+        }
+        const arr = suppressionLog()[deviceId];
+        expect(arr).toHaveLength(cap);
+        // Oldest (m0..m9) dropped; first surviving is m10, last is the newest.
+        expect(arr[0].snippet).toBe('m10');
+        expect(arr[arr.length - 1].snippet).toBe(`m${cap + 9}`);
+    });
+
+    it('returns null (no record) when deviceId is missing', () => {
+        expect(recordSuppressedForward()(null, { reason: 'ack', snippet: 'x' })).toBeNull();
+    });
+});
+
+describe('getBotToBotNextRegenMs()', () => {
+    const checkRL = () => indexModule._checkBotToBotRateLimit;
+    const nextRegen = () => indexModule._getBotToBotNextRegenMs;
+    const remaining = () => indexModule._getBotToBotRemaining;
+    const MAX = () => indexModule._BOT2BOT_MAX_MESSAGES;
+    const INTERVAL = () => indexModule._BOT2BOT_REGEN_INTERVAL_MS;
+    const deviceId = 'supp-b2b-dev';
+    const entityId = 7;
+
+    it('returns 0 when no bucket exists (nothing pending to regen)', () => {
+        expect(nextRegen()(deviceId, 999)).toBe(0);
+        expect(remaining()(deviceId, 999)).toBe(MAX());
+    });
+
+    it('returns a positive countdown <= REGEN_INTERVAL once a token is consumed', () => {
+        const before = Date.now();
+        expect(checkRL()(deviceId, entityId)).toBe(true); // consume 1 token -> count=1
+        const ms = nextRegen()(deviceId, entityId);
+        expect(ms).toBeGreaterThan(0);
+        expect(ms).toBeLessThanOrEqual(INTERVAL());
+        // remaining dropped by exactly 1
+        expect(remaining()(deviceId, entityId)).toBe(MAX() - 1);
+        // sanity: countdown is consistent with just-now lastRegenAt
+        expect(ms).toBeGreaterThan(INTERVAL() - (Date.now() - before) - 2000);
+    });
+});
+
+describe('GET /api/suppression-log', () => {
+    const deviceId = 'supp-ep-dev';
+    const deviceSecret = `secret-${deviceId}`;
+    let botSecret;
+
+    beforeAll(async () => {
+        botSecret = await bindEntity(deviceId, deviceSecret, 0);
+        // seed two suppressed records
+        indexModule._recordSuppressedForward(deviceId, { fromEntityId: 0, reason: 'ack', snippet: '收到 🦞' });
+        indexModule._recordSuppressedForward(deviceId, { fromEntityId: 1, reason: 'heartbeat', snippet: '收到，#6 仍在跑' });
+    });
+
+    it('rejects missing deviceId (400)', async () => {
+        const res = await get('/api/suppression-log');
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+
+    it('rejects bad credentials (403)', async () => {
+        const res = await get(`/api/suppression-log?deviceId=${deviceId}&deviceSecret=wrong`);
+        expect(res.status).toBe(403);
+    });
+
+    it('returns the device ring buffer with deviceSecret auth (oldest-first)', async () => {
+        const res = await get(`/api/suppression-log?deviceId=${deviceId}&deviceSecret=${deviceSecret}`);
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.count).toBe(res.body.items.length);
+        expect(res.body.count).toBeGreaterThanOrEqual(2);
+        const last = res.body.items[res.body.items.length - 1];
+        expect(last).toMatchObject({ reason: 'heartbeat', fromEntityId: 1 });
+        expect(typeof last.ts).toBe('number');
+    });
+
+    it('returns the device ring buffer with botSecret+entityId auth', async () => {
+        const res = await get(`/api/suppression-log?deviceId=${deviceId}&botSecret=${botSecret}&entityId=0`);
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(Array.isArray(res.body.items)).toBe(true);
+    });
+});
+
+describe('GET /api/b2b-status', () => {
+    const deviceId = 'supp-b2bstatus-dev';
+    const deviceSecret = `secret-${deviceId}`;
+    let botSecret;
+
+    beforeAll(async () => {
+        botSecret = await bindEntity(deviceId, deviceSecret, 0);
+    });
+
+    it('rejects bad credentials (403)', async () => {
+        const res = await get(`/api/b2b-status?deviceId=${deviceId}&deviceSecret=wrong`);
+        expect(res.status).toBe(403);
+    });
+
+    it('returns per-entity quota + countdown with deviceSecret auth', async () => {
+        const res = await get(`/api/b2b-status?deviceId=${deviceId}&deviceSecret=${deviceSecret}`);
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.max).toBe(indexModule._BOT2BOT_MAX_MESSAGES);
+        expect(Array.isArray(res.body.entities)).toBe(true);
+        expect(res.body.entities.length).toBeGreaterThanOrEqual(1);
+        const e = res.body.entities[0];
+        expect(e).toHaveProperty('entityId');
+        expect(e).toHaveProperty('remaining');
+        expect(e).toHaveProperty('max');
+        expect(e).toHaveProperty('nextRegenMs');
+        expect(e.max).toBe(indexModule._BOT2BOT_MAX_MESSAGES);
+        // fresh entity: full quota, no pending regen
+        expect(e.remaining).toBe(indexModule._BOT2BOT_MAX_MESSAGES);
+        expect(e.nextRegenMs).toBe(0);
+    });
+
+    it('scopes to a single entity when entityId is provided (bot self-view)', async () => {
+        const res = await get(`/api/b2b-status?deviceId=${deviceId}&botSecret=${botSecret}&entityId=0`);
+        expect(res.status).toBe(200);
+        expect(res.body.entities).toHaveLength(1);
+        expect(res.body.entities[0].entityId).toBe(0);
+    });
+});


### PR DESCRIPTION
Backend for the **suppression transparency + b2b quota countdown** feature (card_59f41e5b). Backend only — the front-end (dashboard chip + transparency drawer) is a separate task for #6; this PR establishes the contract below.

## What changed
**① org-fwd noise filter — Chinese ACK / peer-heartbeat-echo patterns** (`backend/org-fwd-filter.js`)
- Added patterns for bot-to-bot ACK / peer-heartbeat-echo noise that floods the org-chart forward path: `收到 🦞`, `已收到。`, `好的 🦞`, `收到，#6 仍在跑。🦞`, `收到，#6 last output 9m29s 前，watchdog 35m 餘量。🦞`, and a standalone `🦞` — each with an optional `[📢 FWD from #N]` wrapper, mirroring the PR #3758 `#N_PERMISSION_HANDOFF` style.
- Regexes are now grouped by kind; new export `classifyLowSignalFwd(message)` returns the matched reason label (`json_crash | timeout_marker | ack | kanban_echo | model_health | permission_handoff | heartbeat | lobster | low_signal`). `isLowSignalFwd === (classifyLowSignalFwd != null)` — one source of truth, so existing true/false results are unchanged (existing 35 tests still green).
- **False-positive guard:** the peer-heartbeat pattern is END-ANCHORED to a heartbeat-token whitelist and requires a keep-alive keyword, so a real `收到 + actionable` report still forwards. Verified: `收到，正在處理 card_a60568c，預計 30 分鐘內回報`, `收到你的 PR #3758，我來 review`, `了解了，這個 bug 根因是 X，我修`, and `收到，#6 仍在跑，但我發現 card_123 卡住了，需要你決定` all return `false` (forward).
- Implementation note: `🦞` is wrapped as `(?:🦞)?` — a bare `🦞?` (no `/u` flag) would quantify only the low surrogate and wrongly require the high surrogate.

**② drop-but-surface** (`backend/index.js` `orgChartForward()`)
- The low-signal branch now classifies the reason, records the dropped forward into a per-device in-memory ring buffer (cap 50, oldest dropped), and emits a live socket event — instead of dropping silently.

**③ b2b quota regen countdown** (`backend/index.js`)
- New `getBotToBotNextRegenMs(deviceId, entityId)` + exposed via `GET /api/b2b-status`.

## API CONTRACT (for front-end #6)

### Socket event: `suppression:logged`
Emitted to room `deviceId` each time an org-chart forward is suppressed.
```jsonc
{
  "deviceId": "abc123",
  "item": {
    "ts": 1718900000000,        // Date.now() ms
    "fromEntityId": 5,          // origin entity id, or null
    "reason": "heartbeat",      // one of the reason labels above
    "snippet": "收到，#6 仍在跑。🦞"  // trimmed, max 80 chars
  },
  "count": 12                   // current buffer length for the device (cap 50)
}
```

### `GET /api/suppression-log`
Auth (same as other status/mission GETs): `deviceId` + `deviceSecret` (owner) **OR** `deviceId` + `botSecret` + `entityId` (bound bot).
Request: `GET /api/suppression-log?deviceId=...&deviceSecret=...`
Response:
```jsonc
{
  "success": true,
  "count": 2,                   // === items.length, cap 50
  "items": [                    // OLDEST-FIRST (append order); newest is last
    { "ts": 1718900000000, "fromEntityId": 0, "reason": "ack",       "snippet": "收到 🦞" },
    { "ts": 1718900001000, "fromEntityId": 1, "reason": "heartbeat", "snippet": "收到，#6 仍在跑" }
  ]
}
```
Errors: `400` missing deviceId, `404` device not found, `403` bad credentials.

### `GET /api/b2b-status`
Auth: same as above. `entityId` doubles as a scope filter — when a valid `entityId` is supplied the result is scoped to that single entity (so a `botSecret`-authed bot sees only itself); a `deviceSecret`-authed owner with no `entityId` gets every **bound** entity.
Request: `GET /api/b2b-status?deviceId=...&deviceSecret=...` (or `&botSecret=...&entityId=0`)
Response:
```jsonc
{
  "success": true,
  "max": 8,                     // BOT2BOT_MAX_MESSAGES (bucket capacity)
  "entities": [
    { "entityId": 0, "remaining": 8, "max": 8, "nextRegenMs": 0 },
    { "entityId": 1, "remaining": 5, "max": 8, "nextRegenMs": 42173 }
  ]
}
```
`nextRegenMs` = ms until the next token regenerates; `0` when the bucket is full / nothing pending. Errors: `400/404/403` as above.

## Tests
- `backend/tests/jest/org-fwd-filter.test.js` — **43/43** (35 pre-existing + 8 new, incl. the false-positive guards above and `classifyLowSignalFwd` label coverage).
- `backend/tests/jest/suppression-transparency-b2b.test.js` (new) — **13/13** (ring-buffer cap/order, `getBotToBotNextRegenMs` countdown, both endpoints' auth + response shapes).
- `node --check` clean on all edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)