### PR TITLE
chore(release): v1.1.13 (vc124) — internal release of wallpaper fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 118
-        versionName = "1.1.8"
+        versionCode = 124
+        versionName = "1.1.13"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Records the version shipped to the Play **internal** track today (vc124 / 1.1.13), built + signed + uploaded + verified.

Carries the merged wallpaper fixes:
- walking reconnect + action-freeze (#3785)
- drag-to-reposition HARD PIN + #10 position sync (#3790)
- FSM Stage 3 client — server-authoritative activity state (#3791)

The in-file versionCode had drifted (release-time bumps applied locally, not committed; Play was at 123). AndroidPublisher confirms internal track = [124] after upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)