### PR TITLE
feat(entity-status): error counter — 當下累計(resettable) vs 歷史累計(never-reset) + 歷史紀錄 timeline (card_errctr)

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -36,6 +36,11 @@ const CANONICAL_ACHIEVEMENTS = [
     'notes_authored',
 ];
 
+// card_errctr: hard upper bound on retained error-event history rows per
+// (device, entity). pruneErrorEventsFor() trims to the newest N after each
+// append, so the 歷史紀錄 timeline is reviewable but never unbounded.
+const ERROR_EVENT_CAP = 1000;
+
 let pool = null;
 let devicesRef = null;
 // MessageLifecycle dual-write (spec §7, card_1b1c1322). Lazily required to
@@ -84,6 +89,27 @@ function initTable(chatPool) {
         CREATE INDEX IF NOT EXISTS idx_eec_lookup
             ON entity_error_counters(device_id, entity_id);
 
+        -- card_errctr (current-vs-historical split, owner P0 2026-06-27):
+        -- \`count\` is REDEFINED as the resettable "current cumulative" (當下累計).
+        -- \`historical_count\` is the all-time monotonic total (歷史累計) that the
+        -- reset path NEVER touches; \`current_reset_at\` records when \`count\` was
+        -- last cleared so the UI can show "since <time>". Both are additive
+        -- (ADD COLUMN IF NOT EXISTS = metadata-only, no table rewrite on PG11+).
+        ALTER TABLE entity_error_counters
+            ADD COLUMN IF NOT EXISTS historical_count INT NOT NULL DEFAULT 0;
+        ALTER TABLE entity_error_counters
+            ADD COLUMN IF NOT EXISTS current_reset_at TIMESTAMPTZ;
+        -- One-time, invariant-preserving backfill: existing \`count\` rows were
+        -- never resettable before this change, so count == all-time total today.
+        -- Seed historical_count from count, but ONLY when historical is behind
+        -- (historical_count < count). This fires exactly once (just-migrated rows
+        -- start at historical_count=0) and is a SAFE no-op on every later boot —
+        -- after a real reset count=0 <= historical so the WHERE never matches and
+        -- the historical total is preserved.
+        UPDATE entity_error_counters
+            SET historical_count = count
+          WHERE historical_count < count;
+
         CREATE TABLE IF NOT EXISTS entity_operation_log (
             id BIGSERIAL PRIMARY KEY,
             device_id VARCHAR(64) NOT NULL,
@@ -97,6 +123,26 @@ function initTable(chatPool) {
             ON entity_operation_log(device_id, entity_id, occurred_at DESC);
         CREATE INDEX IF NOT EXISTS idx_eol_event_type
             ON entity_operation_log(device_id, entity_id, event_type, occurred_at DESC);
+
+        -- card_errctr: 歷史紀錄 / error-event history. Every counter tick (silent
+        -- recipient swept past its grace window, or a direct push-failure) appends
+        -- ONE row here so the timeline survives a current-counter reset and stays
+        -- reviewable. Bounded per (device, entity) by pruneErrorEventsFor() — kept
+        -- to ERROR_EVENT_CAP newest rows — so it can never grow without limit.
+        CREATE TABLE IF NOT EXISTS entity_error_events (
+            id BIGSERIAL PRIMARY KEY,
+            device_id VARCHAR(64) NOT NULL,
+            entity_id INT NOT NULL,
+            axis VARCHAR(64) NOT NULL,
+            event_type VARCHAR(64),
+            sender_entity_id INT,
+            payload_snippet TEXT,
+            occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE INDEX IF NOT EXISTS idx_eee_lookup
+            ON entity_error_events(device_id, entity_id, id DESC);
+        CREATE INDEX IF NOT EXISTS idx_eee_axis
+            ON entity_error_events(device_id, entity_id, axis, id DESC);
 
         CREATE TABLE IF NOT EXISTS outbound_msg_pending (
             id BIGSERIAL PRIMARY KEY,
@@ -255,7 +301,8 @@ async function sweepExpired() {
     if (!pool) return { tickedCount: 0 };
     try {
         const expired = await pool.query(
-            `SELECT id, device_id, recipient_entity_id, axis
+            `SELECT id, device_id, recipient_entity_id, axis,
+                    event_type, sender_entity_id, payload_snippet
                FROM outbound_msg_pending
               WHERE expires_at <= NOW()
               LIMIT 500`
@@ -263,14 +310,26 @@ async function sweepExpired() {
         if (!expired.rows.length) return { tickedCount: 0 };
         for (const row of expired.rows) {
             try {
+                // card_errctr: bump BOTH the resettable current total and the
+                // never-reset historical total in one upsert.
                 await pool.query(`
-                    INSERT INTO entity_error_counters (device_id, entity_id, axis, count, last_event_at)
-                    VALUES ($1, $2, $3, 1, NOW())
+                    INSERT INTO entity_error_counters (device_id, entity_id, axis, count, historical_count, last_event_at)
+                    VALUES ($1, $2, $3, 1, 1, NOW())
                     ON CONFLICT (device_id, entity_id, axis) DO UPDATE
                     SET count = entity_error_counters.count + 1,
+                        historical_count = entity_error_counters.historical_count + 1,
                         last_event_at = NOW(),
                         updated_at = NOW()
                 `, [row.device_id, row.recipient_entity_id, row.axis]);
+
+                // card_errctr: this expiry IS an error event (recipient stayed
+                // silent past its grace window) — append it to the reviewable
+                // 歷史紀錄 timeline with the pending row's full context.
+                await recordErrorEvent(row.device_id, row.recipient_entity_id, row.axis, {
+                    eventType: row.event_type || 'no_reply',
+                    senderEntityId: row.sender_entity_id,
+                    payloadSnippet: row.payload_snippet,
+                });
 
                 // Dual-write divergence guard (spec §6.5 / §9.10): the legacy
                 // chat_no_reply counter just ticked because the bot stayed
@@ -427,16 +486,16 @@ function bindJwtSecret(secret) {
 async function getCounters(deviceId, entityId) {
     if (!pool) return [];
     const result = await pool.query(
-        `SELECT axis, count, last_event_at
+        `SELECT axis, count, historical_count, last_event_at, current_reset_at
            FROM entity_error_counters
           WHERE device_id = $1 AND entity_id = $2`,
         [deviceId, entityId]
     );
     // Currently-open events per axis: rows still sitting in outbound_msg_pending
     // for this entity-as-recipient. These are the events the panel's drill-down
-    // will surface. `count` (cumulative) stays for backward-compat with any
-    // existing chart/badge; `openCount` is the live health number Hank's spec
-    // is built around — drops as the entity replies.
+    // will surface. `count` is the resettable 當下累計 / current cumulative,
+    // `historicalCount` the never-reset 歷史累計 / historical cumulative, and
+    // `openCount` is the live health number that drops as the entity replies.
     const openRows = await pool.query(
         `SELECT axis, COUNT(*)::int AS open_count
            FROM outbound_msg_pending
@@ -446,6 +505,16 @@ async function getCounters(deviceId, entityId) {
     );
     const openByAxis = new Map(openRows.rows.map(r => [r.axis, Number(r.open_count)]));
     const byAxis = new Map(result.rows.map(r => [r.axis, r]));
+    // historical_count is additive (added after the table shipped) — fall back
+    // to count when the column is absent/null so a pre-migration row never
+    // surfaces a historical total BELOW its current total.
+    const histOf = (row) => {
+        if (!row) return 0;
+        const h = row.historical_count;
+        return (h == null) ? Number(row.count) || 0 : Number(h);
+    };
+    const resetOf = (row) => (row && row.current_reset_at)
+        ? new Date(row.current_reset_at).toISOString() : null;
     // Always surface canonical axes even when count = 0, so the UI can render
     // a stable row order. Extra non-canonical axes (forward-compat) appear after.
     const ordered = [];
@@ -454,8 +523,10 @@ async function getCounters(deviceId, entityId) {
         ordered.push({
             axis,
             count: row ? Number(row.count) : 0,
+            historicalCount: histOf(row),
             openCount: openByAxis.get(axis) || 0,
-            lastEventAt: row && row.last_event_at ? row.last_event_at.toISOString() : null,
+            lastEventAt: row && row.last_event_at ? new Date(row.last_event_at).toISOString() : null,
+            currentResetAt: resetOf(row),
         });
         byAxis.delete(axis);
         openByAxis.delete(axis);
@@ -464,8 +535,10 @@ async function getCounters(deviceId, entityId) {
         ordered.push({
             axis,
             count: Number(row.count),
+            historicalCount: histOf(row),
             openCount: openByAxis.get(axis) || 0,
-            lastEventAt: row.last_event_at ? row.last_event_at.toISOString() : null,
+            lastEventAt: row.last_event_at ? new Date(row.last_event_at).toISOString() : null,
+            currentResetAt: resetOf(row),
         });
         openByAxis.delete(axis);
     }
@@ -473,7 +546,7 @@ async function getCounters(deviceId, entityId) {
     // hasn't fired since first dispatch). Surface them so the drill-down lists
     // line up even before the cumulative row is created.
     for (const [axis, openCount] of openByAxis) {
-        ordered.push({ axis, count: 0, openCount, lastEventAt: null });
+        ordered.push({ axis, count: 0, historicalCount: 0, openCount, lastEventAt: null, currentResetAt: null });
     }
     return ordered;
 }
@@ -847,16 +920,142 @@ async function getAchievementEvents(deviceId, entityId, axis, limit) {
     }
 }
 
-async function incrementCounter(deviceId, entityId, axis) {
+async function incrementCounter(deviceId, entityId, axis, opts) {
     if (!pool) return;
+    // card_errctr: bump BOTH the resettable current total (count) AND the
+    // all-time historical total (historical_count). historical_count is never
+    // touched by the reset path, so it is the monotonic 歷史累計.
     await pool.query(`
-        INSERT INTO entity_error_counters (device_id, entity_id, axis, count, last_event_at)
-        VALUES ($1, $2, $3, 1, NOW())
+        INSERT INTO entity_error_counters (device_id, entity_id, axis, count, historical_count, last_event_at)
+        VALUES ($1, $2, $3, 1, 1, NOW())
         ON CONFLICT (device_id, entity_id, axis) DO UPDATE
         SET count = entity_error_counters.count + 1,
+            historical_count = entity_error_counters.historical_count + 1,
             last_event_at = NOW(),
             updated_at = NOW()
     `, [deviceId, entityId, axis]);
+    // Append to the reviewable error-event history (歷史紀錄). Best-effort —
+    // never let a history-write failure mask the underlying error path.
+    opts = opts || {};
+    await recordErrorEvent(deviceId, entityId, axis, {
+        eventType: opts.eventType || 'counter_inc',
+        senderEntityId: opts.senderEntityId != null ? opts.senderEntityId : null,
+        payloadSnippet: opts.payloadSnippet || null,
+    });
+}
+
+// card_errctr: append one error event to the bounded 歷史紀錄 timeline, then
+// trim to ERROR_EVENT_CAP newest rows for this (device, entity). Fully
+// best-effort — swallows every error so the caller's hot path is unaffected.
+async function recordErrorEvent(deviceId, entityId, axis, opts) {
+    if (!pool || deviceId == null || entityId == null) return;
+    opts = opts || {};
+    try {
+        await pool.query(
+            `INSERT INTO entity_error_events
+                (device_id, entity_id, axis, event_type, sender_entity_id, payload_snippet, occurred_at)
+             VALUES ($1, $2, $3, $4, $5, $6, COALESCE($7::timestamptz, NOW()))`,
+            [
+                String(deviceId).slice(0, 64),
+                Number(entityId),
+                String(axis || 'other').slice(0, 64),
+                opts.eventType ? String(opts.eventType).slice(0, 64) : null,
+                opts.senderEntityId != null ? Number(opts.senderEntityId) : null,
+                opts.payloadSnippet ? String(opts.payloadSnippet).slice(0, 240) : null,
+                opts.occurredAt ? new Date(opts.occurredAt).toISOString() : null,
+            ]
+        );
+        await pruneErrorEventsFor(deviceId, entityId, ERROR_EVENT_CAP);
+    } catch (err) {
+        console.error('[EntityStatus] recordErrorEvent error:', err.message);
+    }
+}
+
+// Bound the history table: delete every row older than the Nth-newest for this
+// (device, entity). Indexed + scoped to one entity, so a no-op when the entity
+// has fewer than `cap` rows. Best-effort.
+async function pruneErrorEventsFor(deviceId, entityId, cap) {
+    if (!pool) return;
+    const keep = Math.max(1, Number(cap) || ERROR_EVENT_CAP);
+    try {
+        await pool.query(
+            `DELETE FROM entity_error_events
+              WHERE device_id = $1 AND entity_id = $2
+                AND id < (
+                    SELECT MIN(id) FROM (
+                        SELECT id FROM entity_error_events
+                         WHERE device_id = $1 AND entity_id = $2
+                         ORDER BY id DESC
+                         LIMIT $3
+                    ) keep
+                )`,
+            [deviceId, Number(entityId), keep]
+        );
+    } catch (err) {
+        console.error('[EntityStatus] pruneErrorEventsFor error:', err.message);
+    }
+}
+
+// Cursor-paginated read of the 歷史紀錄 timeline (newest first). Optional axis
+// filter. Mirrors getOperationLog's cursor shape (beforeId → nextCursor).
+async function getErrorHistory(deviceId, entityId, opts) {
+    if (!pool) return { items: [], nextCursor: null };
+    opts = opts || {};
+    const limit = Math.min(Math.max(parseInt(opts.limit) || 30, 1), 100);
+    const beforeId = parseInt(opts.beforeId) || null;
+    const axis = opts.axis && CANONICAL_AXES.includes(opts.axis) ? opts.axis : null;
+    const params = [deviceId, Number(entityId)];
+    let clause = '';
+    if (axis) { params.push(axis); clause += ` AND axis = $${params.length}`; }
+    if (beforeId) { params.push(beforeId); clause += ` AND id < $${params.length}`; }
+    params.push(limit);
+    const result = await pool.query(
+        `SELECT id, axis, event_type, sender_entity_id, payload_snippet, occurred_at
+           FROM entity_error_events
+          WHERE device_id = $1 AND entity_id = $2
+          ${clause}
+          ORDER BY id DESC
+          LIMIT $${params.length}`,
+        params
+    );
+    const items = result.rows.map(r => ({
+        id: String(r.id),
+        axis: r.axis,
+        eventType: r.event_type || null,
+        senderEntityId: r.sender_entity_id != null ? Number(r.sender_entity_id) : null,
+        payloadSnippet: r.payload_snippet || null,
+        occurredAt: r.occurred_at ? new Date(r.occurred_at).toISOString() : null,
+    }));
+    return {
+        items,
+        nextCursor: items.length === limit ? items[items.length - 1].id : null,
+    };
+}
+
+// card_errctr: reset the CURRENT cumulative counter only. Sets count = 0 and
+// stamps current_reset_at = NOW(); historical_count and the entity_error_events
+// history are left completely untouched. Optional single-axis scope (must be a
+// canonical axis); omit to reset every axis for the entity. Returns the number
+// of counter rows affected.
+async function resetCurrentCounters(deviceId, entityId, axis) {
+    if (!pool || deviceId == null || entityId == null) return 0;
+    const params = [deviceId, Number(entityId)];
+    let clause = '';
+    if (axis) {
+        if (!CANONICAL_AXES.includes(axis)) return 0;
+        params.push(axis);
+        clause = ` AND axis = $${params.length}`;
+    }
+    const result = await pool.query(
+        `UPDATE entity_error_counters
+            SET count = 0,
+                current_reset_at = NOW(),
+                updated_at = NOW()
+          WHERE device_id = $1 AND entity_id = $2
+          ${clause}`,
+        params
+    );
+    return result.rowCount || 0;
 }
 
 function authDeviceOrBot(req) {
@@ -1127,6 +1326,80 @@ router.get('/:eId/log', express.json(), async (req, res) => {
     }
 });
 
+// card_errctr: 歷史紀錄 / error-event history timeline (newest first, cursor
+// paginated). Optional ?axis= filter (must be a canonical axis). This survives
+// a current-counter reset — the whole point of persisting the events.
+router.get('/:eId/errors', async (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) {
+        return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    }
+    const targetEId = parseInt(req.params.eId);
+    if (!Number.isFinite(targetEId) || targetEId < 0) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+    let axis = null;
+    if (req.query.axis) {
+        axis = String(req.query.axis);
+        if (!CANONICAL_AXES.includes(axis)) {
+            return res.status(400).json({ success: false, error: 'Invalid axis' });
+        }
+    }
+    try {
+        const data = await getErrorHistory(auth.deviceId, targetEId, {
+            limit: req.query.limit,
+            beforeId: req.query.before,
+            axis,
+        });
+        res.json({
+            success: true,
+            deviceId: auth.deviceId,
+            entityId: targetEId,
+            items: data.items,
+            nextCursor: data.nextCursor,
+        });
+    } catch (err) {
+        console.error('[EntityStatus] getErrorHistory error:', err.message);
+        res.status(500).json({ success: false, error: 'internal' });
+    }
+});
+
+// card_errctr: reset the CURRENT cumulative counter only. historical_count and
+// the error-event history are untouched. Optional body { axis } restricts the
+// reset to one canonical axis; omit to reset all axes for the entity.
+router.post('/:eId/counter/reset', express.json(), async (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) {
+        return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    }
+    const targetEId = parseInt(req.params.eId);
+    if (!Number.isFinite(targetEId) || targetEId < 0) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+    let axis = null;
+    if (req.body && req.body.axis) {
+        axis = String(req.body.axis);
+        if (!CANONICAL_AXES.includes(axis)) {
+            return res.status(400).json({ success: false, error: 'Invalid axis' });
+        }
+    }
+    try {
+        const affected = await resetCurrentCounters(auth.deviceId, targetEId, axis);
+        const counters = await getCounters(auth.deviceId, targetEId);
+        res.json({
+            success: true,
+            deviceId: auth.deviceId,
+            entityId: targetEId,
+            axis: axis || null,
+            reset: affected,
+            counters,
+        });
+    } catch (err) {
+        console.error('[EntityStatus] resetCurrentCounters error:', err.message);
+        res.status(500).json({ success: false, error: 'internal' });
+    }
+});
+
 router.post('/:eId/quote', express.json(), async (req, res) => {
     const auth = authDeviceOrBot(req);
     if (!auth) {
@@ -1182,6 +1455,11 @@ module.exports = {
     logOperation,
     getOperationLog,
     getLogRowById,
+    recordErrorEvent,
+    pruneErrorEventsFor,
+    getErrorHistory,
+    resetCurrentCounters,
+    ERROR_EVENT_CAP,
     router,
     CANONICAL_AXES,
     CANONICAL_ACHIEVEMENTS,

--- a/backend/index.js
+++ b/backend/index.js
@@ -19423,7 +19423,12 @@ async function pushToBot(entity, deviceId, eventType, payload, opts = {}) {
                 || eventType === 'kanban_nudge') {
                 axis = 'system_msg_no_reply';
             }
-            entityStatus.incrementCounter(deviceId, entity.entityId, axis);
+            // card_errctr: thread the real push event type + failure reason into
+            // the error-event history (歷史紀錄) so the timeline is reviewable.
+            entityStatus.incrementCounter(deviceId, entity.entityId, axis, {
+                eventType: eventType || 'push_failure',
+                payloadSnippet: `push failed: ${reasonCode}`,
+            });
         } catch (_) { /* ignore */ }
         return { pushed: false, reason: reasonCode };
     }

--- a/backend/migrations/20260627_entity_error_counters_current_vs_historical.down.sql
+++ b/backend/migrations/20260627_entity_error_counters_current_vs_historical.down.sql
@@ -1,0 +1,13 @@
+-- Down migration for 20260627_entity_error_counters_current_vs_historical.
+-- Reversible: drops the history table + the two additive columns. NOTE that
+-- dropping historical_count discards the all-time totals and dropping
+-- entity_error_events discards the persisted history — this is a data-losing
+-- rollback by nature, so only run it as a deliberate revert. `count` reverts to
+-- being the (now post-any-reset) current total.
+
+DROP TABLE IF EXISTS entity_error_events;
+
+ALTER TABLE entity_error_counters
+    DROP COLUMN IF EXISTS historical_count;
+ALTER TABLE entity_error_counters
+    DROP COLUMN IF EXISTS current_reset_at;

--- a/backend/migrations/20260627_entity_error_counters_current_vs_historical.up.sql
+++ b/backend/migrations/20260627_entity_error_counters_current_vs_historical.up.sql
@@ -1,0 +1,61 @@
+-- Migration: 20260627_entity_error_counters_current_vs_historical
+-- Card: card_errctr — split the entity error counter into "current cumulative"
+--       (當下累計, resettable) vs "historical cumulative" (歷史累計, never resets)
+--       and persist a reviewable error-event history (歷史紀錄).
+-- Builds on 20260606_entity_status_panel_p0 (entity_error_counters) and
+--          20260607_entity_operation_log_p1 (entity_operation_log).
+--
+-- OWNER SIGN-OFF: this migration is ADDITIVE and reversible (see the .down.sql).
+-- The two ADD COLUMN IF NOT EXISTS are metadata-only on PostgreSQL 11+ (no table
+-- rewrite). entity_error_counters.count is REDEFINED in meaning from "all-time
+-- total" to "current cumulative" — but it stays numerically identical until the
+-- first explicit reset, and the backfill below seeds historical_count = count so
+-- NO existing total is lost. The backend (backend/entity-status.js initTable)
+-- also applies this same idempotent DDL at boot, so production self-heals even if
+-- this file is never run by a migration runner.
+
+-- 歷史累計 / historical cumulative — bumped in lockstep with `count`, NEVER reset.
+ALTER TABLE entity_error_counters
+    ADD COLUMN IF NOT EXISTS historical_count INT NOT NULL DEFAULT 0;
+
+-- When the resettable `count` was last cleared (NULL = never). Lets the UI show
+-- "current since <time>".
+ALTER TABLE entity_error_counters
+    ADD COLUMN IF NOT EXISTS current_reset_at TIMESTAMPTZ;
+
+-- One-time, invariant-preserving backfill: before this change `count` was never
+-- resettable, so it equals the all-time total today. Seed historical_count from
+-- it, but ONLY where historical is behind (handles re-runs safely — after a real
+-- reset count=0 <= historical so this never claws the historical total back).
+UPDATE entity_error_counters
+    SET historical_count = count
+  WHERE historical_count < count;
+
+COMMENT ON COLUMN entity_error_counters.historical_count IS
+    'All-time monotonic error total (歷史累計). NEVER touched by the current-counter reset path; count is the resettable 當下累計.';
+COMMENT ON COLUMN entity_error_counters.current_reset_at IS
+    'Timestamp of the last current-counter reset (count -> 0). NULL = never reset.';
+
+-- 歷史紀錄 / error-event history. One row per counter tick (silent recipient
+-- swept past its grace window, or a direct push failure). Survives a current
+-- reset and is bounded per (device, entity) by the backend pruner.
+CREATE TABLE IF NOT EXISTS entity_error_events (
+    id BIGSERIAL PRIMARY KEY,
+    device_id VARCHAR(64) NOT NULL,
+    entity_id INT NOT NULL,
+    axis VARCHAR(64) NOT NULL,
+    event_type VARCHAR(64),
+    sender_entity_id INT,
+    payload_snippet TEXT,
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_eee_lookup
+    ON entity_error_events(device_id, entity_id, id DESC);
+CREATE INDEX IF NOT EXISTS idx_eee_axis
+    ON entity_error_events(device_id, entity_id, axis, id DESC);
+
+COMMENT ON TABLE entity_error_events IS
+    'Persisted, reviewable timeline of per-entity error events (歷史紀錄) surfaced '
+    'in the entity status drawer. Appended on every counter tick; survives a '
+    'current-counter reset. Bounded per (device, entity) to the newest N rows by '
+    'backend/entity-status.js pruneErrorEventsFor().';

--- a/backend/public/portal/shared/entity-status-panel.js
+++ b/backend/public/portal/shared/entity-status-panel.js
@@ -223,6 +223,41 @@
         return res.json();
     }
 
+    // card_errctr: 歷史紀錄 / error-event history timeline (newest first).
+    async function fetchErrorHistory(eid, before, limit) {
+        const qs = _credQs();
+        qs.set('limit', String(limit || 30));
+        if (before) qs.set('before', String(before));
+        const res = await fetch(`/api/entity-status/${eid}/errors?${qs.toString()}`, {
+            credentials: 'include',
+            headers: _credHeaders(),
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+    }
+
+    // card_errctr: reset the CURRENT cumulative counter only (server keeps the
+    // historical total + the error-event history). Secrets travel in headers.
+    async function fetchResetCounters(eid, axis) {
+        const c = readCreds();
+        const body = {};
+        if (axis) body.axis = axis;
+        if (c.deviceId) body.deviceId = c.deviceId;
+        if (c.deviceSecret) body.deviceSecret = c.deviceSecret;
+        else if (c.botSecret) {
+            body.botSecret = c.botSecret;
+            if (c.entityId) body.entityId = Number(c.entityId);
+        }
+        const res = await fetch(`/api/entity-status/${eid}/counter/reset`, {
+            method: 'POST',
+            headers: Object.assign({ 'Content-Type': 'application/json' }, _credHeaders()),
+            body: JSON.stringify(body),
+            credentials: 'include',
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+    }
+
     function escapeHtml(s) {
         return String(s || '').replace(/[&<>"']/g, (c) => ({
             '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
@@ -421,15 +456,29 @@
                     <button type="button" class="${ROOT_CLASS}__close" aria-label="Close" data-action="close">✕</button>
                 </header>
                 <div class="${ROOT_CLASS}__help-popover" data-role="help-popover" hidden>
-                    <p><strong>Counters</strong> — each row counts open events the entity hasn&#39;t acted on. Number is live: it drops as the entity replies. Click a counter to see <em>which</em> events.</p>
+                    <p><strong>Counters</strong> — each row shows two cumulative error totals: <em>當下 / Current</em> (resettable via the Reset button) and <em>歷史 / All-time</em> (never resets). An amber badge shows events still awaiting a reply. Click a counter to see <em>which</em> events.</p>
+                    <p><strong>歷史紀錄 / Error history</strong> — a persisted, time-stamped log of every error event, kept even after you reset the current counter.</p>
                     <p><strong>Achievements</strong> — cumulative wins: tasks completed, chat 👍/👎, reviews, notes. Click a row to see the contributing cards / messages as chips.</p>
                     <p><strong>Operation log</strong> — recent kanban / message / system events for this entity, newest first. Card chips open the card&#39;s popover; ${ICON_QUOTE} quotes the row into your chat composer.</p>
                 </div>
                 <section class="${ROOT_CLASS}__section" data-section="counters">
-                    <h3 class="${ROOT_CLASS}__section-title">累計錯誤次數 / Error counters</h3>
+                    <div class="${ROOT_CLASS}__section-head">
+                        <h3 class="${ROOT_CLASS}__section-title">累計錯誤次數 / Error counters</h3>
+                        <button type="button" class="${ROOT_CLASS}__reset-btn"
+                            data-action="reset-counters"
+                            title="重置「當下累計」(歷史累計與歷史紀錄不受影響) / Reset the current cumulative only (historical total + history are kept)">
+                            重置當下 / Reset current</button>
+                    </div>
+                    <p class="${ROOT_CLASS}__metric-legend">當下累計 / current (resettable) · 歷史累計 / historical (never resets)</p>
                     <ul class="${ROOT_CLASS}__counter-list" data-role="counter-list">
                         <li class="${ROOT_CLASS}__counter-row" data-state="loading">Loading…</li>
                     </ul>
+                </section>
+                <section class="${ROOT_CLASS}__section" data-section="error-history">
+                    <h3 class="${ROOT_CLASS}__section-title">歷史紀錄 / Error history</h3>
+                    <ol class="${ROOT_CLASS}__log-list" data-role="error-history-list">
+                        <li class="${ROOT_CLASS}__log-row" data-state="loading">Loading…</li>
+                    </ol>
                 </section>
                 <section class="${ROOT_CLASS}__section" data-section="achievements">
                     <h3 class="${ROOT_CLASS}__section-title">成就 / Achievements</h3>
@@ -465,6 +514,11 @@
                 const logId = btn && btn.dataset.logId;
                 if (logId) handleQuoteClick(eid, logId);
                 e.stopPropagation();
+                return;
+            }
+            if (action === 'reset-counters') {
+                e.stopPropagation();
+                handleResetClick(eid);
                 return;
             }
             // Counter drill-down: clicking a counter row expands the open
@@ -517,21 +571,71 @@
             list.innerHTML = `<li class="${ROOT_CLASS}__counter-row" data-state="empty">No counters yet.</li>`;
             return;
         }
-        // Live counter = openCount when the backend provides it; fall back to
-        // cumulative count for old clients / old backends. Hank's spec: the
-        // displayed number is "what's currently open", not lifetime total.
+        // card_errctr: each row shows TWO cumulative numbers — 當下 (current,
+        // resettable) and 歷史 (historical, never resets). `openCount` (events
+        // still awaiting a reply) is surfaced as a small inline badge when >0 so
+        // the live health signal isn't lost. Older backends without the split
+        // degrade gracefully: historicalCount falls back to count.
         list.innerHTML = counters.map(c => {
-            const live = (typeof c.openCount === 'number') ? c.openCount : c.count;
+            const cur = Number(c.count) || 0;
+            const hist = (typeof c.historicalCount === 'number') ? c.historicalCount : cur;
+            const open = (typeof c.openCount === 'number') ? c.openCount : 0;
+            const label = escapeHtml(pickLabel(c.axis));
+            const openBadge = open > 0
+                ? `<span class="${ROOT_CLASS}__counter-open" title="目前未回覆 / currently open">${open} ${pickWord('open')}</span>`
+                : '';
             return `
-            <li class="${ROOT_CLASS}__counter-row" data-axis="${c.axis}"
+            <li class="${ROOT_CLASS}__counter-row" data-axis="${escapeHtml(c.axis)}"
                 role="button" tabindex="0"
                 aria-expanded="false"
-                aria-label="${pickLabel(c.axis)}: ${live} open. Click to see which events.">
+                aria-label="${label}: ${pickWord('current')} ${cur}, ${pickWord('historical')} ${hist}${open > 0 ? ', ' + open + ' open' : ''}. Click to see which events.">
                 ${SVG_CHEVRON}
-                <span class="${ROOT_CLASS}__counter-label">${pickLabel(c.axis)}</span>
-                <span class="${ROOT_CLASS}__counter-value">${live}</span>
+                <span class="${ROOT_CLASS}__counter-label">${label}${openBadge}</span>
+                <span class="${ROOT_CLASS}__counter-metrics">
+                    <span class="${ROOT_CLASS}__counter-metric" title="當下累計 (可重置) / current cumulative (resettable)">
+                        <span class="${ROOT_CLASS}__counter-metric-label">${pickWord('current')}</span>
+                        <span class="${ROOT_CLASS}__counter-value">${cur}</span>
+                    </span>
+                    <span class="${ROOT_CLASS}__counter-metric" title="歷史累計 (永不重置) / historical cumulative (never resets)">
+                        <span class="${ROOT_CLASS}__counter-metric-label">${pickWord('historical')}</span>
+                        <span class="${ROOT_CLASS}__counter-value ${ROOT_CLASS}__counter-value--hist">${hist}</span>
+                    </span>
+                </span>
             </li>`;
         }).join('');
+    }
+
+    // Tiny bilingual word picker for the 當下/歷史 metric labels — mirrors the
+    // local-dict pattern pickLabel() uses (no i18n.js dependency).
+    function pickWord(kind) {
+        const lang = (document.documentElement.getAttribute('lang') || 'en').toLowerCase();
+        const isZh = lang.startsWith('zh') || lang === 'tw' || lang === 'cn';
+        const zh = { current: '當下', historical: '歷史', open: '未回覆', reset: '重置當下' };
+        const en = { current: 'Current', historical: 'All-time', open: 'open', reset: 'Reset current' };
+        return (isZh ? zh : en)[kind] || kind;
+    }
+
+    // POST the current-counter reset (current cumulative → 0). historical_count
+    // and the error-event history are left intact server-side. Confirm first
+    // since it clears the live "current" tally for every axis on this entity.
+    async function handleResetClick(eid) {
+        const isZh = (document.documentElement.getAttribute('lang') || 'en')
+            .toLowerCase().startsWith('zh');
+        const msg = isZh
+            ? '重置「當下累計」歸零?(歷史累計與歷史紀錄會保留)'
+            : 'Reset the CURRENT cumulative to 0? (Historical total + history are kept.)';
+        if (typeof window.confirm === 'function' && !window.confirm(msg)) return;
+        try {
+            const data = await fetchResetCounters(eid);
+            if (rootEl && data && data.counters) {
+                renderCounters(rootEl, data.counters);
+            }
+            // History is unchanged by a reset, but refresh so the UI stays live.
+            if (rootEl) loadErrorHistory(rootEl, eid);
+        } catch (err) {
+            /* surface nothing destructive — the counters simply stay as-is */
+            console.warn('[EntityStatusPanel] reset failed:', err && err.message);
+        }
     }
 
     // Render the drill-down rows for one axis. Each row = (timestamp, chip).
@@ -704,6 +808,43 @@
         }
     }
 
+    // card_errctr: render the 歷史紀錄 / error-history timeline. Each row is a
+    // persisted error event (time · axis label · snippet) that survives a
+    // current-counter reset. XSS-safe — every dynamic field is escaped.
+    function renderErrorHistory(items) {
+        if (!items || items.length === 0) {
+            return `<li class="${ROOT_CLASS}__log-row" data-state="empty">No error history yet. / 尚無歷史紀錄。</li>`;
+        }
+        return items.map(it => {
+            const ts = formatTs(it.occurredAt);
+            const axisLabel = escapeHtml(pickLabel(it.axis));
+            const snippet = it.payloadSnippet ? escapeHtml(it.payloadSnippet) : '';
+            const sender = (it.senderEntityId != null)
+                ? `<span class="${ROOT_CLASS}__hist-from">#${escapeHtml(it.senderEntityId)}</span>` : '';
+            return `
+            <li class="${ROOT_CLASS}__log-row" data-axis="${escapeHtml(it.axis)}">
+                <time class="${ROOT_CLASS}__log-time">${escapeHtml(ts)}</time>
+                <span class="${ROOT_CLASS}__log-summary">
+                    <span class="${ROOT_CLASS}__hist-axis">${axisLabel}</span>
+                    ${sender}
+                    ${snippet ? `<span class="${ROOT_CLASS}__hist-snippet">${snippet}</span>` : ''}
+                </span>
+            </li>`;
+        }).join('');
+    }
+
+    async function loadErrorHistory(root, eid) {
+        const list = root && root.querySelector('[data-role="error-history-list"]');
+        if (!list) return;
+        list.innerHTML = `<li class="${ROOT_CLASS}__log-row" data-state="loading">Loading…</li>`;
+        try {
+            const data = await fetchErrorHistory(eid);
+            list.innerHTML = renderErrorHistory(data.items || []);
+        } catch (err) {
+            list.innerHTML = `<li class="${ROOT_CLASS}__log-row" data-state="error">Failed to load: ${escapeHtml(err.message)}</li>`;
+        }
+    }
+
     function ensureStyles() {
         if (document.getElementById('entity-status-panel-style')) return;
         const style = document.createElement('style');
@@ -746,6 +887,27 @@
 .${ROOT_CLASS}__counter-value { font-size: 16px; font-weight: 600; color: var(--primary, #6c63ff);
     background: rgba(108,99,255,0.12); padding: 2px 10px; border-radius: 999px; min-width: 32px;
     text-align: center; }
+.${ROOT_CLASS}__counter-value--hist { color: var(--text-secondary, #aaa);
+    background: rgba(255,255,255,0.06); }
+.${ROOT_CLASS}__counter-metrics { display: inline-flex; gap: 10px; align-items: center; }
+.${ROOT_CLASS}__counter-metric { display: inline-flex; flex-direction: column; align-items: center; gap: 2px; }
+.${ROOT_CLASS}__counter-metric-label { font-size: 9px; text-transform: uppercase; letter-spacing: 0.04em;
+    color: var(--text-muted, #888); }
+.${ROOT_CLASS}__counter-open { display: inline-block; margin-left: 6px; font-size: 10px;
+    color: var(--warning, #f59e0b); background: rgba(245,158,11,0.14); padding: 0 6px;
+    border-radius: 999px; vertical-align: middle; }
+.${ROOT_CLASS}__section-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.${ROOT_CLASS}__section-head .${ROOT_CLASS}__section-title { margin: 0; }
+.${ROOT_CLASS}__reset-btn { background: none; border: 1px solid var(--card-border, #333);
+    color: var(--text-muted, #888); cursor: pointer; font-size: 11px; padding: 3px 8px;
+    border-radius: 6px; white-space: nowrap; }
+.${ROOT_CLASS}__reset-btn:hover { color: var(--text, #fff); border-color: var(--primary, #6c63ff);
+    background: rgba(108,99,255,0.08); }
+.${ROOT_CLASS}__metric-legend { font-size: 11px; color: var(--text-muted, #888);
+    margin: 4px 0 10px; }
+.${ROOT_CLASS}__hist-axis { color: var(--text, #e0e0e0); font-weight: 600; }
+.${ROOT_CLASS}__hist-from { color: var(--text-muted, #888); font-size: 11px; margin: 0 4px; }
+.${ROOT_CLASS}__hist-snippet { color: var(--text-secondary, #aaa); }
 .${ROOT_CLASS}__counter-events { list-style: none; margin: 4px 0 8px 24px; padding: 0;
     border-left: 2px solid var(--card-border, #333); }
 .${ROOT_CLASS}__counter-event-row { display: grid; grid-template-columns: auto 1fr; gap: 8px;
@@ -827,7 +989,10 @@
                 }
             }
         );
-        await Promise.all([statusP, achP]);
+        // card_errctr: 歷史紀錄 timeline loads alongside counters/achievements;
+        // its own failure stays contained to its section.
+        const histP = loadErrorHistory(rootEl, targetEid);
+        await Promise.all([statusP, achP, histP]);
 
         // Initial log fetch + infinite scroll setup.
         logCursor = null;

--- a/backend/tests/jest/entity-error-counters.test.js
+++ b/backend/tests/jest/entity-error-counters.test.js
@@ -1,0 +1,332 @@
+'use strict';
+
+/**
+ * card_errctr — Entity error counters: current (resettable) vs historical
+ * (monotonic) + persisted error-event history (歷史紀錄).
+ *
+ * Owner P0 (2026-06-27): the single error counter must split into
+ *   - 當下累計 / current cumulative  → `count`            (resettable)
+ *   - 歷史累計 / historical cumulative → `historicalCount` (never resets)
+ *   - 歷史紀錄 / history record        → entity_error_events timeline
+ *
+ * Each test below exercises a FAILURE PATH that FAILS on the pre-change code:
+ *   - accumulate            → old getCounters had no historicalCount field
+ *   - reset-keeps-historical→ old code had no resetCurrentCounters at all
+ *   - history-write         → old code never persisted per-tick error events
+ *   - history-survives-reset→ the core owner requirement (reset must not lose history)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const entityStatus = require('../../entity-status');
+
+// ────────────────────────────────────────────────────────────────────────────
+// Stateful in-memory mock pool. Interprets just the queries this module issues
+// against entity_error_counters / entity_error_events / outbound_msg_pending so
+// the accumulate → reset → history semantics can be asserted end to end.
+// ────────────────────────────────────────────────────────────────────────────
+function makeStatefulPool() {
+    const counters = new Map(); // `${device}|${entity}|${axis}` -> row
+    let events = [];            // entity_error_events rows
+    let pending = [];           // outbound_msg_pending rows
+    let nextEventId = 1;
+    const key = (d, e, a) => `${d}|${e}|${a}`;
+
+    const pool = {
+        // expose internals for test seeding/inspection
+        _counters: counters,
+        _events: () => events,
+        _pending: pending,
+        seedPending(row) {
+            pending.push(Object.assign({
+                id: pending.length + 1,
+                dispatched_at: new Date(),
+                expires_at: new Date(Date.now() - 1000), // already expired
+            }, row));
+        },
+        async query(rawSql, params) {
+            const sql = String(rawSql).replace(/\s+/g, ' ').trim();
+            params = params || [];
+
+            // initTable DDL (CREATE TABLE ... + ALTER ... + backfill UPDATE in
+            // one combined string) — short-circuit so it doesn't match the
+            // behavioral UPDATE/SELECT branches below.
+            if (sql.includes('CREATE TABLE')) return { rows: [] };
+
+            // UPSERT a counter (both incrementCounter + sweepExpired use this).
+            if (sql.includes('INSERT INTO entity_error_counters')) {
+                const [d, e, a] = params;
+                const k = key(d, e, a);
+                const existing = counters.get(k);
+                if (existing) {
+                    existing.count += 1;
+                    existing.historical_count += 1;
+                    existing.last_event_at = new Date();
+                } else {
+                    counters.set(k, {
+                        device_id: d, entity_id: e, axis: a,
+                        count: 1, historical_count: 1,
+                        last_event_at: new Date(), current_reset_at: null,
+                    });
+                }
+                return { rows: [], rowCount: 1 };
+            }
+
+            // INSERT an error event into the history timeline.
+            if (sql.includes('INSERT INTO entity_error_events')) {
+                const [d, e, a, et, sender, snippet, occ] = params;
+                events.push({
+                    id: nextEventId++,
+                    device_id: d, entity_id: e, axis: a,
+                    event_type: et, sender_entity_id: sender,
+                    payload_snippet: snippet,
+                    occurred_at: occ ? new Date(occ) : new Date(),
+                });
+                return { rows: [], rowCount: 1 };
+            }
+
+            // Prune: keep newest `cap` events per (device, entity).
+            if (sql.includes('DELETE FROM entity_error_events')) {
+                const [d, e, cap] = params;
+                const mine = events
+                    .filter(ev => ev.device_id === d && ev.entity_id === e)
+                    .sort((x, y) => y.id - x.id);
+                const keepIds = new Set(mine.slice(0, Number(cap)).map(ev => ev.id));
+                const before = events.length;
+                events = events.filter(ev =>
+                    !(ev.device_id === d && ev.entity_id === e) || keepIds.has(ev.id));
+                return { rows: [], rowCount: before - events.length };
+            }
+
+            // Reset current counters (count -> 0), historical untouched.
+            if (sql.includes('UPDATE entity_error_counters')) {
+                const d = params[0], e = params[1];
+                const axisFilter = sql.includes('axis = $') ? params[2] : null;
+                let n = 0;
+                for (const row of counters.values()) {
+                    if (row.device_id === d && row.entity_id === e
+                        && (!axisFilter || row.axis === axisFilter)) {
+                        row.count = 0;
+                        row.current_reset_at = new Date();
+                        n += 1;
+                    }
+                }
+                return { rows: [], rowCount: n };
+            }
+
+            // getCounters main SELECT.
+            if (sql.includes('FROM entity_error_counters')) {
+                const [d, e] = params;
+                const rows = [];
+                for (const row of counters.values()) {
+                    if (row.device_id === d && row.entity_id === e) {
+                        rows.push({
+                            axis: row.axis,
+                            count: row.count,
+                            historical_count: row.historical_count,
+                            last_event_at: row.last_event_at,
+                            current_reset_at: row.current_reset_at,
+                        });
+                    }
+                }
+                return { rows };
+            }
+
+            // getCounters open-count grouping.
+            if (sql.includes('FROM outbound_msg_pending') && sql.includes('open_count')) {
+                const [d, e] = params;
+                const grouped = new Map();
+                for (const p of pending) {
+                    if (p.device_id === d && p.recipient_entity_id === e) {
+                        grouped.set(p.axis, (grouped.get(p.axis) || 0) + 1);
+                    }
+                }
+                return { rows: Array.from(grouped, ([axis, open_count]) => ({ axis, open_count })) };
+            }
+
+            // sweepExpired SELECT of expired pending rows.
+            if (sql.includes('FROM outbound_msg_pending') && sql.includes('expires_at <= NOW()')) {
+                const now = Date.now();
+                return {
+                    rows: pending
+                        .filter(p => new Date(p.expires_at).getTime() <= now)
+                        .map(p => ({
+                            id: p.id, device_id: p.device_id,
+                            recipient_entity_id: p.recipient_entity_id, axis: p.axis,
+                            event_type: p.event_type, sender_entity_id: p.sender_entity_id,
+                            payload_snippet: p.payload_snippet,
+                        })),
+                };
+            }
+
+            // sweepExpired DELETE by id list.
+            if (sql.includes('DELETE FROM outbound_msg_pending')) {
+                const ids = new Set((params[0] || []).map(Number));
+                const before = pending.length;
+                pending = pending.filter(p => !ids.has(Number(p.id)));
+                return { rows: [], rowCount: before - pending.length };
+            }
+
+            // getErrorHistory SELECT.
+            if (sql.includes('FROM entity_error_events')) {
+                const d = params[0], e = params[1];
+                let idx = 2;
+                const axisFilter = sql.includes('axis = $') ? params[idx++] : null;
+                const beforeId = sql.includes('id < $') ? params[idx++] : null;
+                const limit = Number(params[idx]);
+                let mine = events.filter(ev => ev.device_id === d && ev.entity_id === e);
+                if (axisFilter) mine = mine.filter(ev => ev.axis === axisFilter);
+                if (beforeId) mine = mine.filter(ev => ev.id < Number(beforeId));
+                mine.sort((x, y) => y.id - x.id);
+                return {
+                    rows: mine.slice(0, limit).map(ev => ({
+                        id: ev.id, axis: ev.axis, event_type: ev.event_type,
+                        sender_entity_id: ev.sender_entity_id,
+                        payload_snippet: ev.payload_snippet, occurred_at: ev.occurred_at,
+                    })),
+                };
+            }
+
+            return { rows: [] };
+        },
+    };
+    return pool;
+}
+
+const DEVICE = 'devX';
+const ENTITY = 2;
+const findAxis = (counters, axis) => counters.find(c => c.axis === axis);
+
+describe('entity error counters — current vs historical + history', () => {
+    test('accumulate: each error bumps BOTH current (count) and historical (historicalCount)', async () => {
+        const pool = makeStatefulPool();
+        entityStatus.initTable(pool);
+        await entityStatus.incrementCounter(DEVICE, ENTITY, 'a2a_no_reply');
+        await entityStatus.incrementCounter(DEVICE, ENTITY, 'a2a_no_reply');
+
+        const counters = await entityStatus.getCounters(DEVICE, ENTITY);
+        const row = findAxis(counters, 'a2a_no_reply');
+        // FAILS on old code: getCounters returned no historicalCount field.
+        expect(row.count).toBe(2);
+        expect(row.historicalCount).toBe(2);
+    });
+
+    test('reset clears CURRENT only — historical total + history record survive', async () => {
+        const pool = makeStatefulPool();
+        entityStatus.initTable(pool);
+        for (let i = 0; i < 3; i++) {
+            await entityStatus.incrementCounter(DEVICE, ENTITY, 'a2a_no_reply');
+        }
+
+        // FAILS on old code: resetCurrentCounters did not exist.
+        const affected = await entityStatus.resetCurrentCounters(DEVICE, ENTITY);
+        expect(affected).toBeGreaterThanOrEqual(1);
+
+        const counters = await entityStatus.getCounters(DEVICE, ENTITY);
+        const row = findAxis(counters, 'a2a_no_reply');
+        expect(row.count).toBe(0);            // current cleared
+        expect(row.historicalCount).toBe(3);  // historical preserved
+        expect(row.currentResetAt).toBeTruthy();
+
+        const hist = await entityStatus.getErrorHistory(DEVICE, ENTITY, {});
+        expect(hist.items).toHaveLength(3);   // history untouched by reset
+    });
+
+    test('history-write: every increment appends a reviewable error event', async () => {
+        const pool = makeStatefulPool();
+        entityStatus.initTable(pool);
+        await entityStatus.incrementCounter(DEVICE, ENTITY, 'chat_no_reply', {
+            eventType: 'push_failure', payloadSnippet: 'push failed: push_timeout',
+        });
+
+        // FAILS on old code: getErrorHistory / entity_error_events did not exist.
+        const hist = await entityStatus.getErrorHistory(DEVICE, ENTITY, {});
+        expect(hist.items).toHaveLength(1);
+        expect(hist.items[0].axis).toBe('chat_no_reply');
+        expect(hist.items[0].eventType).toBe('push_failure');
+        expect(hist.items[0].payloadSnippet).toContain('push_timeout');
+        expect(hist.items[0].occurredAt).toBeTruthy();
+    });
+
+    test('sweepExpired: a silent recipient ticks BOTH counters AND writes history', async () => {
+        const pool = makeStatefulPool();
+        entityStatus.initTable(pool);
+        pool.seedPending({
+            device_id: DEVICE, sender_entity_id: 1, recipient_entity_id: ENTITY,
+            event_type: 'entity_message', axis: 'a2a_no_reply',
+            payload_snippet: 'hi from #1',
+        });
+
+        const res = await entityStatus.sweepExpired();
+        expect(res.tickedCount).toBe(1);
+
+        const counters = await entityStatus.getCounters(DEVICE, ENTITY);
+        const row = findAxis(counters, 'a2a_no_reply');
+        expect(row.count).toBe(1);
+        expect(row.historicalCount).toBe(1);  // FAILS on old: only count ticked
+
+        const hist = await entityStatus.getErrorHistory(DEVICE, ENTITY, {});
+        expect(hist.items).toHaveLength(1);    // FAILS on old: sweep never wrote events
+        expect(hist.items[0].axis).toBe('a2a_no_reply');
+        expect(hist.items[0].senderEntityId).toBe(1);
+        expect(hist.items[0].payloadSnippet).toBe('hi from #1');
+    });
+
+    test('core requirement: history record survives a current-counter reset, then keeps growing', async () => {
+        const pool = makeStatefulPool();
+        entityStatus.initTable(pool);
+        await entityStatus.incrementCounter(DEVICE, ENTITY, 'a2a_no_reply');
+        await entityStatus.incrementCounter(DEVICE, ENTITY, 'a2a_no_reply');
+        await entityStatus.resetCurrentCounters(DEVICE, ENTITY);
+        await entityStatus.incrementCounter(DEVICE, ENTITY, 'a2a_no_reply');
+
+        const counters = await entityStatus.getCounters(DEVICE, ENTITY);
+        const row = findAxis(counters, 'a2a_no_reply');
+        expect(row.count).toBe(1);            // current restarted after reset
+        expect(row.historicalCount).toBe(3);  // historical never reset
+
+        const hist = await entityStatus.getErrorHistory(DEVICE, ENTITY, {});
+        expect(hist.items).toHaveLength(3);    // all 3 events retained across the reset
+    });
+
+    test('getErrorHistory honours the axis filter', async () => {
+        const pool = makeStatefulPool();
+        entityStatus.initTable(pool);
+        await entityStatus.incrementCounter(DEVICE, ENTITY, 'a2a_no_reply');
+        await entityStatus.incrementCounter(DEVICE, ENTITY, 'chat_no_reply');
+
+        const onlyChat = await entityStatus.getErrorHistory(DEVICE, ENTITY, { axis: 'chat_no_reply' });
+        expect(onlyChat.items).toHaveLength(1);
+        expect(onlyChat.items[0].axis).toBe('chat_no_reply');
+    });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Frontend contract (static analysis) — the panel must surface BOTH numbers
+// (當下/歷史, EN+ZH), a reset affordance for the current counter, and a way to
+// view the history. Mirrors the existing achievements UI contract test.
+// ────────────────────────────────────────────────────────────────────────────
+describe('entity-status-panel — current/historical/history UI contract', () => {
+    const panelSrc = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'public', 'portal', 'shared', 'entity-status-panel.js'),
+        'utf8'
+    );
+
+    test('renders both current and historical cumulative numbers from the API', () => {
+        expect(panelSrc).toMatch(/historicalCount/);
+        // bilingual labels for the two cumulative numbers (matches the section's
+        // existing inline-bilingual pattern).
+        expect(panelSrc).toMatch(/當下/);
+        expect(panelSrc).toMatch(/歷史/);
+    });
+
+    test('has a reset affordance that POSTs the current-counter reset route', () => {
+        expect(panelSrc).toMatch(/counter\/reset/);
+        expect(panelSrc).toMatch(/reset-counters|resetCurrent|data-action="reset/);
+    });
+
+    test('fetches + renders the error history timeline', () => {
+        expect(panelSrc).toMatch(/\/errors\?/);
+        expect(panelSrc).toMatch(/error-history|errorHistory|歷史紀錄/);
+    });
+});

--- a/backend/tests/jest/entity-status-achievements-ui.test.js
+++ b/backend/tests/jest/entity-status-achievements-ui.test.js
@@ -66,7 +66,9 @@ describe('entity-status-panel — achievements section contract', () => {
     });
 
     test('open() fetches counters and achievements concurrently', () => {
-        expect(panelSrc).toMatch(/Promise\.all\(\[statusP, achP\]\)/);
+        // card_errctr added the error-history fetch (histP) to the same
+        // concurrent batch — counters + achievements + history load together.
+        expect(panelSrc).toMatch(/Promise\.all\(\[statusP, achP, histP\]\)/);
     });
 
     test.each(AXES)('local label fallback covers axis %s in zh + en', (axis) => {


### PR DESCRIPTION
## Owner P0 (2026-06-27)
The entity-status panel's single **「累計錯誤次數 / Error counters」** number conflated everything and lost history on reset. This splits it into three distinct concepts, with the history **persisted**:

| Concept | Storage | Behaviour |
|---|---|---|
| **當下累計 / current cumulative** | `entity_error_counters.count` (existing column, redefined) | resettable |
| **歷史累計 / historical cumulative** | `entity_error_counters.historical_count` (**new column**) | monotonic, **never resets** |
| **歷史紀錄 / history record** | `entity_error_events` (**new bounded table**) | time-stamped error-event timeline, survives reset |

## ⚠️ Schema change — additive & reversible (owner sign-off note)
- Two `ADD COLUMN IF NOT EXISTS` (`historical_count`, `current_reset_at`) — metadata-only on PostgreSQL 11+ (no table rewrite).
- One new table `entity_error_events`.
- **No separate migration run required**: `entity-status.js initTable()` applies the same idempotent DDL at boot (the established pattern in this repo), so prod self-heals. Migration `.up.sql`/`.down.sql` are included for the record and are reversible.
- `count`'s *meaning* shifts from "all-time total" → "current cumulative", but it stays **numerically identical** until the first explicit reset, and an invariant-preserving backfill (`historical_count = count WHERE historical_count < count`) ensures **no existing total is lost**.

## Backend (`entity-status.js`)
- `incrementCounter` + `sweepExpired`: bump **both** counters and append **one** error event to the history (best-effort, never blocks the push/sweep path; bounded to `ERROR_EVENT_CAP = 1000` per entity via `pruneErrorEventsFor`).
- `getCounters`: serializes `historicalCount` + `currentResetAt` (additive — existing `count`/`openCount` consumers unaffected).
- New: `resetCurrentCounters` (sets `count=0` + stamps `current_reset_at`; **historical + history untouched**), `getErrorHistory` (cursor-paginated, optional `axis` filter), `recordErrorEvent`, `pruneErrorEventsFor`.
- New routes: `GET /api/entity-status/:eId/errors`, `POST /api/entity-status/:eId/counter/reset` (same device/bot auth as the rest of the module; reset is current-only + reversible-by-nature so low risk).
- `index.js` push-failure hook threads the real `eventType` + failure reason into the history.

## Frontend (`entity-status-panel.js`)
- Each counter row now shows **both** numbers, clearly labelled **當下 / Current** and **歷史 / All-time** (EN+ZH via the section's existing inline-bilingual pattern — no `i18n.js` touched), plus an amber "open" badge for events still awaiting a reply.
- **「重置當下 / Reset current」** button (confirm-gated) → POSTs the reset route, then re-renders.
- New **「歷史紀錄 / Error history」** section renders the persisted timeline. All dynamic fields `escapeHtml`-escaped (XSS-safe).

## Tests (owner hard rule — failure-path jest)
`backend/tests/jest/entity-error-counters.test.js` (stateful mock pool): accumulate / reset-keeps-historical / history-write / **history-survives-reset** / sweep-ticks-both / axis-filter + a frontend UI contract block.
**Proof:** all 9 tests **FAIL on pre-change code, PASS on this change** (verified by stashing the source and re-running). Full backend suite green: **409 suites / 5750 passed / 0 failed**.

## ⚠️ Needs commander vision-check before merge
This changes user-visible portal UI (the avatar status drawer). Per the UX hard-gate, requires a **desktop (1280×800) + mobile (390×844)** Playwright/screenshot sign-off before merge. **Do not merge** until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)