### PR TITLE
fix(wallpaper): reconnect free-walking (行走功能) + de-dupe walking toggles — consolidate #6 branches

### DIFF
--- a/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
@@ -158,6 +158,14 @@ class WallpaperWanderController(
         } else {
             emptyMap()
         }
+        // 行走功能 (free walking / ambient) needs peer positions so a roaming entity can
+        // visit companions or patrol. Only built when conscious mode is OFF so the
+        // 有意識的行走 (conscious / event-only) path stays allocation-free per frame.
+        val ambientPeers = if (!purposeful) {
+            buildAmbientPeers(basePositions, entities, width, height)
+        } else {
+            emptyList()
+        }
 
         return entities.mapIndexed { index, entity ->
             val base = basePositions.getOrNull(index) ?: (width / 2f to height / 2f)
@@ -170,9 +178,33 @@ class WallpaperWanderController(
                 advanceConversationTarget(entity, base, width, height, nowMs, gatherTargets[entity.entityId])
             } else if (states[entity.entityId]?.manualTarget == true) {
                 advanceManualTarget(entity, base, width, height, nowMs)
-            } else {
+            } else if (purposeful) {
+                // 有意識的行走 (conscious / event-only): idle at home until a chat event fires.
                 advanceHome(entity, base, width, height, nowMs)
+            } else {
+                // 行走功能 (free walking / ambient): roam continuously with goal-based actions.
+                advance(entity, base, width, height, nowMs, purposeful = true, ambientPeers = ambientPeers)
             }
+        }
+    }
+
+    private fun buildAmbientPeers(
+        basePositions: List<Pair<Float, Float>>,
+        entities: List<EntityStatus>,
+        width: Float,
+        height: Float
+    ): List<AmbientPeer> {
+        return entities.mapIndexedNotNull { index, entity ->
+            if (entity.state.pausesAmbientWander) return@mapIndexedNotNull null
+            val base = basePositions.getOrNull(index) ?: (width / 2f to height / 2f)
+            val baseX = (base.first / width).coerceIn(MIN_X_PCT, MAX_X_PCT)
+            val baseY = (base.second / height).coerceIn(MIN_Y_PCT, MAX_Y_PCT)
+            val state = states[entity.entityId]
+            AmbientPeer(
+                entityId = entity.entityId,
+                xPct = state?.xPct ?: baseX,
+                yPct = state?.yPct ?: baseY
+            )
         }
     }
 
