### PR TITLE
fix(owner-decision,org-fwd): harden classifier + suppression per PR audit (card_c6731c2f)

### DIFF
--- a/backend/agent-improvement/owner-decision-classifier.js
+++ b/backend/agent-improvement/owner-decision-classifier.js
@@ -19,15 +19,26 @@
 const OWNER_ONLY_CATEGORIES = Object.freeze([
     {
         category: 'irreversible_data',
-        kws: ['drop table', 'truncate', 'purge', 'delete account', 'wipe', 'irreversible',
+        // Multi-word EN phrases + CJK are unambiguous → safe as substrings.
+        kws: ['drop table', 'delete account', 'irreversible',
             '刪除帳號', '不可逆', '清庫', '抹除'],
-        res: [],
+        // Short ambiguous EN words need word boundaries so they don't match inside
+        // larger words (audit card_c6731c2f): 'wipe'→'swipe', 'truncate'→
+        // 'truncated', and 'purge' inside the bot-resolvable 'auto-purge done
+        // cards' doneRetention flow (excluded via the auto- lookbehind).
+        res: [/\btruncate\b/i, /\bwipe\b/i, /(?<!auto[-\s])\bpurge\b/i],
     },
     {
         category: 'spend_cost',
-        kws: ['provision', 'paid plan', 'budget', 'spend', 'quota raise', 'subscription',
-            'billing', '$', '付費', '訂閱', '花錢', '加預算'],
-        res: [],
+        kws: ['provision', 'paid plan', 'budget', 'quota raise', 'subscription',
+            'billing', '付費', '訂閱', '花錢', '加預算'],
+        // 'spend' as a substring matched 'suspend'/'suspended', and a bare '$'
+        // matched EVERY dev card carrying a dollar sign (shell $1/$PATH, template
+        // ${foo}, jQuery $) — flooding the very inbox this feature keeps short
+        // (audit card_c6731c2f). Word-boundary 'spend' + a real price shape (a
+        // digit then >=1 more digit/sep) for '$' excludes single-digit shell
+        // params and ${...}/$WORD while still catching $200 / $1,000 / $9.99.
+        res: [/\bspend(?:ing|s)?\b/i, /\$\s?\d[\d,.]+/],
     },
     {
         category: 'product_direction',
@@ -53,8 +64,13 @@ const OWNER_ONLY_CATEGORIES = Object.freeze([
 ]);
 
 // Explicit owner flag — an author/gate that literally marks the work as
-// owner-only / un-authorizable / legal-hold / 需要你. Always forces ownerOnly.
-const EXPLICIT_FLAG_RE = /owner[-_ ]?only|需要你|un-?authoriz|不可授權|legal-hold/i;
+// owner-only / un-authorizable / legal-hold. Always forces ownerOnly.
+// NB: bare 需要你 was too loose — it is an everyday Chinese phrase (這個需要你確認 /
+// 需要你幫忙) AND literally the inbox's own display name, so ordinary commander
+// comments tripped it (audit card_c6731c2f). Require a deliberate decision verb
+// after 需要你 (決策/核可/裁示/拍板/定奪/授權) so only an explicit owner-decision
+// marker fires, not casual usage.
+const EXPLICIT_FLAG_RE = /owner[-_ ]?only|un-?authoriz|不可授權|legal-hold|需要你\s*(?:決策|核可|裁示|拍板|定奪|授權)/i;
 
 // painTags (OODA-R taxonomy) that represent pure front-end / appearance work.
 // A screenshot-review card whose pain is ONLY these is a UI vision-check (a

--- a/backend/index.js
+++ b/backend/index.js
@@ -1253,8 +1253,11 @@ function recordSuppressedForward(deviceId, item) {
     const arr = suppressionLog[deviceId] || (suppressionLog[deviceId] = []);
     arr.push(rec);
     if (arr.length > SUPPRESSION_LOG_CAP) arr.splice(0, arr.length - SUPPRESSION_LOG_CAP);
-    // Live UI: notify the dashboard suppression-transparency drawer.
-    if (io) io.to(deviceId).emit('suppression:logged', { deviceId, item: rec, count: arr.length });
+    // Live UI: notify the dashboard suppression-transparency drawer. Must target
+    // the `device:${deviceId}` room the portal/app socket actually joins (see the
+    // socket connection handler) — emitting to a bare `deviceId` room hit nobody,
+    // so the chat ops-strip live feed silently never fired (audit card_c6731c2f F9).
+    if (io) io.to(`device:${deviceId}`).emit('suppression:logged', { deviceId, item: rec, count: arr.length });
     return rec;
 }
 
@@ -8551,7 +8554,15 @@ function authDeviceRead(query) {
 app.get('/api/suppression-log', (req, res) => {
     const auth = authDeviceRead(req.query);
     if (!auth.ok) return res.status(auth.status).json({ success: false, message: auth.error });
-    const items = suppressionLog[auth.deviceId] || [];
+    let items = suppressionLog[auth.deviceId] || [];
+    // Scope a bot-authed (entityId-bearing) caller to its OWN suppressed forwards;
+    // the owner deviceSecret path passes no entityId and sees the whole-device feed
+    // (mirrors /api/b2b-status). Audit card_c6731c2f (F10) — a bot should not read
+    // every entity's suppressed-snippet buffer.
+    const scopeId = parseInt(req.query.entityId);
+    if (Number.isInteger(scopeId) && isValidEntityId(auth.device, scopeId)) {
+        items = items.filter(it => Number(it.fromEntityId) === scopeId);
+    }
     res.json({ success: true, count: items.length, items });
 });
 

--- a/backend/org-fwd-filter.js
+++ b/backend/org-fwd-filter.js
@@ -99,7 +99,11 @@ const ORG_FWD_NOISE_GROUPS = [
     // a genuine permission gate (different leading text) is never swallowed.
     // Reason label kept as 'permission_handoff' for stability across the family.
     ['permission_handoff', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?#\d+_[A-Z]+_HANDOFF\b/i],
-    ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?Codex\s+#?\d*\s*status heartbeat\b/i],
+    // NB: middle gap is \s? (not \s*) — two unbounded whitespace runs (\s+ … \s*)
+    // around the non-whitespace #?\d* caused O(n^2) backtracking on a long space
+    // run that never reaches "status" (audit card_c6731c2f). One bounded gap kills
+    // the quadratic while still matching "Codex #5 status heartbeat" / "Codex status…".
+    ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?Codex\s+#?\d*\s?status heartbeat\b/i],
     ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?Codex\s+(?:bridge error|watchdog|bridge status)\b/i],
     ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?EClaw progress update\b/i],
     // Chinese peer watchdog-narration heartbeat echo (card_59f41e5b + fix-forward).
@@ -119,16 +123,21 @@ const ORG_FWD_NOISE_GROUPS = [
     //      output/仍在跑/還在跑/餘量/僅餘/沉默/在線/resource/到期/觸發/心跳/codex…),
     //      and
     //   3. it ENDS with the 🦞 sign-off (peers' machine heartbeats always do), and
-    //   4. it carries NO actionable-content marker (a card id, PR #, URL, or a
-    //      work verb 我修/修好/完成/我發現/待 review).
+    //   4. it carries NO actionable-content marker (a card id, PR #, URL, a work
+    //      verb 我修/修好/完成/我發現/待 review, OR an ACTIVE owner-ask:
+    //      請 owner / 需要你 / 授權 / rollback / 回滾 / 加額度 / 緊急 / urgent /
+    //      升級 / escalat). The active-ask markers were added after the audit
+    //      (card_c6731c2f) found the heuristic SUPPRESSED real escalations like
+    //      "請 owner 盡快決定要不要 rollback🦞" / "需要你授權加額度🦞" — both end in
+    //      🦞 and mention a heartbeat keyword but are genuine owner pings. The
+    //      PASSIVE "等 owner 處置/決定🦞" (bot waiting, not asking) deliberately
+    //      stays suppressed, so 決定/處置 are NOT in the exclusion list.
     // (1)+(2) say "looks like a heartbeat"; (3)+(4) are the false-positive guards
-    // that keep a REAL escalation forwarding — a genuine owner-ping won't append
-    // 🦞 and a real status report carries a card/PR/verb. The whole feature hinges
-    // on never eating a real escalation, so a borderline non-🦞 heartbeat narration
-    // deliberately FORWARDS (annoying noise ≪ an eaten escalation). NB: [\s\S]
-    // (not the /s flag) handles multi-line bodies; 🦞 is matched as a literal
-    // surrogate pair (no /u flag, consistent with the other patterns here).
-    ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?(?:收到|已收到|了解|#\d+\b)(?=[\s\S]*(?:watchdog|handoff|bridge|last\s*output|仍在跑|還在跑|餘量|僅餘|沉默|沈默|在線|resource|到期|觸發|心跳|heartbeat|codex))(?![\s\S]*(?:card_[0-9a-f]{6}|PR\s*#?\d|https?:\/\/|我修|修好|完成|我發現|待\s*review))[\s\S]*🦞[\s，,。.!！~]*$/i],
+    // that keep a REAL escalation forwarding. The whole feature hinges on never
+    // eating a real escalation, so a borderline narration deliberately FORWARDS
+    // (annoying noise ≪ an eaten escalation). NB: [\s\S] (not the /s flag) handles
+    // multi-line bodies; 🦞 is a literal surrogate pair (no /u flag, like the rest).
+    ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?(?:收到|已收到|了解|#\d+\b)(?=[\s\S]*(?:watchdog|handoff|bridge|last\s*output|仍在跑|還在跑|餘量|僅餘|沉默|沈默|在線|resource|到期|觸發|心跳|heartbeat|codex))(?![\s\S]*(?:card_[0-9a-f]{6}|PR\s*#?\d|https?:\/\/|我修|修好|完成|我發現|待\s*review|請\s*owner|需要你|授權|rollback|回滾|加\s*額度|加.{0,3}額度|緊急|urgent|升級|escalat))[\s\S]*🦞[\s，,。.!！~]*$/i],
 
     // ── Standalone lobster mascot ping (card_59f41e5b) ──
     // A bare 🦞 (optionally FWD-wrapped) carries no information.

--- a/backend/tests/jest/org-fwd-filter.test.js
+++ b/backend/tests/jest/org-fwd-filter.test.js
@@ -383,3 +383,28 @@ describe('isLowSignalFwd()', () => {
         });
     });
 });
+
+describe('audit card_c6731c2f regressions', () => {
+    describe('F7 — real 🦞-signed owner escalations must FORWARD (never eaten)', () => {
+        it('forwards an active owner-ping asking for a rollback decision', () => {
+            expect(isLowSignalFwd('收到，#6 watchdog 觸發了，請 owner 盡快決定要不要 rollback🦞')).toBe(false);
+        });
+        it('forwards an active resource / authorization escalation', () => {
+            expect(isLowSignalFwd('已收到，#1 還在跑，但 resource 快爆了，需要你授權加額度🦞')).toBe(false);
+        });
+        it('still SUPPRESSES a passive watchdog-narration heartbeat (bot waiting, not asking)', () => {
+            expect(classifyLowSignalFwd('收到，#6 last output 66m29s 前，bridge alive，沉默超 1h。等 owner 處置。🦞')).toBe('heartbeat');
+        });
+    });
+
+    describe('F4 — Codex status-heartbeat regex is not quadratic on long whitespace', () => {
+        it('classifies a real heartbeat and resists a pathological space run within budget', () => {
+            expect(classifyLowSignalFwd('Codex #5 status heartbeat')).toBe('heartbeat');
+            const evil = 'Codex ' + ' '.repeat(50000) + 'X';
+            const t0 = Date.now();
+            isLowSignalFwd(evil);
+            // was O(n^2): ~150ms at 20k spaces and climbing; the \s? bound keeps it flat.
+            expect(Date.now() - t0).toBeLessThan(250);
+        });
+    });
+});

--- a/backend/tests/jest/owner-decision-classifier.test.js
+++ b/backend/tests/jest/owner-decision-classifier.test.js
@@ -139,3 +139,41 @@ describe('classifier shape invariants', () => {
         ]);
     });
 });
