### PR TITLE
fix(org-fwd): robust shape-heuristic for peer watchdog heartbeat echoes (card_59f41e5b)

### DIFF
--- a/backend/org-fwd-filter.js
+++ b/backend/org-fwd-filter.js
@@ -19,43 +19,6 @@
 // true). The flat ORG_FWD_NOISE_PATTERNS below is derived from this list so the
 // boolean filter and the classifier can never drift apart.
 
-// ── Peer-heartbeat-echo vocabulary (card_59f41e5b) ──
-// Shared by BOTH peer-heartbeat regexes (the 收到-led one and the #N-led sibling)
-// so the lookahead trigger set and the `$`-anchored body can never drift apart.
-// Two safety properties keep this false-positive safe (the whole feature hinges
-// on never eating a real escalation):
-//   1. HB_TRIGGER — at least one keep-alive keyword MUST be present, so a bare
-//      "收到，#6。" or "#6 …" never matches; and
-//   2. HB_WL — the body is END-ANCHORED to this whitelist of heartbeat-domain
-//      tokens. The instant any real prose appears (a card id, a verb like 修/
-//      發現, a PR ref, words like 重構/完成/dashboard) a non-whitelist char
-//      breaks the `$` anchor and the message FORWARDS. A peer never appends an
-//      escalation to a heartbeat echo — those arrive as separate messages.
-// NB: 🦞 sits as a plain (un-quantified) alternative, so no /u flag is needed
-// (the surrogate pair is matched literally); a bare `🦞?` WOULD need /u.
-const HB_WL = [
-    '[，,。.\\s]',                         // separators / punctuation
-    '#?\\d+(?:[mhsd]|分|秒|時|天)?',       // entity refs (#6) + time spans (42m29s, 45m)
-    '前', '後', '🦞',
-    '仍在跑', '還在跑', '在線', '餘量', '窗口', '仍可守',
-    'bridge', 'alive', 'last', 'output', 'watchdog',
-    // #5's live watchdog narration vocabulary (card_59f41e5b extension)
-    '僅餘', '即將觸發', '觸發', 'handoff', '到期', '進', 'resource',
-    '決定', '處置', '接近', '警戒線', '警戒', '臨界', 'owner', '或',
-    // connectives that merely glue heartbeat tokens into a sentence (NOT triggers)
-    '但', '已', '等',
-].join('|');
-
-// Keep-alive keywords — the lookahead requires ≥1 of these (reachable through
-// HB_WL) so a content-free ack never trips the heartbeat regex. Every token here
-// is also in HB_WL (so a triggered token is always whitelisted by the body).
-const HB_TRIGGER = [
-    '仍在跑', '還在跑', '在線', '餘量', '窗口', '仍可守',
-    'watchdog', 'bridge', 'output',
-    '僅餘', '即將觸發', '觸發', 'handoff', '到期', '進', 'resource',
-    '決定', '處置', '接近', '警戒線', '警戒', '臨界', 'owner', '或',
-].join('|');
-
 const ORG_FWD_NOISE_GROUPS = [
     // ── JSON parse / stack-trace crash fragments (the original Mac_E flood) ──
     ['json_crash', /^\s*Unexpected (non-whitespace character after JSON|token .* in JSON|end of JSON)/i],
@@ -139,28 +102,33 @@ const ORG_FWD_NOISE_GROUPS = [
     ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?Codex\s+#?\d*\s*status heartbeat\b/i],
     ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?Codex\s+(?:bridge error|watchdog|bridge status)\b/i],
     ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?EClaw progress update\b/i],
