### PR TITLE
fix(transform): first-token-only @-mention guard on /api/transform (card_2ee0afbb)

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -1765,7 +1765,11 @@ function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecre
         pushToChannelCallback,
         setKanbanAutoReview,
         setOrgChartForward,
-        verifyChannelKey
+        verifyChannelKey,
+        // Pure first-token-mention helper, also exposed on the factory object
+        // below. Surfaced on the instance so /api/transform (index.js) can
+        // apply the same first-token guard the /api/channel seam uses.
+        messageStartsWithMention
     };
 }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -9658,7 +9658,17 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
             if (tParse.hasAll && !broadcast && !(speakTo && speakTo.length > 0)) {
                 broadcast = true;
                 routingResolvedVia = 'mention';
-            } else if (tParse.mentions.length > 0 && !broadcast && !(speakTo && speakTo.length > 0)) {
+            } else if (tParse.mentions.length > 0 && !broadcast && !(speakTo && speakTo.length > 0) && channelModule.messageStartsWithMention(finalMessage)) {
+                // ── First-token-only guard (card_2ee0afbb / card_488f05280caf) ──
+                // Only auto-promote an in-text @-mention to speakTo when the
+                // message's FIRST non-whitespace/non-emoji token IS the mention.
+                // A casual mid-body reference ("this is broken, ask @xx to look")
+                // is NOT routing intent — promoting it mis-routes the reply into
+                // the referenced entity's chat history, polluting its context.
+                // The /api/channel path already enforces this (channel-api.js);
+                // /api/transform was missing it, so the two routing seams now
+                // agree. `@all` broadcast (above) is intentionally NOT subject to
+                // this rule — preserves the pre-existing "@all anywhere" convention.
                 speakTo = tParse.mentions.map(m => m.publicCode);
                 routingResolvedVia = 'mention';
             }

