### PR TITLE
fix(chat): clear false 'reconnecting' banner when messaging works

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -84,6 +84,20 @@ async function apiCall(method, path, body = null, opts = {}) {
         throw err;
     }
 
+    // Reaching here = a 2xx application response round-tripped, so the channel the
+    // user depends on is demonstrably up. Clear any stale reconnect banner that a
+    // transient blip may have raised (e.g. a single dropped background poll while
+    // the live socket stayed healthy) and record the good round-trip so a lone
+    // later blip is treated as transient rather than alarming. (false-disconnect
+    // banner fix — the overlay used to only self-clear via its own /api/version
+    // probe and ignored every successful message send / poll the user just made.)
+    try {
+        if (typeof window !== 'undefined' && window.__reconnectOverlay
+            && typeof window.__reconnectOverlay.noteServerReachable === 'function') {
+            window.__reconnectOverlay.noteServerReachable();
+        }
+    } catch (_) { /* overlay optional */ }
+
     return data;
 }
 

--- a/backend/public/portal/shared/reconnect-overlay.js
+++ b/backend/public/portal/shared/reconnect-overlay.js
@@ -53,29 +53,73 @@
     let visible = false;
     let probeTimer = null;
     let probeDelay = 5000;
+    // True while a request has FAILED but we have not yet alarmed the user — we
+    // hold the banner back and let a corroborating probe decide. This stops a
+    // lone transient blip (mobile radio sleep, network handoff, a single dropped
+    // background poll) from flashing the scary "disconnected" banner while the
+    // live socket + messaging are perfectly healthy. (false-disconnect-banner fix)
+    let suspecting = false;
+    // Timestamp of the last PROVEN-good round-trip: a 2xx apiCall, a live-socket
+    // (re)connect, or a message that actually went through. A failure that lands
+    // within RECENT_OK_MS of proof is almost certainly a blip, not a real outage,
+    // so we verify before alarming rather than flashing the banner.
+    let lastReachableTs = 0;
+    const RECENT_OK_MS = 6000;
 
-    function show() {
+    // Actually mount + slide the banner in. Separated from show() so the
+    // suspect-then-corroborate path can defer the visible alarm.
+    function reveal() {
         const el = ensureBanner();
         if (!visible) {
             visible = true;
             requestAnimationFrame(() => el.classList.add('visible'));
-            scheduleProbe();
         }
+        if (!probeTimer) scheduleProbe();
+    }
+
+    // A request failed (transport throw / offline event / unavailable). Decide
+    // whether that is worth alarming the user about.
+    function show() {
+        if (visible) return;
+        // If the channel proved good a moment ago, treat this as a possible blip:
+        // probe quietly first and only reveal the banner if the probe ALSO fails.
+        if (Date.now() - lastReachableTs < RECENT_OK_MS) {
+            if (!suspecting) { suspecting = true; if (!probeTimer) scheduleProbe(); }
+            return;
+        }
+        reveal();
     }
 
     function hide() {
         const el = document.getElementById(BANNER_ID);
         if (el) el.classList.remove('visible');
         visible = false;
+        suspecting = false;
         probeDelay = 5000;
         if (probeTimer) { clearTimeout(probeTimer); probeTimer = null; }
     }
 
+    // Proof that the channel the user depends on is up: a 2xx apiCall round-tripped,
+    // the live socket (re)connected, or a message was sent/received. Record it and
+    // clear any stale banner immediately — never leave "reconnecting…" up while
+    // messaging demonstrably works. This is the signal the old code lacked: the
+    // banner could only clear via the /api/version probe and ignored the very
+    // transport (WebSocket + /api/client/speak) the user was actually using.
+    function noteServerReachable() {
+        lastReachableTs = Date.now();
+        hide();
+    }
+
     async function probe() {
+        probeTimer = null;
+        if (!visible && !suspecting) return; // nothing to probe for
         try {
             const r = await fetch('/api/version', { credentials: 'include', cache: 'no-store' });
-            if (r && r.ok) { hide(); return; }
-        } catch (_) { /* still offline */ }
+            if (r && r.ok) { noteServerReachable(); return; }
+        } catch (_) { /* still unreachable */ }
+        // Probe failed → the disconnect looks real. If we were only suspecting (held
+        // the banner back as a possible blip), corroborate it now and reveal.
+        if (suspecting) { suspecting = false; reveal(); return; }
         probeDelay = Math.min(30000, Math.round(probeDelay * 1.5));
         scheduleProbe();
     }
@@ -85,8 +129,8 @@
         probeTimer = setTimeout(probe, probeDelay);
     }
 
-    window.addEventListener('online', () => { if (visible) probe(); });
+    window.addEventListener('online', () => { if (visible || suspecting) probe(); });
     window.addEventListener('offline', () => { show(); });
 
