### PR TITLE
fix(portal-auth): cold-start 503/429 must not redirect-loop (dashboard crash loop)

### DIFF
--- a/backend/public/portal/shared/auth.js
+++ b/backend/public/portal/shared/auth.js
@@ -180,9 +180,21 @@ async function checkAuth() {
         // Distinguish transport-level disconnect from auth-level failure.
         // api.js tags fetch-throw with `networkError:true`; do NOT force logout
         // on transport blips — show the reconnect overlay and keep session state.
-        if (e && (e.networkError || e.name === 'TypeError'
+        // Transient backend unavailability is NOT an auth failure. A cold-start
+        // (Railway redeploy) returns 503 "Server starting up"; an overload returns
+        // 429; a proxy hiccup returns 502/504 or a non-JSON body — none of these
+        // mean the user is logged out. Redirecting to index.html here caused a
+        // CRASH LOOP (card_<dashboard-crash-loop> 2026-06-27): the login page
+        // re-runs checkAuth, hits the same 503, redirects to itself again, forever.
+        // Treat these like a transport blip — keep the session, show the reconnect
+        // overlay (it retries with backoff), and do NOT redirect.
+        const st = e && e.status;
+        const transientStatus = st === 503 || st === 429 || st === 502 || st === 504;
+        const looksTransient = e && typeof e.message === 'string'
+            && /starting up|non-JSON response|temporarily unavailable|service unavailable/i.test(e.message);
+        if (e && (e.networkError || e.name === 'TypeError' || transientStatus || looksTransient
             || (typeof navigator !== 'undefined' && navigator.onLine === false))) {
-            console.warn('[Auth] checkAuth transport failure (network) — keeping session, showing reconnect overlay:', e.message || e);
+            console.warn('[Auth] checkAuth transient/unavailable — keeping session, showing reconnect overlay (no redirect):', st || e.message || e);
             try {
                 if (window.__reconnectOverlay && typeof window.__reconnectOverlay.show === 'function') {
                     window.__reconnectOverlay.show();
@@ -190,8 +202,13 @@ async function checkAuth() {
             } catch (_) { /* overlay optional */ }
             return null;
         }
-        console.error('[Auth] checkAuth failed, redirecting to login:', e.message || e);
-        window.location.href = 'index.html';
+        // Genuine auth failure (401 etc). Redirect to login — but NEVER from
+        // index.html itself (defense-in-depth: a redirect to the page you are
+        // already on is the loop we are guarding against).
+        const onLoginPage = typeof window !== 'undefined' && window.location
+            && /(?:^|\/)index\.html$/.test(window.location.pathname || '');
+        console.error('[Auth] checkAuth failed (auth), redirecting to login:', st || e.message || e);
+        if (!onLoginPage) window.location.href = 'index.html';
         return null;
     }
 }

--- a/backend/tests/jest/portal-auth-coldstart-no-redirect-loop.test.js
+++ b/backend/tests/jest/portal-auth-coldstart-no-redirect-loop.test.js
@@ -1,0 +1,155 @@
+/**
+ * Portal auth — backend cold-start / rate-limit must NOT redirect-loop.
+ *
+ * Incident 2026-06-27 (Hank: "儀表板目前崩潰loop"): after a Railway redeploy the
+ * backend returns 503 "Server starting up" (and 429 under the dashboard's load
+ * fan-out) for ~30-60s. shared/auth.js `checkAuth()` treated that thrown error
+ * as an AUTH failure and did `window.location.href = 'index.html'`. The login
+ * page re-runs checkAuth, hits the same 503, redirects to itself again → an
+ * infinite redirect/reload CRASH LOOP on every portal page.
+ *
+ * Fix: checkAuth treats 503/429/502/504 + "starting up"/non-JSON bodies as
+ * TRANSIENT (keep session, show reconnect overlay, no redirect), and never
+ * redirects from index.html itself. Only a genuine 401 redirects.
+ *
+ * This is the regression gate Hank asked for ("以後漏掉的缺口都要有testcase或
+ * git ci test"): it exercises the FAILURE path (mock 503/429) the mock-200
+ * vision-checks never reached. Loads api.js + auth.js into a vm sandbox and
+ * runs checkAuth() against mocked responses (jest.config testEnvironment:node).
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const API_JS = path.resolve(__dirname, '../../public/portal/shared/api.js');
+const AUTH_JS = path.resolve(__dirname, '../../public/portal/shared/auth.js');
+
+function makeSandbox({ status, body = {}, contentType = 'application/json', pathname = '/portal/dashboard.html' } = {}) {
+    const fakeResponse = {
+        status,
+        ok: status >= 200 && status < 300,
+        headers: { get: () => contentType },
+        json: async () => body,
+        text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+    };
+    const hrefSetter = jest.fn();
+    const locationTarget = { origin: 'http://localhost:8787', pathname, search: '' };
+    const locationProxy = new Proxy(locationTarget, {
+        set(obj, prop, val) {
+            if (prop === 'href') hrefSetter(val);
+            obj[prop] = val;
+            return true;
+        },
+    });
+    const overlayShow = jest.fn();
+    const sandbox = {
+        window: { location: locationProxy, __reconnectOverlay: { show: overlayShow } },
+        document: {
+            cookie: '',
+            getElementById: () => null,
+            createElement: () => ({ appendChild() {}, remove() {}, addEventListener() {}, querySelector: () => ({ focus() {}, addEventListener() {}, select() {} }), querySelectorAll: () => [], textContent: '', innerHTML: '', style: {} }),
+            body: { appendChild() {} },
+        },
+        localStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
+        navigator: { onLine: true },
+        fetch: jest.fn().mockResolvedValue(fakeResponse),
+        console: { log() {}, warn() {}, error() {} },
+        setTimeout: (fn) => { /* do not actually schedule */ return { unref() {} }; },
+        clearTimeout: () => {},
+        Date,
+    };
+    sandbox.window.location = locationProxy;
+    sandbox.location = locationProxy;
+    return { sandbox, hrefSetter, overlayShow };
+}
+
+function load(sandbox) {
+    vm.createContext(sandbox);
+    vm.runInContext(fs.readFileSync(API_JS, 'utf8'), sandbox);
+    vm.runInContext(fs.readFileSync(AUTH_JS, 'utf8'), sandbox);
+}
+
+describe('checkAuth cold-start / rate-limit does NOT redirect-loop', () => {
+    test('503 "Server starting up" ⇒ keep session, show reconnect overlay, NO redirect', async () => {
+        const { sandbox, hrefSetter, overlayShow } = makeSandbox({
+            status: 503,
+            body: { success: false, error: 'Server starting up — please retry in a few seconds' },
+            pathname: '/portal/dashboard.html',
+        });
+        load(sandbox);
+        const user = await sandbox.checkAuth();
+        expect(user).toBeNull();
+        expect(hrefSetter).not.toHaveBeenCalled();   // <-- the loop is gone
+        expect(overlayShow).toHaveBeenCalled();
+    });
+
+    test('429 rate-limit (dashboard fan-out) ⇒ NO redirect', async () => {
+        const { sandbox, hrefSetter, overlayShow } = makeSandbox({
+            status: 429,
+            body: { error: 'Too many requests' },
+            pathname: '/portal/dashboard.html',
+        });
+        load(sandbox);
+        await sandbox.checkAuth();
+        expect(hrefSetter).not.toHaveBeenCalled();
+        expect(overlayShow).toHaveBeenCalled();
+    });
+
+    test('502/504 gateway ⇒ NO redirect', async () => {
+        for (const status of [502, 504]) {
+            const { sandbox, hrefSetter } = makeSandbox({ status, body: { error: 'gateway' } });
+            load(sandbox);
+            await sandbox.checkAuth();
+            expect(hrefSetter).not.toHaveBeenCalled();
+        }
+    });
+
+    test('non-JSON 503 body (proxy/HTML) ⇒ NO redirect', async () => {
+        const { sandbox, hrefSetter } = makeSandbox({
+            status: 503,
+            body: '<html>Service Unavailable</html>',
+            contentType: 'text/html',
+            pathname: '/portal/dashboard.html',
+        });
+        load(sandbox);
+        await sandbox.checkAuth();
+        expect(hrefSetter).not.toHaveBeenCalled();
+    });
+
+    test('CONTRAST: a genuine 401 STILL redirects to login (auth behavior preserved)', async () => {
+        const { sandbox, hrefSetter } = makeSandbox({
+            status: 401,
+            body: { error: 'Not authenticated' },
+            pathname: '/portal/dashboard.html',
+        });
+        load(sandbox);
+        await sandbox.checkAuth();
+        expect(hrefSetter).toHaveBeenCalledWith('index.html');
+    });
+
+    test('defense-in-depth: a 401 on index.html does NOT redirect to itself', async () => {
+        const { sandbox, hrefSetter } = makeSandbox({
+            status: 401,
+            body: { error: 'Not authenticated' },
+            pathname: '/portal/index.html',
+        });
+        load(sandbox);
+        await sandbox.checkAuth();
+        expect(hrefSetter).not.toHaveBeenCalled();
+    });
+});
+
+describe('auth.js static guard — transient statuses are handled before the redirect', () => {
+    const source = fs.readFileSync(AUTH_JS, 'utf8');
+    test('checkAuth classifies 503/429/502/504 as transient', () => {
+        expect(source).toMatch(/===\s*503/);
+        expect(source).toMatch(/===\s*429/);
+        expect(source).toMatch(/starting up/i);
+    });
+    test('explicit redirect is guarded against firing from index.html', () => {
+        expect(source).toMatch(/onLoginPage/);
+        expect(source).toMatch(/if\s*\(\s*!onLoginPage\s*\)\s*window\.location\.href/);
+    });
+});