-    // Chinese peer heartbeat / status-echo ack (card_59f41e5b). These are the
-    // "收到，#6 仍在跑 / last output 9m29s 前 / watchdog 35m 餘量。🦞" keep-alive
-    // echoes peers bounce back, plus #5's live watchdog narration
-    // ("收到，#6 last output 42m29s 前，watchdog 僅餘 2m30s，即將觸發 handoff。🦞" /
-    // "收到，#6 仍在跑，但接近警戒線。🦞"). Built from the shared HB_TRIGGER /
-    // HB_WL vocabulary above so the lookahead and the `$`-anchored body never
-    // drift. Safety: a lookahead REQUIRES ≥1 keep-alive keyword (so a bare
-    // "收到，#6" never matches), and the body is END-ANCHORED to HB_WL — any
-    // real prose (card id, verb, PR ref) breaks the `$` anchor → FORWARDS.
-    ['heartbeat', new RegExp(
-        `^\\s*(?:\\[📢\\s*FWD\\s+from\\s+#\\d+\\]\\s*)?(?:收到|已收到)` +
-        `(?=(?:${HB_WL})*?(?:${HB_TRIGGER}))(?:${HB_WL})*$`, 'i')],
-    // Sibling: the SAME watchdog-narration echo that starts with "#N" instead of
-    // "收到" — e.g. "#6 watchdog 45m 到期，已進 resource handoff。等 #6 或 owner
-    // 決定處置。🦞". To stay false-positive safe it (a) requires a heartbeat
-    // keyword IMMEDIATELY after "#N " (so "#6 的 avatar bug 我修好了，PR #3760"
-    // never matches), and (b) is `$`-anchored to HB_WL (so "#6 watchdog
-    // dashboard 重構完成，PR #3761" breaks on "dashboard" → FORWARDS). It does
-    // NOT match a bare message merely starting with "#N".
-    ['heartbeat', new RegExp(
-        `^\\s*(?:\\[📢\\s*FWD\\s+from\\s+#\\d+\\]\\s*)?#\\d+\\s+` +
-        `(?:watchdog|resource(?:\\s+handoff)?|仍在跑|還在跑|到期)(?:${HB_WL})*$`, 'i')],
+    // Chinese peer watchdog-narration heartbeat echo (card_59f41e5b + fix-forward).
+    // #5 (and peers) bounce keep-alive "watchdog narration" echoes up the org
+    // chart — e.g. "收到，#6 last output 66m29s 前，bridge alive，沉默超 1h。等
+    // owner 處置。🦞" / "#6 watchdog 45m 到期，已進 resource handoff。🦞". The
+    // earlier approach END-ANCHORED the body to a hand-maintained whitelist of
+    // heartbeat tokens, but #5's LLM keeps inventing new narration words ("沉默超
+    // 1h", "Codex 沉默中", …) that aren't in the list, so the `$` anchor broke and
+    // the echo SLIPPED THROUGH (verified live: classifyLowSignalFwd("收到，#6 last
+    // output 66m29s 前，bridge alive，沉默超 1h。等 owner 處置。🦞") === null).
+    // This robust SHAPE heuristic does NOT enumerate the body vocabulary. One
+    // regex suppresses iff ALL hold:
+    //   1. after an optional "[📢 FWD from #N]" prefix the message STARTS with an
+    //      ack (收到/已收到/了解) or an entity ref (#N), and
+    //   2. it CONTAINS ≥1 heartbeat-domain keyword (watchdog/handoff/bridge/last
+    //      output/仍在跑/還在跑/餘量/僅餘/沉默/在線/resource/到期/觸發/心跳/codex…),
+    //      and
+    //   3. it ENDS with the 🦞 sign-off (peers' machine heartbeats always do), and
+    //   4. it carries NO actionable-content marker (a card id, PR #, URL, or a
+    //      work verb 我修/修好/完成/我發現/待 review).
+    // (1)+(2) say "looks like a heartbeat"; (3)+(4) are the false-positive guards
+    // that keep a REAL escalation forwarding — a genuine owner-ping won't append
+    // 🦞 and a real status report carries a card/PR/verb. The whole feature hinges
+    // on never eating a real escalation, so a borderline non-🦞 heartbeat narration
+    // deliberately FORWARDS (annoying noise ≪ an eaten escalation). NB: [\s\S]
+    // (not the /s flag) handles multi-line bodies; 🦞 is matched as a literal
+    // surrogate pair (no /u flag, consistent with the other patterns here).
+    ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?(?:收到|已收到|了解|#\d+\b)(?=[\s\S]*(?:watchdog|handoff|bridge|last\s*output|仍在跑|還在跑|餘量|僅餘|沉默|沈默|在線|resource|到期|觸發|心跳|heartbeat|codex))(?![\s\S]*(?:card_[0-9a-f]{6}|PR\s*#?\d|https?:\/\/|我修|修好|完成|我發現|待\s*review))[\s\S]*🦞[\s，,。.!！~]*$/i],
 
     // ── Standalone lobster mascot ping (card_59f41e5b) ──
     // A bare 🦞 (optionally FWD-wrapped) carries no information.

--- a/backend/tests/jest/org-fwd-filter.test.js
+++ b/backend/tests/jest/org-fwd-filter.test.js
@@ -223,7 +223,10 @@ describe('isLowSignalFwd()', () => {
 
         it('suppresses the watchdog/last-output peer heartbeat echo', () => {
             expect(isLowSignalFwd('收到，#6 last output 9m29s 前，watchdog 35m 餘量。🦞')).toBe(true);
-            expect(isLowSignalFwd('[📢 FWD from #6] 收到，#5 bridge alive，窗口 40m 仍可守')).toBe(true);
+            // Robust heuristic (card_59f41e5b fix-forward) requires the 🦞 sign-off
+            // as a false-positive guard, so a heartbeat echo with bridge-alive
+            // narration now carries the mascot it always has in production.
+            expect(isLowSignalFwd('[📢 FWD from #6] 收到，#5 bridge alive，窗口 40m 仍可守。🦞')).toBe(true);
             expect(isLowSignalFwd('已收到，#1 還在跑')).toBe(true);
         });
 
@@ -289,6 +292,38 @@ describe('isLowSignalFwd()', () => {
             expect(classifyLowSignalFwd('#6 watchdog dashboard 重構完成，PR #3761')).toBeNull();
             // a heartbeat echo with an appended escalation must still forward
             expect(classifyLowSignalFwd('收到，#6 仍在跑，但我發現 card_123 卡住了，需要你決定')).toBeNull();
+        });
+    });
+
+    describe('robust watchdog-narration heartbeat heuristic (card_59f41e5b fix-forward)', () => {
+        // The `$`-anchored whitelist approach was fragile: #5's LLM kept inventing
+        // narration words ("沉默超 1h", "Codex 沉默中") absent from the whitelist,
+        // so the echo slipped through (verified live: classifyLowSignalFwd("收到，
+        // #6 last output 66m29s 前，bridge alive，沉默超 1h。等 owner 處置。🦞")
+        // === null). The replacement is a SHAPE heuristic: ack/#N start + a
+        // heartbeat-domain keyword + a 🦞 sign-off + no actionable marker. It does
+        // NOT enumerate the body vocabulary, so new narration words don't leak.
+
+        it('MUST-SUPPRESS: watchdog narration with novel words (沉默超 1h / Codex 沉默中)', () => {
+            expect(classifyLowSignalFwd('收到，#6 last output 66m29s 前，bridge alive，沉默超 1h。等 owner 處置。🦞')).toBe('heartbeat');
+            expect(classifyLowSignalFwd('收到，#6 last output 54m29s 前，bridge alive，Codex 沉默中。等 owner 處理 handoff。🦞')).toBe('heartbeat');
+            expect(classifyLowSignalFwd('#6 watchdog 45m 到期，已進 resource handoff。等 #6 或 owner 決定處置。🦞')).toBe('heartbeat');
+            expect(classifyLowSignalFwd('[📢 FWD from #5] 收到，#6 仍在跑，但接近警戒線。🦞')).toBe('heartbeat');
+        });
+
+        it('MUST-FORWARD: real work / escalations still forward (classify === null)', () => {
+            // no heartbeat keyword → forwards
+            expect(classifyLowSignalFwd('收到，正在處理 card_a60568c，預計 30 分鐘內回報')).toBeNull();
+            expect(classifyLowSignalFwd('收到你的 PR #3758，我來 review')).toBeNull();
+            expect(classifyLowSignalFwd('#6 的 avatar bug 我修好了，PR #3760 待 review')).toBeNull();
+            // has watchdog keyword BUT actionable (完成/PR) + no 🦞 → forwards
+            expect(classifyLowSignalFwd('#6 watchdog dashboard 重構完成，PR #3761')).toBeNull();
+            // no 🦞 sign-off → forwards
+            expect(classifyLowSignalFwd('了解了，這個 bug 根因是 X，我修')).toBeNull();
+            // heartbeat keyword but appended escalation (card_ / 我發現) → forwards
+            expect(classifyLowSignalFwd('收到，#6 仍在跑，但我發現 card_123 卡住了，需要你決定')).toBeNull();
+            // does not start with an ack/#N token → forwards
+            expect(classifyLowSignalFwd('好的，我先把 deploy 跑起來再回報結果')).toBeNull();
         });
     });
 


### PR DESCRIPTION
## Problem (card_59f41e5b)

The two `$`-anchored **whitelist** heartbeat regexes in `backend/org-fwd-filter.js`
(the `收到`-led one built from `HB_WL`/`HB_TRIGGER`, and the `#N`-led sibling) are
**fragile**: #5's LLM keeps inventing new "watchdog narration" words (e.g. `沉默超 1h`,
`Codex 沉默中`) that aren't in the whitelist, so the body breaks the `$` anchor and the
heartbeat echo **slips through** the noise filter and floods the user's chat.

