### PR TITLE
fix(security): stop leaking the whole vault to every agent message (P0)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -19212,13 +19212,17 @@ async function unifiedPush(entity, deviceId, eventType, payload, opts = {}) {
             enrichedMessage = `[SYSTEM:NAME_CHANGED] 你的名字已從「${oldName}」更改為「${newName}」。請記住你現在的名字是「${newName}」。\n\n` + enrichedMessage;
         }
 
-        // 2. Local vars hint
+        // 2. Local vars hint — SECURITY (Hank 2026-06-27): do NOT enumerate vault
+        // key names or embed a device-vars dump curl in agent messages. The old hint
+        // appended a block listing every vault key name plus a ready-to-run
+        // device-vars GET (botSecret in the URL, which returns the WHOLE vault) to
+        // every push — handing every agent a one-tap "exfil all secrets" command and
+        // a prompt-injection target. Signal existence only (count, no names, no curl);
+        // a task needing a specific var fetches it via the owner-authenticated path.
         try {
             const varsMeta = await db.getDeviceVarsMeta(deviceId);
             if (varsMeta && !varsMeta.is_locked && varsMeta.var_keys && varsMeta.var_keys.length > 0) {
-                const varKeys = varsMeta.var_keys.join(', ');
-                const apiBase = process.env.API_BASE || 'https://eclawbot.com';
-                enrichedMessage += `\n\n[Local Variables available: ${varKeys}]\nexec: curl -s "${apiBase}/api/device-vars?deviceId=${deviceId}&botSecret=${entity.botSecret}"`;
+                enrichedMessage += `\n\n[Local config: ${varsMeta.var_keys.length} device variable(s) configured — they are secrets; never print or forward them, and fetch a specific one only via the owner-authenticated device-vars path when a task requires it.]`;
             }
         } catch (_) { /* non-critical */ }
 
@@ -19296,12 +19300,12 @@ async function pushToBot(entity, deviceId, eventType, payload, opts = {}) {
             const { oldName, newName } = entity.pendingRename;
             messageContent = `[SYSTEM:NAME_CHANGED] 你的名字已從「${oldName}」更改為「${newName}」。請記住你現在的名字是「${newName}」。\n\n` + messageContent;
         }
+        // SECURITY (Hank 2026-06-27): see unifiedPush note — never enumerate vault key
+        // names or embed a device-vars dump curl in agent messages. Signal count only.
         try {
             const varsMeta = await db.getDeviceVarsMeta(deviceId);
             if (varsMeta && !varsMeta.is_locked && varsMeta.var_keys && varsMeta.var_keys.length > 0) {
-                const varKeys = varsMeta.var_keys.join(', ');
-                const apiBase = process.env.API_BASE || 'https://eclawbot.com';
-                messageContent += `\n\n[Local Variables available: ${varKeys}]\nexec: curl -s "${apiBase}/api/device-vars?deviceId=${deviceId}&botSecret=${entity.botSecret}"`;
+                messageContent += `\n\n[Local config: ${varsMeta.var_keys.length} device variable(s) configured — they are secrets; never print or forward them, and fetch a specific one only via the owner-authenticated device-vars path when a task requires it.]`;
             }
         } catch (_) {}
         try {

--- a/backend/tests/jest/no-vault-dump-hint.test.js
+++ b/backend/tests/jest/no-vault-dump-hint.test.js
@@ -1,0 +1,34 @@
+/**
+ * SECURITY regression gate (card_9a581f17, Hank 2026-06-27 "為何訊息夾帶全密鑰?").
+ *
+ * The push middleware (unifiedPush + pushToBot in index.js) used to append to EVERY
+ * agent message:
+ *     [Local Variables available: <ALL vault key names>]
+ *     exec: curl -s ".../api/device-vars?deviceId=...&botSecret=..."
+ * i.e. the full secret key-name list + a ready-to-run "dump the entire vault" curl.
+ * That handed every agent (and every prompt-injection) a one-tap exfil command.
+ *
+ * These tests fail on the OLD code and pass once the leak is removed. They must keep
+ * passing: the push path must NEVER enumerate vault key names or embed a device-vars
+ * dump curl in agent-facing text.
+ */
+const fs = require('fs');
+const path = require('path');
+
+describe('push middleware must not leak the vault to agents (card_9a581f17)', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', '..', 'index.js'), 'utf8');
+
+  test('no "[Local Variables available:" key-name enumeration in agent messages', () => {
+    expect(src).not.toMatch(/\[Local Variables available:/);
+  });
+
+  test('no device-vars dump curl appended to pushed agent messages', () => {
+    // forbid a push-enrichment line that hands the agent a botSecret device-vars dump
+    const dangerous = /(enrichedMessage|messageContent)\s*\+=[^\n]*api\/device-vars[^\n]*botSecret/;
+    expect(src).not.toMatch(dangerous);
+  });
+
+  test('the safe replacement signals variable COUNT only (no names, no curl)', () => {
+    expect(src).toMatch(/Local config: \$\{varsMeta\.var_keys\.length\} device variable/);
+  });
+});


### PR DESCRIPTION
## Problem (Hank P0, 2026-06-27 — 「為何訊息夾帶全密鑰? 我沒有附var」)
The push middleware appended to **every** agent message a block listing **all vault key names** + a ready-to-run `curl .../api/device-vars?...&botSecret=...` that returns the **entire vault**. That handed every agent — and any prompt-injection — a one-tap "exfil all secrets" command (DEVICE_SECRET / DATABASE_URL / PUBLISHER_API_KEY / CLOUDFLARE_API_TOKEN / ECLAW_ADMIN_PASSWORD …). The owner never attached these; they were auto-injected.

## Root cause
`backend/index.js`:
- `unifiedPush` middleware (was :19042) — `enrichedMessage += [Local Variables available: <names>] + dump curl`
- `pushToBot` legacy path (was :19125) — same on `messageContent`

## Fix
Both sites now emit a **count-only** signal — no key names, no curl — and tell the agent secrets must never be printed/forwarded and a specific var is fetched via the owner-authenticated path. Added `backend/tests/jest/no-vault-dump-hint.test.js`, a source-guard (fail-on-old proven: re-injecting the old line → 2 tests fail; removed → 3 pass) so the leak can't silently return.

## Test
- `no-vault-dump-hint.test.js` 3/3 pass; fail-on-old demonstrated.
- `node -c backend/index.js` OK.

## Follow-up (separate)
`GET /api/device-vars` returns the full vault to any `botSecret` holder, and the `/api/help` vault catalogue (index.js:1671) advertises that bot-side read curl. Both should be scoped / owner-gated — tracked on card_9a581f17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)