### PR TITLE
fix(dashboard): remove redundant entity-overview summary panel (card_e19560f3)

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -30,105 +30,6 @@
             color: var(--primary);
         }
 
-        .dashboard-entity-summary {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 14px;
-            padding: 12px 14px;
-            margin-bottom: 14px;
-            background: var(--card-bg);
-            border: 1px solid var(--card-border);
-            border-radius: var(--radius);
-        }
-
-        .dashboard-entity-summary[data-state="ready"] {
-            border-color: rgba(79, 195, 247, 0.35);
-        }
-
-        .dashboard-entity-summary[data-state="empty"] {
-            border-color: rgba(255, 193, 7, 0.36);
-        }
-
-        .dashboard-entity-summary[data-state="error"] {
-            border-color: rgba(255, 107, 107, 0.45);
-        }
-
-        .dashboard-entity-summary-copy {
-            flex: 1 1 260px;
-            min-width: 0;
-        }
-
-        .dashboard-entity-summary-title {
-            font-size: 14px;
-            font-weight: 700;
-            color: var(--text);
-            line-height: 1.35;
-        }
-
-        .dashboard-entity-summary-meta {
-            margin-top: 3px;
-            font-size: 12px;
-            color: var(--text-secondary);
-            line-height: 1.4;
-            word-break: break-word;
-        }
-
-        .dashboard-entity-metrics {
-            display: grid;
-            grid-template-columns: repeat(4, minmax(72px, 1fr));
-            gap: 8px;
-            flex: 1 1 360px;
-            min-width: 0;
-        }
-
-        .dashboard-entity-metric {
-            display: flex;
-            flex-direction: column;
-            gap: 2px;
-            min-width: 0;
-            padding: 8px 10px;
-            background: var(--input-bg);
-            border: 1px solid var(--card-border);
-            border-radius: 8px;
-            /* tiles are now <button>s (clickable drill-in, card_cb00b807) — reset the
-               UA button look + signal interactivity. */
-            font: inherit;
-            text-align: left;
-            cursor: pointer;
-            -webkit-appearance: none;
-            appearance: none;
-            transition: border-color 0.12s, background 0.12s, transform 0.06s;
-        }
-        .dashboard-entity-metric:hover {
-            border-color: var(--accent-cyan, #4fc3f7);
-            background: var(--card-bg);
-        }
-        .dashboard-entity-metric:active { transform: scale(0.98); }
-        .dashboard-entity-metric:focus-visible {
-            outline: 2px solid var(--accent-cyan, #4fc3f7);
-            outline-offset: 2px;
-        }
-
-        .dashboard-entity-metric strong {
-            color: var(--primary);
-            font-size: 18px;
-            line-height: 1;
-            font-variant-numeric: tabular-nums;
-        }
-
-        .dashboard-entity-metric span {
-            color: var(--text-secondary);
-            font-size: 11px;
-            line-height: 1.25;
-        }
-
-        .dashboard-entity-actions {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            flex: 0 0 auto;
-        }
 
         .entity-grid {
             display: grid;
@@ -346,26 +247,6 @@
             .page-header > div {
                 width: 100%;
                 justify-content: space-between;
-            }
-            .dashboard-entity-summary {
-                align-items: stretch;
-                flex-direction: column;
-                /* Override the base justify-content:space-between — on a column this
-                   pushed the title to the top and metrics/actions to the bottom,
-                   leaving a large empty gap on phones (card_cb00b807, Hank). Stack
-                   tightly top-down instead. */
-                justify-content: flex-start;
-            }
-            .dashboard-entity-metrics {
-                grid-template-columns: repeat(2, minmax(0, 1fr));
-                width: 100%;
-            }
-            .dashboard-entity-actions {
-                width: 100%;
-            }
-            .dashboard-entity-actions .btn {
-                flex: 1 1 0;
-                min-width: 0;
             }
             .entity-grid {
                 grid-template-columns: 1fr;
@@ -2203,22 +2084,6 @@
             </button>
         </div>
 
-        <section class="dashboard-entity-summary" id="dashboardEntitySummary" data-state="loading" data-tab-content="entities" aria-labelledby="dashboardEntitySummaryTitle">
-            <div class="dashboard-entity-summary-copy" id="dashboardEntitySummaryStatus" role="status" aria-live="polite" aria-atomic="true">
-                <div class="dashboard-entity-summary-title" id="dashboardEntitySummaryTitle">Loading entities / 載入實體中</div>
-                <div class="dashboard-entity-summary-meta" id="dashboardEntitySummaryMeta">Checking bound entity slots. / 正在檢查實體欄位。</div>
-            </div>
-            <div class="dashboard-entity-metrics" aria-label="Dashboard entity overview">
-                <button type="button" class="dashboard-entity-metric" data-metric="bound" onclick="drillDashboardMetric('bound')" title="已綁定實體數 — 點此查看實體清單 / Bound entities — view the list"><strong id="dashboardMetricBound">--</strong><span>Bound / 已綁定</span></button>
-                <button type="button" class="dashboard-entity-metric" data-metric="active" onclick="drillDashboardMetric('active')" title="目前在線的實體 — 點此查看 / Active (online) entities — view the list"><strong id="dashboardMetricActive">--</strong><span>Active / 活動中</span></button>
-                <button type="button" class="dashboard-entity-metric" data-metric="channel" onclick="drillDashboardMetric('channel')" title="使用 EClaw Channel 綁定的實體 — 點此到頻道綁定設定 / Channel-bound — open channel binding"><strong id="dashboardMetricChannel">--</strong><span>Channel / 頻道</span></button>
-                <button type="button" class="dashboard-entity-metric" data-metric="e2ee" onclick="drillDashboardMetric('e2ee')" title="啟用端到端加密的實體 — 點此查看 / End-to-end-encrypted entities — view the list"><strong id="dashboardMetricE2ee">--</strong><span>E2EE / 加密</span></button>
-            </div>
-            <div class="dashboard-entity-actions">
-                <button class="btn btn-sm btn-outline" id="dashboardSummaryRefresh" type="button" onclick="refreshDashboardEntities()">Refresh / 重新整理</button>
-                <button class="btn btn-sm btn-primary" id="dashboardSummaryAdd" type="button" onclick="focusAddEntity()">Add / 新增</button>
-            </div>
-        </section>
 
         <!-- Tab: Entity Cards Grid -->
         <div class="entity-grid" id="entityGrid" data-tab-content="entities">
@@ -2775,107 +2640,6 @@
             return div.innerHTML;
         }
 
-        function formatDashboardText(template, values = {}) {
-            return Object.keys(values).reduce((text, key) => {
-                return text.split(`{${key}}`).join(String(values[key]));
-            }, template);
-        }
-
-        function dashboardText(key, fallback, params = {}) {
-            const value = (typeof i18n !== 'undefined' && typeof i18n.t === 'function') ? i18n.t(key, params) : null;
-            return value && value !== key ? value : formatDashboardText(fallback, params);
-        }
-
-        function setDashboardMetric(id, value) {
-            const el = document.getElementById(id);
-            if (el) el.textContent = String(value);
-        }
-
-        function isDashboardEntityActive(entity) {
-            const state = String(entity && entity.state || '').toLowerCase();
-            return !!state && !['idle', 'offline', 'unknown'].includes(state);
-        }
-
-        function renderDashboardEntitySummary(stateOverride) {
-            const summary = document.getElementById('dashboardEntitySummary');
-            const title = document.getElementById('dashboardEntitySummaryTitle');
-            const meta = document.getElementById('dashboardEntitySummaryMeta');
-            if (!summary || !title || !meta) return;
-
-            const bound = entities.length;
-            const active = entities.filter(isDashboardEntityActive).length;
-            const channel = entities.filter(e => e.bindingType === 'channel').length;
-            const e2ee = entities.filter(e => e.encryptionStatus === 'e2ee').length;
-            const state = stateOverride || (bound > 0 ? 'ready' : 'empty');
-
-            summary.dataset.state = state;
-            if (state === 'loading') {
-                title.textContent = dashboardText('dashboard_summary_loading_title', 'Loading entities');
-                meta.textContent = dashboardText('dashboard_summary_loading_meta', 'Checking bound entity slots.');
-                ['dashboardMetricBound', 'dashboardMetricActive', 'dashboardMetricChannel', 'dashboardMetricE2ee'].forEach(id => setDashboardMetric(id, '--'));
-                return;
-            }
-            if (state === 'error') {
-                title.textContent = dashboardText('dashboard_summary_error_title', 'Entity list unavailable');
-                meta.textContent = dashboardText('dashboard_summary_error_meta', 'Check your connection or retry.');
-                ['dashboardMetricBound', 'dashboardMetricActive', 'dashboardMetricChannel', 'dashboardMetricE2ee'].forEach(id => setDashboardMetric(id, '--'));
-                return;
-            }
-
-            setDashboardMetric('dashboardMetricBound', bound);
-            setDashboardMetric('dashboardMetricActive', active);
-            setDashboardMetric('dashboardMetricChannel', channel);
-            setDashboardMetric('dashboardMetricE2ee', e2ee);
-
-            if (state === 'empty') {
-                title.textContent = dashboardText('dashboard_summary_empty_title', 'No entities bound');
-                meta.textContent = dashboardText('dashboard_summary_empty_meta', 'Add a slot below to start routing messages.');
-                return;
-            }
-
-            title.textContent = (bound === 1)
-                ? dashboardText('dashboard_summary_ready_one', '1 entity ready')
-                : dashboardText('dashboard_summary_ready_many', '{count} entities ready', { count: bound });
-            meta.textContent = dashboardText('dashboard_summary_ready_meta', '{active} active, {channel} channel-bound, {e2ee} E2EE', { active, channel, e2ee });
-        }
-
-        async function refreshDashboardEntities() {
-            const btn = document.getElementById('dashboardSummaryRefresh');
-            if (isEditMode) {
-                renderDashboardEntitySummary();
-                return;
-            }
-            if (btn) btn.disabled = true;
-            renderDashboardEntitySummary('loading');
-            try {
-                await loadEntities();
-            } finally {
-                if (btn) btn.disabled = false;
-            }
-        }
-
-        function focusAddEntity() {
-            const card = document.getElementById('addEntityCard');
-            if (!isAddExpanded) toggleAddEntity();
-            if (card) card.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-
-        // Overview stat tiles are clickable (card_cb00b807): clicking a metric scrolls
-        // the user to the relevant area so the number means something actionable, not
-        // just a static figure. Bound/Active/E2EE → the entity list; Channel → the
-        // channel-binding section (falls back to the list if that section isn't present).
-        function drillDashboardMetric(which) {
-            const grid = document.getElementById('entityGrid');
-            let target = grid;
-            if (which === 'channel') {
-                target = document.getElementById('channelPromo')
-                    || document.querySelector('.channel-promo, .channel-bind-warning')
-                    || grid;
-            }
-            if (target && typeof target.scrollIntoView === 'function') {
-                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            }
-        }
 
         // getAvatarForEntity is provided by shared/entity-utils.js
 
@@ -3271,7 +3035,6 @@
             } catch (e) {
                 // Only show error on first load
                 const grid = document.getElementById('entityGrid');
-                renderDashboardEntitySummary('error');
                 if (grid.querySelector('#loadingState')) {
                     grid.innerHTML = '<div class="empty-state">' + i18n.t('dash_err_load_entities') + '</div>';
                 }
@@ -3388,7 +3151,6 @@
             const emptyState = document.getElementById('emptyState');
 
             if (entities.length === 0) {
-                renderDashboardEntitySummary('empty');
                 grid.innerHTML = '';
                 emptyState.style.display = '';
                 // Auto-expand add entity when empty
@@ -3398,7 +3160,6 @@
                 return;
             }
 
-            renderDashboardEntitySummary('ready');
             emptyState.style.display = 'none';
             grid.classList.toggle('edit-mode', isEditMode);
             grid.innerHTML = entities.map(entity => {
@@ -4591,14 +4352,11 @@
             const entityGrid = document.getElementById('entityGrid');
             const emptyState = document.getElementById('emptyState');
             const orgContainer = document.getElementById('orgChartContainer');
-            const entitySummary = document.getElementById('dashboardEntitySummary');
             if (tab === 'entities') {
-                if (entitySummary) entitySummary.style.display = '';
                 entityGrid.style.display = '';
                 if (emptyState) emptyState.style.display = entities.filter(e => e.isBound).length === 0 ? '' : 'none';
                 orgContainer.classList.remove('active');
             } else {
-                if (entitySummary) entitySummary.style.display = 'none';
                 entityGrid.style.display = 'none';
                 if (emptyState) emptyState.style.display = 'none';
                 orgContainer.classList.add('active');

--- a/backend/tests/jest/dashboard-page-ui.test.js
+++ b/backend/tests/jest/dashboard-page-ui.test.js
@@ -1,100 +1,64 @@
 const fs = require('fs');
 const path = require('path');
 
-describe('dashboard page self-improvement UI', () => {
+/**
+ * Dashboard "實體總覽" entity-overview summary panel REMOVAL guard.
+ *
+ * 2026-06-27 (Hank, web_chat): the codex #3740 "entity overview" panel — a big
+ * Loading/Bound/Active/Channel/E2EE summary block above the entity grid — was a
+ * useless DUPLICATE of the entity grid/list it sat on top of (it just restated
+ * counts while filling the whole first screen). Hank asked to remove it and told
+ * the designing entity to assess existing UI before enhancing, not duplicate
+ * functionality. PR removes the panel (HTML + CSS + JS cluster + the loadEntities
+ * side-effect calls + the tab-visibility refs).
+ *
+ * These tests are the regression guard (per Hank「漏掉的缺口都要有testcase」): they
+ * fail if the duplicate panel — or any of its symbols — is reintroduced, and
+ * confirm the real content (entity grid, tabs, add-entity, loader) is intact.
+ */
+describe('dashboard entity-overview panel is removed (no duplicate of the entity grid)', () => {
     const pagePath = path.join(__dirname, '../../public/portal/dashboard.html');
-    const i18nPath = path.join(__dirname, '../../public/shared/i18n.js');
     const html = fs.readFileSync(pagePath, 'utf8');
-    const i18n = fs.readFileSync(i18nPath, 'utf8');
 
-    test('renders a live entity overview panel with stable actions', () => {
-        expect(html).toContain('class="dashboard-entity-summary" id="dashboardEntitySummary" data-state="loading" data-tab-content="entities"');
-        expect(html).toContain('id="dashboardEntitySummaryStatus" role="status" aria-live="polite" aria-atomic="true"');
-        expect(html).toContain('id="dashboardEntitySummaryTitle"');
-        expect(html).toContain('id="dashboardEntitySummaryMeta"');
-        expect(html).toContain('id="dashboardMetricBound"');
-        expect(html).toContain('id="dashboardMetricActive"');
-        expect(html).toContain('id="dashboardMetricChannel"');
-        expect(html).toContain('id="dashboardMetricE2ee"');
-        expect(html).toContain('id="dashboardSummaryRefresh" type="button" onclick="refreshDashboardEntities()"');
-        expect(html).toContain('id="dashboardSummaryAdd" type="button" onclick="focusAddEntity()"');
+    test('the summary panel markup is gone', () => {
+        expect(html).not.toContain('dashboardEntitySummary');
+        expect(html).not.toContain('class="dashboard-entity-summary"');
+        expect(html).not.toContain('dashboard-entity-metrics');
+        expect(html).not.toContain('dashboard-entity-metric');
+        expect(html).not.toContain('dashboard-entity-actions');
+        expect(html).not.toContain('id="dashboardMetricBound"');
+        expect(html).not.toContain('id="dashboardMetricActive"');
+        expect(html).not.toContain('id="dashboardMetricChannel"');
+        expect(html).not.toContain('id="dashboardMetricE2ee"');
+        expect(html).not.toContain('id="dashboardSummaryRefresh"');
+        expect(html).not.toContain('id="dashboardSummaryAdd"');
     });
 
-    test('updates the overview state from existing entity data without HTML injection', () => {
-        expect(html).toContain('function renderDashboardEntitySummary(stateOverride)');
-        expect(html).toContain("summary.dataset.state = state;");
-        expect(html).toContain("entities.filter(isDashboardEntityActive).length");
-        expect(html).toContain("entities.filter(e => e.bindingType === 'channel').length");
-        expect(html).toContain("entities.filter(e => e.encryptionStatus === 'e2ee').length");
-        expect(html).toContain("title.textContent = dashboardText('dashboard_summary_error_title'");
-        expect(html).toContain("meta.textContent = dashboardText('dashboard_summary_empty_meta'");
-        expect(html).toContain("function formatDashboardText(template, values = {})");
-        expect(html).toContain("i18n.t(key, params)");
-        expect(html).toContain("return value && value !== key ? value : formatDashboardText(fallback, params);");
-        expect(html).toContain("dashboardText('dashboard_summary_ready_many', '{count} entities ready', { count: bound })");
-        expect(html).toContain("dashboardText('dashboard_summary_ready_meta', '{active} active, {channel} channel-bound, {e2ee} E2EE', { active, channel, e2ee })");
-        expect(html).not.toContain('dashboard_summary_ready_many_suffix');
-        expect(html).not.toContain('1 entity ready / 1 個實體可用');
-        expect(html).not.toContain('entities ready /');
-        expect(html).not.toContain("+ e2ee + ' E2EE / '");
-        expect(html).not.toContain('dashboardEntitySummaryTitle.innerHTML');
-        expect(html).not.toContain('dashboardEntitySummaryMeta.innerHTML');
+    test('the panel JS cluster is gone (no dead code / dangling refs)', () => {
+        expect(html).not.toContain('renderDashboardEntitySummary');
+        expect(html).not.toContain('drillDashboardMetric');
+        expect(html).not.toContain('refreshDashboardEntities');
+        expect(html).not.toContain('function focusAddEntity');
+        expect(html).not.toContain('function setDashboardMetric');
+        expect(html).not.toContain('function dashboardText');
+        expect(html).not.toContain('function formatDashboardText');
+        expect(html).not.toContain('function isDashboardEntityActive');
     });
 
-    test('defines localized entity summary keys without bilingual fallbacks', () => {
-        [
-            'dashboard_summary_loading_title',
-            'dashboard_summary_loading_meta',
-            'dashboard_summary_error_title',
-            'dashboard_summary_error_meta',
-            'dashboard_summary_empty_title',
-            'dashboard_summary_empty_meta',
-            'dashboard_summary_ready_one',
-            'dashboard_summary_ready_many',
-            'dashboard_summary_ready_meta',
-        ].forEach((key) => {
-            const occurrences = i18n.match(new RegExp(`"${key}"`, 'g')) || [];
-            expect(occurrences.length).toBeGreaterThanOrEqual(4);
-        });
-        expect(i18n).toContain('"dashboard_summary_ready_many": "{count} entities ready"');
-        expect(i18n).toContain('"dashboard_summary_ready_many": "{count} 個實體可用"');
-        expect(i18n).toContain('"dashboard_summary_ready_many": "{count} 个实体可用"');
+    test('the panel CSS is gone', () => {
+        expect(html).not.toMatch(/\.dashboard-entity-summary\s*\{/);
+        expect(html).not.toMatch(/\.dashboard-entity-metric\s*\{/);
     });
 
-    test('keeps loading, empty, error, and tab visibility synchronized', () => {
-        expect(html).toContain("renderDashboardEntitySummary('loading');");
-        expect(html).toContain("renderDashboardEntitySummary('error');");
-        expect(html).toContain("renderDashboardEntitySummary('empty');");
-        expect(html).toContain("renderDashboardEntitySummary('ready');");
-        expect(html).toContain("if (entitySummary) entitySummary.style.display = '';");
-        expect(html).toContain("if (entitySummary) entitySummary.style.display = 'none';");
-        expect(html).toContain('async function refreshDashboardEntities()');
-        expect(html).toContain('function focusAddEntity()');
-    });
-
-    test('adds mobile-safe layout guards for dashboard controls', () => {
-        expect(html).toMatch(/\.dashboard-entity-summary\s*\{[\s\S]*justify-content:\s*space-between/);
-        expect(html).toMatch(/\.dashboard-entity-metrics\s*\{[\s\S]*grid-template-columns:\s*repeat\(4,\s*minmax\(72px,\s*1fr\)\)/);
-        expect(html).toMatch(/@media \(max-width: 640px\)[\s\S]*\.page-header\s*\{[\s\S]*flex-direction:\s*column/);
-        expect(html).toMatch(/@media \(max-width: 640px\)[\s\S]*\.dashboard-entity-summary\s*\{[\s\S]*flex-direction:\s*column/);
-        expect(html).toMatch(/@media \(max-width: 640px\)[\s\S]*\.dashboard-entity-metrics\s*\{[\s\S]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)/);
-        expect(html).toMatch(/@media \(max-width: 640px\)[\s\S]*\.dashboard-entity-actions \.btn\s*\{[\s\S]*min-width:\s*0/);
-    });
-
-    test('card_cb00b807: mobile summary collapses the empty gap (justify-content:flex-start)', () => {
-        // The base rule is space-between (horizontal row); the mobile column MUST
-        // override it to flex-start or the title/metrics get pushed apart vertically.
-        expect(html).toMatch(/@media \(max-width: 640px\)[\s\S]*\.dashboard-entity-summary\s*\{[\s\S]*flex-direction:\s*column[\s\S]*justify-content:\s*flex-start/);
-    });
-
-    test('card_cb00b807: the 4 overview tiles are actionable buttons with drill-in + labels', () => {
-        // each metric is a <button> wired to drillDashboardMetric + a descriptive title
-        ['bound', 'active', 'channel', 'e2ee'].forEach((m) => {
-            expect(html).toMatch(new RegExp(`<button[^>]*class="dashboard-entity-metric"[^>]*data-metric="${m}"[^>]*onclick="drillDashboardMetric\\('${m}'\\)"[^>]*title=`));
-        });
-        expect(html).toMatch(/function drillDashboardMetric\(/);
-        // interactivity affordance + a11y focus ring on the tiles
-        expect(html).toMatch(/\.dashboard-entity-metric\s*\{[\s\S]*cursor:\s*pointer/);
-        expect(html).toMatch(/\.dashboard-entity-metric:focus-visible\s*\{[\s\S]*outline:/);
+    test('the REAL entity content the panel duplicated is preserved', () => {
+        // entity grid + its loader (the canonical source of the counts the panel echoed)
+        expect(html).toContain("id=\"entityGrid\"");
+        expect(html).toMatch(/async function loadEntities\(\)/);
+        // the Entities / Org Chart tabs + add-entity flow still present
+        expect(html).toContain('data-tab-content="entities"') ; // grid section keeps the tab hook
+        expect(html).toMatch(/id=["']addEntityCard["']/);
+        expect(html).toMatch(/function toggleAddEntity\(/);
+        // tab-visibility no longer references the removed summary element
+        expect(html).not.toContain("getElementById('dashboardEntitySummary')");
     });
 });


### PR DESCRIPTION
## Remove the duplicate dashboard "實體總覽" entity-overview panel

**Hank (web_chat, 2026-06-27):** the codex #3740 entity-overview panel (a big Loading + Bound/Active/Channel/E2EE summary + Refresh/Add, sitting above the entity grid) is a **useless duplicate** of the entity grid/list — it restated counts while filling the whole first screen. Remove it + assess removal risk + tell the designing entity to assess existing UI before enhancing, don't duplicate functionality.

**Removed:** the `<section class="dashboard-entity-summary">` markup, all its CSS (main + mobile `@media`), the self-contained JS cluster (`formatDashboardText`/`dashboardText`/`setDashboardMetric`/`isDashboardEntityActive`/`renderDashboardEntitySummary`/`refreshDashboardEntities`/`focusAddEntity`/`drillDashboardMetric`), the 3 side-effect render calls inside `loadEntities()`, and the tab-visibility refs. **grep confirms 0 dangling references.**

**Risk: LOW** — the entity grid, org chart, and add-entity flow all load via `loadEntities()` independently of the panel; the removed functions were side-effect-only; the tab-visibility refs were null-guarded.

**Tests (per Hank's testcase rule):** `dashboard-page-ui.test.js` rewritten as a **removal guard** — asserts the panel markup + JS cluster + CSS are all absent (so the duplicate can't be reintroduced) + a "real content preserved" check (entityGrid, loadEntities, tabs, addEntityCard present; no dangling `getElementById('dashboardEntitySummary')`). 22/22 across the dashboard suites.

**Vision-checked** locally (auth-stubbed render, desktop 1280 + mobile 390): panel gone, grid/usage/add/rental/footer render clean, **no empty gap**, no JS errors. (Screenshots on the card.)

-242 lines net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)