### PR TITLE
feat(plan-e): wire ratify-loop — server-recompute + N-cap + dark worker pass (card_e9d01b6e)

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -33,6 +33,12 @@ const safeEqual = require('./safe-equal');
 // timeout-minutes from here. Tests may inject a `getDevicePrefs` override on the
 // factory options to avoid touching it.
 const devicePrefs = require('./device-preferences');
+// 計畫E ratify-loop (card_e9d01b6e): the fail-CLOSED green-light predicate that
+// decides whether an agent-consensus decision may be armed for *passive
+// default-agree* (silence ⇒ the decided option ships). NEVER trust an agent's
+// claimed mode — the server recomputes it here (PUT) and again at fire time
+// (worker). See ratify-reversibility.js for the design invariant.
+const { classifyRatifyMode } = require('./agent-improvement/ratify-reversibility');
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
@@ -52,6 +58,14 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 // re-requiring / re-instantiating the factory never stacks intervals.
 const TIMEOUT_SWEEP_INTERVAL_MS = 5 * 60 * 1000; // every 5 minutes
 let timeoutSweepTimer = null;
+
+// 計畫E ratify-loop (card_e9d01b6e). N-cap: after this many *armed* default_agree
+// rounds for one request, the server refuses to re-arm (forces hold) — a redo
+// loop can't silently auto-merge forever. Server-enforced via the audit trail
+// (not agent self-report). Default grace window before a default_agree row is
+// auto-resolved by silence reuses the 24h (1440-min) timeout default.
+const MAX_RATIFY_RETRIES = 2;
+const RATIFY_DEFAULT_GRACE_MINUTES = 1440;
 
 async function initAgentActionRequestsDatabase() {
     try {
@@ -209,6 +223,66 @@ function validateDecisionContext(value) {
     try { json = JSON.stringify(value); } catch (_) { return { ok: false, value: null }; }
     if (json == null || json.length > 8192) return { ok: false, value: null };
     return { ok: true, value: json };
+}
+
+// 計畫E ratify-loop (card_e9d01b6e). Build the RatifyInput the green-light
+// predicate expects from a request's prompt + its decisionContext.ratify block.
+function ratifyInputFrom(prompt, ratify) {
+    const r = (ratify && typeof ratify === 'object') ? ratify : {};
+    return {
+        proposalText: typeof prompt === 'string' ? prompt : '',
+        decidedOptionLabel: typeof r.decidedOptionLabel === 'string' ? r.decidedOptionLabel : '',
+        reversibilityClass: r.reversibilityClass,
+        changedFiles: Array.isArray(r.changedFiles) ? r.changedFiles : undefined,
+        diffSummary: typeof r.diffSummary === 'string' ? r.diffSummary : undefined,
+        prUrl: r.prUrl,
+        relatedCardText: typeof r.relatedCardText === 'string' ? r.relatedCardText : '',
+    };
+}
+
+// 計畫E ratify-loop (card_e9d01b6e). SERVER-AUTHORITATIVE recompute of a ratify
+// block's mode. NEVER trusts the agent-supplied `mode` — recomputes it via the
+// fail-closed green-light predicate, then applies the N-cap from the AUDIT trail
+// (how many prior default_agree arms this request already has). Returns a NEW
+// ratify object with server-stamped {mode, holdReasons, serverComputed, armedAt}.
+// `armedAt` is refreshed only when the new mode is default_agree (it anchors the
+// silence-grace window in the worker); a hold clears it.
+//   - mode='default_agree' ONLY when classifyRatifyMode says so AND prior arms < N
+//   - any predicate hold, classifier veto, or retry-cap → mode='hold'
+async function recomputeRatifyMode(client, requestId, prompt, ratify, nowMs) {
+    const r = (ratify && typeof ratify === 'object') ? { ...ratify } : {};
+    const verdict = classifyRatifyMode(ratifyInputFrom(prompt, r));
+    let mode = verdict.mode;
+    const holdReasons = [...(verdict.holdReasons || [])];
+
+    // N-cap (server-enforced, reconstructed from the immutable audit trail — not
+    // the agent's self-reported attempt counter). Count how many prior PUTs armed
+    // a default_agree ratify on THIS request; if we are at/over the cap, refuse.
+    let priorArms = 0;
+    try {
+        const c = await client.query(
+            `SELECT COUNT(*)::int AS n FROM agent_action_request_audit
+              WHERE request_id = $1
+                AND changes #>> '{decisionContext,new,ratify,mode}' = 'default_agree'`,
+            [requestId]
+        );
+        priorArms = (c.rows[0] && c.rows[0].n) || 0;
+    } catch (_) {
+        // Fail-closed: if we cannot establish the count, do not arm.
+        priorArms = MAX_RATIFY_RETRIES;
+        holdReasons.push('retry_count_unavailable');
+    }
+    if (mode === 'default_agree' && priorArms >= MAX_RATIFY_RETRIES) {
+        mode = 'hold';
+        holdReasons.push(`retry_cap_reached:${priorArms}/${MAX_RATIFY_RETRIES}`);
+    }
+
+    r.mode = mode;
+    r.holdReasons = holdReasons;
+    r.serverComputed = true;
+    r.priorArms = priorArms;
+    r.armedAt = mode === 'default_agree' ? nowMs : null;
+    return r;
 }
 
 function rowToApi(row) {
@@ -434,6 +508,78 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
     // row never aborts the sweep. Exported for direct test invocation. The
     // periodic timer is registered once at module init (NODE_ENV !== 'test').
     // ══════════════════════════════════════════════════════════════════════
+    // ══════════════════════════════════════════════════════════════════════
+    // 計畫E RATIFY PASS (card_e9d01b6e) — passive default-agree on silence.
+    // ──────────────────────────────────────────────────────────────────────
+    // DARK-LAUNCH: runs ONLY when a device has explicitly set the new pref
+    // `action_request_ratify_enabled === true` (default undefined/false ⇒ no-op).
+    //
+    // For each pending request whose decision_context.ratify was armed
+    // default_agree (server-stamped — see recomputeRatifyMode) and whose silence
+    // grace window has elapsed, this RE-RUNS the fail-closed green-light at fire
+    // time and, only if it still says default_agree, resolves the request with the
+    // decided option as the answer (silence ⇒ agree → the emitting agent merges
+    // its PR). If anything drifted (class/path/diff/veto), it HOLDS — never
+    // resolves. This is a SEPARATE pass from the timeout-policy worker so it is not
+    // skipped by 'keep' and not blocked by the decision_context pin (which keeps
+    // every OTHER owner-decision row waiting for Hank).
+    //
+    // Stacked safety: dark-default-off; matches ratify.mode==='default_agree'
+    // EXACTLY; re-derives the verdict at fire time; the N-cap already capped how
+    // many times it could be armed (PUT handler); grace anchored to armedAt.
+    // ══════════════════════════════════════════════════════════════════════
+    async function runRatifyPass(deviceId, prefs, device) {
+        if (!prefs || prefs.action_request_ratify_enabled !== true) return; // dark launch
+        const graceRaw = prefs.action_request_ratify_grace_minutes;
+        const graceMin = Number.isFinite(Number(graceRaw)) ? Number(graceRaw) : RATIFY_DEFAULT_GRACE_MINUTES;
+        const graceMs = graceMin * 60 * 1000;
+        const nowMs = Date.now();
+
+        let rows = [];
+        try {
+            const r = await pool.query(
+                `SELECT * FROM agent_action_requests
+                  WHERE device_id = $1 AND status = 'pending'
+                    AND decision_context #>> '{ratify,planE}' = 'true'
+                    AND decision_context #>> '{ratify,mode}' = 'default_agree'
+                  ORDER BY created_at ASC LIMIT ${MAX_LIST_LIMIT}`,
+                [deviceId]
+            );
+            rows = r.rows || [];
+        } catch (err) {
+            console.error(`[AgentActionRequests] ratify pass query failed device=${deviceId}:`, err.message);
+            return;
+        }
+
+        for (const row of rows) {
+            try {
+                const dc = row.decision_context || {};
+                const ratify = (dc && typeof dc === 'object' && dc.ratify) || {};
+                // Silence grace anchored to when default_agree was armed, not emit time.
+                const armedAt = Number(ratify.armedAt);
+                if (!Number.isFinite(armedAt) || (nowMs - armedAt) < graceMs) continue;
+                // RE-RUN the fail-closed green-light at fire time. Any drift ⇒ HOLD,
+                // never resolve (the whole point of double fail-closed).
+                const verdict = classifyRatifyMode(ratifyInputFrom(row.prompt, ratify));
+                if (verdict.mode !== 'default_agree') {
+                    log('info', `ratify fire-time gate HOLD id=${row.id}: ${verdict.holdReasons.join(';')}`, { deviceId });
+                    continue;
+                }
+                const answer = typeof ratify.decidedOptionLabel === 'string' ? ratify.decidedOptionLabel : '';
+                // Resolve via the shared path → notifies the emitter + emits
+                // kind='resolved' identically to a human answer; the agent merges.
+                await resolveActionRequest(
+                    deviceId, row.id,
+                    { text: `[計畫E 追認] 靜默逾時視同同意，依追認決定續跑：${answer}`, auto: true, reason: 'ratify_default_agree' },
+                    device
+                );
+                log('info', `ratify default_agree resolved id=${row.id} from=${row.from_entity_id}`, { deviceId });
+            } catch (rowErr) {
+                console.error(`[AgentActionRequests] ratify resolve failed id=${row.id}:`, rowErr.message);
+            }
+        }
+    }
+
     async function enforceActionRequestTimeouts() {
         let deviceIds = [];
         try {
@@ -450,6 +596,13 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
             try {
                 let prefs = {};
                 try { prefs = (await readDevicePrefs(deviceId)) || {}; } catch (_) { prefs = {}; }
+                // 計畫E (card_e9d01b6e): run the independent ratify pass FIRST — it is
+                // gated on its own dark-launch pref (action_request_ratify_enabled),
+                // must not be skipped by 'keep', and must run before the
+                // decision_context pin below (which keeps every OTHER owner-decision
+                // row waiting for Hank). Failure-isolated so it never aborts the sweep.
+                try { await runRatifyPass(deviceId, prefs, devices && devices[deviceId]); }
+                catch (e) { console.error(`[AgentActionRequests] ratify pass failed device=${deviceId}:`, e.message); }
                 const policy = prefs.action_request_timeout_policy || 'keep';
                 if (policy === 'keep') continue; // default: never auto-act
                 const minutesRaw = prefs.action_request_timeout_minutes;
@@ -831,6 +984,27 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
                 return res.status(409).json({ success: false, error: 'Only pending requests can be edited' });
             }
 
+            // 計畫E ratify-loop (card_e9d01b6e): if this edit arms a ratify block
+            // (decisionContext.ratify.planE), the server RE-DERIVES its mode here —
+            // the agent's claimed mode is never trusted. classifyRatifyMode is
+            // fail-closed and the N-cap is read from the audit trail (same txn, row
+            // already locked). The recomputed block (with server-stamped mode /
+            // holdReasons / armedAt) replaces what the agent sent.
+            if (hasDecisionContext && decisionContextNew != null) {
+                let dcObj = null;
+                try { dcObj = JSON.parse(decisionContextNew); } catch (_) { dcObj = null; }
+                if (dcObj && dcObj.ratify && typeof dcObj.ratify === 'object' && dcObj.ratify.planE === true) {
+                    const nowMs = Date.now();
+                    dcObj.ratify = await recomputeRatifyMode(client, id, before.prompt, dcObj.ratify, nowMs);
+                    decisionContextNew = JSON.stringify(dcObj);
+                    // Re-check the 8KB cap after the server stamp (holdReasons grow it).
+                    if (decisionContextNew.length > 8192) {
+                        await client.query('ROLLBACK');
+                        return res.status(400).json({ success: false, error: 'decisionContext too large after server ratify stamp' });
+                    }
+                }
+            }
+
             // Build the partial UPDATE + the per-field old→new change set. Only
             // fields whose value ACTUALLY changes are written / audited.
             const sets = [];
@@ -942,3 +1116,8 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
 };
 
 module.exports.initAgentActionRequestsDatabase = initAgentActionRequestsDatabase;
+// 計畫E (card_e9d01b6e): exported for unit tests — the SERVER-authoritative ratify
+// recompute (fail-closed mode + audit-trail N-cap) and its input builder.
+module.exports.recomputeRatifyMode = recomputeRatifyMode;
+module.exports.ratifyInputFrom = ratifyInputFrom;
+module.exports.MAX_RATIFY_RETRIES = MAX_RATIFY_RETRIES;

--- a/backend/agent-improvement/ratify-reversibility.js
+++ b/backend/agent-improvement/ratify-reversibility.js
@@ -1,0 +1,164 @@
+// 計畫E ratify-loop — reversibility/low-risk GREEN-LIGHT predicate (card_e9d01b6e).
+//
+// Decides whether an agent-consensus decision may be armed for *passive
+// default-agree* (silence ⇒ the decided option ships) versus must HOLD for an
+// explicit owner tap.
+//
+// 🔑 DESIGN INVARIANT (the whole point — see the card's design comment): the
+// owner-decision classifier is a VETO ONLY, never the green light. It DEFAULTS
+// ownerOnly=false (tuned to keep the 需要你 inbox short → its failure mode is a
+// false-NEGATIVE). For *surfacing* a false-negative is benign; for *default-
+// agree* the polarity flips and a false-negative would auto-ship an irreversible
+// change = fail-OPEN. So the green light is this SEPARATE, fail-CLOSED predicate:
+// a small reversible-class allowlist AND a branch-first prove (prUrl) AND a
+// diff/path scanner for irreversible-once-merged changes the lexicon can't see
+// (migrations, DROP/TRUNCATE, billing/auth/secret/deploy paths, fs.unlink) AND
+// the classifier not vetoing. ANY missing/unknown/oversized input ⇒ 'hold'.
+//
+// Pure, no DB/network. Imports classifyOwnerDecision for the veto only.
+
+'use strict';
+
+const { classifyOwnerDecision } = require('./owner-decision-classifier');
+
+// Only these change-classes are ever eligible for passive default-agree. Anything
+// else (or an unrecognised value) is NOT reversible-by-construction → hold.
+const ALLOWED_CLASSES = Object.freeze(new Set([
+    'config_toggle',        // a reversible feature-flag / pref flip
+    'copy_text',            // user-facing copy / i18n string
+    'reversible_code_branch', // ordinary code on an UNMERGED branch (revert = drop branch)
+    'doc',                  // docs / comments only
+]));
+
+// Cap on the text we will scan — an oversized/binary diff is un-auditable → hold.
+const MAX_DIFF_CHARS = 200000;
+
+// Changed-file paths that make a change irreversible-once-merged or high-blast —
+// these the keyword classifier cannot see (it only reads prose). Case-insensitive.
+const DENY_PATH_RES = Object.freeze([
+    /(^|\/)migrations?\//i,           // DB migrations
+    /_schema\.sql$/i,                 // schema DDL
+    /\.sql$/i,                        // any raw SQL file
+    /(^|\/)(billing|payments?|wallet|stripe)\b/i, // money paths
+    /(^|\/)(auth|oauth|session|login|password|credential)/i, // authn/z paths
+    /(secret|vault|\.env|private[_-]?key)/i,      // secrets
+    /(^|\/)(Dockerfile|Procfile|nixpacks\.toml|railway\.(json|toml)|fly\.toml)$/i, // deploy/infra
+    /\.github\/workflows\//i,         // CI definitions
+]);
+
+// Diff-content patterns that are destructive/irreversible regardless of path.
+const DENY_DIFF_RES = Object.freeze([
+    /\bDROP\s+(TABLE|COLUMN|DATABASE|SCHEMA|INDEX)\b/i,
+    /\bTRUNCATE\b/i,
+    /\bALTER\s+TABLE\b[\s\S]{0,80}?\bDROP\b/i,
+    /\bDELETE\s+FROM\b(?![\s\S]{0,200}?\bWHERE\b)/i, // DELETE without a WHERE in the next ~200 chars
+    /\bfs\.(unlink|rm|rmdir)\b/i,
+    /\brm\s+-rf\b/i,
+    /\bdropDatabase\b/i,
+]);
+
+/**
+ * @typedef {Object} RatifyInput
+ * @property {string}   proposalText        the action-request prompt / what the agents decided about
+ * @property {string}   decidedOptionLabel  the chosen option's STRING (load-bearing — feed it to the veto)
+ * @property {string}   reversibilityClass  one of ALLOWED_CLASSES (anything else ⇒ hold)
+ * @property {string[]} [changedFiles]      paths the PR touches (for the path scanner)
+ * @property {string}   [diffSummary]       unified diff or summary text (for the content scanner)
+ * @property {string}   [prUrl]             branch-first prove; absent ⇒ hold
+ * @property {string}   [relatedCardText]   optional extra context (title/desc/comment) for the veto
+ */
+
+/**
+ * @typedef {Object} RatifyVerdict
+ * @property {('default_agree'|'hold')} mode
+ * @property {string[]} holdReasons   why it is HOLD (empty when default_agree)
+ * @property {string}   summary
+ */
+
+function isHttpUrl(u) {
+    return typeof u === 'string' && /^https?:\/\/[^\s]+$/i.test(u.trim());
+}
+
+/**
+ * Fail-closed green-light predicate. Returns mode='default_agree' ONLY when every
+ * condition holds; otherwise 'hold' with the specific reasons.
+ * @param {RatifyInput} input
+ * @returns {RatifyVerdict}
+ */
+function classifyRatifyMode(input) {
+    const holdReasons = [];
+    const inp = (input && typeof input === 'object') ? input : {};
+
+    const proposalText = typeof inp.proposalText === 'string' ? inp.proposalText : '';
+    const decidedOptionLabel = typeof inp.decidedOptionLabel === 'string' ? inp.decidedOptionLabel : '';
+    const cls = typeof inp.reversibilityClass === 'string' ? inp.reversibilityClass.trim() : '';
+    const changedFiles = Array.isArray(inp.changedFiles) ? inp.changedFiles.filter(f => typeof f === 'string') : null;
+    const diffSummary = typeof inp.diffSummary === 'string' ? inp.diffSummary : '';
+    const prUrl = inp.prUrl;
+    const relatedCardText = typeof inp.relatedCardText === 'string' ? inp.relatedCardText : '';
+
+    // 1. Reversibility class must be in the allowlist (unknown/missing ⇒ hold).
+    if (!ALLOWED_CLASSES.has(cls)) {
+        holdReasons.push(`reversibility_class_not_allowed:${cls || 'missing'}`);
+    }
+
+    // 2. Branch-first prove: a real PR URL must be present (revert = drop the
+    //    unmerged branch; without a PR there is nothing cheap to revert).
+    if (!isHttpUrl(prUrl)) {
+        holdReasons.push('missing_or_invalid_pr_url');
+    }
+
+    // 3. We must actually have something to scan. A claim with neither changed
+    //    files nor a diff is un-auditable → hold (fail-closed).
+    if ((!changedFiles || changedFiles.length === 0) && !diffSummary.trim()) {
+        holdReasons.push('no_changed_files_or_diff_to_audit');
+    }
+    // Oversized/binary diff can't be audited → hold.
+    if (diffSummary.length > MAX_DIFF_CHARS) {
+        holdReasons.push('diff_too_large_to_audit');
+    }
+
+    // 4. Path scanner — any dangerous/irreversible-once-merged path ⇒ hold.
+    if (changedFiles) {
+        for (const f of changedFiles) {
+            const hit = DENY_PATH_RES.find(re => re.test(f));
+            if (hit) { holdReasons.push(`danger_path:${f}`); break; }
+        }
+    }
+
+    // 5. Diff-content scanner — destructive SQL / fs ops ⇒ hold.
+    if (diffSummary) {
+        const hit = DENY_DIFF_RES.find(re => re.test(diffSummary));
+        if (hit) { holdReasons.push(`destructive_diff:${hit.source.slice(0, 24)}`); }
+    }
+
+    // 6. Owner-decision VETO (necessary, NOT sufficient): if the proposal/decided
+    //    option reads as owner-only, force hold. (Never used as the green light.)
+    const vetoText = [proposalText, decidedOptionLabel, relatedCardText].filter(Boolean).join('\n');
+    let veto = { ownerOnly: true, categories: ['veto_eval_failed'] };
+    try {
+        veto = classifyOwnerDecision(vetoText);
+    } catch (_) {
+        holdReasons.push('classifier_veto_threw'); // fail-closed
+    }
+    if (veto && veto.ownerOnly) {
+        holdReasons.push(`owner_decision_veto:${(veto.categories || []).join(',') || 'ownerOnly'}`);
+    }
+
+    const mode = holdReasons.length === 0 ? 'default_agree' : 'hold';
+    return {
+        mode,
+        holdReasons,
+        summary: mode === 'default_agree'
+            ? `reversible/low-risk (${cls}) with PR + clean diff/path + no owner veto → eligible for passive default-agree`
+            : `HOLD — ${holdReasons.join('; ')}`,
+    };
+}
+
+module.exports = {
+    classifyRatifyMode,
+    ALLOWED_CLASSES,
+    MAX_DIFF_CHARS,
+    DENY_PATH_RES,
+    DENY_DIFF_RES,
+};

--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -68,6 +68,17 @@ const DEFAULTS = {
     // Deadline (minutes) after which the policy above fires. Default 1440 (24h).
     // Clamped to [5, 43200] (5 min .. 30 days).
     action_request_timeout_minutes: 1440,
+    // 計畫E ratify-loop (card_e9d01b6e). DARK-LAUNCH master switch: when true, the
+    // worker's independent ratify pass may passively default-agree (silence ⇒ the
+    // agent's server-armed decided option ships) on requests whose
+    // decision_context.ratify.mode was recomputed to 'default_agree'. DEFAULT FALSE
+    // — flipping it on in prod is the OWNER's decision; everything else (build /
+    // merge) ships dark. Consumed by runRatifyPass in agent-action-requests.js.
+    action_request_ratify_enabled: false,
+    // Silence grace (minutes) before an armed default_agree ratify auto-resolves,
+    // anchored to when it was armed (decision_context.ratify.armedAt), not emit
+    // time. Default 1440 (24h); clamped [5, 43200] like the timeout deadline.
+    action_request_ratify_grace_minutes: 1440,
 };
 
 const ACTION_REQUEST_TIMEOUT_POLICIES = new Set(['keep', 'auto_dismiss', 'safe_default', 'consensus']);
@@ -95,11 +106,14 @@ function coerceValue(key, raw) {
     // Auto-escalation toggles accept a real boolean OR the string 'true'/'false'
     // (a bare `!!raw` would coerce the string 'false' to true — wrong for an API
     // that may serialize the flag as a query/JSON string).
-    if (key === 'kanban_auto_escalate_enabled' || key === 'kanban_auto_escalate_skip_automation') {
+    if (key === 'kanban_auto_escalate_enabled' || key === 'kanban_auto_escalate_skip_automation'
+        || key === 'action_request_ratify_enabled') {
+        // 計畫E: ratify master switch — same string-safe boolean coercion (a bare
+        // `!!raw` would turn the string 'false' true, fail-OPEN for an auto-merge gate).
         return raw === true || raw === 'true';
     }
     if (typeof def === 'boolean') return !!raw;
-    if (key === 'action_request_timeout_minutes') {
+    if (key === 'action_request_timeout_minutes' || key === 'action_request_ratify_grace_minutes') {
         // parseInt-style coercion + clamp to [5, 43200]; invalid → default 1440.
         const n = parseInt(raw, 10);
         if (!Number.isFinite(n)) return def;

--- a/backend/tests/jest/ratify-loop-wiring.test.js
+++ b/backend/tests/jest/ratify-loop-wiring.test.js
@@ -1,0 +1,244 @@
+/**
+ * 計畫E ratify-loop WIRING tests (card_e9d01b6e).
+ *
+ * Two integration seams on top of the pure ratify-reversibility.js predicate:
+ *
+ *  1. recomputeRatifyMode (PUT handler): SERVER-authoritative — never trusts the
+ *     agent's claimed `mode`; re-derives it fail-closed AND applies the N-cap from
+ *     the immutable audit trail. Stamps armedAt only on default_agree.
+ *
+ *  2. runRatifyPass (worker): DARK-LAUNCH (action_request_ratify_enabled !== true ⇒
+ *     no-op / no query). When enabled, resolves only planE default_agree rows past
+ *     their armedAt silence grace, RE-RUNNING the green-light fail-closed at fire
+ *     time; any drift ⇒ HOLD (never resolves). Failure-isolated.
+ */
+'use strict';
+
+const mockPoolQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockPoolQuery,
+        connect: jest.fn().mockResolvedValue({ query: mockPoolQuery, release: jest.fn() }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const factory = require('../../agent-action-requests');
+const { recomputeRatifyMode, ratifyInputFrom, MAX_RATIFY_RETRIES } = factory;
+
+const deviceId = 'dev-1';
+const UUID = '11111111-2222-3333-4444-555555555555';
+const PR = 'https://github.com/HankHuang0516/EClaw/pull/9999';
+
+afterEach(() => { mockPoolQuery.mockReset(); mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 }); });
+
+// ───────────────────────── recomputeRatifyMode (PUT seam) ─────────────────────────
+describe('recomputeRatifyMode — server-authoritative mode + audit-trail N-cap', () => {
+    // a stub client whose audit-count query returns `n` prior default_agree arms.
+    const clientWithArms = (n) => ({ query: jest.fn().mockResolvedValue({ rows: [{ n }] }) });
+
+    const cleanRatify = (over = {}) => ({
+        planE: true,
+        decidedOptionLabel: 'use the friendlier copy',
+        reversibilityClass: 'copy_text',
+        changedFiles: ['backend/public/portal/chat.html'],
+        diffSummary: '- old\n+ new friendlier copy',
+        prUrl: PR,
+        mode: 'default_agree', // agent-claimed — must be IGNORED and recomputed
+        ...over,
+    });
+
+    test('a clean reversible proposal with 0 prior arms ⇒ default_agree + armedAt stamped', async () => {
+        const out = await recomputeRatifyMode(clientWithArms(0), UUID, 'tweak copy', cleanRatify(), 1700);
+        expect(out.mode).toBe('default_agree');
+        expect(out.serverComputed).toBe(true);
+        expect(out.armedAt).toBe(1700);
+        expect(out.priorArms).toBe(0);
+    });
+
+    test('NEVER trusts the agent-claimed mode: claimed default_agree but danger path ⇒ hold', async () => {
+        const out = await recomputeRatifyMode(
+            clientWithArms(0), UUID, 'touch auth',
+            cleanRatify({ reversibilityClass: 'reversible_code_branch', changedFiles: ['backend/auth.js'], mode: 'default_agree' }),
+            1700,
+        );
+        expect(out.mode).toBe('hold');
+        expect(out.armedAt).toBeNull();
+        expect(out.holdReasons.join(';')).toMatch(/danger_path/);
+    });
+
+    test('owner-decision veto in the proposal forces hold even when the agent claims default_agree', async () => {
+        const out = await recomputeRatifyMode(
+            clientWithArms(0), UUID, '加預算升級付費訂閱方案',
+            cleanRatify({ decidedOptionLabel: '核准付費' }), 1700,
+        );
+        expect(out.mode).toBe('hold');
+        expect(out.holdReasons.join(';')).toMatch(/owner_decision_veto/);
+    });
+
+    test('N-cap: at MAX_RATIFY_RETRIES prior arms, a would-be default_agree is forced to hold', async () => {
+        const out = await recomputeRatifyMode(clientWithArms(MAX_RATIFY_RETRIES), UUID, 'tweak copy', cleanRatify(), 1700);
+        expect(out.mode).toBe('hold');
+        expect(out.armedAt).toBeNull();
+        expect(out.holdReasons.join(';')).toMatch(/retry_cap_reached/);
+    });
+
+    test('N-cap boundary: exactly MAX-1 prior arms still permits default_agree', async () => {
+        const out = await recomputeRatifyMode(clientWithArms(MAX_RATIFY_RETRIES - 1), UUID, 'tweak copy', cleanRatify(), 1700);
+        expect(out.mode).toBe('default_agree');
+    });
+
+    test('fail-closed when the audit count query throws (count unavailable ⇒ hold)', async () => {
+        const client = { query: jest.fn().mockRejectedValue(new Error('db down')) };
+        const out = await recomputeRatifyMode(client, UUID, 'tweak copy', cleanRatify(), 1700);
+        expect(out.mode).toBe('hold');
+        expect(out.holdReasons.join(';')).toMatch(/retry_count_unavailable/);
+    });
+
+    test('ratifyInputFrom maps the ratify block + prompt into the predicate input shape', () => {
+        const inp = ratifyInputFrom('the proposal', { decidedOptionLabel: 'go', reversibilityClass: 'doc', prUrl: PR });
+        expect(inp.proposalText).toBe('the proposal');
+        expect(inp.decidedOptionLabel).toBe('go');
+        expect(inp.reversibilityClass).toBe('doc');
+        expect(inp.prUrl).toBe(PR);
+    });
+});
+
+// ───────────────────────── runRatifyPass (worker seam) ─────────────────────────
+function buildModule({ prefs } = {}) {
+    const emitToRoom = jest.fn();
+    const io = { to: jest.fn(() => ({ emit: emitToRoom })) };
+    const unifiedPush = jest.fn().mockResolvedValue({ pushed: true });
+    const pushToBot = jest.fn().mockResolvedValue({ pushed: true });
+    const getDevicePrefs = jest.fn().mockResolvedValue(prefs);
+    const dev = {
+        [deviceId]: {
+            deviceSecret: 'sek',
+            entities: { 1: { isBound: true, botSecret: 'bot-1', bindingType: 'channel' } },
+        },
+    };
+    const mod = factory(dev, { serverLog: () => {}, io, unifiedPush, pushToBot, getDevicePrefs });
+    return { mod, emitToRoom, unifiedPush };
+}
+
+// a pending row whose decision_context.ratify is armed default_agree.
+function ratifyRow(over = {}, ratifyOver = {}) {
+    return {
+        id: UUID, device_id: deviceId, from_entity_id: 1, anchor_message_id: null,
+        type: 'decision', prompt: 'ship the friendlier copy?', options: null,
+        status: 'pending', answer: null,
+        created_at: new Date('2026-06-01T00:00:00Z'), resolved_at: null, consensus_triggered_at: null,
+        decision_context: {
+            ratify: {
+                planE: true, mode: 'default_agree', decidedOptionLabel: 'ship it',
+                reversibilityClass: 'copy_text', changedFiles: ['backend/public/portal/chat.html'],
+                diffSummary: '+ friendlier copy', prUrl: PR, armedAt: 1000, ...ratifyOver,
+            },
+        },
+        ...over,
+    };
+}
+
+describe('runRatifyPass via enforceActionRequestTimeouts — dark launch + fire-time fail-closed', () => {
+    test('DARK LAUNCH: ratify_enabled unset ⇒ no ratify query at all (device scan only, policy=keep)', async () => {
+        const { mod } = buildModule({ prefs: { action_request_timeout_policy: 'keep' } });
+        mockPoolQuery.mockResolvedValueOnce({ rows: [{ device_id: deviceId }] }); // scan
+        await mod.enforceActionRequestTimeouts();
+        // only the DISTINCT scan ran — ratify pass returned before querying, keep skipped the rest
+        expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+        expect(mockPoolQuery.mock.calls[0][0]).toMatch(/SELECT DISTINCT device_id/);
+    });
+
+    test('enabled + default_agree row past grace ⇒ resolve with reason ratify_default_agree', async () => {
+        const { mod, emitToRoom, unifiedPush } = buildModule({
+            prefs: { action_request_ratify_enabled: true, action_request_ratify_grace_minutes: 1, action_request_timeout_policy: 'keep' },
+        });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }] })                 // scan
+            .mockResolvedValueOnce({ rows: [ratifyRow()] })                             // ratify candidate SELECT (armedAt=1000, far in the past)
+            .mockResolvedValueOnce({ rows: [ratifyRow({ status: 'resolved', resolved_at: new Date() })] }); // resolve UPDATE
+        await mod.enforceActionRequestTimeouts();
+
+        // candidate SELECT filters on planE + mode=default_agree
+        expect(mockPoolQuery.mock.calls[1][0]).toMatch(/ratify,planE/);
+        expect(mockPoolQuery.mock.calls[1][0]).toMatch(/ratify,mode/);
+        // the resolve UPDATE carried the ratify answer payload
+        const resolveCall = mockPoolQuery.mock.calls[2];
+        expect(resolveCall[0]).toMatch(/SET status = 'resolved'/);
+        const answer = JSON.parse(resolveCall[1][0]);
+        expect(answer.reason).toBe('ratify_default_agree');
+        expect(answer.auto).toBe(true);
+        expect(emitToRoom).toHaveBeenCalledWith('action_request:changed', { kind: 'resolved', requestId: UUID, fromEntityId: 1 });
+        expect(unifiedPush.mock.calls.some(c => /RESOLVED/.test(c[3].message))).toBe(true);
+    });
+
+    test('enabled but row NOT past grace (armedAt recent) ⇒ no resolve', async () => {
+        const recent = Date.now() - 1000; // 1s ago, grace is 1440min default
+        const { mod, emitToRoom } = buildModule({ prefs: { action_request_ratify_enabled: true, action_request_timeout_policy: 'keep' } });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }] })
+            .mockResolvedValueOnce({ rows: [ratifyRow({}, { armedAt: recent })] });
+        await mod.enforceActionRequestTimeouts();
+        // scan + candidate SELECT only; no resolve UPDATE
+        expect(mockPoolQuery).toHaveBeenCalledTimes(2);
+        expect(emitToRoom).not.toHaveBeenCalled();
+    });
+
+    test('FIRE-TIME fail-closed: armed default_agree but danger path now ⇒ HOLD, no resolve', async () => {
+        const { mod, emitToRoom } = buildModule({
+            prefs: { action_request_ratify_enabled: true, action_request_ratify_grace_minutes: 1, action_request_timeout_policy: 'keep' },
+        });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }] })
+            .mockResolvedValueOnce({ rows: [ratifyRow({}, { reversibilityClass: 'reversible_code_branch', changedFiles: ['backend/auth.js'] })] });
+        await mod.enforceActionRequestTimeouts();
+        // re-derive at fire time HOLDs → no resolve UPDATE
+        expect(mockPoolQuery).toHaveBeenCalledTimes(2);
+        expect(emitToRoom).not.toHaveBeenCalled();
+    });
+
+    test('ratify pass is failure-isolated: a throwing candidate SELECT does not abort the sweep', async () => {
+        const { mod } = buildModule({ prefs: { action_request_ratify_enabled: true, action_request_timeout_policy: 'keep' } });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }] }) // scan
+            .mockRejectedValueOnce(new Error('boom'));                  // ratify SELECT throws
+        // keep policy means nothing else runs; the point is it does not throw out of the sweep
+        await expect(mod.enforceActionRequestTimeouts()).resolves.toBeUndefined();
+    });
+});
+
+// ───────────────────────── device-preferences coercion ─────────────────────────
+describe('device-preferences: ratify pref coercion (dark-launch safe)', () => {
+    const devicePrefs = require('../../device-preferences');
+
+    test('DEFAULTS: ratify disabled + 1440-min grace', () => {
+        expect(devicePrefs.DEFAULTS.action_request_ratify_enabled).toBe(false);
+        expect(devicePrefs.DEFAULTS.action_request_ratify_grace_minutes).toBe(1440);
+    });
+
+    test('action_request_ratify_enabled string-safe: only true/`true` enable; `false`/junk stay off', async () => {
+        const written = [];
+        const stubPool = { query: jest.fn((sql, params) => { written.push({ sql, params }); return Promise.resolve({ rows: [] }); }) };
+        await devicePrefs.initTable(stubPool);
+        const readBack = () => JSON.parse(written[written.length - 1].params[1]);
+        const cases = [[true, true], ['true', true], [false, false], ['false', false], ['nonsense', false], [1, false]];
+        for (const [input, expected] of cases) {
+            written.length = 0;
+            await devicePrefs.updatePrefs(deviceId, { action_request_ratify_enabled: input });
+            expect(readBack().action_request_ratify_enabled).toBe(expected);
+        }
+    });
+
+    test('action_request_ratify_grace_minutes clamps [5,43200]; invalid → 1440', async () => {
+        const written = [];
+        const stubPool = { query: jest.fn((sql, params) => { written.push({ sql, params }); return Promise.resolve({ rows: [] }); }) };
+        await devicePrefs.initTable(stubPool);
+        const readBack = () => JSON.parse(written[written.length - 1].params[1]);
+        const cases = [[1, 5], [5, 5], [60, 60], [99999, 43200], ['120', 120], ['oops', 1440], [null, 1440]];
+        for (const [input, expected] of cases) {
+            written.length = 0;
+            await devicePrefs.updatePrefs(deviceId, { action_request_ratify_grace_minutes: input });
+            expect(readBack().action_request_ratify_grace_minutes).toBe(expected);
+        }
+    });
+});