--- a/backend/tests/jest/transform-firsttoken-mention-route.test.js
+++ b/backend/tests/jest/transform-firsttoken-mention-route.test.js
@@ -1,0 +1,146 @@
+/**
+ * /api/transform — first-token-only @-mention auto-promote guard (card_2ee0afbb defect 2)
+ *
+ * The /api/channel seam already restricts auto-promoting an in-text @-mention to
+ * `speakTo` to messages whose FIRST non-whitespace/non-emoji token IS the
+ * mention (channel-api.js, via messageStartsWithMention). /api/transform was
+ * MISSING that guard, so a message that merely CONTAINED a mention mid-body
+ * ("this is broken, ask @#1 to take a look") hijacked routing and delivered the
+ * reply into the referenced entity's chat history.
+ *
+ * Failure path exercised: with the guard removed, the mid-text case below
+ * resolves via 'mention' and routes to entity 1 (the bug). With the guard, it
+ * resolves to nothing. A genuine LEADING mention must still route.
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+async function registerDevice(id) {
+    const secret = `secret-${id}`;
+    await post('/api/device/register').send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+    return secret;
+}
+
+async function bindEntity(deviceId, deviceSecret, entityId = 0) {
+    const regRes = await post('/api/device/register')
+        .send({ deviceId, deviceSecret, entityId });
+    const code = regRes.body.bindingCode;
+    if (!code) return undefined;
+    const bindRes = await post('/api/bind').send({ code });
+    return bindRes.body.botSecret;
+}
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+describe('POST /api/transform — first-token-only @-mention guard', () => {
+    let deviceId, deviceSecret, botSecret0, entity1PublicCode;
+
+    beforeAll(async () => {
+        deviceId = 'ft-device';
+        deviceSecret = await registerDevice(deviceId);
+        botSecret0 = await bindEntity(deviceId, deviceSecret, 0);
+
+        const addRes = await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+        expect(addRes.status).toBe(200);
+
+        await bindEntity(deviceId, deviceSecret, 1);
+
+        const { devices } = require('../../index');
+        entity1PublicCode = devices[deviceId].entities[1].publicCode;
+        expect(entity1PublicCode).toBeTruthy();
+    });
+
+    it('a MID-TEXT @#N mention is NOT auto-promoted to speakTo (the defect)', async () => {
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 0,
+            botSecret: botSecret0,
+            state: 'IDLE',
+            message: 'this is broken, ask @#1 to take a look'
+        });
+
+        expect(res.status).toBe(200);
+        // Pre-fix this resolved via 'mention' and routed to entity 1.
+        expect(res.body.routing.resolvedVia).toBeNull();
+        expect(res.body.routing.routedTo).toHaveLength(0);
+    });
+
+    it('a MID-TEXT bare @publicCode mention is NOT auto-promoted either', async () => {
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 0,
+            botSecret: botSecret0,
+            state: 'IDLE',
+            message: `please review the PR, then ping @${entity1PublicCode} for the ack`
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.routing.resolvedVia).toBeNull();
+        expect(res.body.routing.routedTo).toHaveLength(0);
+    });
+
+    it('a LEADING @#N mention STILL auto-promotes to speakTo (legit routing preserved)', async () => {
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 0,
+            botSecret: botSecret0,
+            state: 'IDLE',
+            message: '@#1 please ack this'
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.routing.resolvedVia).toBe('mention');
+        expect(res.body.routing.routedTo).toHaveLength(1);
+        expect(res.body.routing.routedTo[0]).toMatchObject({
+            kind: 'entity',
+            entityId: 1,
+            publicCode: entity1PublicCode
+        });
+    });
+
+    it('a LEADING bare @publicCode mention STILL auto-promotes to speakTo', async () => {
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 0,
+            botSecret: botSecret0,
+            state: 'IDLE',
+            message: `@${entity1PublicCode} please ack this`
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.routing.resolvedVia).toBe('mention');
+        expect(res.body.routing.routedTo).toHaveLength(1);
+        expect(res.body.routing.routedTo[0]).toMatchObject({
+            kind: 'entity',
+            entityId: 1,
+            publicCode: entity1PublicCode
+        });
+    });
+
+    it('a leading emoji before the @mention still counts as first-token (parity with /api/channel)', async () => {
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 0,
+            botSecret: botSecret0,
+            state: 'IDLE',
+            message: `\u{1F44B} @${entity1PublicCode} ack please`
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.routing.resolvedVia).toBe('mention');
+        expect(res.body.routing.routedTo).toHaveLength(1);
+    });
+});

--- a/backend/tests/jest/transform-self-save-phantom.test.js
+++ b/backend/tests/jest/transform-self-save-phantom.test.js
@@ -132,7 +132,11 @@ describe('POST /api/transform — self-save phantom-row regression (#2282)', () 
             entityId: 2,
             botSecret: botSecret2,
             state: 'IDLE',
-            message: `${tag} @#1 hello`,
+            // card_2ee0afbb defect 2: /api/transform now auto-promotes an
+            // in-text @-mention to speakTo only when it is the FIRST token
+            // (parity with /api/channel). Lead with @#1 so this phantom-row
+            // regression keeps exercising the real-delivery path it targets.
+            message: `@#1 ${tag} hello`,
         });
 
         expect(res.status).toBe(200);

--- a/backend/tests/jest/transform-sender-hint.test.js
+++ b/backend/tests/jest/transform-sender-hint.test.js
@@ -233,7 +233,11 @@ describe('POST /api/transform — senderHint', () => {
         const res = await post('/api/transform').send({
             deviceId, entityId: 1, botSecret: botSecret1,
             state: 'IDLE',
-            message: `> @all in quote\nplease send this to @#3`
+            // card_2ee0afbb defect 2: a direct mention only auto-routes when it
+            // is the FIRST token, so lead with @#3 (the legitimate routing
+            // intent). The quoted @all on the next line is still escaped by the
+            // contextual-escape pass, proving the two mechanisms coexist.
+            message: `@#3 please send this\n> @all in quote`
         });
 
         expect(res.status).toBe(200);


### PR DESCRIPTION
## What & why (b2b reply-routing correctness — card_2ee0afbb, defect 2)

`/api/transform` auto-promoted **any** in-text @-mention to `speakTo`, so a message that merely **contained** a mention mid-body ("this is broken, ask @xx to look") hijacked routing and delivered the reply into the referenced entity's chat history, polluting its context window.

The `/api/channel` seam already restricts auto-promote to **first-token** mentions via `messageStartsWithMention` (card_488f05280caf). `/api/transform` was missing the guard, leaving the two routing seams inconsistent.

## Changes
- **`backend/index.js`**: gate the mentions `else if` branch on `channelModule.messageStartsWithMention(finalMessage)`. The `@all` broadcast branch is intentionally left unguarded (preserves the pre-existing "@all anywhere" convention — matches `/api/channel`).
- **`backend/channel-api.js`**: `messageStartsWithMention` was only a static on the factory function, not on its returned instance. Surface it on the returned object so `index.js`'s `channelModule` can call it. (The factory static is kept for existing direct-`require` consumers/tests.)

## Tests (failure path exercised)
- **New** `backend/tests/jest/transform-firsttoken-mention-route.test.js`: mid-text `@#N` and bare `@publicCode` do NOT auto-promote (`resolvedVia: null`, `routedTo: []`); leading mentions — and an emoji-prefixed leading mention — STILL route. Verified the **old** (guard-removed) code FAILS the two mid-text cases while passing the leading ones, then passes all five with the guard restored.
- Two existing transform tests encoded the pre-fix mid-text-routing behavior and were updated to **lead** with the mention, preserving their primary assertions:
  - `transform-self-save-phantom.test.js` (phantom-row regression) — message now leads with `@#1`.
  - `transform-sender-hint.test.js` (@all-in-quote escape + direct mention) — message now leads with `@#3`; the quoted `@all` on the next line is still escaped, proving the two mechanisms coexist.

Full backend jest suite: **405 suites, 5622 passed, 17 skipped, 0 failed**. ESLint clean on changed source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBmn5NeYXxoWMYX6QPx2mt