### PR TITLE
fix(security): accept device/bot secret via headers, not just URL query (Stage 1+2)

### DIFF
--- a/backend/api_kanban_dependencies.js
+++ b/backend/api_kanban_dependencies.js
@@ -17,6 +17,7 @@
 const express = require('express');
 const { Pool } = require('pg');
 const safeEqual = require('./safe-equal');
+const extractCreds = require('./extract-creds');
 const { detectDependencyCycle } = require('./kanban-dependencies');
 
 const VALID_DEPENDENCY_TYPES = new Set(['blocks', 'requires', 'related']);
@@ -47,8 +48,10 @@ module.exports = function (devices, options = {}) {
     }
 
     function authenticate(req, res) {
-        const params = { ...req.query, ...req.body };
-        const { deviceId, deviceSecret, botSecret, entityId } = params;
+        // Accepts secrets via query/body (legacy) OR X-Device-Secret /
+        // X-Bot-Secret headers (secret-leakage hardening). Additive: query/body
+        // still take precedence so existing callers are unaffected.
+        const { deviceId, deviceSecret, botSecret, entityId } = extractCreds(req);
 
         if (!deviceId) {
             res.status(400).json({ success: false, error: 'Missing deviceId' });

--- a/backend/api_refs.js
+++ b/backend/api_refs.js
@@ -33,6 +33,7 @@ const { execFile } = require('child_process');
 const { promisify } = require('util');
 const { Pool } = require('pg');
 const safeEqual = require('./safe-equal');
+const extractCreds = require('./extract-creds');
 
 const execFileAsync = promisify(execFile);
 
@@ -368,8 +369,10 @@ function readCache() {
 // botSecret + entityId) both work. Refs reads are device-scoped, so any valid
 // credential pair for the device is accepted.
 function authDevice(devices, req) {
-    const params = { ...(req.query || {}), ...(req.body || {}) };
-    const { deviceId, deviceSecret, botSecret, entityId } = params;
+    // Secrets may arrive via query/body (legacy) OR via X-Device-Secret /
+    // X-Bot-Secret headers (secret-leakage hardening — keeps secrets out of
+    // URLs/logs). extractCreds keeps query/body precedence for back-compat.
+    const { deviceId, deviceSecret, botSecret, entityId } = extractCreds(req);
     if (!deviceId) return null;
     const device = devices?.[deviceId];
     if (!device) return null;

--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -20,6 +20,7 @@ const path = require('path');
 const { Pool } = require('pg');
 const { syncPetdexCatalog, R2_KEY_PREFIX, PROXY_PATH_PREFIX } = require('./petdex-bridge');
 const { extractFrameZero } = require('./companion-avatar-util');
+const extractCreds = require('./extract-creds');
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
@@ -275,10 +276,14 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
     // `req.botAuth.entityId` may be null on device-only auth — `scope=mine`
     // still requires botSecret because it filters by author entity.
     function authReader(req, res, next) {
-        const deviceId = req.query.deviceId || req.body?.deviceId;
-        const deviceSecret = req.query.deviceSecret || req.body?.deviceSecret;
-        const botSecret = req.query.botSecret || req.body?.botSecret;
-        const entityIdRaw = req.query.entityId || req.body?.entityId;
+        // Accepts secrets via query/body (legacy) OR X-Device-Secret /
+        // X-Bot-Secret headers (secret-leakage hardening). Additive: query/body
+        // still take precedence so existing callers are unaffected.
+        const creds = extractCreds(req);
+        const deviceId = creds.deviceId;
+        const deviceSecret = creds.deviceSecret;
+        const botSecret = creds.botSecret;
+        const entityIdRaw = creds.entityId;
         const entityId = entityIdRaw != null ? parseInt(entityIdRaw, 10) : null;
 
         if (!deviceId || (!deviceSecret && !botSecret)) {

--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -13,6 +13,7 @@
 
 const express = require('express');
 const safeEqual = require('./safe-equal');
+const extractCreds = require('./extract-creds');
 const { entityGitEmail } = require('./scripts/entity-git-author');
 
 const CANONICAL_AXES = [
@@ -859,10 +860,14 @@ async function incrementCounter(deviceId, entityId, axis) {
 }
 
 function authDeviceOrBot(req) {
-    let deviceId = req.query.deviceId || req.body?.deviceId;
-    const deviceSecret = req.query.deviceSecret || req.body?.deviceSecret;
-    const botSecret = req.query.botSecret || req.body?.botSecret;
-    const callerEntityId = parseInt(req.query.entityId || req.body?.entityId) || 0;
+    // Accepts secrets via query/body (legacy) OR X-Device-Secret / X-Bot-Secret
+    // headers (secret-leakage hardening). Additive: query/body still win so
+    // existing callers are unaffected.
+    const creds = extractCreds(req);
+    let deviceId = creds.deviceId;
+    const deviceSecret = creds.deviceSecret;
+    const botSecret = creds.botSecret;
+    const callerEntityId = parseInt(creds.entityId) || 0;
 
     // Portal sessions hit this endpoint with a JWT cookie and no explicit
     // device/bot secret in the query string. Mirror the same fallback used by

--- a/backend/extract-creds.js
+++ b/backend/extract-creds.js
@@ -1,0 +1,72 @@
+/**
+ * extract-creds.js — centralized device/bot credential extraction.
+ *
+ * SECURITY (secret-leakage hardening): historically these endpoints read the
+ * deviceSecret / botSecret from the URL query string. Secrets in a GET query
+ * leak into browser history, server access logs, Cloudflare logs and the
+ * `Referer` header. This helper ADDITIVELY accepts the secret from request
+ * HEADERS so callers can stop putting it in the URL — without breaking the
+ * existing query/body callers (that removal is a later, breaking Stage 3).
+ *
+ * Header convention (matches the existing one already used by
+ * index.js handleVisibility / interview-arena.js / index.js:7939):
+ *   X-Device-Id      → deviceId   (not secret, but accepted for symmetry)
+ *   X-Device-Secret  → deviceSecret
+ *   X-Bot-Secret     → botSecret
+ *   X-Entity-Id      → entityId
+ * `Authorization: Bearer <secret>` is also accepted: the bearer token is
+ * surfaced as BOTH a deviceSecret and a botSecret candidate so existing
+ * device-or-bot auth logic can match it against either (it only validates a
+ * value it can verify, so the unused one is harmless).
+ *
+ * Precedence (purely additive — query/body keep winning so behavior is
+ * unchanged for current callers): query/body  >  X-* header  >  Bearer.
+ */
+'use strict';
+
+function bearerToken(req) {
+    const h = (req && req.headers) || {};
+    const raw = h.authorization || h.Authorization;
+    if (typeof raw === 'string' && /^Bearer\s+/i.test(raw)) {
+        const tok = raw.replace(/^Bearer\s+/i, '').trim();
+        return tok || undefined;
+    }
+    return undefined;
+}
+
+/**
+ * Extract { deviceId, deviceSecret, botSecret, entityId } from a request,
+ * sourcing from query/body first, then X-* headers, then a Bearer token.
+ * Never logs or echoes any value.
+ *
+ * @param {object} req Express request
+ * @returns {{deviceId:any, deviceSecret:any, botSecret:any, entityId:any}}
+ */
+function extractCreds(req) {
+    const query = (req && req.query) || {};
+    const body = (req && req.body && typeof req.body === 'object') ? req.body : {};
+    const headers = (req && req.headers) || {};
+    // Body overrides query (preserves the existing `{ ...query, ...body }`
+    // precedence used across the codebase); headers are a lower-priority
+    // fallback so current query/body callers are completely unaffected.
+    const merged = { ...query, ...body };
+    const bearer = bearerToken(req);
+
+    const pick = (mergedKey, headerKey) =>
+        (merged[mergedKey] != null ? merged[mergedKey] : headers[headerKey]);
+
+    return {
+        deviceId: pick('deviceId', 'x-device-id'),
+        deviceSecret: pick('deviceSecret', 'x-device-secret') != null
+            ? pick('deviceSecret', 'x-device-secret')
+            : bearer,
+        botSecret: pick('botSecret', 'x-bot-secret') != null
+            ? pick('botSecret', 'x-bot-secret')
+            : bearer,
+        entityId: pick('entityId', 'x-entity-id'),
+    };
+}
+
+module.exports = extractCreds;
+module.exports.extractCreds = extractCreds;
+module.exports.bearerToken = bearerToken;

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -41,6 +41,7 @@ const path = require('path');
 const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const safeEqual = require('./safe-equal');
+const extractCreds = require('./extract-creds');
 const { newCardId } = require('./entity-id');
 const { tKanban, statusLabel } = require('./i18n/kanban-notifications');
 const devicePrefs = require('./device-preferences');
@@ -541,8 +542,10 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
     }
 
     function authenticate(req, res) {
-        const params = { ...req.query, ...req.body };
-        const { deviceId, deviceSecret, botSecret, entityId } = params;
+        // Accepts secrets via query/body (legacy) OR X-Device-Secret /
+        // X-Bot-Secret headers (secret-leakage hardening). Additive: query/body
+        // still take precedence so existing callers are unaffected.
+        const { deviceId, deviceSecret, botSecret, entityId } = extractCreds(req);
 
         if (!deviceId) {
             res.status(400).json({ success: false, error: 'Missing deviceId' });

--- a/backend/public/portal/shared/autolink-chip-preview.js
+++ b/backend/public/portal/shared/autolink-chip-preview.js
@@ -125,11 +125,13 @@
             if (kind === 'kanban' && type === 'card') {
                 const deviceId = (global.currentUser && global.currentUser.deviceId) || '';
                 const deviceSecret = (global.currentUser && global.currentUser.deviceSecret) || '';
-                const qs = deviceId
-                    ? '?deviceId=' + encodeURIComponent(deviceId) + (deviceSecret ? '&deviceSecret=' + encodeURIComponent(deviceSecret) : '')
-                    : '';
+                // deviceId is non-secret and stays in the query; deviceSecret
+                // moves to the X-Device-Secret header so it never lands in
+                // browser history / access logs / the Referer header.
+                const qs = deviceId ? '?deviceId=' + encodeURIComponent(deviceId) : '';
                 const url = '/api/mission/card/card_' + id + qs;
-                return fetch(url, { credentials: 'include' })
+                const headers = deviceSecret ? { 'X-Device-Secret': deviceSecret } : {};
+                return fetch(url, { credentials: 'include', headers })
                     .then(r => r.json())
                     .then(j => {
                         if (j && j.success === false) throw new Error(j.error || 'fetch failed');

--- a/backend/public/portal/shared/entity-link-render.js
+++ b/backend/public/portal/shared/entity-link-render.js
@@ -189,7 +189,11 @@
     async function navigateCardDependency(cardId, direction) {
         try {
             // Fetch dependency data for the card
-            const response = await fetch(`/api/mission/card/${cardId}/dependencies?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`);
+            // deviceSecret travels in the X-Device-Secret header (not the URL
+            // query) to keep it out of browser history / access logs / Referer.
+            const response = await fetch(`/api/mission/card/${cardId}/dependencies?deviceId=${encodeURIComponent(currentUser.deviceId)}`, {
+                headers: { 'X-Device-Secret': currentUser.deviceSecret },
+            });
             const data = await response.json();
 
             if (!data.success || !data.dependencies || data.dependencies.length === 0) {
@@ -207,7 +211,10 @@
                 openEntityModal('card', targetCard.cardId);
             } else if (direction === 1) {
                 // Fetch dependents (what depends on this card)
-                const depResponse = await fetch(`/api/mission/card/${cardId}/dependents?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`);
+                // deviceSecret travels in the X-Device-Secret header (see above).
+                const depResponse = await fetch(`/api/mission/card/${cardId}/dependents?deviceId=${encodeURIComponent(currentUser.deviceId)}`, {
+                    headers: { 'X-Device-Secret': currentUser.deviceSecret },
+                });
                 const depData = await depResponse.json();
 
                 if (depData.success && depData.dependents && depData.dependents.length > 0) {

--- a/backend/public/portal/shared/entity-status-panel.js
+++ b/backend/public/portal/shared/entity-status-panel.js
@@ -129,15 +129,24 @@
         };
     }
 
+    // Secrets now travel in request HEADERS (X-Device-Secret / X-Bot-Secret),
+    // never in the URL query, to keep them out of browser history, server /
+    // Cloudflare access logs and the Referer header. The query keeps only
+    // non-secret routing params (deviceId, and entityId for bot-auth).
+    function _credHeaders() {
+        const c = readCreds();
+        const h = {};
+        if (c.deviceSecret) h['X-Device-Secret'] = c.deviceSecret;
+        else if (c.botSecret) h['X-Bot-Secret'] = c.botSecret;
+        return h;
+    }
+
     function _credQs() {
         const c = readCreds();
         const qs = new URLSearchParams();
         if (c.deviceId) qs.set('deviceId', c.deviceId);
-        if (c.deviceSecret) qs.set('deviceSecret', c.deviceSecret);
-        else if (c.botSecret) {
-            qs.set('botSecret', c.botSecret);
-            if (c.entityId) qs.set('entityId', String(c.entityId));
-        }
+        // entityId is only needed (non-secret) for bot-auth disambiguation.
+        if (!c.deviceSecret && c.botSecret && c.entityId) qs.set('entityId', String(c.entityId));
         return qs;
     }
 
@@ -145,6 +154,7 @@
         const qs = _credQs();
         const res = await fetch(`/api/entity-status/${eid}?${qs.toString()}`, {
             credentials: 'include',
+            headers: _credHeaders(),
         });
         if (!res.ok) throw new Error('HTTP ' + res.status);
         return res.json();
@@ -156,6 +166,7 @@
         if (before) qs.set('before', String(before));
         const res = await fetch(`/api/entity-status/${eid}/log?${qs.toString()}`, {
             credentials: 'include',
+            headers: _credHeaders(),
         });
         if (!res.ok) throw new Error('HTTP ' + res.status);
         return res.json();
@@ -166,6 +177,7 @@
         qs.set('limit', '50');
         const res = await fetch(`/api/entity-status/${eid}/counter/${encodeURIComponent(axis)}/events?${qs.toString()}`, {
             credentials: 'include',
+            headers: _credHeaders(),
         });
         if (!res.ok) throw new Error('HTTP ' + res.status);
         return res.json();
@@ -175,6 +187,7 @@
         const qs = _credQs();
         const res = await fetch(`/api/entity-status/${eid}/achievements?${qs.toString()}`, {
             credentials: 'include',
+            headers: _credHeaders(),
         });
         if (!res.ok) throw new Error('HTTP ' + res.status);
         return res.json();
@@ -185,6 +198,7 @@
         qs.set('limit', '50');
         const res = await fetch(`/api/entity-status/${eid}/achievement/${encodeURIComponent(axis)}/events?${qs.toString()}`, {
             credentials: 'include',
+            headers: _credHeaders(),
         });
         if (!res.ok) throw new Error('HTTP ' + res.status);
         return res.json();

--- a/backend/public/shared/avatar-petdx.js
+++ b/backend/public/shared/avatar-petdx.js
@@ -92,10 +92,15 @@
         if (inflightByEntityId.has(eid)) return inflightByEntityId.get(eid);
 
         const params = new URLSearchParams({ deviceId, entityId: String(eid) });
-        if (deviceSecret) params.set('deviceSecret', deviceSecret);
-        else if (botSecret) params.set('botSecret', botSecret);
+        // The secret travels in a request header (X-Device-Secret /
+        // X-Bot-Secret), never in the URL query, so it doesn't leak into
+        // browser history / access logs / the Referer header.
+        const headers = {};
+        if (deviceSecret) headers['X-Device-Secret'] = deviceSecret;
+        else if (botSecret) headers['X-Bot-Secret'] = botSecret;
         const p = fetch('/api/companion/current?' + params.toString(), {
-            credentials: 'same-origin'
+            credentials: 'same-origin',
+            headers
         }).then(async (r) => {
             if (!r.ok) {
                 // Preserve last good descriptor across transient API failures

--- a/backend/public/shared/refs-popover.js
+++ b/backend/public/shared/refs-popover.js
@@ -183,12 +183,16 @@
         if (!deviceId) throw new Error('missing_creds');
         const params = ['from=' + encodeURIComponent(fromId),
                         'deviceId=' + encodeURIComponent(deviceId)];
+        // Secrets travel in request headers (X-Device-Secret / X-Bot-Secret),
+        // never in the URL query, so they don't leak into browser history,
+        // server/Cloudflare access logs or the Referer header.
         // Prefer deviceSecret (kanban portal convention); fall back to botSecret
         // for bot-authed callers / tests.
+        const headers = {};
         if (deviceSecret) {
-            params.push('deviceSecret=' + encodeURIComponent(deviceSecret));
+            headers['X-Device-Secret'] = deviceSecret;
         } else if (botSecret) {
-            params.push('botSecret=' + encodeURIComponent(botSecret));
+            headers['X-Bot-Secret'] = botSecret;
         } else {
             throw new Error('missing_creds');
         }
@@ -196,7 +200,7 @@
             params.push('entityId=' + encodeURIComponent(entityId));
         }
         const url = REFS_ENDPOINT + '?' + params.join('&');
-        const res = await fetch(url, { credentials: 'same-origin' });
+        const res = await fetch(url, { credentials: 'same-origin', headers });
         if (!res.ok) throw new Error('http_' + res.status);
         const json = await res.json();
         if (!json || json.success !== true) throw new Error('api_error');

--- a/backend/tests/jest/devicesecret-header-auth.test.js
+++ b/backend/tests/jest/devicesecret-header-auth.test.js
@@ -1,0 +1,167 @@
+/**
+ * Secret-leakage hardening — header-based credential auth (Jest).
+ *
+ * Background: deviceSecret / botSecret used to be required in the GET URL query
+ * string, which leaks them into browser history, server/Cloudflare access logs
+ * and the Referer header. Stage 1 made the affected endpoints ADDITIVELY accept
+ * the secret via request headers (X-Device-Secret / X-Bot-Secret, and an
+ * Authorization: Bearer token), via the shared extract-creds.js helper.
+ *
+ * These tests assert, against a REAL affected endpoint (GET /api/refs):
+ *   - auth SUCCEEDS when the secret arrives ONLY via the new header
+ *     (the URL query carries no secret — the path that previously 401'd),
+ *   - auth still SUCCEEDS via the legacy query param (back-compat),
+ *   - auth is REJECTED when no secret is supplied anywhere.
+ * Plus focused unit tests of the extract-creds helper itself.
+ *
+ * No real secret values are used — only test fixtures.
+ */
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const createRefsModule = require('../../api_refs');
+const extractCreds = require('../../extract-creds');
+const express = require('express');
+const http = require('http');
+
+const FROM = 'card_aa15ed2618c9246d11a0f6b1';
+
+function makeDevices() {
+    return {
+        'dev-A': {
+            deviceSecret: 'sec-A',
+            entities: {
+                2: { botSecret: 'bot-A2' },
+                3: { botSecret: 'bot-A3' },
+            },
+        },
+    };
+}
+
+function spinUp() {
+    const devices = makeDevices();
+    const prevEnabled = process.env.ECLAW_REFS_INDEX_ENABLED;
+    process.env.ECLAW_REFS_INDEX_ENABLED = '1';
+    const mod = createRefsModule(devices);
+    process.env.ECLAW_REFS_INDEX_ENABLED = prevEnabled;
+    mod._internals.stopScanLoop();
+    const app = express();
+    app.use('/api', mod.router);
+    return { app, devices, mod };
+}
+
+// GET helper that supports custom request headers.
+function request(app, urlPath, headers = {}) {
+    return new Promise((resolve, reject) => {
+        const server = app.listen(0, () => {
+            const port = server.address().port;
+            http.get({ host: '127.0.0.1', port, path: urlPath, headers }, (res) => {
+                let body = '';
+                res.on('data', (c) => (body += c));
+                res.on('end', () => {
+                    server.close();
+                    try {
+                        resolve({ status: res.statusCode, json: body ? JSON.parse(body) : null });
+                    } catch (e) { reject(e); }
+                });
+            }).on('error', reject);
+        });
+    });
+}
+
+describe('header-auth: deviceSecret/botSecret via headers (no secret in URL)', () => {
+    test('NEW: deviceSecret via X-Device-Secret header (no secret in query) → 200', async () => {
+        const { app } = spinUp();
+        // The URL carries only the non-secret deviceId; the secret is a header.
+        const r = await request(app, `/api/refs?from=${FROM}&deviceId=dev-A`, {
+            'X-Device-Secret': 'sec-A',
+        });
+        expect(r.status).toBe(200);
+        expect(r.json.success).toBe(true);
+    });
+
+    test('NEW: botSecret via X-Bot-Secret header + entityId in query → 200', async () => {
+        const { app } = spinUp();
+        const r = await request(app, `/api/refs?from=${FROM}&deviceId=dev-A&entityId=2`, {
+            'X-Bot-Secret': 'bot-A2',
+        });
+        expect(r.status).toBe(200);
+        expect(r.json.success).toBe(true);
+    });
+
+    test('NEW: Authorization Bearer <deviceSecret> → 200', async () => {
+        const { app } = spinUp();
+        const r = await request(app, `/api/refs?from=${FROM}&deviceId=dev-A`, {
+            Authorization: 'Bearer sec-A',
+        });
+        expect(r.status).toBe(200);
+        expect(r.json.success).toBe(true);
+    });
+
+    test('NEW: wrong deviceSecret via header → 401', async () => {
+        const { app } = spinUp();
+        const r = await request(app, `/api/refs?from=${FROM}&deviceId=dev-A`, {
+            'X-Device-Secret': 'wrong',
+        });
+        expect(r.status).toBe(401);
+    });
+});
+
+describe('back-compat: legacy query-param secret still works', () => {
+    test('deviceSecret via query → 200', async () => {
+        const { app } = spinUp();
+        const r = await request(app, `/api/refs?from=${FROM}&deviceId=dev-A&deviceSecret=sec-A`);
+        expect(r.status).toBe(200);
+        expect(r.json.success).toBe(true);
+    });
+});
+
+describe('rejection: no secret supplied anywhere', () => {
+    test('deviceId only, no secret in query OR header → 401', async () => {
+        const { app } = spinUp();
+        const r = await request(app, `/api/refs?from=${FROM}&deviceId=dev-A`);
+        expect(r.status).toBe(401);
+    });
+});
+
+describe('extractCreds helper (unit)', () => {
+    test('reads secrets from X-* headers when query/body absent', () => {
+        const req = {
+            query: { deviceId: 'dev-A', entityId: '2' },
+            body: {},
+            headers: { 'x-device-secret': 'sec-A', 'x-bot-secret': 'bot-A2' },
+        };
+        const c = extractCreds(req);
+        expect(c.deviceId).toBe('dev-A');
+        expect(c.deviceSecret).toBe('sec-A');
+        expect(c.botSecret).toBe('bot-A2');
+        expect(c.entityId).toBe('2');
+    });
+
+    test('query/body still take precedence over headers (additive, non-breaking)', () => {
+        const req = {
+            query: { deviceSecret: 'from-query' },
+            body: {},
+            headers: { 'x-device-secret': 'from-header' },
+        };
+        expect(extractCreds(req).deviceSecret).toBe('from-query');
+    });
+
+    test('Authorization Bearer surfaces as both device- and bot-secret candidate', () => {
+        const req = { query: {}, body: {}, headers: { authorization: 'Bearer tok-X' } };
+        const c = extractCreds(req);
+        expect(c.deviceSecret).toBe('tok-X');
+        expect(c.botSecret).toBe('tok-X');
+    });
+
+    test('returns undefined secrets when nothing supplied', () => {
+        const c = extractCreds({ query: {}, body: {}, headers: {} });
+        expect(c.deviceSecret).toBeUndefined();
+        expect(c.botSecret).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Problem
`deviceSecret` / `botSecret` were required in the **GET URL query string**, so they leak into browser history, server access logs, Cloudflare logs and the `Referer` header. Owner-approved fix: move secrets to request headers via a **staged, non-breaking migration**.

## Stage 1 — backend (ADDITIVE, non-breaking)
New shared helper `backend/extract-creds.js`. It reads creds from query/body (legacy — still takes precedence, so existing callers are unaffected) **OR** from headers:
- `X-Device-Secret` → deviceSecret
- `X-Bot-Secret` → botSecret
- `X-Device-Id` / `X-Entity-Id` (non-secret, for symmetry)
- `Authorization: Bearer <secret>` (surfaced as both device- and bot-secret candidate)

Header names match the existing convention already used in `index.js` `handleVisibility` and `interview-arena.js` (`x-device-id` / `x-device-secret` / `x-bot-secret`).

Wired into the auth extractors of the 5 modules behind the known leak sites (query/body acceptance retained):
- `api_refs.js` (`authDevice`)
- `api_kanban_dependencies.js` (`authenticate`)
- `kanban.js` (`authenticate` — GET `/card/:id`)
- `entity-status.js` (`authDeviceOrBot`)
- `companion-api.js` (`authReader`)

No edits to `index.js` (kept clear of the concurrent b2b-routing work near line 9661).

## Stage 2 — frontend
All 5 known leak sites turned out to be `fetch()`-based — **none are `<img src>`** — so all 5 are fixed (none deferred). Each now sends the secret in `X-Device-Secret` / `X-Bot-Secret` headers and keeps only non-secret params (`deviceId`, `entityId`) in the URL:

| Site | Endpoint | Type | Status |
|---|---|---|---|
| `entity-link-render.js` (deps/dependents) | `/api/mission/card/:id/dependencies`+`/dependents` | fetch | fixed |
| `autolink-chip-preview.js` | `/api/mission/card/:id` | fetch | fixed |
| `entity-status-panel.js` (`_credHeaders`, 5 GETs) | `/api/entity-status/:id*` | fetch | fixed |
| `refs-popover.js` | `/api/refs` | fetch | fixed |
| `avatar-petdx.js` | `/api/companion/current` | fetch | fixed |

(`entity-status-panel.js`'s `fetchQuote` already used a POST body, not the URL — left as-is.)

## Test
`backend/tests/jest/devicesecret-header-auth.test.js` (10 tests, green) exercises a real affected endpoint (`GET /api/refs`):
- authenticates via the **new header** with **no secret in the URL** (the path that previously 401'd),
- still authenticates via the legacy query param (back-compat),
- rejects when no secret is supplied anywhere,
- plus `extract-creds` unit tests (header read, query precedence, Bearer, empty).

Existing suites for all touched modules pass (`api-refs-auth`, `api-kanban-dependencies`, `companion-api`, `entity-status-achievements`).

## Remaining follow-ups (NOT in this PR)
- **Stage 3 (breaking):** remove query/body acceptance of secrets once all clients use headers. Needs owner sign-off + a deprecation window.
- **img-src token sites:** none found among the 5 known sites; if future `<img src>`/webview URLs need device-scoped secrets, mint a short-lived scoped token rather than embedding the raw secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBmn5NeYXxoWMYX6QPx2mt