--- a/backend/tests/jest/ratify-reversibility.test.js
+++ b/backend/tests/jest/ratify-reversibility.test.js
@@ -1,0 +1,111 @@
+/**
+ * 計畫E ratify-reversibility — unit tests (card_e9d01b6e).
+ *
+ * The green-light predicate is fail-CLOSED: default_agree ONLY when a reversible
+ * class + a real PR + a clean diff/path scan + no owner-decision veto all hold.
+ * These tests pin every HOLD path so a regression can't silently widen
+ * auto-merge eligibility.
+ */
+'use strict';
+
+const { classifyRatifyMode, ALLOWED_CLASSES } = require('../../agent-improvement/ratify-reversibility');
+
+const base = (over = {}) => ({
+    proposalText: 'Tweak the empty-state copy on the dashboard',
+    decidedOptionLabel: 'use the friendlier wording',
+    reversibilityClass: 'copy_text',
+    changedFiles: ['backend/public/portal/chat.html'],
+    diffSummary: '- old copy\n+ new friendlier copy',
+    prUrl: 'https://github.com/HankHuang0516/EClaw/pull/9999',
+    ...over,
+});
+
+const mode = (over) => classifyRatifyMode(base(over)).mode;
+
+describe('classifyRatifyMode — the happy (default_agree) path', () => {
+    test('reversible copy change with PR + clean diff + no veto ⇒ default_agree', () => {
+        const v = classifyRatifyMode(base());
+        expect(v.mode).toBe('default_agree');
+        expect(v.holdReasons).toEqual([]);
+    });
+    test('each allowed class can pass when everything else is clean', () => {
+        for (const cls of ALLOWED_CLASSES) {
+            expect(mode({ reversibilityClass: cls,
+                proposalText: 'minor reversible change', decidedOptionLabel: 'do the small thing',
+                diffSummary: '+ a harmless line' })).toBe('default_agree');
+        }
+    });
+});
+
+describe('classifyRatifyMode — fail-closed HOLD paths', () => {
+    test('unknown / missing reversibility class ⇒ hold', () => {
+        expect(mode({ reversibilityClass: 'something_new' })).toBe('hold');
+        expect(mode({ reversibilityClass: undefined })).toBe('hold');
+    });
+    test('missing or non-http PR url ⇒ hold (branch-first prove)', () => {
+        expect(mode({ prUrl: undefined })).toBe('hold');
+        expect(mode({ prUrl: 'not-a-url' })).toBe('hold');
+        expect(mode({ prUrl: 'javascript:alert(1)' })).toBe('hold');
+    });
+    test('no changed files AND no diff ⇒ hold (un-auditable)', () => {
+        expect(mode({ changedFiles: [], diffSummary: '' })).toBe('hold');
+    });
+    test('oversized diff ⇒ hold', () => {
+        expect(mode({ diffSummary: 'x'.repeat(200001) })).toBe('hold');
+    });
+
+    describe('path scanner — irreversible-once-merged / high-blast paths', () => {
+        const cases = [
+            'backend/migrations/0007_drop_legacy.sql',
+            'backend/agent_action_requests_schema.sql',
+            'backend/billing/charge.js',
+            'backend/auth.js',
+            'backend/routes/oauth-callback.js',
+            'backend/.env.production',
+            'Dockerfile',
+            'railway.json',
+            '.github/workflows/ci.yml',
+        ];
+        test.each(cases)('danger path %s ⇒ hold', (f) => {
+            expect(mode({ reversibilityClass: 'reversible_code_branch', changedFiles: [f] })).toBe('hold');
+        });
+        test('an ordinary source path does NOT trip the scanner', () => {
+            expect(mode({ reversibilityClass: 'reversible_code_branch',
+                changedFiles: ['backend/utils/format.js'] })).toBe('default_agree');
+        });
+    });
+
+    describe('diff-content scanner — destructive ops regardless of path', () => {
+        const danger = [
+            'ALTER TABLE users DROP COLUMN email;',
+            'DROP TABLE sessions;',
+            'TRUNCATE chat_history;',
+            'DELETE FROM devices;',          // no WHERE
+            'await fs.unlink(path);',
+            'rm -rf /var/data',
+        ];
+        test.each(danger)('destructive diff %s ⇒ hold', (d) => {
+            expect(mode({ reversibilityClass: 'reversible_code_branch', diffSummary: d })).toBe('hold');
+        });
+        test('a scoped DELETE ... WHERE is not flagged by the no-WHERE rule', () => {
+            expect(mode({ reversibilityClass: 'reversible_code_branch',
+                diffSummary: 'DELETE FROM devices WHERE id = $1;' })).toBe('default_agree');
+        });
+    });
+
+    describe('owner-decision classifier is a VETO (necessary, never the green light)', () => {
+        test('an owner-only proposal ⇒ hold even with a clean diff + PR + allowed class', () => {
+            expect(mode({ proposalText: '加預算改用付費方案 升級訂閱', decidedOptionLabel: '核准付費' })).toBe('hold');
+            expect(mode({ proposalText: 'this is owner-only / 不可授權', decidedOptionLabel: 'go' })).toBe('hold');
+        });
+        test('relatedCardText also feeds the veto', () => {
+            expect(mode({ relatedCardText: '這操作不可逆，會抹除資料' })).toBe('hold');
+        });
+    });
+
+    test('fail-closed on a non-object input', () => {
+        expect(classifyRatifyMode(undefined).mode).toBe('hold');
+        expect(classifyRatifyMode(null).mode).toBe('hold');
+        expect(classifyRatifyMode('nope').mode).toBe('hold');
+    });
+});

