### PR TITLE
feat(chat-ui): 計畫E ratify badge on 需要你 inbox — silence-semantics made unmistakable (card_e9d01b6e)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -444,6 +444,43 @@
             .action-request-evidence-chip { max-width: 100%; }
             .action-request-evidence-chip .ar-chip-label { max-width: 60vw; }
         }
+        /* 計畫E ratify-loop (card_e9d01b6e): per-item badge on a 需要你 request whose
+           decisionContext.ratify was server-ARMED. Rendered ONLY when the device pref
+           action_request_ratify_enabled is ON (dark-launch default OFF). default_agree
+           = ACTION-BEARING warning (silence auto-sends → amber + live countdown);
+           hold = calm owner-decision (silence does NOT send → neutral). Both are
+           visually distinct from the blue "Recommended" pill, which is record-only. */
+        .action-request-ratify {
+            display: flex; flex-direction: column; gap: 4px;
+            border-radius: 9px; padding: 7px 10px; font-size: 12px; line-height: 1.45;
+            border: 1px solid var(--card-border, #333355);
+        }
+        .action-request-ratify-head { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
+        .action-request-ratify-title { font-weight: 700; }
+        .action-request-ratify-hint { font-size: 11px; line-height: 1.4; opacity: 0.9; overflow-wrap: anywhere; }
+        .action-request-ratify-countdown {
+            display: inline-flex; align-items: center; gap: 4px; margin-left: auto;
+            font-variant-numeric: tabular-nums; font-weight: 700;
+        }
+        .action-request-ratify-countdown .ar-ratify-cd-label { font-weight: 400; opacity: 0.85; }
+        /* default_agree: amber, time-sensitive — silence WILL send + execute. */
+        .action-request-ratify.is-default-agree {
+            border-color: rgba(245,158,11,0.6); color: #f59e0b; background: rgba(245,158,11,0.12);
+        }
+        .action-request-ratify.is-default-agree .action-request-ratify-hint { color: #fbbf24; opacity: 1; }
+        /* terminal state once the countdown hits 0 — escalate to red "sending". */
+        .action-request-ratify.is-sending {
+            border-color: rgba(239,68,68,0.65); color: #ef4444; background: rgba(239,68,68,0.14);
+        }
+        /* hold: calm/neutral — needs your approval, silence does NOT send. */
+        .action-request-ratify.is-hold {
+            border-color: var(--card-border, #333355); color: var(--text-secondary, #AAAAAA);
+            background: rgba(148,163,184,0.10);
+        }
+        @media (prefers-reduced-motion: no-preference) {
+            .action-request-ratify.is-sending { animation: ratify-sending-pulse 1.2s ease-in-out infinite; }
+        }
+        @keyframes ratify-sending-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.65; } }
         /* Ops status strip (card_59f41e5b): suppression transparency + b2b countdown.
            Read-only owner surface above the message list; hidden when nothing to show. */
         .ops-status-strip { margin: 0 0 6px; display: flex; flex-direction: column; gap: 6px; }
@@ -4144,6 +4181,15 @@
         let actionRequestRealtimeEnabled = true;
         let actionRequestTimeoutPolicy = 'keep';
         const actionRequestConsensusTriggeredIds = new Set();
+        // 計畫E ratify-loop (card_e9d01b6e): dark-launch device prefs mirrored to the
+        // client so the per-item ratify badge only renders when the loop is actually
+        // ON, and so the default_agree silence countdown anchors to (armedAt + grace).
+        // Defaults MUST match device-preferences.js (action_request_ratify_enabled:false,
+        // action_request_ratify_grace_minutes:1440).
+        const RATIFY_DEFAULT_GRACE_MINUTES = 1440;
+        let actionRequestRatifyEnabled = false;
+        let actionRequestRatifyGraceMinutes = RATIFY_DEFAULT_GRACE_MINUTES;
+        let _ratifyCountdownTicker = null;
 
         // ── Ops status strip (card_59f41e5b): suppression transparency + b2b countdown.
         // Read-only owner-facing surface; declared early to avoid TDZ from the socket
@@ -4290,6 +4336,13 @@
         function applyActionRequestPrefs(prefs = {}) {
             actionRequestRealtimeEnabled = prefs.action_request_realtime !== false;
             actionRequestTimeoutPolicy = normalizeActionRequestTimeoutPolicy(prefs.action_request_timeout_policy);
+            // 計畫E ratify-loop (card_e9d01b6e): mirror the dark-launch master switch +
+            // silence grace. Badge is gated on this being strictly true (default OFF).
+            actionRequestRatifyEnabled = prefs.action_request_ratify_enabled === true;
+            const ratifyGrace = Number(prefs.action_request_ratify_grace_minutes);
+            actionRequestRatifyGraceMinutes = (Number.isFinite(ratifyGrace) && ratifyGrace > 0)
+                ? ratifyGrace
+                : RATIFY_DEFAULT_GRACE_MINUTES;
         }
 
         async function loadChatAvatarSizePreference() {
@@ -7691,6 +7744,134 @@
             return String(request && request.type) === 'consensus' || isActionRequestConsensusTriggered(request);
         }
 
+        // 計畫E ratify-loop (card_e9d01b6e): build the per-item ratify badge for a
+        // 需要你 request. PURE + XSS-safe — every string lands via textContent / DOM
+        // nodes, NEVER innerHTML string-concat. Returns an Element, or null when the
+        // badge must not show. opts = { enabled:boolean, graceMinutes:number, now:ms }.
+        // Fail-closed gates:
+        //   - opts.enabled !== true             → null (device pref OFF; dark launch)
+        //   - ratify missing / not a plain obj  → null
+        //   - mode not 'default_agree'|'hold'   → null
+        //   - default_agree without a finite armedAt → null (not server-ARMED yet)
+        // default_agree = ACTION-BEARING: silence auto-sends → amber badge + a live
+        // countdown to (armedAt + grace) + an unmistakable "doing nothing sends it"
+        // hint. hold = calm owner-decision: silence does NOT send.
+        function buildRatifyBadge(ratify, opts) {
+            const o = opts || {};
+            if (o.enabled !== true) return null;
+            if (!ratify || typeof ratify !== 'object' || Array.isArray(ratify)) return null;
+            const mode = ratify.mode;
+            if (mode !== 'default_agree' && mode !== 'hold') return null;
+            const t = actionRequestT;
+
+            const badge = document.createElement('div');
+            badge.className = 'action-request-ratify';
+            badge.setAttribute('role', 'status');
+            const head = document.createElement('div');
+            head.className = 'action-request-ratify-head';
+            const title = document.createElement('span');
+            title.className = 'action-request-ratify-title';
+            const hint = document.createElement('div');
+            hint.className = 'action-request-ratify-hint';
+
+            if (mode === 'default_agree') {
+                const armedAt = Number(ratify.armedAt);
+                if (!Number.isFinite(armedAt) || armedAt <= 0) return null;
+                const graceMin = (Number.isFinite(Number(o.graceMinutes)) && Number(o.graceMinutes) > 0)
+                    ? Number(o.graceMinutes)
+                    : (typeof RATIFY_DEFAULT_GRACE_MINUTES !== 'undefined' ? RATIFY_DEFAULT_GRACE_MINUTES : 1440);
+                const deadline = armedAt + graceMin * 60 * 1000;
+                const now = Number.isFinite(Number(o.now)) ? Number(o.now) : Date.now();
+                const remaining = deadline - now;
+
+                badge.classList.add('is-default-agree');
+                title.textContent = t('action_request_ratify_default_agree_badge', '⏳ Awaiting your call · silence approves');
+                head.appendChild(title);
+
+                const cd = document.createElement('span');
+                cd.className = 'action-request-ratify-countdown';
+                cd.setAttribute('data-ratify-deadline', String(deadline));
+                // aria-hidden: the 1s ticker rewrites this every second; inside the
+                // role="status" badge that would spam screen readers. Title + hint
+                // stay announceable; only the ticking glyph is muted.
+                cd.setAttribute('aria-hidden', 'true');
+                const cdLabel = document.createElement('span');
+                cdLabel.className = 'ar-ratify-cd-label';
+                const cdClock = document.createElement('span');
+                cdClock.className = 'ar-ratify-cd-clock';
+                if (remaining <= 0) {
+                    badge.classList.add('is-sending');
+                    cd.removeAttribute('data-ratify-deadline'); // already elapsed → ticker skips it
+                    cdLabel.textContent = '';
+                    cdClock.textContent = t('action_request_ratify_sending', 'Sending…');
+                } else {
+                    cdLabel.textContent = t('action_request_ratify_countdown_prefix', 'Auto-sends in');
+                    cdClock.textContent = (typeof _schedFmtCountdown === 'function')
+                        ? _schedFmtCountdown(remaining)
+                        : String(Math.max(0, Math.round(remaining / 1000))) + 's';
+                }
+                cd.appendChild(cdLabel);
+                cd.appendChild(cdClock);
+                head.appendChild(cd);
+                badge.appendChild(head);
+
+                hint.textContent = t('action_request_ratify_default_agree_hint',
+                    'If you do nothing, this will be sent and executed automatically when the countdown ends.');
+                badge.appendChild(hint);
+            } else { // hold
+                badge.classList.add('is-hold');
+                title.textContent = t('action_request_ratify_hold_badge', 'Needs your approval');
+                head.appendChild(title);
+                badge.appendChild(head);
+                hint.textContent = t('action_request_ratify_hold_hint', 'Nothing is sent unless you approve.');
+                badge.appendChild(hint);
+            }
+            return badge;
+        }
+
+        // Live-updates every visible default_agree countdown once per second. Mirrors
+        // the b2b countdown ticker (_opsEnsureCountdownTicker): self-clears the moment
+        // no node carries [data-ratify-deadline] so it never leaks across re-renders.
+        function _ratifyEnsureCountdownTicker() {
+            if (typeof document === 'undefined' || typeof document.querySelector !== 'function') return;
+            const hasCd = !!document.querySelector('[data-ratify-deadline]');
+            if (hasCd && !_ratifyCountdownTicker) {
+                _ratifyCountdownTicker = setInterval(_ratifyTickCountdowns, 1000);
+            } else if (!hasCd && _ratifyCountdownTicker) {
+                clearInterval(_ratifyCountdownTicker); _ratifyCountdownTicker = null;
+            }
+        }
+
+        function _ratifyTickCountdowns() {
+            if (typeof document === 'undefined' || typeof document.querySelectorAll !== 'function') {
+                if (_ratifyCountdownTicker) { clearInterval(_ratifyCountdownTicker); _ratifyCountdownTicker = null; }
+                return;
+            }
+            const els = document.querySelectorAll('[data-ratify-deadline]');
+            if (!els.length) {
+                if (_ratifyCountdownTicker) { clearInterval(_ratifyCountdownTicker); _ratifyCountdownTicker = null; }
+                return;
+            }
+            const now = Date.now();
+            els.forEach(cd => {
+                const deadline = Number(cd.getAttribute('data-ratify-deadline'));
+                const clock = cd.querySelector ? cd.querySelector('.ar-ratify-cd-clock') : null;
+                const label = cd.querySelector ? cd.querySelector('.ar-ratify-cd-label') : null;
+                const badge = cd.closest ? cd.closest('.action-request-ratify') : null;
+                const remaining = (Number.isFinite(deadline) ? deadline : 0) - now;
+                if (remaining <= 0) {
+                    if (badge && badge.classList) badge.classList.add('is-sending');
+                    if (label) label.textContent = '';
+                    if (clock) clock.textContent = actionRequestT('action_request_ratify_sending', 'Sending…');
+                    cd.removeAttribute('data-ratify-deadline'); // stop ticking this one
+                } else if (clock) {
+                    clock.textContent = (typeof _schedFmtCountdown === 'function')
+                        ? _schedFmtCountdown(remaining)
+                        : String(Math.round(remaining / 1000)) + 's';
+                }
+            });
+        }
+
         function renderActionRequestInbox(banner) {
             if (!banner) return;
             const t = actionRequestT;
@@ -7818,6 +7999,22 @@
                 const dc = (request.decisionContext && typeof request.decisionContext === 'object'
                     && !Array.isArray(request.decisionContext)) ? request.decisionContext : null;
 
+                // 計畫E ratify-loop (card_e9d01b6e): when this request's ratify block was
+                // server-ARMED and the loop is ON (device pref), surface a badge that makes
+                // the silence-semantics unmistakable — placed high (right under the prompt)
+                // so a "silence auto-sends" warning is seen first. typeof-guarded so the
+                // behavioral test harness (which doesn't declare these) is unaffected, and
+                // the badge never renders when the pref is OFF.
+                const ratifyOn = (typeof actionRequestRatifyEnabled !== 'undefined') && actionRequestRatifyEnabled === true;
+                if (ratifyOn && dc && dc.ratify) {
+                    const ratifyBadge = buildRatifyBadge(dc.ratify, {
+                        enabled: true,
+                        graceMinutes: actionRequestRatifyGraceMinutes,
+                        now: Date.now(),
+                    });
+                    if (ratifyBadge) item.appendChild(ratifyBadge);
+                }
+
                 // Block 1 — what was done (commander text → textContent, XSS-safe).
                 if (dc && typeof dc.whatWasDone === 'string' && dc.whatWasDone.trim()) {
                     const wwd = document.createElement('div');
@@ -7912,6 +8109,10 @@
                             const recBadge = document.createElement('span');
                             recBadge.className = 'action-request-recommended-badge';
                             recBadge.textContent = t('action_request_recommended_badge', 'Recommended');
+                            // 計畫E: disambiguate a record-only SUGGESTION from a default_agree
+                            // ratify (which auto-sends on silence). The "Recommended" pill is
+                            // never action-bearing; spell that out so the two never blur.
+                            recBadge.title = t('action_request_recommended_badge_title', 'Suggestion only — recorded, not auto-sent');
                             btn.appendChild(recBadge);
                         }
                         btn.title = t('action_request_option_title', 'Use option: {option}', { option: String(option) });
@@ -7971,6 +8172,10 @@
             wrap.appendChild(body);
             banner.appendChild(wrap);
             banner.style.display = '';
+            // 計畫E: start/refresh the 1s ratify countdown ticker if any default_agree
+            // badge mounted; it self-clears when no [data-ratify-deadline] node remains.
+            // typeof-guarded for the test harness (no _ratifyEnsureCountdownTicker there).
+            if (typeof _ratifyEnsureCountdownTicker === 'function') _ratifyEnsureCountdownTicker();
         }
 
         function collectActionRequestReplyContexts() {

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650613,6 +650613,14 @@ const TRANSLATIONS = {
         "cron_current_usage_label": "Current: 5h N% / 7d M%",
 
         "chat_sendto_button_label_many_more": "+{count} more",
+
+        "action_request_ratify_default_agree_badge": "⏳ Awaiting your call · silence approves",
+        "action_request_ratify_default_agree_hint": "If you do nothing, this will be sent and executed automatically when the countdown ends.",
+        "action_request_ratify_countdown_prefix": "Auto-sends in",
+        "action_request_ratify_sending": "Sending…",
+        "action_request_ratify_hold_badge": "Needs your approval",
+        "action_request_ratify_hold_hint": "Nothing is sent unless you approve.",
+        "action_request_recommended_badge_title": "Suggestion only — recorded, not auto-sent",
 },
 
 
@@ -1235663,6 +1235671,14 @@ const TRANSLATIONS = {
         "cron_skip_dispatch_reason": "跳過：用量超過閾值",
 
         "chat_sendto_button_label_many_more": "+{count} 位",
+
+        "action_request_ratify_default_agree_badge": "⏳ 追認中 · 靜默視同同意",
+        "action_request_ratify_default_agree_hint": "若不處理，倒數結束後將自動送出並執行。",
+        "action_request_ratify_countdown_prefix": "距自動送出",
+        "action_request_ratify_sending": "即將送出…",
+        "action_request_ratify_hold_badge": "需你核可",
+        "action_request_ratify_hold_hint": "未經你核可不會送出。",
+        "action_request_recommended_badge_title": "僅供參考 · 不會自動送出",
 },
 
 
@@ -1849917,6 +1849933,14 @@ const TRANSLATIONS = {
         "cron_skip_help_text": "此排程在 entity 5 小时用量超过 X% 或 7 天用量超过 Y% 时会跳过。预设值保护高负载 entity 不被 cron 额外加负担。可调范围 50%-99%。跳过的 cron 下次 tick 自动重试，不会 lost。",
         "cron_current_usage_label": "目前 5h: N% / 7d: M%",
         "cron_skip_dispatch_reason": "跳过：用量超过阈值",
+
+        "action_request_ratify_default_agree_badge": "⏳ 追认中 · 静默视同同意",
+        "action_request_ratify_default_agree_hint": "若不处理，倒计时结束后将自动送出并执行。",
+        "action_request_ratify_countdown_prefix": "距自动送出",
+        "action_request_ratify_sending": "即将送出…",
+        "action_request_ratify_hold_badge": "需你核可",
+        "action_request_ratify_hold_hint": "未经你核可不会送出。",
+        "action_request_recommended_badge_title": "仅供参考 · 不会自动送出",
 },
 
 

--- a/backend/tests/jest/chat-action-request-ratify-badge.test.js
+++ b/backend/tests/jest/chat-action-request-ratify-badge.test.js
@@ -1,0 +1,289 @@
+/**
+ * chat-action-request-ratify-badge — tests for the 計畫E ratify-loop per-item
+ * badge on the "需要你" action-request inbox (card_e9d01b6e, frontend).
+ *
+ * Three layers:
+ *   1. i18n parity — the 7 new keys exist (non-empty) in ALL three locales the
+ *      app ships Chinese in: en, zh (Traditional / ZH-Hant canonical), zh-CN
+ *      (Simplified / ZH-Hans), with genuine Traditional≠Simplified text.
+ *   2. static-source guards — the render gates on the device pref, the badge is
+ *      built XSS-safe (textContent / DOM nodes, NO innerHTML), the CSS classes
+ *      exist, and the function/keys are wired (mirrors dashboard-page-ui.test.js
+ *      style for code that is awkward to fully execute).
+ *   3. behavioral — buildRatifyBadge() is extracted out of chat.html (it has no
+ *      module export, same brace-count technique as
+ *      chat-action-request-inbox-behavior.test.js) and executed against a tiny
+ *      DOM shim: default_agree → amber badge + live countdown to (armedAt+grace);
+ *      hold → calm 核可 badge; a missing / unarmed / pref-OFF ratify → NO badge;
+ *      an already-elapsed default_agree → terminal "sending" state.
+ *
+ * jest.config.js is testEnvironment:'node' (no jsdom) — same as the sibling
+ * behavior test, so we hand-roll the minimal DOM the badge builder touches.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.join(__dirname, '..', '..');
+const CHAT_HTML_PATH = path.join(ROOT, 'public', 'portal', 'chat.html');
+const I18N_PATH = path.join(ROOT, 'public', 'shared', 'i18n.js');
+const chatHtml = fs.readFileSync(CHAT_HTML_PATH, 'utf8');
+
+const NEW_I18N_KEYS = [
+    'action_request_ratify_default_agree_badge',
+    'action_request_ratify_default_agree_hint',
+    'action_request_ratify_countdown_prefix',
+    'action_request_ratify_sending',
+    'action_request_ratify_hold_badge',
+    'action_request_ratify_hold_hint',
+    'action_request_recommended_badge_title',
+];
+
+// ── Load TRANSLATIONS out of i18n.js (same VM technique as i18n-fallback-chain) ─
+function loadTranslations() {
+    const src = fs.readFileSync(I18N_PATH, 'utf8');
+    const noop = () => {};
+    const sandbox = {
+        _result: null,
+        localStorage: { getItem: () => null, setItem: noop },
+        navigator: { language: 'en' },
+        document: { querySelectorAll: () => [], documentElement: { lang: 'en' }, addEventListener: noop, getElementById: () => null },
+        window: { location: { search: '' } },
+        setTimeout: noop,
+        console: { log: noop, warn: noop, error: noop },
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(src + '\n_result = TRANSLATIONS;', sandbox, { timeout: 8000 });
+    return sandbox._result;
+}
+
+// ── brace-count a top-level function body out of chat.html (no module export) ──
+function extractFunction(name) {
+    const re = new RegExp(`(?:async\\s+)?function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`, 'g');
+    const m = re.exec(chatHtml);
+    if (!m) throw new Error(`function ${name} not found in chat.html`);
+    let depth = 1;
+    let i = m.index + m[0].length;
+    while (i < chatHtml.length && depth > 0) {
+        const ch = chatHtml[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+        i++;
+    }
+    return chatHtml.slice(m.index, i);
+}
+
+// ── minimal DOM shim (only what buildRatifyBadge touches) ─────────────────────
+function makeEl(tag) {
+    const el = { tagName: String(tag || 'div').toUpperCase(), _class: '', _text: '', attrs: {}, children: [], parent: null };
+    Object.defineProperty(el, 'className', { get() { return el._class; }, set(v) { el._class = String(v); } });
+    Object.defineProperty(el, 'textContent', {
+        get() { return el._text; },
+        set(v) { el._text = String(v); el.children.length = 0; },
+    });
+    el.classList = {
+        add(c) { const s = new Set(el._class.split(/\s+/).filter(Boolean)); s.add(c); el._class = Array.from(s).join(' '); },
+        remove(c) { const s = new Set(el._class.split(/\s+/).filter(Boolean)); s.delete(c); el._class = Array.from(s).join(' '); },
+        contains(c) { return el._class.split(/\s+/).filter(Boolean).indexOf(c) !== -1; },
+    };
+    el.setAttribute = (k, v) => { el.attrs[k] = String(v); };
+    el.getAttribute = (k) => (Object.prototype.hasOwnProperty.call(el.attrs, k) ? el.attrs[k] : null);
+    el.removeAttribute = (k) => { delete el.attrs[k]; };
+    el.appendChild = (c) => { c.parent = el; el.children.push(c); return c; };
+    el.querySelector = (sel) => {
+        const want = sel.replace(/^\./, '');
+        const stack = el.children.slice();
+        while (stack.length) { const n = stack.shift(); if (n.classList && n.classList.contains(want)) return n; stack.push(...n.children); }
+        return null;
+    };
+    return el;
+}
+function findByClass(root, cls) {
+    const stack = root.children.slice();
+    while (stack.length) { const n = stack.shift(); if (n.classList && n.classList.contains(cls)) return n; stack.unshift(...n.children); }
+    return null;
+}
+
+function makeBadgeBuilder() {
+    const documentShim = { createElement: (t) => makeEl(t) };
+    // actionRequestT stub: return a token so we can prove the i18n key is wired.
+    const tStub = (key /*, fallback, vars */) => '[' + key + ']';
+    const body = `
+        const RATIFY_DEFAULT_GRACE_MINUTES = 1440;
+        ${extractFunction('_schedFmtCountdown')}
+        ${extractFunction('buildRatifyBadge')}
+        return { buildRatifyBadge };
+    `;
+    /* eslint-disable no-new-func */
+    const factory = new Function('document', 'actionRequestT', body);
+    return factory(documentShim, tStub).buildRatifyBadge;
+}
+
+const GRACE_MIN = 1440;
+const GRACE_MS = GRACE_MIN * 60 * 1000;
+
+// ════════════════════════════════════════════════════════════════════════════
+// 1) i18n parity — all 7 keys in en + zh + zh-CN, genuine 繁/简 distinction
+// ════════════════════════════════════════════════════════════════════════════
+describe('i18n — ratify badge keys exist in all 3 locales (en / zh-Hant / zh-Hans)', () => {
+    let T;
+    beforeAll(() => { T = loadTranslations(); });
+
+    test.each(['en', 'zh', 'zh-CN'])('locale "%s" has every new key with a non-empty string', (loc) => {
+        expect(T[loc]).toBeDefined();
+        for (const k of NEW_I18N_KEYS) {
+            expect(typeof T[loc][k]).toBe('string');
+            expect(T[loc][k].trim().length).toBeGreaterThan(0);
+        }
+    });
+
+    test('zh (Traditional) and zh-CN (Simplified) are genuinely different copy', () => {
+        // 追認/认 + 倒數/倒计时 differ between Traditional and Simplified.
+        expect(T['zh']['action_request_ratify_default_agree_badge'])
+            .not.toBe(T['zh-CN']['action_request_ratify_default_agree_badge']);
+        expect(T['zh']['action_request_ratify_default_agree_hint'])
+            .not.toBe(T['zh-CN']['action_request_ratify_default_agree_hint']);
+        // English is distinct from both Chinese variants.
+        expect(T['en']['action_request_ratify_default_agree_badge'])
+            .not.toBe(T['zh']['action_request_ratify_default_agree_badge']);
+    });
+
+    test('the spec copy lands verbatim: default_agree = 靜默視同同意, hold = 需你核可 (zh)', () => {
+        expect(T['zh']['action_request_ratify_default_agree_badge']).toContain('靜默視同同意');
+        expect(T['zh']['action_request_ratify_hold_badge']).toBe('需你核可');
+        expect(T['zh-CN']['action_request_ratify_default_agree_badge']).toContain('静默视同同意');
+    });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 2) static-source guards (pref gate, XSS-safety, CSS classes, wiring)
+// ════════════════════════════════════════════════════════════════════════════
+describe('chat.html — ratify badge source guards', () => {
+    test('buildRatifyBadge + the countdown ticker functions are defined', () => {
+        expect(chatHtml).toMatch(/function buildRatifyBadge\(ratify, opts\)/);
+        expect(chatHtml).toMatch(/function _ratifyEnsureCountdownTicker\(\)/);
+        expect(chatHtml).toMatch(/function _ratifyTickCountdowns\(\)/);
+    });
+
+    test('render gates the badge on the device pref (action_request_ratify_enabled)', () => {
+        expect(chatHtml).toContain('actionRequestRatifyEnabled = prefs.action_request_ratify_enabled === true;');
+        // The pref mirror feeds the render gate `ratifyOn`.
+        expect(chatHtml).toMatch(/const ratifyOn = .*actionRequestRatifyEnabled === true;/);
+        expect(chatHtml).toContain('if (ratifyOn && dc && dc.ratify) {');
+        // buildRatifyBadge itself fails closed when not enabled.
+        expect(chatHtml).toContain('if (o.enabled !== true) return null;');
+    });
+
+    test('badge is built XSS-safe — textContent/DOM only, no innerHTML in the badge code', () => {
+        const fn = extractFunction('buildRatifyBadge');
+        expect(fn).toContain('document.createElement');
+        expect(fn).toContain('.textContent');
+        expect(fn).not.toContain('innerHTML');
+        expect(fn).not.toContain('insertAdjacentHTML');
+        const tick = extractFunction('_ratifyTickCountdowns');
+        expect(tick).not.toContain('innerHTML');
+    });
+
+    test('the CSS classes for default_agree / hold / sending / countdown exist', () => {
+        expect(chatHtml).toContain('.action-request-ratify.is-default-agree');
+        expect(chatHtml).toContain('.action-request-ratify.is-hold');
+        expect(chatHtml).toContain('.action-request-ratify.is-sending');
+        expect(chatHtml).toContain('.action-request-ratify-countdown');
+    });
+
+    test('recommended pill carries a record-only clarifier (distinct from auto-send)', () => {
+        expect(chatHtml).toContain("t('action_request_recommended_badge_title'");
+    });
+
+    test('the countdown ticker self-clears (no interval leak)', () => {
+        const ensure = extractFunction('_ratifyEnsureCountdownTicker');
+        expect(ensure).toContain("document.querySelector('[data-ratify-deadline]')");
+        const tick = extractFunction('_ratifyTickCountdowns');
+        expect(tick).toContain('clearInterval(_ratifyCountdownTicker)');
+    });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 3) behavioral — buildRatifyBadge() executed against the DOM shim
+// ════════════════════════════════════════════════════════════════════════════
+describe('buildRatifyBadge() — runtime behavior', () => {
+    let build;
+    beforeAll(() => { build = makeBadgeBuilder(); });
+
+    test('default_agree (armed) → amber badge + live countdown to armedAt+grace', () => {
+        const armedAt = 1_700_000_000_000;
+        const now = armedAt + 1000; // 1s after arming → ~grace remaining
+        const badge = build({ mode: 'default_agree', armedAt, planE: true }, { enabled: true, graceMinutes: GRACE_MIN, now });
+
+        expect(badge).not.toBeNull();
+        expect(badge.classList.contains('action-request-ratify')).toBe(true);
+        expect(badge.classList.contains('is-default-agree')).toBe(true);
+        expect(badge.classList.contains('is-sending')).toBe(false);
+        expect(badge.getAttribute('role')).toBe('status');
+
+        // title uses the default_agree i18n key
+        const title = findByClass(badge, 'action-request-ratify-title');
+        expect(title._text).toBe('[action_request_ratify_default_agree_badge]');
+
+        // countdown carries the deadline anchored to armedAt + grace
+        const cd = findByClass(badge, 'action-request-ratify-countdown');
+        expect(cd).not.toBeNull();
+        expect(cd.getAttribute('data-ratify-deadline')).toBe(String(armedAt + GRACE_MS));
+        expect(cd.getAttribute('aria-hidden')).toBe('true');
+        const clock = findByClass(badge, 'ar-ratify-cd-clock');
+        expect(clock._text).toMatch(/^\d{1,2}:\d{2}:\d{2}$/); // HH:MM:SS remaining
+
+        // the unmistakable "doing nothing sends it" hint
+        const hint = findByClass(badge, 'action-request-ratify-hint');
+        expect(hint._text).toBe('[action_request_ratify_default_agree_hint]');
+    });
+
+    test('default_agree past its deadline → terminal "sending" state, no live ticker node', () => {
+        const armedAt = 1_700_000_000_000;
+        const now = armedAt + GRACE_MS + 5000; // already elapsed
+        const badge = build({ mode: 'default_agree', armedAt }, { enabled: true, graceMinutes: GRACE_MIN, now });
+
+        expect(badge).not.toBeNull();
+        expect(badge.classList.contains('is-sending')).toBe(true);
+        const cd = findByClass(badge, 'action-request-ratify-countdown');
+        // elapsed → deadline attribute removed so the ticker skips it (no leak)
+        expect(cd.getAttribute('data-ratify-deadline')).toBeNull();
+        const clock = findByClass(badge, 'ar-ratify-cd-clock');
+        expect(clock._text).toBe('[action_request_ratify_sending]');
+    });
+
+    test('hold → calm 核可 badge, no countdown', () => {
+        const badge = build({ mode: 'hold', armedAt: null }, { enabled: true, graceMinutes: GRACE_MIN, now: Date.now() });
+        expect(badge).not.toBeNull();
+        expect(badge.classList.contains('is-hold')).toBe(true);
+        expect(badge.classList.contains('is-default-agree')).toBe(false);
+        const title = findByClass(badge, 'action-request-ratify-title');
+        expect(title._text).toBe('[action_request_ratify_hold_badge]');
+        // hold never shows a countdown
+        expect(findByClass(badge, 'action-request-ratify-countdown')).toBeNull();
+        const hint = findByClass(badge, 'action-request-ratify-hint');
+        expect(hint._text).toBe('[action_request_ratify_hold_hint]');
+    });
+
+    test('pref OFF (enabled !== true) → NO badge', () => {
+        const armedAt = 1_700_000_000_000;
+        const ratify = { mode: 'default_agree', armedAt };
+        expect(build(ratify, { enabled: false, graceMinutes: GRACE_MIN, now: armedAt + 1000 })).toBeNull();
+        expect(build(ratify, { graceMinutes: GRACE_MIN, now: armedAt + 1000 })).toBeNull(); // enabled omitted
+    });
+
+    test('missing / partial / unarmed ratify → NO badge', () => {
+        const now = Date.now();
+        expect(build(null, { enabled: true, graceMinutes: GRACE_MIN, now })).toBeNull();
+        expect(build(undefined, { enabled: true, graceMinutes: GRACE_MIN, now })).toBeNull();
+        expect(build([], { enabled: true, graceMinutes: GRACE_MIN, now })).toBeNull(); // array, not plain obj
+        expect(build({}, { enabled: true, graceMinutes: GRACE_MIN, now })).toBeNull(); // no mode
+        expect(build({ mode: 'bogus' }, { enabled: true, graceMinutes: GRACE_MIN, now })).toBeNull();
+        // default_agree WITHOUT a server-stamped armedAt → not armed yet → no badge
+        expect(build({ mode: 'default_agree' }, { enabled: true, graceMinutes: GRACE_MIN, now })).toBeNull();
+        expect(build({ mode: 'default_agree', armedAt: null }, { enabled: true, graceMinutes: GRACE_MIN, now })).toBeNull();
+        expect(build({ mode: 'default_agree', armedAt: 0 }, { enabled: true, graceMinutes: GRACE_MIN, now })).toBeNull();
+    });
+});


### PR DESCRIPTION
## What & why
On each **「需要你」** inbox item in `backend/public/portal/chat.html`, render a badge when that request's `decisionContext.ratify` has been **server-ARMED**, so the silence-semantics of 計畫E's ratify loop are unmistakable to the owner.

Backend already shipped (PR #3775); this is the **frontend surface only**, gated behind the dark-launch device pref `action_request_ratify_enabled` (**default OFF → no badge, zero prod impact until go-live**).

## Page
`backend/public/portal/chat.html` (the `renderActionRequestInbox()` 需要你 inbox render).

## Behavior
- **`mode === 'default_agree'`** → amber, **action-bearing** badge `⏳ 追認中 · 靜默視同同意` + a **live 1s countdown** to `(armedAt + grace)` + an unmistakable hint *"if you do nothing this will be sent & executed automatically"*. When the countdown reaches 0 it escalates to a red terminal `即將送出/Sending…` state.
- **`mode === 'hold'`** → calm/neutral `需你核可` badge; silence does **NOT** send.
- The blue **"Recommended"** pill (a record-only suggestion via `recommendedOptionIndex`) now carries a clarifier `title` (`仅供参考 · 不会自动送出`) so a *pure suggestion* can never blur with a *default_agree auto-send*.
- **Pref OFF → no badge.** Gated three ways: render checks `actionRequestRatifyEnabled`, `buildRatifyBadge` fails closed on `opts.enabled !== true`, and default_agree additionally requires a finite `armedAt`.

## Confirmed `decisionContext.ratify` field names (from backend source)
`recomputeRatifyMode()` stamps the block and `rowToApi()` serializes `decisionContext` verbatim:
- `agent-action-requests.js:280` `r.mode = mode;` → `'default_agree' | 'hold'`
- `agent-action-requests.js:284` `r.armedAt = mode === 'default_agree' ? nowMs : null;` (epoch **ms**; null for hold)
- `agent-action-requests.js:297` `decisionContext: row.decision_context || null` (the JSONB blob → `decisionContext.ratify`)
- **Grace is NOT in the ratify payload** — it is the device pref `action_request_ratify_grace_minutes` (default **1440 min**, `device-preferences.js:81`), read by the worker at `agent-action-requests.js:533-535`. The frontend mirrors it into `actionRequestRatifyGraceMinutes` via `applyActionRequestPrefs()`; the countdown deadline = `armedAt + graceMinutes*60000`.

⚠️ Correctness note: the server re-stamps `ratify.mode/armedAt` on any PUT with `ratify.planE === true` **regardless of the pref** (the pref only gates the worker's auto-resolve pass). So a stamped ratify object can exist while the pref is OFF — the badge would then falsely claim "silence auto-sends". Therefore the render is gated on the **pref**, not merely on the armed object. Safest interpretation, per spec.

## XSS / leak safety
- Badge built entirely with `document.createElement` + `.textContent` — **no `innerHTML` / `insertAdjacentHTML`** (asserted in test).
- The 1s countdown ticker mirrors the existing `_opsEnsureCountdownTicker` pattern and **self-clears** when no `[data-ratify-deadline]` node remains (no interval leak across re-renders); `typeof`-guarded so the existing behavioral test harness is unaffected.

## i18n — all 3 shipped locales
Added 7 keys to `en`, `zh` (Traditional / ZH-Hant canonical), and `zh-CN` (Simplified / ZH-Hans) via the AST-based `i18n-insert-locale-keys.js`. Genuine 繁/简 distinction (`追認`/`追认`, `倒數`/`倒计时`).

## Verification
- New suite `backend/tests/jest/chat-action-request-ratify-badge.test.js` — **16/16 green**: 3-locale parity (+ 繁≠简), static XSS/pref-gate/CSS guards, behavioral `buildRatifyBadge()` (default_agree countdown / hold / elapsed→sending / pref-OFF→null / unarmed→null).
- No regressions: `action-request*`, `agent-action-requests`, `chat-action-request-inbox(-behavior)`, `chat-render-load-order`, `i18n-fallback-chain/syntax/lint-dup-keys` → **199 + 72 pass**.
- `node scripts/i18n-check.js` exit 0; `i18n-lint-dup-keys` clean; all 4 inline `<script>` blocks parse (espree).

## TODO before merge
**HARD vision-check (desktop 1280 + mobile 390) + merge owned by #2.** Backend pref `action_request_ratify_enabled` is OFF, so there is no prod impact until go-live. Worktree left at `/private/tmp/wt-ratify-badge` for the no-preview Playwright harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBmn5NeYXxoWMYX6QPx2mt