### PR TITLE
feat(portal): destructive confirms use action-specific verbs (刪除/解除綁定…), not generic 確認

### DIFF
--- a/backend/public/portal/admin.html
+++ b/backend/public/portal/admin.html
@@ -1463,7 +1463,7 @@
         }
 
         async function revokeSkill(skillId) {
-            if (!await showConfirm({ message: i18n.t('skill_contrib_revoke_confirm'), danger: true, itemName: skillId })) return;
+            if (!await showConfirm({ message: i18n.t('skill_contrib_revoke_confirm'), confirmText: i18n.t('common_revoke'), danger: true, itemName: skillId })) return;
             try {
                 await apiCall('DELETE', '/api/skill-templates/' + encodeURIComponent(skillId));
                 showToast(i18n.t('skill_contrib_revoked'), 'success');
@@ -1474,7 +1474,7 @@
         }
 
         async function revokeSoul(soulId) {
-            if (!await showConfirm({ message: i18n.t('soul_contrib_revoke_confirm'), danger: true, itemName: soulId })) return;
+            if (!await showConfirm({ message: i18n.t('soul_contrib_revoke_confirm'), confirmText: i18n.t('common_revoke'), danger: true, itemName: soulId })) return;
             try {
                 await apiCall('DELETE', '/api/soul-templates/' + encodeURIComponent(soulId));
                 showToast(i18n.t('soul_contrib_revoked'), 'success');
@@ -1485,7 +1485,7 @@
         }
 
         async function revokeRule(ruleId) {
-            if (!await showConfirm({ message: i18n.t('rule_contrib_revoke_confirm'), danger: true, itemName: ruleId })) return;
+            if (!await showConfirm({ message: i18n.t('rule_contrib_revoke_confirm'), confirmText: i18n.t('common_revoke'), danger: true, itemName: ruleId })) return;
             try {
                 await apiCall('DELETE', '/api/rule-templates/' + encodeURIComponent(ruleId));
                 showToast(i18n.t('rule_contrib_revoked'), 'success');

--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -1689,7 +1689,7 @@
         }
 
         async function toggleBlockFromList(publicCode, currentlyBlocked) {
-            if (!currentlyBlocked && !await showConfirm({ message: t('cardholder_block_confirm', 'Block this agent? They will not be able to send you messages.'), danger: true, itemName: publicCode })) return;
+            if (!currentlyBlocked && !await showConfirm({ message: t('cardholder_block_confirm', 'Block this agent? They will not be able to send you messages.'), confirmText: t('common_block', 'Block'), danger: true, itemName: publicCode })) return;
             try {
                 await apiCall('PATCH', `/api/contacts/${publicCode}`, {
                     deviceId: currentUser.deviceId,
@@ -1728,7 +1728,7 @@
             const card = collectedCards.find(c => c.publicCode === publicCode);
             if (!card) return;
             const newBlocked = !card.blocked;
-            if (newBlocked && !await showConfirm({ message: t('cardholder_block_confirm', 'Block this agent?'), danger: true, itemName: card.name || card.publicCode })) return;
+            if (newBlocked && !await showConfirm({ message: t('cardholder_block_confirm', 'Block this agent?'), confirmText: t('common_block', 'Block'), danger: true, itemName: card.name || card.publicCode })) return;
             try {
                 await apiCall('PATCH', `/api/contacts/${publicCode}`, {
                     deviceId: currentUser.deviceId,
@@ -1766,7 +1766,7 @@
         async function removeCard(publicCode) {
             const card = collectedCards.find(c => c.publicCode === publicCode);
             const name = card ? (card.name || card.publicCode) : publicCode;
-            if (!await showConfirm({ message: t('cardholder_remove_confirm', `Remove ${name} from card holder?`).replace('{name}', name), danger: true, itemName: name })) return;
+            if (!await showConfirm({ message: t('cardholder_remove_confirm', `Remove ${name} from card holder?`).replace('{name}', name), confirmText: t('common_remove', 'Remove'), danger: true, itemName: name })) return;
             try {
                 await apiCall('DELETE', '/api/contacts', {
                     deviceId: currentUser.deviceId,
@@ -1835,7 +1835,7 @@
         }
 
         async function unfriend(publicCode) {
-            if (!await showConfirm({ message: t('cardholder_unfriend_confirm', 'Remove this friend?'), danger: true, itemName: publicCode })) return;
+            if (!await showConfirm({ message: t('cardholder_unfriend_confirm', 'Remove this friend?'), confirmText: t('common_remove', 'Remove'), danger: true, itemName: publicCode })) return;
             try {
                 await apiCall('DELETE', `/api/contacts/${publicCode}/unfriend`, {
                     deviceId: currentUser.deviceId,

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -5671,7 +5671,7 @@
             if (event) event.stopPropagation();
             const contact = contacts.find(c => c.publicCode === publicCode);
             const name = contact ? (contact.name || contact.publicCode) : publicCode;
-            if (!await showConfirm({ message: i18n.t('chat_contacts_remove_confirm').replace('{name}', name), danger: true, itemName: name })) return;
+            if (!await showConfirm({ message: i18n.t('chat_contacts_remove_confirm').replace('{name}', name), confirmText: i18n.t('common_remove'), danger: true, itemName: name })) return;
             try {
                 await apiCall('DELETE', '/api/contacts', {
                     deviceId: currentUser.deviceId,
@@ -9660,6 +9660,7 @@
         async function schedCancel(id) {
             const ok = await showConfirm({
                 message: i18n.t('chat_schedule_delete_confirm') || 'Cancel this scheduled message?',
+                confirmText: i18n.t('common_delete'),
                 danger: true,
                 itemName: id
             });
@@ -10033,7 +10034,7 @@
             }
         }
         async function deleteR2File(fileId) {
-            if (!await showConfirm({ message: '確定刪除這個檔案？（無法復原）', danger: true, itemName: fileId })) return;
+            if (!await showConfirm({ message: '確定刪除這個檔案？（無法復原）', confirmText: i18n.t('common_delete'), danger: true, itemName: fileId })) return;
             try {
                 const res = await fetch(API_BASE + '/api/files/' + encodeURIComponent(fileId), {
                     method: 'DELETE',

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -3549,7 +3549,7 @@
         }
 
         async function resetXdSettings(entityId) {
-            if (!await showConfirm({ message: i18n.t('dash_xd_reset_confirm'), danger: true, itemName: entityId })) return;
+            if (!await showConfirm({ message: i18n.t('dash_xd_reset_confirm'), confirmText: i18n.t('common_reset'), danger: true, itemName: entityId })) return;
             try {
                 var data = await apiCall('DELETE', '/api/entity/cross-device-settings', {
                     deviceId: currentUser.deviceId,
@@ -3798,7 +3798,7 @@
         }
 
         async function deleteIdentity(entityId) {
-            if (!await showConfirm({ message: i18n.t('dash_id_clear_confirm') + entityId + '?', danger: true, itemName: entityId })) return;
+            if (!await showConfirm({ message: i18n.t('dash_id_clear_confirm') + entityId + '?', confirmText: i18n.t('common_clear'), danger: true, itemName: entityId })) return;
             try {
                 var data = await apiCall('DELETE', '/api/entity/identity', {
                     deviceId: currentUser.deviceId,
@@ -4872,7 +4872,7 @@
 
         async function resetOrgChart() {
             const t = (typeof i18n !== 'undefined' && i18n.t) ? i18n.t.bind(i18n) : (k, fb) => fb || k;
-            if (!await showConfirm({ message: t('org_reset_confirm', 'Reset organization chart to saved default?'), danger: true })) return;
+            if (!await showConfirm({ message: t('org_reset_confirm', 'Reset organization chart to saved default?'), confirmText: t('common_reset', 'Reset'), danger: true })) return;
             const validIds = entities.filter(e => e.isBound).map(e => e.entityId);
             const validSet = new Set(validIds);
             const saved = loadOrgChartDefault();

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -946,7 +946,7 @@
         }
 
         async function deleteFolder(name) {
-            if (!await showConfirm({ message: i18n.t('files_folder_delete_confirm').replace('%1$s', name), danger: true, itemName: name })) return;
+            if (!await showConfirm({ message: i18n.t('files_folder_delete_confirm').replace('%1$s', name), confirmText: i18n.t('common_delete'), danger: true, itemName: name })) return;
             const folders = getFileFolders().filter(f => f !== name);
             saveFileFolders(folders);
             // Remove folder assignments
@@ -1392,7 +1392,7 @@
         async function deleteFile(idx) {
             const file = allFiles[idx];
             if (!file) return;
-            if (!await showConfirm({ message: i18n.t('files_delete_confirm', 'Are you sure you want to delete this file?'), danger: true, itemName: file.text || file.url })) return;
+            if (!await showConfirm({ message: i18n.t('files_delete_confirm', 'Are you sure you want to delete this file?'), confirmText: i18n.t('common_delete'), danger: true, itemName: file.text || file.url })) return;
 
             try {
                 const resp = await apiCall(

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -2502,7 +2502,7 @@
         async function archiveTaskCard(cardId) {
             const card = findCard(cardId);
             if (!card) return;
-            if (!await showConfirm({ message: t('kb_archive_confirm', 'Archive this card?'), itemName: card.title || card.id, danger: true })) return;
+            if (!await showConfirm({ message: t('kb_archive_confirm', 'Archive this card?'), itemName: card.title || card.id, confirmText: t('common_archive', 'Archive'), danger: true })) return;
             // Optimistic: drop the card from the board right away; revert on
             // server failure. Undo path uses the existing /restore endpoint.
             const idx = allCards.findIndex(c => c.id === cardId);
@@ -2685,7 +2685,7 @@
         async function archiveCardFromDetail(cardId) {
             const card = findCard(cardId);
             if (!card) return;
-            if (!await showConfirm({ message: t('kb_archive_confirm', 'Archive this card?'), itemName: card.title || card.id, danger: true })) return;
+            if (!await showConfirm({ message: t('kb_archive_confirm', 'Archive this card?'), itemName: card.title || card.id, confirmText: t('common_archive', 'Archive'), danger: true })) return;
             await withAutoAction(null, () => apiCall('DELETE', `/api/mission/card/${cardId}?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`), {
                 closeOnDone: true, successMsg: '🗑 ' + t('kb_archive', 'Archive'),
             });
@@ -3018,7 +3018,7 @@
         async function deleteAutomation(cardId) {
             const card = findCard(cardId);
             if (!card) return;
-            if (!await showConfirm({ message: t('kb_auto_delete_confirm', `Delete automation "${card.title}"? This will archive the card.`), itemName: card.title || card.id, danger: true })) return;
+            if (!await showConfirm({ message: t('kb_auto_delete_confirm', `Delete automation "${card.title}"? This will archive the card.`), itemName: card.title || card.id, confirmText: t('common_delete', 'Delete'), danger: true })) return;
             const btn = document.querySelector('.kb-auto-action-btn.delete');
             await withAutoAction(btn, () => apiCall('DELETE', `/api/mission/card/${cardId}?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`), {
                 closeOnDone: true, successMsg: '🗑 ' + t('toast_entity_deleted', 'Deleted'),

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -1820,8 +1820,8 @@
         }
 
         // Unified bulk operation: apply mutation, save immediately, offer undo on success.
-        async function bulkOp({ confirmMsg, applyFn, restoreFn, overlayMsg, successMsg }) {
-            if (!await showConfirm({ message: confirmMsg, danger: true })) return;
+        async function bulkOp({ confirmMsg, confirmText, applyFn, restoreFn, overlayMsg, successMsg }) {
+            if (!await showConfirm({ message: confirmMsg, confirmText, danger: true })) return;
             applyFn();
             showBulkOverlay(overlayMsg);
             try {
@@ -1857,6 +1857,7 @@
 
             await bulkOp({
                 confirmMsg: i18n.t('mc_confirm_clear_category') || `Clear all items in "${cat}"?`,
+                confirmText: i18n.t('common_clear'),
                 applyFn: () => { dashboard[key] = dashboard[key].filter(item => item.category !== cat); },
                 restoreFn: () => { dashboard[key] = backup; },
                 overlayMsg: i18n.t('mc_bulk_clearing') || 'Clearing...',
@@ -1873,6 +1874,7 @@
 
             await bulkOp({
                 confirmMsg: i18n.t('mc_confirm_delete_category') || `Delete category "${cat}"? Items will become uncategorized.`,
+                confirmText: i18n.t('common_delete'),
                 applyFn: () => {
                     const order = getCategoryOrder(section);
                     const idx = order.indexOf(cat);
@@ -2305,7 +2307,7 @@
         async function deleteNote(id) {
             const note = dashboard.notes.find(n => n.id === id);
             const itemName = note ? (note.title || note.id) : id;
-            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
+            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, confirmText: i18n.t('common_delete'), danger: true })) {
                 dashboard.notes = dashboard.notes.filter(n => n.id !== id);
                 markChanged();
                 renderNotes();
@@ -2323,7 +2325,7 @@
             menu.querySelector('.context-menu-item').onclick = async () => {
                 const note = dashboard.notes.find(n => n.id === id);
                 const itemName = note ? (note.title || note.id) : id;
-                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
+                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, confirmText: i18n.t('common_delete'), danger: true })) {
                     dashboard.notes = dashboard.notes.filter(n => n.id !== id);
                     markChanged();
                     renderNotes();
@@ -2593,7 +2595,7 @@
         }
 
         async function clearDrawing() {
-            if (!await showConfirm({ message: i18n.t('mc_note_draw_clear_confirm') || 'Clear all drawings?', danger: true })) return;
+            if (!await showConfirm({ message: i18n.t('mc_note_draw_clear_confirm') || 'Clear all drawings?', confirmText: i18n.t('common_clear'), danger: true })) return;
             drawStrokes = [];
             redrawCanvas();
         }
@@ -2888,7 +2890,7 @@
         async function deleteNotePage(noteId) {
             const note = dashboard.notes.find(n => n.id === noteId);
             const itemName = note ? (note.title || note.id) : noteId;
-            if (!await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) return;
+            if (!await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, confirmText: i18n.t('common_delete'), danger: true })) return;
             try {
                 await apiCall('DELETE', '/api/mission/note/page', {
                     deviceId: currentUser.deviceId,
@@ -3372,7 +3374,7 @@
         async function deleteSkill(id) {
             const skill = dashboard.skills.find(s => s.id === id);
             const itemName = skill ? (skill.title || skill.id) : id;
-            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
+            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, confirmText: i18n.t('common_delete'), danger: true })) {
                 dashboard.skills = dashboard.skills.filter(s => s.id !== id);
                 markChanged();
                 renderSkills();
@@ -3390,7 +3392,7 @@
             menu.querySelector('.context-menu-item').onclick = async () => {
                 const skill = dashboard.skills.find(s => s.id === id);
                 const itemName = skill ? (skill.title || skill.id) : id;
-                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
+                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, confirmText: i18n.t('common_delete'), danger: true })) {
                     dashboard.skills = dashboard.skills.filter(s => s.id !== id);
                     markChanged();
                     renderSkills();
@@ -3503,7 +3505,7 @@
         async function deleteRule(id) {
             const rule = dashboard.rules.find(r => r.id === id);
             const itemName = rule ? (rule.name || rule.id) : id;
-            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
+            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, confirmText: i18n.t('common_delete'), danger: true })) {
                 dashboard.rules = dashboard.rules.filter(r => r.id !== id);
                 markChanged();
                 renderRules();
@@ -3521,7 +3523,7 @@
             menu.querySelector('.context-menu-item').onclick = async () => {
                 const rule = dashboard.rules.find(r => r.id === id);
                 const itemName = rule ? (rule.name || rule.id) : id;
-                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
+                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, confirmText: i18n.t('common_delete'), danger: true })) {
                     dashboard.rules = dashboard.rules.filter(r => r.id !== id);
                     markChanged();
                     renderRules();
@@ -3720,7 +3722,7 @@
         async function deleteSoul(id) {
             const soul = dashboard.souls.find(s => s.id === id);
             const itemName = soul ? (soul.name || soul.id) : id;
-            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
+            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, confirmText: i18n.t('common_delete'), danger: true })) {
                 dashboard.souls = dashboard.souls.filter(s => s.id !== id);
                 markChanged();
                 renderSouls();
@@ -3738,7 +3740,7 @@
             menu.querySelector('.context-menu-item').onclick = async () => {
                 const soul = dashboard.souls.find(s => s.id === id);
                 const itemName = soul ? (soul.name || soul.id) : id;
-                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
+                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, confirmText: i18n.t('common_delete'), danger: true })) {
                     dashboard.souls = dashboard.souls.filter(s => s.id !== id);
                     markChanged();
                     renderSouls();

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -2236,7 +2236,7 @@
             const acct = (currentUser && Array.isArray(currentUser.channelAccounts))
                 ? currentUser.channelAccounts.find(a => a.id === id) : null;
             const itemName = acct ? (acct.label || acct.handle || acct.channel || id) : id;
-            if (!await showConfirm({ message: i18n.t('toast_delete_channel_confirm'), itemName, danger: true })) return;
+            if (!await showConfirm({ message: i18n.t('toast_delete_channel_confirm'), itemName, confirmText: i18n.t('common_delete'), danger: true })) return;
             try {
                 await apiCall('DELETE', `/api/channel/account/${id}`);
                 // Re-fetch fresh user data to sync channel accounts

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650621,6 +650621,11 @@ const TRANSLATIONS = {
         "action_request_ratify_hold_badge": "Needs your approval",
         "action_request_ratify_hold_hint": "Nothing is sent unless you approve.",
         "action_request_recommended_badge_title": "Suggestion only — recorded, not auto-sent",
+
+        "common_revoke": "Revoke",
+        "common_block": "Block",
+        "common_reset": "Reset",
+        "common_archive": "Archive",
 },
 
 
@@ -1235679,6 +1235684,11 @@ const TRANSLATIONS = {
         "action_request_ratify_hold_badge": "需你核可",
         "action_request_ratify_hold_hint": "未經你核可不會送出。",
         "action_request_recommended_badge_title": "僅供參考 · 不會自動送出",
+
+        "common_revoke": "撤銷",
+        "common_block": "封鎖",
+        "common_reset": "重設",
+        "common_archive": "封存",
 },
 
 
@@ -1849941,6 +1849951,12 @@ const TRANSLATIONS = {
         "action_request_ratify_hold_badge": "需你核可",
         "action_request_ratify_hold_hint": "未经你核可不会送出。",
         "action_request_recommended_badge_title": "仅供参考 · 不会自动送出",
+
+        "common_revoke": "撤销",
+        "common_block": "封锁",
+        "common_reset": "重置",
+        "common_archive": "归档",
+        "common_clear": "清除",
 },
 
 

--- a/backend/tests/jest/destructive-confirm-verbs.test.js
+++ b/backend/tests/jest/destructive-confirm-verbs.test.js
@@ -1,0 +1,218 @@
+'use strict';
+
+/**
+ * destructive-confirm-verbs — regression guard for action-specific verbs on
+ * destructive confirm dialogs.
+ *
+ * Background (P3 UX, card-recommended option b):
+ *   showConfirm({danger:true}) in backend/public/portal/shared/api.js renders
+ *   the destructive OK button with a GENERIC fallback label
+ *   (⚠ + t('dialog_confirm','Confirm')) whenever the caller passes no
+ *   `confirmText`. Material Design / Apple HIG require destructive action
+ *   buttons to use a SPECIFIC verb (Delete / Remove / Revoke / Block / Reset /
+ *   Clear / Archive …) so the user — and screen-reader users (the button's
+ *   aria-label is otherwise generic "Confirm destructive action") — know the
+ *   consequence before committing. ~30 portal danger call-sites previously fell
+ *   back to the generic label.
+ *
+ * This file is the anti-regression gate (per the team rule「漏掉的缺口都要有
+ * testcase或CI」): every `showConfirm({ ... danger: true ... })` call-site in the
+ * portal MUST pass a `confirmText`. The api.js generic fallback stays as a
+ * last-resort default for non-danger confirms, but danger sites must be
+ * explicit. The test exercises the FAILURE path too: a synthetic danger call
+ * with no confirmText must be flagged by the same scanner the gate uses.
+ *
+ * jest.config.js is testEnvironment:'node'; this is a pure static-source +
+ * i18n-dictionary scan, no DOM needed.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.join(__dirname, '..', '..');                       // backend/
+const PORTAL_DIR = path.join(ROOT, 'public', 'portal');
+const API_JS = path.join(PORTAL_DIR, 'shared', 'api.js');            // implementation — excluded
+const I18N_PATH = path.join(ROOT, 'public', 'shared', 'i18n.js');
+
+// ── recursive walk for .html / .js, skipping the api.js implementation ────────
+function walkPortal(dir) {
+    const out = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name.startsWith('.')) continue;
+        if (entry.name === 'node_modules' || entry.name === 'assets') continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...walkPortal(full));
+        else if ((full.endsWith('.html') || full.endsWith('.js')) && full !== API_JS) out.push(full);
+    }
+    return out;
+}
+
+// ── extract every showConfirm( ... ) call argument string ─────────────────────
+// Balanced-paren scan that is aware of '…' "…" and `…` string literals so that
+// parens inside message strings (e.g. fullwidth （）, or `.replace('{name}', n)`)
+// do not throw off the depth counter. Returns the substring from `showConfirm(`
+// through its matching `)`.
+function extractShowConfirmCalls(src) {
+    const calls = [];
+    const NEEDLE = 'showConfirm(';
+    let idx = 0;
+    while ((idx = src.indexOf(NEEDLE, idx)) !== -1) {
+        // Guard against matching identifiers like `fooShowConfirm(` — require the
+        // char before the needle to be a non-identifier char.
+        const before = idx > 0 ? src[idx - 1] : ' ';
+        if (/[A-Za-z0-9_$]/.test(before)) { idx += NEEDLE.length; continue; }
+
+        let i = idx + NEEDLE.length;   // first char inside the opening paren
+        let depth = 1;
+        let str = null;                // current string delimiter, or null
+        while (i < src.length && depth > 0) {
+            const ch = src[i];
+            const prev = src[i - 1];
+            if (str) {
+                if (ch === str && prev !== '\\') str = null;
+            } else if (ch === '"' || ch === "'" || ch === '`') {
+                str = ch;
+            } else if (ch === '(') {
+                depth++;
+            } else if (ch === ')') {
+                depth--;
+            }
+            i++;
+        }
+        calls.push(src.slice(idx, i));
+        idx = i;
+    }
+    return calls;
+}
+
+const IS_DANGER_RE = /\bdanger\s*:\s*true\b/;
+// Matches both `confirmText: <expr>` and the bare shorthand `confirmText` (used
+// when a wrapper threads the prop through, e.g. mission.html bulkOp()).
+const HAS_CONFIRMTEXT_RE = /\bconfirmText\b/;
+
+// Returns the list of danger:true showConfirm calls in `src` that are MISSING a
+// confirmText. (The gate AND the failure-path test both call this.)
+function findDangerCallsMissingConfirmText(src) {
+    return extractShowConfirmCalls(src).filter(
+        call => IS_DANGER_RE.test(call) && !HAS_CONFIRMTEXT_RE.test(call)
+    );
+}
+
+// ── load TRANSLATIONS from i18n.js (same VM technique as i18n-check.js) ────────
+function loadTranslations() {
+    const srcCode = fs.readFileSync(I18N_PATH, 'utf8');
+    const noop = () => {};
+    const sandbox = {
+        _result: null,
+        localStorage: { getItem: () => null, setItem: noop },
+        navigator: { language: 'en' },
+        document: { querySelectorAll: () => [], documentElement: { lang: 'en' }, addEventListener: noop, getElementById: () => null },
+        window: { location: { search: '' } },
+        setTimeout: noop,
+        console: { log: noop, warn: noop, error: noop },
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(srcCode + '\n_result = TRANSLATIONS;', sandbox, { timeout: 8000 });
+    return sandbox._result;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// 1) THE GATE — no portal danger confirm may fall back to the generic label
+// ════════════════════════════════════════════════════════════════════════════
+describe('destructive confirm verbs — every danger showConfirm passes confirmText', () => {
+    const files = walkPortal(PORTAL_DIR);
+
+    test('portal scan found showConfirm call-sites (scanner is wired)', () => {
+        const total = files.reduce(
+            (n, f) => n + extractShowConfirmCalls(fs.readFileSync(f, 'utf8')).filter(c => IS_DANGER_RE.test(c)).length,
+            0
+        );
+        // There are ~30 danger call-sites today; a hard floor proves the scanner
+        // actually traverses the portal (catches a regex/path break that would
+        // otherwise make the gate vacuously pass).
+        expect(total).toBeGreaterThanOrEqual(25);
+    });
+
+    test.each(walkPortal(PORTAL_DIR).map(f => [path.relative(ROOT, f), f]))(
+        '%s — no danger:true confirm without a specific confirmText',
+        (_rel, file) => {
+            const missing = findDangerCallsMissingConfirmText(fs.readFileSync(file, 'utf8'));
+            // On failure, surface the offending call so the fix is obvious.
+            expect(missing).toEqual([]);
+        }
+    );
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 2) FAILURE-PATH PROOF — the scanner actually catches a bad call
+// ════════════════════════════════════════════════════════════════════════════
+describe('scanner failure path (proves the gate is not vacuous)', () => {
+    test('flags a danger call with NO confirmText', () => {
+        const bad = `if (!await showConfirm({ message: 'Delete it?', danger: true, itemName: x })) return;`;
+        expect(findDangerCallsMissingConfirmText(bad)).toHaveLength(1);
+    });
+
+    test('passes a danger call WITH confirmText (single line)', () => {
+        const good = `await showConfirm({ message: 'Delete it?', confirmText: i18n.t('common_delete'), danger: true });`;
+        expect(findDangerCallsMissingConfirmText(good)).toEqual([]);
+    });
+
+    test('passes a danger call WITH confirmText (multiline)', () => {
+        const good = `await showConfirm({
+            message: 'Cancel this scheduled message?',
+            confirmText: i18n.t('common_delete'),
+            danger: true,
+            itemName: id
+        });`;
+        expect(findDangerCallsMissingConfirmText(good)).toEqual([]);
+    });
+
+    test('passes the bare-shorthand confirmText (wrapper thread-through)', () => {
+        const good = `await showConfirm({ message: confirmMsg, confirmText, danger: true });`;
+        expect(findDangerCallsMissingConfirmText(good)).toEqual([]);
+    });
+
+    test('ignores NON-danger confirms (generic OK fallback is allowed there)', () => {
+        const ok = `await showConfirm({ message: 'Proceed?' });`;
+        expect(findDangerCallsMissingConfirmText(ok)).toEqual([]);
+    });
+
+    test('string-aware paren counting survives parens inside the message', () => {
+        // fullwidth （）, an ASCII .replace('(x)', y), and a nested i18n.t(...)
+        const good = `await showConfirm({ message: i18n.t('k').replace('(a)', '(b)'), confirmText: i18n.t('common_delete'), danger: true });`;
+        const bad = `await showConfirm({ message: i18n.t('k').replace('(a)', '(b)'), danger: true });`;
+        expect(findDangerCallsMissingConfirmText(good)).toEqual([]);
+        expect(findDangerCallsMissingConfirmText(bad)).toHaveLength(1);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 3) i18n PARITY — every verb key the danger sites use resolves in all 3 locales
+// ════════════════════════════════════════════════════════════════════════════
+describe('verb i18n keys exist in en / zh (ZH-Hant) / zh-CN (ZH-Hans)', () => {
+    // The verbs actually referenced by the portal danger call-sites. delete /
+    // remove / clear pre-existed in the dictionary; revoke / block / reset /
+    // archive are added by this change.
+    const VERB_KEYS = [
+        'common_delete', 'common_remove', 'common_clear',
+        'common_revoke', 'common_block', 'common_reset', 'common_archive',
+    ];
+    let T;
+    beforeAll(() => { T = loadTranslations(); });
+
+    test.each(['en', 'zh', 'zh-CN'])('locale "%s" has every verb key non-empty', (loc) => {
+        expect(T[loc]).toBeDefined();
+        for (const k of VERB_KEYS) {
+            expect(typeof T[loc][k]).toBe('string');
+            expect(T[loc][k].trim().length).toBeGreaterThan(0);
+        }
+    });
+
+    test('newly-added verbs are genuinely Traditional ≠ Simplified', () => {
+        // (common_clear is 清除 in both — identical glyphs — so it is excluded.)
+        for (const k of ['common_revoke', 'common_block', 'common_reset', 'common_archive']) {
+            expect(T.zh[k]).not.toBe(T['zh-CN'][k]);
+        }
+    });
+});


### PR DESCRIPTION
## What & why (P3 UX)
`showConfirm({danger:true})` (backend/public/portal/shared/api.js) renders the destructive OK button with a GENERIC fallback — `⚠ 確認 / Confirm` + a generic `Confirm destructive action` aria-label — whenever the caller passes no `confirmText`. **~30 of the portal's destructive call-sites did exactly that**, so a delete, a block, a revoke, a reset etc. all showed the same vague verb. Material Design / Apple HIG require the destructive action button to name the consequence (and the aria-label is the only cue a screen-reader user gets). This is a button-COPY enhancement — the modal a11y (role=alertdialog, focus-trap, danger→focus Cancel, Esc/Enter semantics) was already good.

## Approach (card option b)
1. **Call-sites** — all 30 portal `danger:true` `showConfirm` calls now pass an action-specific `confirmText`:
   - admin.html ×3 (revoke) · card-holder.html ×4 (block ×2 / remove ×2) · chat.html ×3 (remove / delete-schedule / delete-file) · dashboard.html ×3 (reset ×2 / clear) · files.html ×2 (delete) · mission.html ×13 (delete ×11 / clear ×2) · settings.html ×1 (delete) · kanban.html ×3 (archive ×2 / delete)
   - `mission.html` `bulkOp()` now threads a `confirmText` param through so its clear-category vs delete-category callers each get the right verb.
   - `env-vars.html` already passed `confirmText: common_delete` — left as-is (already compliant).
2. **i18n** — reused existing `common_delete` / `common_remove` / `common_clear`; added **`common_revoke` / `common_block` / `common_reset` / `common_archive`** (plus `common_clear` for zh-CN, which lacked it) to **en + zh (ZH-Hant) + zh-CN (ZH-Hans)** via the AST-safe `i18n-insert-locale-keys.js`. Genuine 繁≠简 (撤銷/撤销, 封鎖/封锁, 重設/重置, 封存/归档).
3. **Regression guard** — `backend/tests/jest/destructive-confirm-verbs.test.js`: a static-source scan over every portal HTML/JS file that **fails if any `showConfirm` `danger:true` call lacks a `confirmText`** (string-aware balanced-paren extractor so parens inside messages don't fool it). Exercises the **failure path** (a danger call with no confirmText is flagged; non-danger confirms are ignored; bare-shorthand `confirmText` thread-through passes). 93/93.
4. api.js keeps the generic fallback as a last-resort default for **non-danger** confirms; the guard keeps danger sites explicit.

## Verification
- **Guard proves the gate both ways**: FAILS on origin/main pre-fix (30 violations across the 8 pages) and PASSES on this change (0).
- `node backend/scripts/i18n-check.js` → ✅ all referenced keys resolve in EN (the fanout/coverage warnings are pre-existing `action_request_*` items, warn-only).
- `node backend/scripts/i18n-lint-dup-keys.js` → all 16 locale blocks clean.
- `jest`: new guard 93/93; broader sweep (i18n syntax/dup/fallback + dashboard/chat-ratify/kanban/mission/settings/admin) **60 suites, 670 passed, 1 skipped**. The chat ratify-badge test passes → #3779 ratify code untouched.

## Merge gate
This is portal UI — **desktop (1280×800) + mobile (390×844) vision-check by the commander is the merge gate.** Do not merge on green CI alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBmn5NeYXxoWMYX6QPx2mt