### PR TITLE
fix(kanban): stale-card watcher must not re-nudge parked backlog cards

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -932,8 +932,10 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 cardParams.push(cardId);
                 cardWhere += ` AND id = $${cardParams.length}`;
             } else {
+                // Mirror checkStaleCards' candidate set so this diagnostic reflects
+                // what actually gets nudged: backlog is parked → never stale-nudged.
                 cardWhere += `
-                  AND status IN ('backlog', 'todo', 'in_progress', 'review')
+                  AND status IN ('todo', 'in_progress', 'review')
                   AND EXTRACT(EPOCH FROM (NOW() - status_changed_at)) * 1000 > stale_threshold_ms`;
             }
             const cardsRes = await pool.query(
@@ -3586,7 +3588,16 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         try {
             // Fetch stale candidates WITHOUT the global nudge-gap filter; we apply
             // per-device nudge interval + status filter (from device_preferences) below.
-            // backlog (待排程) included here and filtered per-device — users can opt in.
+            // backlog (待排程) is EXCLUDED here: backlog = intentionally parked / "not
+            // now", so a parked card must never be flood re-nudged "please continue"
+            // (owner-reported zombie nudge, card_3e95f4c1: a parked #6 recurring-driver
+            // card and a parked daily-E2E card re-nudged every ~17 min for 7+ hours each).
+            // Only actively-worked statuses (todo / in_progress / review) get stale
+            // nudges; done + archived are already excluded (status filter + the
+            // archived = false guard). This extends the #3781 hygiene that stopped
+            // re-nudging archived/done parents — now to parked backlog cards too.
+            // Backlog cards stay fully visible on the board; this only stops the active
+            // re-nudge pings, not their board presence.
             // Skip recurring-schedule automation parents: their status_changed_at never
             // moves (cron creates child cards instead), so they would always look stale
             // and get escalated to P0 every staleThresholdMs window. Mirrors the same
@@ -3599,14 +3610,10 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             // Once run_at passes (timer fires or window elapses without fire), the card
             // falls back into stale eligibility — preserves L1/L2/L3 safety rails for
             // actually-stuck post-runAt cards.
-            // gated=true only suppresses L1/L2/L3 for backlog cards (launch-pending
-            // drafts). Active-status cards (todo/in_progress/review) keep escalating
-            // even if a stale gated flag is left over — defense-in-depth alongside
-            // the API guard + /move auto-reset.
             const result = await pool.query(`
                 SELECT * FROM kanban_cards
                 WHERE archived = false
-                  AND status IN ('backlog', 'todo', 'in_progress', 'review')
+                  AND status IN ('todo', 'in_progress', 'review')
                   AND EXTRACT(EPOCH FROM (NOW() - status_changed_at)) * 1000 > stale_threshold_ms
                   AND (schedule_enabled = false OR schedule_type != 'recurring' OR schedule_enabled IS NULL)
                   AND NOT (
@@ -3615,7 +3622,6 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     AND schedule_run_at IS NOT NULL
                     AND schedule_run_at > NOW()
                   )
-                  AND (status != 'backlog' OR COALESCE(gated, false) = false)
                   -- Suppress nudges on orphaned children of a stopped parent:
                   -- if the parent card is archived (any child) or the parent is
                   -- DONE and this is a cron-spawned child (is_auto_generated),

--- a/backend/tests/jest/kanban-stale-skip-backlog.test.js
+++ b/backend/tests/jest/kanban-stale-skip-backlog.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * Owner-reported zombie nudge (card_3e95f4c1): the stale-card watcher kept actively
+ * re-nudging cards parked in `backlog` — a parked #6 recurring-driver card and a
+ * parked daily-E2E card each re-nudged "please continue" every ~17 minutes for 7+
+ * hours, spamming the channel. `backlog` means "intentionally parked / not now", so
+ * a backlog card must NOT be flood-nudged. This is the same class of zombie nudge
+ * that PR #3781 fixed for archived/done parents — here extended to `backlog`.
+ *
+ * Root cause: checkStaleCards' candidate SELECT scoped to
+ *   status IN ('backlog', 'todo', 'in_progress', 'review')
+ * so any backlog card past stale_threshold_ms became a stale candidate and (if a
+ * device opted backlog into kanban_nudge_statuses) flowed straight into the L1/L2/L3
+ * nudge ladder. Fix: drop 'backlog' from the candidate SELECT — the single chokepoint
+ * every stale candidate flows through. Only actively-worked statuses
+ * (todo / in_progress / review) are eligible; done + archived stay excluded.
+ *
+ * This test reconstructs the candidate-selection semantics from the REAL SQL literal
+ * in kanban.js (parsing the `status IN (...)` list the DB actually filters on) and
+ * asserts the behaviour:
+ *   (a) a backlog card past the stale threshold  ⇒ NOT a candidate (no nudge)
+ *   (b) an in_progress card past the threshold   ⇒ still a candidate (nudge fires)
+ *
+ * Fail-on-old proof: on pre-fix origin/main the IN-list contains 'backlog', so the
+ * backlog card IS selected → case (a) FAILS. After the fix it is dropped → PASS.
+ * Case (b) passes on both (unchanged), guarding against an over-broad regression.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const kanbanSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'kanban.js'),
+    'utf8'
+);
+
+function extractFunctionBody(src, signature) {
+    const start = src.indexOf(signature);
+    if (start === -1) throw new Error(`function not found: ${signature}`);
+    const open = src.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) return src.slice(open, i + 1);
+        }
+    }
+    throw new Error(`unterminated function: ${signature}`);
+}
+
+// Parse the `status IN ('a', 'b', ...)` whitelist out of a function body and return
+// a predicate modelling "would the candidate SELECT accept this status?". This reads
+// the REAL SQL the watcher runs, so the predicate's behaviour tracks production.
+function statusCandidatePredicate(body) {
+    const m = body.match(/status IN \(([^)]*)\)/);
+    if (!m) throw new Error('status IN (...) clause not found');
+    const statuses = m[1]
+        .split(',')
+        .map(s => s.trim().replace(/^'/, '').replace(/'$/, ''))
+        .filter(Boolean);
+    return (status) => statuses.includes(status);
+}
+
+describe('checkStaleCards — parked backlog cards are not stale-nudge candidates', () => {
+    const body = extractFunctionBody(kanbanSrc, 'async function checkStaleCards()');
+    const isStaleCandidate = statusCandidatePredicate(body);
+
+    // (a) parked backlog card past threshold → NO nudge (FAILS on pre-fix code).
+    test('a backlog card past the stale threshold is NOT a nudge candidate', () => {
+        expect(isStaleCandidate('backlog')).toBe(false);
+    });
+
+    // (b) actively-worked card past threshold → still nudged (unchanged).
+    test('an in_progress card past the stale threshold is still a nudge candidate', () => {
+        expect(isStaleCandidate('in_progress')).toBe(true);
+    });
+
+    test('todo and review remain nudge candidates (active work)', () => {
+        expect(isStaleCandidate('todo')).toBe(true);
+        expect(isStaleCandidate('review')).toBe(true);
+    });
+
+    test('done and blocked are not nudge candidates (already excluded)', () => {
+        expect(isStaleCandidate('done')).toBe(false);
+        expect(isStaleCandidate('blocked')).toBe(false);
+    });
+
+    test('candidate SELECT also keeps the archived = false guard (done/archived stay out)', () => {
+        expect(body).toMatch(/archived\s*=\s*false/);
+    });
+
+    test('source no longer lists backlog in the candidate SELECT', () => {
+        expect(body).not.toMatch(/status IN \([^)]*'backlog'[^)]*\)/);
+    });
+});

--- a/backend/tests/jest/kanban-stale-skip-recurring.test.js
+++ b/backend/tests/jest/kanban-stale-skip-recurring.test.js
@@ -55,8 +55,11 @@ describe('checkStaleCards — recurring-schedule skip filter', () => {
         );
     });
 
-    test('SELECT still scopes to active statuses', () => {
-        expect(body).toMatch(/status IN \('backlog', 'todo', 'in_progress', 'review'\)/);
+    test('SELECT still scopes to active statuses (backlog now excluded — parked)', () => {
+        // backlog dropped from the candidate set: parked cards must not be re-nudged
+        // (see kanban-stale-skip-backlog.test.js for the fail-on-old behavioural proof).
+        expect(body).toMatch(/status IN \('todo', 'in_progress', 'review'\)/);
+        expect(body).not.toMatch(/status IN \([^)]*'backlog'[^)]*\)/);
     });
 });
 


### PR DESCRIPTION
## Problem
Owner-reported zombie nudge (**card_3e95f4c1**): the stale-card nudge watcher kept **actively re-nudging cards parked in `backlog`**. A parked #6 recurring-driver card and a parked daily-E2E card each re-nudged `⏰ 請繼續推進 / please continue` every ~17 min for **7+ hours**, spamming the channel. `backlog` means *intentionally parked / not now*, so a backlog card must **not** be flood-nudged. This is the same class of zombie nudge **PR #3781** fixed for archived/done parents — here extended to `backlog`.

## Root cause
`checkStaleCards()`'s candidate `SELECT` scoped to:
```sql
status IN ('backlog', 'todo', 'in_progress', 'review')
```
so any backlog card past `stale_threshold_ms` became a stale candidate and (if a device opted backlog into `kanban_nudge_statuses`) flowed straight into the L1/L2/L3 nudge ladder via `processDeviceStaleCards → fireLevelOneNudge`.

## Fix (minimal, server-side, mirrors the #3781 SQL-guard style)
- **Drop `'backlog'`** from the candidate `SELECT` in `checkStaleCards` (`backend/kanban.js`) — the single chokepoint every stale candidate flows through. Only actively-worked statuses (**todo / in_progress / review**) are eligible; **done + archived** stay excluded (status filter + `archived = false`). The now-dead backlog `gated` clause is removed.
- Mirror the same drop in the `/debug/kanban-codex-nudge` diagnostic so it reflects what actually gets nudged.
- **Backlog cards stay fully visible on the board** — this only stops the active re-nudge pings, not their board presence.
- **Card-scheduler (`schedule`/cron / `checkScheduleTriggers`) behaviour is untouched.**

### Status set before → after (stale-nudge eligibility)
| | backlog | todo | in_progress | review | done | archived | blocked |
|---|---|---|---|---|---|---|---|
| before | ✅ nudged (opt-in) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
| after | ❌ skipped (parked) | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |

## Tests (fail-on-old proven)
- **New** `kanban-stale-skip-backlog.test.js` parses the REAL `status IN (...)` from `checkStaleCards` and asserts **(a)** a backlog card past threshold is **NOT** a nudge candidate, **(b)** an in_progress card past threshold **still IS**. Reverting the fix (backlog back in the IN-list) makes case (a) **FAIL**; case (b) passes on both — guards against an over-broad regression.
- Updated `kanban-stale-skip-recurring.test.js` to pin the new active-only IN-list.
- `node -c backend/kanban.js` OK. Full backend jest suite green: **417 suites, 5836 passed, 17 skipped, 0 failed** (CI-matching jest 29.7.0).

## Reversibility
Additive/reversible — a plain `git revert` restores the prior candidate set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBmn5NeYXxoWMYX6QPx2mt