### PR DESCRIPTION
## P0 — portal crash loop on backend cold-start (Hank-reported)

**Symptom:** 「儀表板目前崩潰loop」. After a Railway redeploy the backend returns `503 "Server starting up"` (and `429` under the dashboard's API fan-out) for ~30-60s.

**Root cause:** `shared/auth.js` `checkAuth()` treated the 503 thrown error as an **auth failure** → `window.location.href='index.html'`. The login page re-runs `checkAuth`, hits the same 503, redirects to itself → **infinite redirect/reload crash loop on every portal page** (auth.js is shared). The transient branch only caught `networkError`/`TypeError`, not HTTP 503/429/5xx.

**Trigger:** 5 PRs merged in ~1h → 5 Railway redeploys → repeated cold-start 503/429 windows → the loop fired right then.

**Fix:** `checkAuth` treats `503/429/502/504` + "starting up"/non-JSON/"service unavailable" as **transient** (keep session, show reconnect overlay, **no redirect**); never redirects from `index.html` itself. Only a genuine **401** redirects.

**Regression test (per Hank「以後漏掉的缺口都要有testcase或git ci test」):** `portal-auth-coldstart-no-redirect-loop.test.js` — loads api.js + auth.js into a vm sandbox and exercises the FAILURE path the mock-200 vision-checks never reached:
- mock 503 / 429 / 502 / 504 / non-JSON ⇒ **assert NO redirect** + reconnect overlay shown
- contrast: genuine 401 ⇒ still redirects to login
- 401 on index.html ⇒ no self-redirect

8/8 green; existing `portal-auth-race.test.js` still 8/8.

**Verified:** prod dashboard reloaded on the warm backend → 0 console errors, renders clean (the loop was the cold-start window; this fix makes future cold-starts degrade to a reconnect overlay instead of looping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)