-    window.__reconnectOverlay = { show, hide, isVisible: () => visible };
+    window.__reconnectOverlay = { show, hide, isVisible: () => visible, noteServerReachable };
 })();

--- a/backend/public/portal/shared/socket.js
+++ b/backend/public/portal/shared/socket.js
@@ -27,6 +27,16 @@ function initPortalSocket() {
 
     portalSocket.on('connect', () => {
         console.log('[Socket] Connected');
+        // The live channel the user actually depends on is up. On socket.io
+        // auto-reconnect this is what flips the reconnect banner back off, and it
+        // clears a banner that a transient HTTP blip raised while the socket was
+        // healthy all along. Without this the overlay could only self-clear via
+        // its /api/version probe and never reacted to the real transport recovering.
+        try {
+            if (window.__reconnectOverlay && typeof window.__reconnectOverlay.noteServerReachable === 'function') {
+                window.__reconnectOverlay.noteServerReachable();
+            }
+        } catch (_) { /* overlay optional */ }
         updateNotifBadge();
     });
 

--- a/backend/tests/jest/reconnect-overlay.test.js
+++ b/backend/tests/jest/reconnect-overlay.test.js
@@ -1,0 +1,177 @@
+const fs = require('fs');
+const path = require('path');
+
+// Regression for the false "網路連線中斷，正在重新連線…" (reconnecting) banner that
+// stayed up in the Android chat WebView even though the user could send/receive
+// messages (Hank P0 2026-06-27).
+//
+// Root cause: the portal reconnect overlay (backend/public/portal/shared/
+// reconnect-overlay.js) was shown by ANY transport-level fetch failure and could
+// only ever clear itself via its own GET /api/version probe. It ignored the
+// transport the user actually depends on — the live socket + /api/client/speak —
+// so a lone background-poll blip (or a spurious Android-WebView `offline` event)
+// flashed the banner while messaging kept working, and a successful message
+// round-trip never cleared it.
+//
+// Fix:
+//   1. noteServerReachable() — proof-of-connectivity signal, called by api.js on
+//      every 2xx round-trip and by socket.js on (re)connect; clears the banner.
+//   2. transient-blip grace — a failure that lands within RECENT_OK_MS of proof
+//      is verified by a probe before the banner is ever revealed.
+//
+// jest env here is 'node' (no jsdom), so the DOM-coupled overlay IIFE is loaded
+// into a hand-rolled window/document stub via `new Function` and exercised for
+// real (state machine + probe + timers), rather than statically scanned.
+
+const SHARED = path.join(__dirname, '..', '..', 'public', 'portal', 'shared');
+const OVERLAY_PATH = path.join(SHARED, 'reconnect-overlay.js');
+const API_PATH = path.join(SHARED, 'api.js');
+const SOCKET_PATH = path.join(SHARED, 'socket.js');
+
+function makeNode() {
+    const node = {
+        _children: [],
+        style: {},
+        attributes: {},
+        title: '',
+        _classes: new Set(),
+        classList: {
+            add: (c) => node._classes.add(c),
+            remove: (c) => node._classes.delete(c),
+            contains: (c) => node._classes.has(c),
+        },
+        setAttribute(k, v) { this.attributes[k] = v; },
+        appendChild(c) { this._children.push(c); return c; },
+    };
+    return node;
+}
+
+// Build a fresh sandbox and load the overlay IIFE into it.
+function loadOverlay(opts = {}) {
+    const registry = {};
+    const document = {
+        getElementById: (id) => registry[id] || null,
+        createElement: () => {
+            const n = makeNode();
+            Object.defineProperty(n, 'id', {
+                get() { return n._id; },
+                set(v) { n._id = v; if (v) registry[v] = n; },
+                configurable: true,
+            });
+            return n;
+        },
+        head: makeNode(),
+        body: makeNode(),
+    };
+    const listeners = {};
+    const window = {
+        addEventListener: (ev, cb) => { (listeners[ev] = listeners[ev] || []).push(cb); },
+    };
+    const nowRef = { value: opts.now || 100000 };
+    const DateStub = { now: () => nowRef.value };
+    const fetchRef = { fn: opts.fetchFn || (async () => ({ ok: true })) };
+    const fetchFn = (...args) => fetchRef.fn(...args);
+    const raf = (cb) => { cb(); return 1; };
+
+    const src = fs.readFileSync(OVERLAY_PATH, 'utf8');
+    // Free identifiers in the IIFE (window/document/fetch/timers/Date) resolve to
+    // these params; built-ins (Promise/Math) stay native so async/await is real.
+    // eslint-disable-next-line no-new-func
+    const runner = new Function(
+        'window', 'document', 'requestAnimationFrame', 'fetch', 'setTimeout', 'clearTimeout', 'Date',
+        src,
+    );
+    runner(window, document, raf, fetchFn, setTimeout, clearTimeout, DateStub);
+
+    return {
+        overlay: window.__reconnectOverlay,
+        registry,
+        setNow: (v) => { nowRef.value = v; },
+        setFetch: (fn) => { fetchRef.fn = fn; },
+        fireWindow: (ev) => (listeners[ev] || []).forEach((cb) => cb()),
+    };
+}
+
+describe('reconnect overlay — false-disconnect banner', () => {
+    beforeEach(() => { jest.useFakeTimers(); });
+    afterEach(() => { jest.useRealTimers(); });
+
+    test('exposes a noteServerReachable() connectivity signal', () => {
+        const { overlay } = loadOverlay();
+        expect(typeof overlay.noteServerReachable).toBe('function');
+    });
+
+    test('show() reveals the banner when nothing proved the channel good recently', () => {
+        const { overlay } = loadOverlay({ now: 100000 }); // lastReachable=0 → no recent proof
+        overlay.show();
+        expect(overlay.isVisible()).toBe(true);
+    });
+
+    // FAIL-ON-OLD: old overlay had no way to clear on a proven round-trip; the
+    // banner could only self-clear via its own /api/version probe.
+    test('noteServerReachable() clears a visible reconnect banner (a message round-tripped)', () => {
+        const { overlay } = loadOverlay({ now: 100000 });
+        overlay.show();
+        expect(overlay.isVisible()).toBe(true);
+        overlay.noteServerReachable(); // simulate a successful apiCall / socket connect
+        expect(overlay.isVisible()).toBe(false);
+    });
+
+    // FAIL-ON-OLD: old show() revealed immediately on the first failed request, so
+    // a lone blip while messaging works flashed the scary banner.
+    test('a transient blip right after a good round-trip does NOT alarm the user', async () => {
+        const { overlay, setNow } = loadOverlay({ now: 100000, fetchFn: async () => ({ ok: true }) });
+        overlay.noteServerReachable();   // proof the channel is good at t=100000
+        setNow(101000);                  // 1s later — well within the grace window
+        overlay.show();                  // a single background fetch just failed
+        expect(overlay.isVisible()).toBe(false); // held back — not alarmed
+
+        // The corroborating probe finds the server reachable → banner stays hidden.
+        await jest.advanceTimersByTimeAsync(6000);
+        expect(overlay.isVisible()).toBe(false);
+    });
+
+    test('a blip that the probe CANNOT corroborate is escalated to a real banner', async () => {
+        let online = true; // probe will fail
+        const { overlay, setNow } = loadOverlay({
+            now: 100000,
+            fetchFn: async () => { if (!online) throw new Error('net'); return { ok: true }; },
+        });
+        overlay.noteServerReachable();
+        setNow(101000);
+        online = false;             // network truly dropped right after the proof
+        overlay.show();
+        expect(overlay.isVisible()).toBe(false); // suspect first, don't flash
+        await jest.advanceTimersByTimeAsync(5000); // probe fails → corroborated
+        expect(overlay.isVisible()).toBe(true);
+    });
+
+    test('a genuine outage stays shown until a probe confirms recovery (no false hide, no latch)', async () => {
+        let online = false;
+        const { overlay } = loadOverlay({
+            now: 100000,
+            fetchFn: async () => { if (!online) throw new Error('net'); return { ok: true }; },
+        });
+        overlay.show();                              // no recent proof → reveal immediately
+        expect(overlay.isVisible()).toBe(true);
+        await jest.advanceTimersByTimeAsync(5000);   // probe #1 fails
+        expect(overlay.isVisible()).toBe(true);      // still down → stays up (not falsely hidden)
+        online = true;
+        await jest.advanceTimersByTimeAsync(30000);  // a later probe succeeds (backoff)
+        expect(overlay.isVisible()).toBe(false);     // recovered → cleared, did not latch
+    });
+});
+
+describe('reconnect overlay — wiring into the real transports', () => {
+    // FAIL-ON-OLD: old api.js never told the overlay about a successful round-trip.
+    test('api.js clears the banner on a successful (2xx) apiCall round-trip', () => {
+        const src = fs.readFileSync(API_PATH, 'utf8');
+        expect(src).toMatch(/__reconnectOverlay\.noteServerReachable\s*\(\s*\)/);
+    });
+
+    // FAIL-ON-OLD: old socket.js 'connect' handler only logged + updated the badge.
+    test("socket.js clears the banner when the live socket (re)connects", () => {
+        const src = fs.readFileSync(SOCKET_PATH, 'utf8');
+        expect(src).toMatch(/on\('connect'[\s\S]{0,900}__reconnectOverlay\.noteServerReachable\s*\(\s*\)/);
+    });
+});


### PR DESCRIPTION
## Bug (Hank P0, 2026-06-27)
The in-app chat WebView showed a persistent red **"網路連線中斷，正在重新連線…"** (network disconnected, reconnecting…) banner at the top **even though the user could still send and receive messages**. The connection-status indicator was a false-positive.

## Root cause — frontend overlay, NOT native `app/`
The exact banner text lives in `backend/public/portal/shared/reconnect-overlay.js` (the portal reconnect overlay rendered inside the Android chat WebView), not in any native Kotlin code. The native `ReconnectOverlayController` ("重新連線中…") only fires on a whole-page main-frame load failure and is not involved when messaging works.

Mechanism of the false positive:
- The overlay is raised by **any** transport-level `fetch` failure (`api.js` `apiCall` catch + `auth.js` `checkAuth`).
- It could **only ever clear itself via its own `GET /api/version` probe**.
- It was **completely decoupled from the transport the user actually depends on** — the live `socket.io` connection + `POST /api/client/speak`. `socket.js`'s `connect`/`disconnect` handlers only `console.log`; a successful message round-trip never cleared the banner.

So a lone background-poll blip, a spurious Android-WebView `offline` event, or a transient `/api/version` 429/503 during a Railway cold-start — while the **already-open WebSocket kept delivering messages** — latched the alarming banner while messaging worked fine. This is "likely cause (b)": messaging uses a different transport than the banner's health-check.

Key file:line:
- `reconnect-overlay.js:46` — banner text `'網路連線中斷，正在重新連線…'`
- `api.js:29-31` (old) — `show()` on every fetch throw, but **no** hide on success
- `socket.js:28-31` (old) — `connect` handler only logs, never touches the overlay
- `reconnect-overlay.js` (old) `probe()` — sole clear path was `/api/version` 2xx

## Fix (minimal, client-side only; no server logic, no `app/` changes)
1. **`reconnect-overlay.js`**: add `noteServerReachable()` — a proof-of-connectivity signal that clears the banner immediately and records the good round-trip. Add a **transient-blip grace**: a failure landing within `RECENT_OK_MS` (6s) of proof is verified by a probe **before** the banner is ever shown, so a momentary blip no longer flashes "disconnected". A genuine outage still shows and only clears once a probe (or real traffic) confirms recovery — **no real outage is masked**.
2. **`api.js`**: call `noteServerReachable()` on every 2xx `apiCall` round-trip (every successful send/poll proves the channel is up).
3. **`socket.js`**: call `noteServerReachable()` on socket `'connect'` — this is what flips the banner off on `socket.io` auto-reconnect.

## Tests
`backend/tests/jest/reconnect-overlay.test.js` loads the DOM-coupled overlay IIFE into a hand-rolled node `window`/`document` stub (jest env is `node`, no jsdom) and exercises the **real** state machine + probe + fake timers:
- `noteServerReachable()` clears a visible banner (a message round-tripped)
- a transient blip right after a good round-trip does **not** alarm the user
- an un-corroborated blip **is** escalated to a real banner
- a genuine outage stays shown until a probe confirms recovery (no false hide, no latch)
- `api.js` / `socket.js` wiring checks

**Fail-on-old proven:** reverting all three source files and running the suite fails **6 / 8** tests; restoring makes all 8 green.

## Build / lint / test status
- `npx jest tests/jest/reconnect-overlay.test.js` → **8/8 green**
- `node --check` clean on all 4 files (local `eslint` not installed; `eslint .` runs in CI; additions follow existing browser-global style + `eslint-disable-next-line no-new-func` on the test's sandbox loader)
- **No `app/` files changed** → Android build (`:app:assembleDebug`) is unaffected; `#3790` drag-pin / `#3791` FSM touch a different area, no conflict.

## Scope note for reviewer
The task was scoped "app/ only unless server-side". The actual root cause is a **frontend web asset served by the backend** (`backend/public/portal/shared/`), not native `app/` and not backend request-handling logic. I fixed it because it is the genuine P0 root cause and a low-risk, fully-unit-tested client-JS change. Only the 4 files above are staged (no CRLF churn, `google-services.json` uncommitted).

## Emulator QA for #2
1. Open the in-app chat → confirm **no** reconnect banner while connected and messaging works.
2. Toggle airplane mode briefly (a real, sustained drop) → banner appears; restore network → banner clears within a few seconds (or immediately on the next message / socket reconnect).
3. Send a message during a momentary radio blip → confirm the banner does **not** flash while the send succeeds.
4. Confirm a genuine, sustained outage still shows the banner (no masking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBmn5NeYXxoWMYX6QPx2mt