@@ -301,7 +333,10 @@ class WallpaperWanderController(
         val state = stateFor(entityId, base, width, height, nowMs)
         state.homeXPct = (base.first / width).coerceIn(MIN_X_PCT, MAX_X_PCT)
         state.homeYPct = (base.second / height).coerceIn(MIN_Y_PCT, MAX_Y_PCT)
-        if (state.motionState == MotionState.SLEEPING) {
+        // Ambient roaming never produces STOPPED on its own; a STOPPED/SLEEPING state here
+        // means the entity just arrived home in conscious mode and the user switched to free
+        // walking — resume wandering instead of staying frozen.
+        if (state.motionState == MotionState.SLEEPING || state.motionState == MotionState.STOPPED) {
             state.motionState = MotionState.WANDERING
             state.idleUntilMs = 0L
         }

--- a/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
@@ -57,7 +57,8 @@ class WallpaperWanderController(
         var targetXPct: Float,
         var targetYPct: Float,
         var lastUpdateMs: Long,
-        var idleUntilMs: Long,
+        var actionUntilMs: Long,
+        var nextActionAtMs: Long,
         var retargetAtMs: Long,
         var moving: Boolean,
         var motionState: MotionState,
@@ -81,6 +82,16 @@ class WallpaperWanderController(
     }
 
     fun isWalking(entityId: Int): Boolean = states[entityId]?.moving == true
+
+    /**
+     * True while an ambient entity is mid random-action: during this ~3s window the entity
+     * holds its position (stationary gesture) and the renderer can overlay an action pose.
+     * Uses lastUpdateMs (set each advance tick) as "now" so callers need not pass time.
+     */
+    fun isPerformingAction(entityId: Int): Boolean {
+        val state = states[entityId] ?: return false
+        return state.lastUpdateMs < state.actionUntilMs
+    }
 
     fun ambientGoal(entityId: Int): AmbientWanderGoal {
         return states[entityId]?.ambientGoal ?: AmbientWanderGoal.RANDOM
@@ -121,7 +132,7 @@ class WallpaperWanderController(
         val state = states[entityId] ?: return
         if (state.motionState == MotionState.STOPPED) {
             state.motionState = MotionState.WANDERING
-            state.idleUntilMs = 0L
+            state.actionUntilMs = 0L
         }
     }
 
@@ -129,7 +140,7 @@ class WallpaperWanderController(
         val state = commandState(entityId)
         state.motionState = MotionState.WANDERING
         state.moving = false
-        state.idleUntilMs = 0L
+        state.actionUntilMs = 0L
         state.manualTarget = false
         state.onArrive = null
     }
@@ -335,10 +346,12 @@ class WallpaperWanderController(
         state.homeYPct = (base.second / height).coerceIn(MIN_Y_PCT, MAX_Y_PCT)
         // Ambient roaming never produces STOPPED on its own; a STOPPED/SLEEPING state here
         // means the entity just arrived home in conscious mode and the user switched to free
-        // walking — resume wandering instead of staying frozen.
+        // walking — resume wandering instead of staying frozen, and re-arm the action cadence
+        // so it roams first before the next stationary action.
         if (state.motionState == MotionState.SLEEPING || state.motionState == MotionState.STOPPED) {
             state.motionState = MotionState.WANDERING
-            state.idleUntilMs = 0L
+            state.actionUntilMs = 0L
+            state.nextActionAtMs = nowMs + ACTION_INTERVAL_MS
         }
 
         val dtSeconds = ((nowMs - state.lastUpdateMs).coerceIn(0L, 1000L)) / 1000f
@@ -363,7 +376,21 @@ class WallpaperWanderController(
             MotionState.WANDERING -> Unit
         }
 
-        if (nowMs < state.idleUntilMs) {
+        // Every ~10s the entity performs a ~3s stationary random action. The cadence is
+        // independent of arrival so it reliably fires (the old arrival-only idle almost never
+        // triggered: retarget every 3-8s reassigned the target before the slow 0.04/s wander
+        // could arrive, so the entity roamed nonstop and never paused).
+        if (nowMs >= state.nextActionAtMs) {
+            state.actionUntilMs = nowMs + ACTION_DURATION_MS
+            state.nextActionAtMs = nowMs + ACTION_INTERVAL_MS
+            // Pick a fresh random ambient goal as the "action" flourish for this pause.
+            state.ambientGoal = randomActionGoal()
+            state.ambientStep++
+        }
+
+        // During the action window hold the position: the entity is stationary while the
+        // action gesture plays (locomotion is gated off).
+        if (nowMs < state.actionUntilMs) {
             state.moving = false
             return state.xPct * width to state.yPct * height
         }
@@ -373,13 +400,19 @@ class WallpaperWanderController(
         }
 
         if (moveTowardTarget(state, width, height, wanderSpeedPctPerSecond, dtSeconds)) {
+            // Arrived early: just pick the next roam target and keep going. The stationary
+            // pause is driven by the action cadence above, not by arrival.
             state.moving = false
-            state.idleUntilMs = nowMs + randomLong(0L, MAX_IDLE_MS)
-            retarget(state, state.idleUntilMs, entity, purposeful, ambientPeers)
+            retarget(state, nowMs, entity, purposeful, ambientPeers)
         }
 
         coerceToSafeBounds(state)
         return state.xPct * width to state.yPct * height
+    }
+
+    private fun randomActionGoal(): AmbientWanderGoal {
+        val goals = AmbientWanderGoal.values()
+        return goals[random.nextInt(goals.size)]
     }
 
     private fun stateFor(
@@ -401,7 +434,8 @@ class WallpaperWanderController(
                 targetXPct = target.first,
                 targetYPct = target.second,
                 lastUpdateMs = nowMs,
-                idleUntilMs = nowMs + randomLong(0L, MAX_IDLE_MS),
+                actionUntilMs = 0L,
+                nextActionAtMs = nowMs + ACTION_INTERVAL_MS,
                 retargetAtMs = nowMs + randomLong(MIN_RETARGET_MS, MAX_RETARGET_MS),
                 moving = false,
                 motionState = MotionState.WANDERING,
@@ -424,7 +458,8 @@ class WallpaperWanderController(
                 targetXPct = 0.5f,
                 targetYPct = 0.5f,
                 lastUpdateMs = 0L,
-                idleUntilMs = 0L,
+                actionUntilMs = 0L,
+                nextActionAtMs = 0L,
                 retargetAtMs = 0L,
                 moving = false,
                 motionState = MotionState.STOPPED,
@@ -570,7 +605,9 @@ class WallpaperWanderController(
         const val DEFAULT_GATHER_SPACING_PCT = 0.18f
         private const val ARRIVAL_EPSILON_PX = 1f
         private const val FACING_EPSILON_PX = 0.5f
-        private const val MAX_IDLE_MS = 3000L
+        // Free-walking action cadence: every ~10s the entity performs a ~3s stationary action.
+        private const val ACTION_INTERVAL_MS = 10000L
+        private const val ACTION_DURATION_MS = 3000L
         private const val MIN_RETARGET_MS = 3000L
         private const val MAX_RETARGET_MS = 8000L
         private const val MIN_X_PCT = 0.08f

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -776,9 +776,9 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="wallpaper_usage_engine_codex">Codex</string>
     <string name="wallpaper_usage_items">显示项目</string>
     <string name="wallpaper_walking_title">行走功能</string>
-    <string name="wallpaper_walking_settings_desc">让壁纸实体慢慢依目标移动</string>
+    <string name="wallpaper_walking_settings_desc">让壁纸实体会走动；搭配「有意识地行走」可选择只在聊天时移动或自由漫游。</string>
     <string name="wallpaper_walking_help_button">关于壁纸行走功能</string>
-    <string name="wallpaper_walking_help">说明：壁纸上的实体平时会待在各自原位，只有 speak-to、@all 或 broadcast 聊天事件发生时才会移动。sender 与 receiver 会保持一个实体单位间距聚集到中间，消息气泡 TTL 结束后回到原位。\n\n需要：已开启实时壁纸、至少一个已绑定实体、方向性行走动画可用。\n\n测试：发送实体间 speak-to 或 broadcast 消息，观察 sender 与 receiver 聚集后回家。</string>
+    <string name="wallpaper_walking_help">说明：这是壁纸走动的总开关。当「有意识地行走」开启(默认)时，实体平时待在各自原位，只有 speak-to、@all 或 broadcast 聊天事件发生时才移动；sender 与 receiver 会保持一个实体单位间距聚集到中间，消息气泡 TTL 结束后回到原位。当「有意识地行走」关闭时，实体会一直自由走动，每隔几秒做一个随机目标动作(拜访同伴、巡逻、回到活动区)。\n\n需要：已开启实时壁纸、至少一个已绑定实体、方向性行走动画可用。\n\n测试：关闭「有意识地行走」观察实体自由漫游；或保持开启并发送 speak-to/broadcast 观察聚集后回家。</string>
     <string name="wallpaper_custom_layout_help_button">关于自定义布局</string>
     <string name="wallpaper_custom_layout_help">可拖拽实体并保存壁纸原位；有意识地行走与看板任务物件都会以这些原位作为来源。</string>
     <string name="wallpaper_background_help_button">关于自定义背景</string>
@@ -925,10 +925,8 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="wallpaper_setting_bubble_duration_value">%1$d 秒</string>
     <string name="wallpaper_setting_bubble_duration_minutes_value">%1$d 分钟</string>
     <string name="wallpaper_setting_bubble_duration_minutes_seconds_value">%1$d 分 %2$d 秒</string>
-    <string name="wallpaper_setting_purposeful_walking">有目的的行走</string>
-    <string name="wallpaper_setting_purposeful_walking_desc">让待机伙伴会拜访同伴、巡逻、回到自己的活动区。</string>
     <string name="wallpaper_setting_conscious_walking">有意识地行走</string>
-    <string name="wallpaper_setting_conscious_walking_desc">只有 speak-to、@all 与 broadcast 聊天事件会让实体移动；sender 与 receiver 会保持一个实体单位间距聚集到中间，气泡 TTL 结束后回到各自原位。</string>
+    <string name="wallpaper_setting_conscious_walking_desc">开启：只有 speak-to、@all 与 broadcast 聊天事件会让实体移动；sender 与 receiver 会保持一个实体单位间距聚集到中间，气泡 TTL 结束后回到各自原位。关闭：实体会自由漫游，并做拜访同伴、巡逻等目标动作。</string>
     <string name="wallpaper_setting_entity_interactions">实体互动</string>
     <string name="wallpaper_setting_entity_interactions_desc">伙伴碰到彼此时会一起播放同一个随机动作：挥手、跳跃、失败或审视。</string>
     <string name="wallpaper_setting_collision_duration">碰撞动作持续时间</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -795,9 +795,9 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="wallpaper_usage_engine_codex">Codex</string>
     <string name="wallpaper_usage_items">顯示項目</string>
     <string name="wallpaper_walking_title">行走功能</string>
-    <string name="wallpaper_walking_settings_desc">讓桌布實體慢慢依目標走動</string>
+    <string name="wallpaper_walking_settings_desc">讓桌布實體會走動;搭配「有意識地走路」可選擇只在聊天時移動或自由漫遊。</string>
     <string name="wallpaper_walking_help_button">關於桌布行走功能</string>
-    <string name="wallpaper_walking_help">說明：桌布上的實體平時會待在各自原位，只有 speak-to、@all 或 broadcast 聊天事件發生時才會移動。sender 與 receiver 會保持一個實體單位間距聚集到中間，訊息泡泡 TTL 結束後回到原位。\n\n需要：已開啟即時桌布、至少一個已綁定實體、方向性走路動畫可用。\n\n測試：傳送實體間 speak-to 或 broadcast 訊息，觀察 sender 與 receiver 聚集後回家。</string>
+    <string name="wallpaper_walking_help">說明：這是桌布走動的總開關。當「有意識地走路」開啟(預設)時，實體平時待在各自原位，只有 speak-to、@all 或 broadcast 聊天事件發生時才移動;sender 與 receiver 會保持一個實體單位間距聚集到中間，訊息泡泡 TTL 結束後回到原位。當「有意識地走路」關閉時，實體會一直自由走動，每隔幾秒做一個隨機目標動作(拜訪同伴、巡邏、回到活動區)。\n\n需要：已開啟即時桌布、至少一個已綁定實體、方向性走路動畫可用。\n\n測試：關閉「有意識地走路」觀察實體自由漫遊;或保持開啟並傳送 speak-to/broadcast 觀察聚集後回家。</string>
     <string name="wallpaper_custom_layout_help_button">關於自訂佈局</string>
     <string name="wallpaper_custom_layout_help">可拖曳實體並保存桌布原位；有意識地走路與看板任務物件都會以這些原位作為來源。</string>
     <string name="wallpaper_background_help_button">關於自訂背景</string>
@@ -839,10 +839,8 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="wallpaper_setting_bubble_duration_value">%1$d 秒</string>
     <string name="wallpaper_setting_bubble_duration_minutes_value">%1$d 分鐘</string>
     <string name="wallpaper_setting_bubble_duration_minutes_seconds_value">%1$d 分 %2$d 秒</string>
-    <string name="wallpaper_setting_purposeful_walking">有目的的走路</string>
-    <string name="wallpaper_setting_purposeful_walking_desc">讓待機夥伴會拜訪同伴、巡邏、回到自己的活動區。</string>
     <string name="wallpaper_setting_conscious_walking">有意識地走路</string>
-    <string name="wallpaper_setting_conscious_walking_desc">只有 speak-to、@all 與 broadcast 聊天事件會讓實體移動；sender 與 receiver 會保持一個實體單位間距聚集到中間，泡泡 TTL 結束後回到各自原位。</string>
+    <string name="wallpaper_setting_conscious_walking_desc">開啟：只有 speak-to、@all 與 broadcast 聊天事件會讓實體移動；sender 與 receiver 會保持一個實體單位間距聚集到中間，泡泡 TTL 結束後回到各自原位。關閉：實體會自由漫遊，並做拜訪同伴、巡邏等目標動作。</string>
     <string name="wallpaper_setting_entity_interactions">實體互動</string>
     <string name="wallpaper_setting_entity_interactions_desc">夥伴碰到彼此時會一起播放同一個隨機動作：揮手、跳躍、失敗或審視。</string>
     <string name="wallpaper_setting_collision_duration">碰撞動作持續時間</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,9 +93,9 @@
     <string name="drag_to_position">Drag entities to position them</string>
     <string name="pinch_to_resize">Drag to move; pinch entities or usage to resize</string>
     <string name="wallpaper_walking_title">Walking Feature</string>
-    <string name="wallpaper_walking_settings_desc">Slow goal-based movement for wallpaper entities</string>
+    <string name="wallpaper_walking_settings_desc">Lets wallpaper entities walk. Pair with Conscious walking to pick event-only or free roaming.</string>
     <string name="wallpaper_walking_help_button">About wallpaper walking</string>
-    <string name="wallpaper_walking_help">What: wallpaper entities stay at their home positions until a speak-to, @all, or broadcast conversation happens. The sender and receivers gather at the center with one-entity spacing, then return home when the message bubble TTL ends.\n\nNeeds: live wallpaper enabled, at least one bound entity, and directional walking animation available.\n\nTest: send a speak-to or broadcast message between entities, then watch the sender and receivers gather and return.</string>
+    <string name="wallpaper_walking_help">What: this is the master switch for wallpaper movement. With Conscious walking ON (default), entities stay at their home positions and only move for a speak-to, @all, or broadcast conversation — the sender and receivers gather at the center with one-entity spacing, then return home when the message bubble TTL ends. With Conscious walking OFF, entities roam freely all the time, doing a random goal action (visit a peer, patrol, return home) every few seconds.\n\nNeeds: live wallpaper enabled, at least one bound entity, and directional walking animation available.\n\nTest: turn Conscious walking off and watch entities wander; or leave it on and send a speak-to/broadcast to watch them gather and return.</string>
     <string name="wallpaper_custom_layout_help_button">About custom layout</string>
     <string name="wallpaper_custom_layout_help">Lets you drag entities to persistent wallpaper home positions. Conscious walking and kanban task objects use these home positions as their source of truth.</string>
     <string name="wallpaper_background_help_button">About custom background</string>
@@ -140,10 +140,8 @@
     <string name="wallpaper_setting_bubble_duration_value">%1$d sec</string>
     <string name="wallpaper_setting_bubble_duration_minutes_value">%1$d min</string>
     <string name="wallpaper_setting_bubble_duration_minutes_seconds_value">%1$d min %2$d sec</string>
-    <string name="wallpaper_setting_purposeful_walking">Purposeful walking</string>
-    <string name="wallpaper_setting_purposeful_walking_desc">Give idle companions goals like visiting peers, patrolling, and returning home.</string>
     <string name="wallpaper_setting_conscious_walking">Conscious walking</string>
-    <string name="wallpaper_setting_conscious_walking_desc">Only move entities for speak-to, @all, and broadcast conversations. The sender and receivers gather at the center with one-entity spacing, then return home when the bubble TTL ends.</string>
+    <string name="wallpaper_setting_conscious_walking_desc">On: entities only move for speak-to, @all, and broadcast conversations — the sender and receivers gather at the center with one-entity spacing, then return home when the bubble TTL ends. Off: entities roam freely with goal actions like visiting peers and patrolling.</string>
     <string name="wallpaper_setting_entity_interactions">Entity interactions</string>
     <string name="wallpaper_setting_entity_interactions_desc">Let companions react when they bump into each other. Both entities play the same random action: wave, jump, fail, or review.</string>
     <string name="wallpaper_setting_collision_duration">Collision action duration</string>

--- a/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
@@ -202,6 +202,43 @@ class WallpaperWanderControllerTest {
     }
 
     @Test
+    fun freeWalkingHoldsPositionDuringRandomActionAndRoamsBetween() {
+        // 行走功能 (free walking): every ~10s the entity performs a ~3s stationary random
+        // action — during that window its position MUST NOT change (it freezes while the
+        // gesture plays), and it MUST roam (advance) between actions.
+        // Pre-fix bug: the pause was armed only on arrival, which the 0.04/s wander almost
+        // never reached before the 3-8s retarget, so the entity moved nonstop and never held.
+        val controller = WallpaperWanderController(random = Random(5))
+        val entities = listOf(EntityStatus(entityId = 1, state = CharacterState.IDLE))
+        val base = listOf(250f to 500f)
+
+        controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = false, nowMs = 0L)
+        var t = 0L
+        var prev: Pair<Float, Float>? = null
+        var sawActionHold = false
+        var sawRoamMove = false
+        repeat(400) { // 40s at 100ms ticks -> several 10s action cadences
+            t += 100L
+            val pos = controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = false, nowMs = t)[0]
+            val acting = controller.isPerformingAction(1)
+            val previous = prev
+            if (previous != null) {
+                val moved = pos.first != previous.first || pos.second != previous.second
+                if (acting) {
+                    assertFalse("position must NOT change during a stationary random action (t=$t)", moved)
+                    sawActionHold = true
+                } else if (moved) {
+                    sawRoamMove = true
+                }
+            }
+            prev = pos
+        }
+
+        assertTrue("expected at least one stationary action window within 40s", sawActionHold)
+        assertTrue("entity must roam (advance) between actions", sawRoamMove)
+    }
+
+    @Test
     fun walkingStateConstantMatchesPetdxDescriptorStateName() {
         assertEquals("WALKING", WallpaperWanderController.WALKING_STATE_ASSET)
     }

--- a/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
@@ -153,6 +153,55 @@ class WallpaperWanderControllerTest {
     }
 
     @Test
+    fun freeWalkingRoamsAwayFromHomeWhenConsciousModeOff() {
+        // 行走功能 (free walking / ambient): with conscious mode OFF (purposeful = false)
+        // entities must roam continuously, not stay frozen at their home positions.
+        // Regression guard for the #3617 wiring that left advance() unreachable.
+        val controller = WallpaperWanderController(random = Random(5))
+        val entities = listOf(
+            EntityStatus(entityId = 1, state = CharacterState.IDLE),
+            EntityStatus(entityId = 2, state = CharacterState.IDLE)
+        )
+        val base = listOf(250f to 500f, 750f to 500f)
+
+        controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = false, nowMs = 0L)
+        var maxDisplacement = 0f
+        var t = 0L
+        repeat(60) {
+            t += 500L
+            val pos = controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = false, nowMs = t)
+            for (i in pos.indices) {
+                val dx = pos[i].first - base[i].first
+                val dy = pos[i].second - base[i].second
+                maxDisplacement = maxOf(maxDisplacement, kotlin.math.hypot(dx.toDouble(), dy.toDouble()).toFloat())
+            }
+        }
+
+        assertTrue(
+            "free walking (conscious OFF) must roam away from home, got max=$maxDisplacement",
+            maxDisplacement > 20f
+        )
+    }
+
+    @Test
+    fun consciousModeKeepsEntitiesHomeWithoutConversation() {
+        // 有意識的行走 (conscious / event-only, purposeful = true): entities idle at home
+        // and never ambient-roam without a chat event.
+        val controller = WallpaperWanderController(random = Random(5))
+        val entities = listOf(EntityStatus(entityId = 1, state = CharacterState.IDLE))
+        val base = listOf(250f to 500f)
+
+        controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = true, nowMs = 0L)
+        var t = 0L
+        repeat(60) {
+            t += 500L
+            val pos = controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = true, nowMs = t)
+            assertEquals("conscious mode must stay at home x", base[0].first, pos[0].first, 0.001f)
+            assertEquals("conscious mode must stay at home y", base[0].second, pos[0].second, 0.001f)
+        }
+    }
+
+    @Test
     fun walkingStateConstantMatchesPetdxDescriptorStateName() {
         assertEquals("WALKING", WallpaperWanderController.WALKING_STATE_ASSET)
     }


### PR DESCRIPTION
## What & why

Fixes the reported 桌布 walking bug: **entities are all stuck in place — 行走功能 (free walking) never happens**, plus the two walking toggles' copy overlapped confusingly.

### Root cause (verified against origin/main)
`#3617 [codex] Enhance wallpaper conversation and kanban motion` added the conscious/event-only gather-to-center behavior and, in doing so, **replaced the ambient `advance()` call in `WallpaperWanderController.positionsFor()` with `advanceHome()`** — leaving the entire free-walking engine (`advance` / `retarget` / `purposefulTarget` / patrol / companion-visit) as **dead code**. So with walking enabled, entities only ever idled at home or gathered on chat events; ambient roaming was unreachable. The `purposeful` flag plumbed from `wallpaperPurposefulWalkingEnabled` was accepted but ignored.

## Spec conformance (owner's two modes, now cleanly separated)
- **有意識的行走 (conscious) = EVENT-ONLY** (`purposeful = true`, default): idle at home; move only on speak-to / @all / broadcast; gather to center with ~1 entity-unit spacing; return home on bubble TTL. *(unchanged)*
- **行走功能 (free) = AMBIENT** (`purposeful = false`): roam continuously via `advance()` with a goal action (visit peer / patrol / return-home) every few seconds. *(reconnected)*

`positionsFor()` now routes the default (non-conversation, non-sleep, non-manual) branch by the toggle; `buildAmbientPeers()` supplies peer positions only in the ambient path (conscious path stays allocation-free). `advance()` also resumes a `STOPPED` state so toggling conscious-off mid-session un-freezes entities (ambient flow never produces `STOPPED` itself). Sleeping/paused states (`pausesAmbientWander`) still idle in both modes, by design.

## Copy fix (the "confusing overlap")
Removed the **orphaned, unreferenced** `wallpaper_setting_purposeful_walking` string (it described ambient roaming but was wired to nothing and clashed with "Conscious walking"). Rewrote the master **Walking Feature** help + **Conscious walking** description to explain both modes, across all 3 locales (`values/`, `values-zh-rTW/`, `values-zh-rCN/`).

## Consolidation note (important)
The two #6/codex branches are **mostly already merged**. `git cherry` + patch-id:
- `2483723e Make wallpaper walking purposeful` → already in main (= #3612)
- `c22e25c3 Remove duplicate settings walking toggle` → already in main
- `169c826a Add wallpaper bubble duration control` → already in main
- `ce379475 Add wallpaper bubble range and entity interactions` → only unmerged commit, but **superseded** by main's newer controllers (main's `WallpaperInteractionController`/`WallpaperWanderController`/`LayoutPreferences` are larger/newer than the branch's).

A literal `git merge` of the branches would **regress** months of landed work, so this PR delivers their *intent* (working free-walking + non-overlapping toggles) on top of current `main` instead.

## Gradle (worktree off origin/main + google-services.json copied in)
- `:app:testDebugUnitTest` — **236/236 green, 0 failures**
- `:app:lintDebug` — **green**
- `:app:assembleDebug` — **green** (APK built + installed on emulator)

New tests:
- `freeWalkingRoamsAwayFromHomeWhenConsciousModeOff` — **proven to FAIL on old main code** (entities frozen at home, max displacement ≈ 0) and PASS on the fix.
- `consciousModeKeepsEntitiesHomeWithoutConversation` — guards the event-only path.

## Emulator visual QA (partial — motion not yet captured live)
- emulator-5554 running; app logged in (test acct, 7/9 entities); `ClawWallpaperService` active; wallpaper renders all entities.
- Drove UI to More wallpaper settings → toggled **Conscious walking OFF** (verified `wallpaper_purposeful_walking_enabled=false` persisted).
- **Blocker for live motion proof:** at capture time all 7 bound agents were in **SLEEPING** state (server-driven, ~01:00). Sleeping entities correctly `pausesAmbientWander` (and don't gather) → no movement regardless of mode. The baseline screenshot ~15 min earlier showed the same entities **IDLE** (awake), which is the state under which free-walking engages.
- **Remaining to verify before merge:** re-run a 6-frame (~3s apart) home-screen capture while ≥1 agent is IDLE/BUSY/awake and confirm positions advance between frames + a goal action; confirm conscious mode (toggle ON) idles at home. Screenshots saved at `/private/tmp/wt-walking-screenshots/` (`00_baseline_home.png` = IDLE baseline; `free_walk_01..06.png` = all-sleeping frames).

The algorithmic fix is proven deterministically by the unit test; the only unverified piece is a live on-device motion clip, blocked solely by the agents' current sleep state.
