### PR TITLE
feat(action-requests): surface negotiation/consensus history (Stage C, additive) (card_ce0d685b)

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -299,6 +299,11 @@ function rowToApi(row) {
         answer: row.answer || null,
         createdAt: new Date(row.created_at).getTime(),
         resolvedAt: row.resolved_at ? new Date(row.resolved_at).getTime() : null,
+        // Negotiation marker (card_ce0d685b): the timeout worker stamps this when
+        // it opens a consensus round. Exposed (ms, matching the timestamps above;
+        // null when the request was never negotiated) so clients can tell which
+        // resolved rows were the product of a negotiation vs a plain human resolve.
+        consensusTriggeredAt: row.consensus_triggered_at ? new Date(row.consensus_triggered_at).getTime() : null,
     };
 }
 
@@ -807,6 +812,12 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
             return res.status(400).json({ success: false, error: 'status must be pending|resolved|dismissed|all' });
         }
         const fromEntityId = req.query.fromEntityId;
+        // Negotiation-history filter (card_ce0d685b): when set, restrict to rows
+        // the timeout worker opened a consensus round on (consensus_triggered_at
+        // IS NOT NULL). Purely additive — composes with status, so callers fetch
+        // negotiation history via ?status=resolved&negotiatedOnly=true (or
+        // ?status=all&negotiatedOnly=true to include in-flight rounds).
+        const negotiatedOnly = String(req.query.negotiatedOnly) === 'true';
 
         try {
             const params = [deviceId];
@@ -818,6 +829,9 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
             if (fromEntityId != null && fromEntityId !== '') {
                 params.push(parseInt(fromEntityId, 10));
                 sql += ` AND from_entity_id = $${params.length}`;
+            }
+            if (negotiatedOnly) {
+                sql += ` AND consensus_triggered_at IS NOT NULL`;
             }
             sql += ` ORDER BY created_at ASC LIMIT ${MAX_LIST_LIMIT}`;
             const result = await pool.query(sql, params);

--- a/backend/tests/jest/agent-action-requests.test.js
+++ b/backend/tests/jest/agent-action-requests.test.js
@@ -175,6 +175,74 @@ describe('GET / (list)', () => {
     });
 });
 
+// ════════════════════════════════════════
+// Negotiation-history surfacing (card_ce0d685b, Stage C — additive read path).
+//   (a) rowToApi maps consensus_triggered_at → consensusTriggeredAt (ms / null).
+//   (b) ?negotiatedOnly=true adds `consensus_triggered_at IS NOT NULL` and
+//       returns ONLY negotiated rows (excludes a resolved-by-human row that has
+//       no consensus marker).
+// ════════════════════════════════════════
+describe('negotiation history (card_ce0d685b)', () => {
+    const NEG_TS = new Date('2026-06-26T03:00:00Z');
+
+    it('(a) rowToApi exposes consensus_triggered_at as consensusTriggeredAt (ms)', async () => {
+        mockPoolQuery.mockResolvedValueOnce({
+            rows: [rowFixture({ status: 'resolved', answer: { decision: 'A' }, consensus_triggered_at: NEG_TS })],
+        });
+        const res = await get('/api/action-requests?deviceId=' + deviceId + '&deviceSecret=' + deviceSecret + '&status=resolved');
+        expect(res.status).toBe(200);
+        const r = res.body.requests[0];
+        expect(r.consensusTriggeredAt).toBe(NEG_TS.getTime());
+        // The negotiated decision rides along in `answer`.
+        expect(r.answer).toEqual({ decision: 'A' });
+    });
+
+    it('(a) consensusTriggeredAt is null when the row was never negotiated', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture()] }); // fixture has no consensus_triggered_at
+        const res = await get('/api/action-requests?deviceId=' + deviceId + '&deviceSecret=' + deviceSecret);
+        expect(res.status).toBe(200);
+        expect(res.body.requests[0].consensusTriggeredAt).toBeNull();
+    });
+
+    it('(b) ?negotiatedOnly=true filters the SQL to consensus_triggered_at IS NOT NULL', async () => {
+        mockPoolQuery.mockResolvedValueOnce({
+            rows: [rowFixture({ status: 'resolved', answer: { decision: 'B' }, consensus_triggered_at: NEG_TS })],
+        });
+        const res = await get('/api/action-requests?deviceId=' + deviceId + '&deviceSecret=' + deviceSecret + '&status=resolved&negotiatedOnly=true');
+        expect(res.status).toBe(200);
+        const [sql] = mockPoolQuery.mock.calls[0];
+        expect(sql).toMatch(/consensus_triggered_at IS NOT NULL/);
+        expect(res.body.requests).toHaveLength(1);
+        expect(res.body.requests[0].consensusTriggeredAt).toBe(NEG_TS.getTime());
+    });
+
+    it('(b) omitting negotiatedOnly does NOT add the consensus filter', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+        await get('/api/action-requests?deviceId=' + deviceId + '&deviceSecret=' + deviceSecret + '&status=resolved');
+        const [sql] = mockPoolQuery.mock.calls[0];
+        expect(sql).not.toMatch(/consensus_triggered_at/);
+    });
+
+    it('(b) negotiatedOnly excludes a resolved-by-human row that lacks the consensus marker', async () => {
+        // The DB only returns rows matching `consensus_triggered_at IS NOT NULL`,
+        // so a human-resolved row (consensus_triggered_at NULL) never comes back.
+        // Assert both: the WHERE clause is present AND the negotiated-only payload
+        // carries the marker while the human row would be filtered out by it.
+        const negotiated = rowFixture({ id: UUID, status: 'resolved', answer: { decision: 'A' }, consensus_triggered_at: NEG_TS });
+        mockPoolQuery.mockResolvedValueOnce({ rows: [negotiated] }); // DB applied the filter
+        const res = await get('/api/action-requests?deviceId=' + deviceId + '&deviceSecret=' + deviceSecret + '&status=all&negotiatedOnly=true');
+        expect(res.status).toBe(200);
+        const [sql] = mockPoolQuery.mock.calls[0];
+        expect(sql).toMatch(/consensus_triggered_at IS NOT NULL/);
+        // status=all → no status predicate, only the negotiation predicate.
+        expect(sql).not.toMatch(/status = \$/);
+        // Every returned row is a real negotiation (non-null marker); the
+        // human-resolved row (marker null) is excluded by the WHERE clause.
+        expect(res.body.requests.every(r => r.consensusTriggeredAt != null)).toBe(true);
+        expect(res.body.requests.map(r => r.id)).toEqual([UUID]);
+    });
+});
+
 describe('POST /:id/resolve', () => {
     it('resolves a pending request by id+device, returns updated row', async () => {
         mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ status: 'resolved', answer: 'A', resolved_at: new Date() })] });


