### PR TITLE
fix(activity): a bot with open assigned kanban cards never shows asleep

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6277,6 +6277,39 @@ function loadSkillDoc() {
 const activityPrefsCache = new Map(); // deviceId -> { idleAfterMs, sleepAfterMs, fetchedAt }
 const ACTIVITY_PREFS_TTL_MS = 60 * 1000;
 
+// Per-batch cache of which bound entities have OPEN (todo/in_progress) assigned
+// kanban cards. Without this, a bot with a piled-up TASK queue but an empty
+// MESSAGE queue is judged IDLE→SLEEPING and shows "Zzz" on the wallpaper while
+// work is outstanding (card_52b9032216e43e6c75ca2b6a). ONE grouped query for ALL
+// devices, refreshed lazily at most once per TTL — the 5 s activity loop NEVER
+// issues a DB query per entity per tick; each tick reads the last-known cache.
+let pendingKanbanCache = { byDevice: new Map(), fetchedAt: 0 };
+let pendingKanbanRefreshing = false;
+const PENDING_KANBAN_TTL_MS = 30 * 1000;
+
+function refreshPendingKanbanCache(now) {
+    if (!chatPool) return;
+    if (pendingKanbanRefreshing) return;
+    if (pendingKanbanCache.fetchedAt && now - pendingKanbanCache.fetchedAt <= PENDING_KANBAN_TTL_MS) return;
+    pendingKanbanRefreshing = true;
+    // Single grouped read across every device; the status filter hits
+    // idx_kanban_cards_status (device_id, status). bucketPendingKanban (pure)
+    // folds the rows into Map<deviceId, Set<entityId>>.
+    chatPool.query(
+        `SELECT device_id, status, archived, assigned_bots
+           FROM kanban_cards
+          WHERE status IN ('todo', 'in_progress')
+            AND (archived IS NULL OR archived = false)`
+    ).then(res => {
+        pendingKanbanCache = {
+            byDevice: entityActivity.bucketPendingKanban(res.rows),
+            fetchedAt: Date.now(),
+        };
+    }).catch(err => {
+        console.error('[ActivityKanban] pending-kanban refresh failed:', err.message);
+    }).finally(() => { pendingKanbanRefreshing = false; });
+}
+
 function getActivityThresholds(deviceId, now) {
     const cached = activityPrefsCache.get(deviceId);
     if (!cached || now - cached.fetchedAt > ACTIVITY_PREFS_TTL_MS) {
@@ -6358,13 +6391,18 @@ function evaluateEntityActivity(entity, now, idleAfterMs, sleepAfterMs) {
 // Evaluate every bound entity once. `optsOverride` lets tests force explicit
 // thresholds (bypassing the per-device pref cache) for deterministic assertions.
 function runEntityActivityEvaluation(now = Date.now(), optsOverride = null) {
+    refreshPendingKanbanCache(now); // non-blocking; this tick uses the last-known cache
     for (const deviceId in devices) {
         const device = devices[deviceId];
         if (!device || !device.entities) continue;
         const thresholds = optsOverride || getActivityThresholds(deviceId, now);
+        const openKanban = pendingKanbanCache.byDevice.get(deviceId);
         for (const i of Object.keys(device.entities).map(Number)) {
             const entity = device.entities[i];
             if (!entity || !entity.isBound) continue;
+            // Open assigned kanban card (todo/in_progress) → pendingWork → the
+            // evaluator forbids IDLE/SLEEPING, so a busy bot never shows asleep.
+            entity._pendingKanban = !!(openKanban && openKanban.has(entity.entityId));
             evaluateEntityActivity(entity, now, thresholds.idleAfterMs, thresholds.sleepAfterMs);
         }
     }

--- a/backend/lib/entity-activity.js
+++ b/backend/lib/entity-activity.js
@@ -36,6 +36,15 @@ const BUSY_FAMILY = new Set(['BUSY', 'PROCESSING', 'WORKING', 'IN_PROGRESS', 'IN
 // Agent-declared transient expressive poses rendered as TTL overlays.
 const EXPRESSIVE = new Set(['EXCITED', 'HAPPY', 'WAVING', 'JUMPING', 'REVIEW', 'FAILED']);
 
+// Kanban statuses that count as UNFINISHED assigned work for activity purposes.
+// Canonical enum (public/shared/kanban-status.js): backlog, todo, in_progress,
+// review, done, blocked. Only 'todo' + 'in_progress' mean "the bot has work it
+// must act on NOW" → it must stay awake. Excluded: 'backlog' (not yet pulled
+// onto the board), 'review'/'done' (handed off for sign-off / finished),
+// 'blocked' (cannot act — waiting on a dependency). Mirrors the org-forward
+// task-check status filter in index.js.
+const UNFINISHED_KANBAN_STATUSES = new Set(['todo', 'in_progress']);
+
 // How long an expressive overlay shows before reverting to the activity base.
 const OVERLAY_TTL_MS = 30 * 1000;
 
@@ -67,6 +76,35 @@ function computePendingWork(entity) {
     if (entity._pendingKanban === true) return true;
     if (entity._pendingScheduled === true) return true;
     return false;
+}
+
+// PURE bucketing helper for the kanban pendingWork signal. Given kanban_cards
+// rows ({ device_id, status, archived, assigned_bots }), return
+// Map<deviceId, Set<entityId>> of entities that have ≥1 UNFINISHED, non-archived
+// assigned card. The DB query (index.js) already filters status/archived for
+// efficiency; this re-applies the same policy so the filter is unit-testable and
+// the helper is robust to an unfiltered or malformed feed. No I/O — the caller
+// runs the single grouped query and passes the rows in.
+function bucketPendingKanban(rows) {
+    const byDevice = new Map();
+    if (!Array.isArray(rows)) return byDevice;
+    for (const row of rows) {
+        if (!row) continue;
+        if (row.archived === true) continue;
+        if (!UNFINISHED_KANBAN_STATUSES.has(String(row.status || '').trim())) continue;
+        let ids = row.assigned_bots;
+        // assigned_bots is JSONB (array of entity IDs); some drivers return it as
+        // a string — parse defensively and skip anything that isn't an array.
+        if (typeof ids === 'string') { try { ids = JSON.parse(ids); } catch (_) { ids = null; } }
+        if (!Array.isArray(ids)) continue;
+        let set = byDevice.get(row.device_id);
+        if (!set) { set = new Set(); byDevice.set(row.device_id, set); }
+        for (const raw of ids) {
+            const id = Number(raw);
+            if (Number.isFinite(id)) set.add(id);
+        }
+    }
+    return byDevice;
 }
 
 // DETERMINISTIC activity evaluator — NO randomness, NO side effects.
@@ -112,12 +150,14 @@ module.exports = {
     ACTIVITY,
     BUSY_FAMILY,
     EXPRESSIVE,
+    UNFINISHED_KANBAN_STATUSES,
     OVERLAY_TTL_MS,
     DEFAULT_IDLE_AFTER_MS,
     DEFAULT_SLEEP_AFTER_MS,
     isBusyFamilyState,
     isExpressiveState,
     computePendingWork,
+    bucketPendingKanban,
     evaluateActivityState,
     overlayActive,
     defaultMessageForState,

--- a/backend/tests/jest/entity-activity-state-machine.test.js
+++ b/backend/tests/jest/entity-activity-state-machine.test.js
@@ -176,6 +176,85 @@ describe('entity-activity: SLEEPING only after SLEEP_AFTER with no pending', () 
     });
 });
 
+describe('entity-activity: open kanban assignment forbids sleep (card_52b9032216e43e6c75ca2b6a)', () => {
+    // Mirrors the index.js wiring: a single grouped query returns kanban_cards
+    // rows, bucketPendingKanban folds them into Map<deviceId, Set<entityId>>, the
+    // loop sets entity._pendingKanban = set.has(entityId), then evaluates.
+    const DEVICE = 'dev-A';
+    const STALE = {
+        // far past SLEEP_AFTER + empty message queue → OLD wiring (no kanban
+        // signal) would let this bot decay to SLEEPING ("Zzz" while tasks pile up).
+        lastSendAt: NOW - (SLEEP_AFTER_MS + 5 * 60 * 1000),
+        lastActivityAt: NOW - (SLEEP_AFTER_MS + 5 * 60 * 1000),
+        messageQueue: [],
+    };
+
+    function wire(entityId, rows) {
+        const byDevice = activity.bucketPendingKanban(rows);
+        const openSet = byDevice.get(DEVICE);
+        const entity = makeEntity({ entityId, ...STALE });
+        entity._pendingKanban = !!(openSet && openSet.has(entity.entityId));
+        return entity;
+    }
+
+    // ── (a) open assigned card + stale + empty queue → ACTIVE, never SLEEPING ──
+    test('(a) bot with an open assigned (in_progress) card is ACTIVE, NOT SLEEPING', () => {
+        const rows = [
+            { device_id: DEVICE, status: 'in_progress', archived: false, assigned_bots: [2] },
+            { device_id: DEVICE, status: 'todo', archived: false, assigned_bots: [5, 7] },
+        ];
+        const bot2 = wire(2, rows);
+        // FAIL-ON-OLD: without the kanban signal this entity is SLEEPING…
+        expect(activity.evaluateActivityState(makeEntity({ entityId: 2, ...STALE }), NOW, OPTS))
+            .toBe(ACTIVITY.SLEEPING);
+        // …with it, the wired entity stays awake.
+        expect(bot2._pendingKanban).toBe(true);
+        expect(activity.evaluateActivityState(bot2, NOW, OPTS)).toBe(ACTIVITY.ACTIVE);
+        expect(activity.evaluateActivityState(bot2, NOW, OPTS)).not.toBe(ACTIVITY.SLEEPING);
+
+        // a multi-assignee 'todo' card keeps EACH assignee awake.
+        expect(activity.evaluateActivityState(wire(5, rows), NOW, OPTS)).toBe(ACTIVITY.ACTIVE);
+        expect(activity.evaluateActivityState(wire(7, rows), NOW, OPTS)).toBe(ACTIVITY.ACTIVE);
+    });
+
+    // ── (b) no assigned cards + stale → SLEEPING (unchanged) ──
+    test('(b) bot with NO assigned open cards still SLEEPS after SLEEP_AFTER', () => {
+        const rows = [{ device_id: DEVICE, status: 'in_progress', archived: false, assigned_bots: [2] }];
+        const bot9 = wire(9, rows); // entity 9 is on no card
+        expect(bot9._pendingKanban).toBe(false);
+        expect(activity.evaluateActivityState(bot9, NOW, OPTS)).toBe(ACTIVITY.SLEEPING);
+    });
+
+    // ── (c) done / review / archived / backlog cards do NOT count as pending ──
+    test('(c) done, review, archived and backlog cards do NOT keep a bot awake', () => {
+        const rows = [
+            { device_id: DEVICE, status: 'done', archived: false, assigned_bots: [2] },
+            { device_id: DEVICE, status: 'review', archived: false, assigned_bots: [2] },
+            { device_id: DEVICE, status: 'backlog', archived: false, assigned_bots: [2] },
+            { device_id: DEVICE, status: 'in_progress', archived: true, assigned_bots: [2] }, // archived
+        ];
+        const bot2 = wire(2, rows);
+        expect(bot2._pendingKanban).toBe(false);
+        expect(activity.evaluateActivityState(bot2, NOW, OPTS)).toBe(ACTIVITY.SLEEPING);
+    });
+
+    test('bucketPendingKanban folds rows per device + parses stringified JSONB, ignores junk', () => {
+        const rows = [
+            { device_id: 'dev-A', status: 'todo', archived: false, assigned_bots: '[2,4]' }, // string JSONB
+            { device_id: 'dev-B', status: 'in_progress', archived: false, assigned_bots: [4] },
+            { device_id: 'dev-A', status: 'done', archived: false, assigned_bots: [9] },       // finished
+            null,                                                                              // junk row
+            { device_id: 'dev-A', status: 'todo', archived: false, assigned_bots: null },      // no array
+        ];
+        const map = activity.bucketPendingKanban(rows);
+        expect([...map.get('dev-A')].sort((a, b) => a - b)).toEqual([2, 4]);
+        expect([...map.get('dev-B')]).toEqual([4]);
+        expect(map.has('dev-C')).toBe(false);
+        expect(activity.bucketPendingKanban(null).size).toBe(0);
+        expect(activity.bucketPendingKanban([]).size).toBe(0);
+    });
+});
+
 describe('entity-activity: expressive overlays + state classifiers', () => {
     test('busy-family states classify as active', () => {
         for (const s of ['BUSY', 'PROCESSING', 'WORKING', 'IN_PROGRESS', 'IN-PROGRESS', 'busy', ' processing ']) {


### PR DESCRIPTION
## Problem
`card_52b9032216e43e6c75ca2b6a` (Hank P1): wallpaper entities showed **Zzz / 睡覺** while assigned kanban tasks were piled up. Stage 1-2 (#3788) made the activity FSM deterministic, but `pendingWork` only reflected the in-process **message** queue. A bot with open assigned cards (todo/in_progress) but an empty message queue got judged `IDLE → SLEEPING`.

## Fix
The pure evaluator (`lib/entity-activity.js`) already honoured an OPTIONAL `entity._pendingKanban` flag — nothing wired it. This wires it:

- **`lib/entity-activity.js`** — add `UNFINISHED_KANBAN_STATUSES` (`todo`/`in_progress`) and a PURE `bucketPendingKanban(rows)` helper that folds `kanban_cards` rows into `Map<deviceId, Set<entityId>>` (excludes `done`/`review`/`backlog` + `archived`). No I/O — caller passes rows in.
- **`index.js`** — `refreshPendingKanbanCache()` runs **ONE grouped query** across all devices (`status IN ('todo','in_progress') AND NOT archived`; uses `idx_kanban_cards_status(device_id,status)`), cached ~30s. `runEntityActivityEvaluation` sets `entity._pendingKanban = openSet.has(entity.entityId)` before evaluating, so the 5s loop **never issues a per-entity DB query**.

Status policy: `todo`+`in_progress` = "work the bot must act on now". Excluded: `backlog` (not pulled), `review`/`done` (handed off/finished), `blocked` (cannot act). Mirrors the existing org-forward task-check filter.

## Tests (fail-on-old proven)
New kanban-assignment block in `entity-activity-state-machine.test.js`:
- **(a)** open assigned card + stale `lastSendAt` + empty queue → **ACTIVE**, not SLEEPING (the no-signal path is asserted SLEEPING in the same test).
- **(b)** no assigned cards + stale → **SLEEPING** (unchanged).
- **(c)** `done`/`review`/`backlog`/`archived` cards do **not** keep a bot awake.
- `bucketPendingKanban` folding + stringified-JSONB parse + junk-row resilience.

Against `origin/main` lib the 4 new tests error (`bucketPendingKanban is not a function`). **24/24 green**; `node -c index.js` + `node -c lib/entity-activity.js` clean.

Additive + reversible. No client change (canonical `ACTIVE → 'BUSY'` wire state unchanged). After merge + Railway redeploy, an entity with open cards flips from Zzz to active on the wallpaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBmn5NeYXxoWMYX6QPx2mt