### PR TITLE
fix(org-fwd): drop bare 緊急/urgent from F7 exclusion — stop passive-watchdog reflood (card_8008278a)

### DIFF
--- a/backend/org-fwd-filter.js
+++ b/backend/org-fwd-filter.js
@@ -132,12 +132,20 @@ const ORG_FWD_NOISE_GROUPS = [
     //      🦞 and mention a heartbeat keyword but are genuine owner pings. The
     //      PASSIVE "等 owner 處置/決定🦞" (bot waiting, not asking) deliberately
     //      stays suppressed, so 決定/處置 are NOT in the exclusion list.
+    //      ⚠ bare 緊急/urgent were REMOVED from the exclusion (card_8008278a): #5's
+    //      passive narration "…沉默 9h，等 owner 緊急處置🦞" repeats every ~15min and
+    //      the bare 緊急 forced every copy to FORWARD → flood. 緊急/urgent appear in
+    //      passive watchdog status, not just active asks; the active-ask markers
+    //      (請 owner / 需要你 / 授權 / rollback / 加額度 / 升級 / escalat) already
+    //      keep genuine pings forwarding, and the heartbeat SHAPE gate (ack-start +
+    //      🦞-end) means only machine-narration is affected — a fresh human-style
+    //      "緊急!" escalation won't match the shape and is never reached by this rule.
     // (1)+(2) say "looks like a heartbeat"; (3)+(4) are the false-positive guards
     // that keep a REAL escalation forwarding. The whole feature hinges on never
     // eating a real escalation, so a borderline narration deliberately FORWARDS
     // (annoying noise ≪ an eaten escalation). NB: [\s\S] (not the /s flag) handles
     // multi-line bodies; 🦞 is a literal surrogate pair (no /u flag, like the rest).
-    ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?(?:收到|已收到|了解|#\d+\b)(?=[\s\S]*(?:watchdog|handoff|bridge|last\s*output|仍在跑|還在跑|餘量|僅餘|沉默|沈默|在線|resource|到期|觸發|心跳|heartbeat|codex))(?![\s\S]*(?:card_[0-9a-f]{6}|PR\s*#?\d|https?:\/\/|我修|修好|完成|我發現|待\s*review|請\s*owner|需要你|授權|rollback|回滾|加\s*額度|加.{0,3}額度|緊急|urgent|升級|escalat))[\s\S]*🦞[\s，,。.!！~]*$/i],
+    ['heartbeat', /^\s*(?:\[📢\s*FWD\s+from\s+#\d+\]\s*)?(?:收到|已收到|了解|#\d+\b)(?=[\s\S]*(?:watchdog|handoff|bridge|last\s*output|仍在跑|還在跑|餘量|僅餘|沉默|沈默|在線|resource|到期|觸發|心跳|heartbeat|codex))(?![\s\S]*(?:card_[0-9a-f]{6}|PR\s*#?\d|https?:\/\/|我修|修好|完成|我發現|待\s*review|請\s*owner|需要你|授權|rollback|回滾|加\s*額度|加.{0,3}額度|升級|escalat))[\s\S]*🦞[\s，,。.!！~]*$/i],
 
     // ── Standalone lobster mascot ping (card_59f41e5b) ──
     // A bare 🦞 (optionally FWD-wrapped) carries no information.

--- a/backend/tests/jest/org-fwd-filter.test.js
+++ b/backend/tests/jest/org-fwd-filter.test.js
@@ -395,6 +395,17 @@ describe('audit card_c6731c2f regressions', () => {
         it('still SUPPRESSES a passive watchdog-narration heartbeat (bot waiting, not asking)', () => {
             expect(classifyLowSignalFwd('收到，#6 last output 66m29s 前，bridge alive，沉默超 1h。等 owner 處置。🦞')).toBe('heartbeat');
         });
+        // card_8008278a: bare 緊急/urgent were REMOVED from the forward-exclusion —
+        // #5's PASSIVE narration "…沉默 9h，等 owner 緊急處置🦞" repeats every ~15min
+        // and the bare 緊急 forced every copy to FORWARD (flood). It is passive
+        // watchdog status (等 owner 緊急處置), not an active ask, so it must SUPPRESS.
+        it('SUPPRESSES the repeating passive "等 owner 緊急處置" watchdog narration (flood fix)', () => {
+            expect(classifyLowSignalFwd('收到，#6 last output 565m58s，bridge alive，沉默 9h25m，heartbeat 延遲。等 owner 緊急處置。🦞')).toBe('heartbeat');
+        });
+        it('STILL forwards an active ask even though 緊急 is no longer a marker (請 owner / 授權 carry it)', () => {
+            expect(isLowSignalFwd('收到，#6 緊急！請 owner 盡快決定要不要 rollback🦞')).toBe(false);
+            expect(isLowSignalFwd('已收到 #1 緊急，需要你授權加額度🦞')).toBe(false);
+        });
     });
 
     describe('F4 — Codex status-heartbeat regex is not quadratic on long whitespace', () => {


### PR DESCRIPTION
## Why
PR #3763's F7 fix added `緊急/urgent` to the heartbeat shape-heuristic's forward-exclusion (so genuine owner escalations aren't eaten). But `緊急/urgent` also appear in #5's **passive** watchdog narration (`…沉默 9h，等 owner 緊急處置🦞`), which repeats ~every 15min — so every copy **forwarded** → channel flood (observed live for hours during the #6 outage).

## Fix
Remove bare `緊急/urgent` from the exclusion. Genuine **active** owner-asks still forward via the remaining markers (`請 owner / 需要你 / 授權 / rollback / 回滾 / 加額度 / 升級 / escalat`). The heartbeat **shape** gate (ack-start + heartbeat keyword + 🦞-end) means only machine-narration is affected; a fresh human-style "緊急!" escalation won't match the shape and never reaches this rule.

## Result
- passive `等 owner 緊急處置🦞` → re-**suppresses** (flood gone)
- active asks that also contain 緊急 → still **forward** (carry an active-ask marker)
- +2 regression tests; org-fwd suite **56/56 green**, ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)