+
+describe('audit card_c6731c2f — false-positive hardening', () => {
+    const fp = (s) => expect(classifyOwnerDecision(s).ownerOnly).toBe(false);
+    const tp = (s, cat) => {
+        const r = classifyOwnerDecision(s);
+        expect(r.ownerOnly).toBe(true);
+        if (cat) expect(r.categories).toContain(cat);
+    };
+
+    test('F1 — a bare $ no longer trips spend_cost (shell / template / jQuery)', () => {
+        fp('fix shell script using $1 and $PATH');
+        fp('template literal uses ${foo}');
+        fp('refactor the jQuery $ selector');
+    });
+    test('F1 — a real price shape still fires spend_cost', () => {
+        tp('bump the plan, it is $200 per month', 'spend_cost');
+        tp('花錢 $1,000 budget', 'spend_cost');
+    });
+    test('F2 — substring over-matches are gone (suspend / swipe / auto-purge / truncated)', () => {
+        fp('account suspended after 3 failed logins');
+        fp('fix swipe up gesture');
+        fp('auto-purge done cards via doneRetention');
+        fp('the log output was truncated');
+    });
+    test('F2 — the real words still fire', () => {
+        tp('we should spend more on infra', 'spend_cost');
+        tp('truncate the orders table', 'irreversible_data');
+        tp('purge the production database', 'irreversible_data');
+    });
+    test('F3 — casual 需要你 is not an explicit owner flag', () => {
+        fp('這個需要你確認一下');
+        fp('需要你幫忙看一下 log');
+    });
+    test('F3 — a deliberate 需要你<decision-verb> marker still forces ownerOnly', () => {
+        tp('需要你決策要不要 rollback', 'explicit_flag');
+        tp('這題需要你核可', 'explicit_flag');
+    });
+});