Verified live before the fix:
```
classifyLowSignalFwd("收到，#6 last output 66m29s 前，bridge alive，沉默超 1h。等 owner 處置。🦞") === null
```

## Change

Replace BOTH brittle peer-watchdog regexes with **ONE robust SHAPE heuristic**
(reason label `'heartbeat'`) that does **not** enumerate the body vocabulary. It
suppresses iff ALL hold:

1. after an optional `[📢 FWD from #N]` prefix the message **starts** with an ack
   (`收到`/`已收到`/`了解`) or an entity ref (`#N`);
2. it **contains** ≥1 heartbeat-domain keyword (`watchdog`/`handoff`/`bridge`/`last
   output`/`仍在跑`/`餘量`/`沉默`/`在線`/`resource`/`到期`/`觸發`/`心跳`/`codex`…);
3. it **ends** with the 🦞 sign-off (peers' machine heartbeats always do); and
4. it carries **no** actionable marker (`card_<6hex>` / `PR #` / URL / `我修` / `修好`
   / `完成` / `我發現` / `待 review`).

(1)+(2) say "looks like a heartbeat"; (3)+(4) are the false-positive guards that keep
a **real** escalation forwarding — a genuine owner-ping won't append 🦞 and a real
status report carries a card/PR/verb. The feature hinges on never eating a real
escalation, so a borderline non-🦞 heartbeat narration deliberately forwards
(annoying noise ≪ an eaten escalation).

Now-dead `HB_WL`/`HB_TRIGGER` constants removed. **All other patterns untouched**
(json_crash, ack, kanban_echo, model_health, `#N_<UPPER>_HANDOFF`, the machine
Codex-heartbeat templates, lobster, length catch-all).

## Tests

`backend/tests/jest/org-fwd-filter.test.js` — **50/50 green** (`node --check` clean).
Adds a `robust watchdog-narration heartbeat heuristic` describe block with the
must-suppress (incl. the novel `沉默超 1h` / `Codex 沉默中` narrations) and the
critical must-forward false-positive guards.

One pre-existing assertion was updated: the lone heartbeat-echo test case that
lacked a trailing 🦞 (`[📢 FWD from #6] 收到，#5 bridge alive，窗口 40m 仍可守`) now
carries the 🦞 it always has in production, since the robust pattern requires the
🦞 sign-off as a false-positive guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)