--- a/docs/specs/plan-e-ratify-loop-spec.md
+++ b/docs/specs/plan-e-ratify-loop-spec.md
@@ -1,0 +1,76 @@
+# 計畫E — 「需要你」決策追認 (ratify) 迴圈
+
+> Status: **dark-launched** (server pref `action_request_ratify_enabled` default **OFF**).
+> Card: card_e9d01b6e. Builds on the owner-decision inbox infra (decision_context
+> JSONB, PUT edit endpoint, resolve push-back, timeout worker) — **no schema
+> migration, no new endpoint**.
+
+## What it is
+
+計畫B 第二階段。When autonomous agents reach a consensus decision on a *reversible,
+low-risk* change, instead of silently auto-executing (resolve) or blocking forever
+waiting for Hank, they **arm a ratify row**: the decided option is written back and,
+if Hank stays silent past a grace window, **silence is treated as agreement** and the
+agent ships its (already-open, unmerged) PR. If Hank vetoes (answers anything other
+than the decided option) the agent abandons the branch and re-implements.
+
+The whole design rests on one invariant:
+
+> 🔑 **The owner-decision classifier is a VETO ONLY, never the green light.** It
+> defaults `ownerOnly=false` (tuned to keep the 需要你 inbox short → its failure mode
+> is a false-NEGATIVE). Surfacing a false-negative is benign; *default-agreeing* on
+> one would auto-ship an irreversible change = **fail-OPEN**. So the green light is a
+> SEPARATE, fail-CLOSED predicate (`backend/agent-improvement/ratify-reversibility.js`)
+> and the classifier can only ever force HOLD.
+
+## Server pieces (this PR)
+
+| piece | file | behaviour |
+|---|---|---|
+| green-light predicate | `agent-improvement/ratify-reversibility.js` | `classifyRatifyMode()` → `default_agree` ONLY when reversible-class ∈ {config_toggle, copy_text, reversible_code_branch, doc} AND a real `prUrl` AND a clean diff/path scan (no migrations / DROP·TRUNCATE / billing·auth·secret·deploy paths / `fs.unlink`) AND the classifier does not veto. Anything missing/unknown/oversized ⇒ `hold`. |
+| PUT recompute + N-cap | `agent-action-requests.js` `recomputeRatifyMode()` | On `PUT /api/action-requests/:id` with a `decisionContext.ratify.planE` block, the server **re-derives** the mode (the agent's claimed `mode` is ignored) and stamps `armedAt`. **N-cap**: after `MAX_RATIFY_RETRIES` (2) prior armed default_agree rounds — counted from the immutable `agent_action_request_audit` trail, not agent self-report — a would-be default_agree is forced to `hold`. |
+| worker ratify pass | `agent-action-requests.js` `runRatifyPass()` | A SEPARATE pass in the 5-min sweep, gated on `action_request_ratify_enabled === true` (dark default off). Resolves only planE `default_agree` rows past their `armedAt` + grace, **re-running the green-light fail-closed at fire time**; any drift ⇒ HOLD (never resolves). Runs before the timeout-policy `keep` short-circuit and does NOT disturb the L477 pin that keeps every *other* owner-decision row waiting for Hank. |
+| prefs | `device-preferences.js` | `action_request_ratify_enabled` (bool, default false, string-safe) + `action_request_ratify_grace_minutes` (default 1440, clamped [5,43200]). |
+
+Stacked fail-closed: dark-default-off · matches `ratify.mode==='default_agree'` exactly ·
+re-derives the verdict at fire time · N-cap from the audit trail · grace anchored to `armedAt`.
+
+## Agent loop (how an agent uses it)
+
+```
+1. Reach consensus on a change. Open a PR (branch-first — do NOT merge yet).
+2. PUT /api/action-requests/:id with:
+     decisionContext.ratify = {
+       planE: true,
+       decidedOptionIndex, decidedOptionLabel,   // the option you'll implement
+       note: '將以此實作',
+       reversibilityClass,                        // config_toggle | copy_text | reversible_code_branch | doc
+       prUrl, headSha,                            // the unmerged PR + its head sha
+       changedFiles: [...], diffSummary: '...'    // for the server path/diff scan
+     }
+   → the SERVER recomputes ratify.mode. Read it back:
+       mode==='default_agree' → armed; silence past grace will resolve → you merge.
+       mode==='hold'          → NOT armed; this needs an explicit owner tap. Wait.
+3. On resolve push-back (notifyAgentResolved):
+     answer === decidedOptionLabel (or silence-default) → VERIFY HEAD === ratify.headSha,
+       then merge the PR.
+     answer !== decidedOptionLabel (veto) → ABANDON the unmerged branch, re-implement,
+       PUT again (attempt++). At MAX_RATIFY_RETRIES the server refuses to re-arm
+       (mode forced hold) → escalate to Hank.
+```
+
+`recommendedOptionIndex` (owner-decision inbox) is **record-only**; `ratify.note='將以此實作'`
+is the load-bearing signal that silence ships. The chat UI must visibly distinguish the two
+(see the front-end child card).
+
+## Front-end (separate child card → #6)
+
+A ratify badge on the 需要你 inbox item: `⏳ 追認中 · 靜默視同同意` + a countdown to
+`armedAt + grace`, or `需你核可` for a hold. XSS-safe (`textContent`), EN+ZH+zh-CN i18n.
+Only renders once `action_request_ratify_enabled` is on, so it does not affect prod today.
+
+## Go-live (OWNER decision)
+
+Everything above ships dark. The ONLY owner step is flipping
+`action_request_ratify_enabled = true` for the device in prod. Before that, the
+front-end badge child + a vision-check pass should land.


### PR DESCRIPTION
## 計畫E — 「需要你」決策追認(ratify)迴圈 (card_e9d01b6e, 計畫B 第二階段)

Ships **DARK**: server pref `action_request_ratify_enabled` default **OFF** → zero prod behaviour change until the owner flips it. No schema migration, no new endpoint.

### Invariant
The owner-decision classifier is a **VETO ONLY** (it defaults `ownerOnly=false` → fail-NEGATIVE; using it as the green light would fail-OPEN for auto-merge). The green light is a SEPARATE fail-CLOSED predicate (`ratify-reversibility.js`).

### What this wires
- **`recomputeRatifyMode()` (PUT `/api/action-requests/:id`)** — server re-derives `ratify.mode` (agent-claimed mode **ignored**), stamps `armedAt`, applies the **N-cap** (≥2 prior armed `default_agree` rounds, counted from the immutable `agent_action_request_audit` trail — not agent self-report — force `hold`), re-checks the 8KB cap.
- **`runRatifyPass()` (worker)** — a SEPARATE 5-min sweep pass gated on the dark pref; resolves only planE `default_agree` rows past their `armedAt` grace, **re-running the green-light fail-closed at fire time** (any drift ⇒ HOLD). Runs before the timeout `keep` short-circuit; leaves the owner-decision pin (every *other* `decision_context` row) intact. Failure-isolated.
- **prefs** — `action_request_ratify_enabled` (bool, default false, string-safe boolean) + `action_request_ratify_grace_minutes` (default 1440, clamped [5,43200]).
- **docs** — `docs/specs/plan-e-ratify-loop-spec.md` (agent runbook + invariant).

### Stacked fail-closed
dark-default-off · matches `ratify.mode==='default_agree'` exactly · re-derives at fire time · N-cap from audit trail · grace anchored to `armedAt`.

### Tests
`ratify-loop-wiring.test.js` (15): recompute override / N-cap / armedAt / audit-count-failure-fail-closed; worker dark-launch / grace / fire-time-HOLD / failure-isolation; pref coercion. Plus `ratify-reversibility.test.js` (26). **Full backend jest: 5582 pass / 0 fail.**

### Out of scope (follow-up)
chat.html ratify badge (`⏳追認中·靜默視同同意`+countdown / `需你核可`, XSS-safe, EN+ZH) → separate child card for #6 design + vision-check before go-live. The only owner step is flipping the pref ON in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)