### PR DESCRIPTION
## Why
A self-audit (covering rate-limited #1's scheduled 12h PR Quality Audit) of this session's PRs #3756–#3762, with adversarial per-finding verification, surfaced **real defects in the just-shipped owner-decision + org-fwd features**. This PR fixes the confirmed, live ones.

## Fixes (all regression-tested)
**`owner-decision-classifier.js`**
- **F1 (HIGH):** bare `'$'` in `spend_cost.kws` + substring matching → ANY card with a dollar sign (`shell $1/$PATH`, `template ${foo}`, `jQuery $`) classified owner-only → flooded the 需要你 inbox the feature exists to keep short. `$` now requires a real price shape `/\$\s?\d[\d,.]+/` ($200/$1,000/$9.99 fire; $1/${foo}/$WORD don't).
- **F2:** substring over-match (`spend`→`suspend`, `wipe`→`swipe`, `purge`→`auto-purge`, `truncate`→`truncated`). Ambiguous EN words → word-boundary regexes; `purge` excludes the bot-resolvable `auto-purge` doneRetention flow.
- **F3:** bare `需要你` (everyday phrase + the inbox's own name) forced ownerOnly; now requires a deliberate decision verb (`需要你決策/核可/裁示/拍板/定奪/授權`).

**`org-fwd-filter.js`**
- **F4 (MED, quadratic ReDoS):** `Codex …status heartbeat` had two unbounded whitespace runs around `#?\d*` → O(n²) (~150ms@20k spaces). Bounded the middle gap to `\s?` (flat).
- **F7 (MED):** the Chinese peer-heartbeat shape-heuristic **suppressed genuine 🦞-signed owner escalations** (`請 owner …rollback🦞`, `需要你授權加額度🦞`) — violating its "never eat an escalation" invariant. Broadened the actionable-marker exclusion to active owner-asks; passive `等 owner 處置🦞` stays suppressed.

**`index.js`**
- **F9 (HIGH):** `recordSuppressedForward` emitted `suppression:logged` to a bare `deviceId` room, but portals join `device:${deviceId}` → the #3762 live feed never fired (silently fell back to 30s poll). Now targets the correct room.
- **F10 (LOW):** `GET /api/suppression-log` scopes a bot-authed (entityId) caller to its own suppressed forwards (mirrors `/api/b2b-status`); the owner `deviceSecret` path still sees the whole-device feed.

## Tests
+regression suites for F1/F2/F3 (classifier) and F7/F4 (org-fwd). Affected jest set green locally (**111 tests**).

## Not fixed (verified non-issues)
The audit's two "CRITICAL ReDoS" findings were on **#3759/#3760 intermediate regexes already replaced by #3761's shape heuristic** — not in live code (verified 0.3ms at 30k chars). No live DoS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)