### PR DESCRIPTION
## What & why
Stage C (backend only, purely **additive** — no behavior change to the timeout/consensus worker) for surfacing 「需要你」 negotiation/consensus history.

Two gaps closed in `backend/agent-action-requests.js`:

1. **`rowToApi()` did not expose the negotiation marker.** Added `consensusTriggeredAt` (ms epoch, matching the existing `createdAt`/`resolvedAt` style; `null` when the request was never negotiated). Clients can now distinguish a resolved row that came out of a consensus round from a plain human resolve.

2. **No read path returned negotiation history.** Added an additive `?negotiatedOnly=true` query param on the existing `GET /` list route. It appends `AND consensus_triggered_at IS NOT NULL` to the WHERE clause and **composes with** the existing `status` filter. Auth is identical to the existing list route.

### Request → response
```
GET /api/action-requests?deviceId=<id>&deviceSecret=<secret>&status=resolved&negotiatedOnly=true
```
```json
{
  "success": true,
  "requests": [
    {
      "id": "…", "fromEntityId": 2, "type": "decision",
      "status": "resolved",
      "answer": { "decision": "A" },
      "consensusTriggeredAt": 1782702000000,
      "createdAt": 1782700000000, "resolvedAt": 1782703000000
    }
  ]
}
```
Use `&status=all&negotiatedOnly=true` to also include in-flight (pending) negotiation rounds.

## Not touched (separate, held stage)
Timeout worker, the consensus `IS NULL` skip, and `createActionRequest` — unchanged. Frontend (chat.html) is a separate PR.

## Tests (`backend/tests/jest/agent-action-requests.test.js`)
New `negotiation history (card_ce0d685b)` block asserts:
- `rowToApi` maps `consensus_triggered_at` → `consensusTriggeredAt` (and `null` when absent).
- `?negotiatedOnly=true` adds `consensus_triggered_at IS NOT NULL` and returns ONLY negotiated rows (excludes a resolved-by-human row lacking the marker).
- omitting the param does NOT add the filter (no over-match).

Verified the new assertions **fail on origin/main source** and **pass on the fix** (4/5 fail on old code; the 5th is a negative guard valid on both). Suite: 39/39 pass; all 178 action-request jest tests pass. Full backend suite green except one unrelated flaky timeout in `bot-registration.test.js` (passes 13/13 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBmn5NeYXxoWMYX6QPx2mt