### PR TITLE
feat(activity): real-activity-driven entity state (BUSY/REVIEW/FAILED/IDLE/SLEEPING) — stages 0-2

### DIFF
--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -97,12 +97,19 @@ const DEFAULTS = {
     // entity_sleep_after_minutes: minutes of inactivity (no pending work, no
     //   message in the window) before IDLE → SLEEPING. Default 20; clamped [1, 1440].
     entity_sleep_after_minutes: 20,
+    // entity_runtime_state_stale_seconds: how long a heartbeat-reported
+    //   runtimeState (busy|stuck|crashed|idle) is TRUSTED by the activity machine
+    //   before it is treated as stale and ignored (the evaluator then falls back
+    //   to lastSend / kanban-floor heuristics). Default 45; clamped [5, 600].
+    entity_runtime_state_stale_seconds: 45,
 };
 
 const ENTITY_IDLE_AFTER_SECONDS_MIN = 15;
 const ENTITY_IDLE_AFTER_SECONDS_MAX = 3600;
 const ENTITY_SLEEP_AFTER_MINUTES_MIN = 1;
 const ENTITY_SLEEP_AFTER_MINUTES_MAX = 1440;
+const ENTITY_RUNTIME_STATE_STALE_SECONDS_MIN = 5;
+const ENTITY_RUNTIME_STATE_STALE_SECONDS_MAX = 600;
 
 const ACTION_REQUEST_TIMEOUT_POLICIES = new Set(['keep', 'auto_dismiss', 'safe_default', 'consensus']);
 const ACTION_REQUEST_TIMEOUT_MINUTES_MIN = 5;
@@ -176,6 +183,9 @@ function coerceValue(key, raw) {
         }
         if (key === 'entity_sleep_after_minutes') {
             return Math.max(ENTITY_SLEEP_AFTER_MINUTES_MIN, Math.min(ENTITY_SLEEP_AFTER_MINUTES_MAX, Math.round(n)));
+        }
+        if (key === 'entity_runtime_state_stale_seconds') {
+            return Math.max(ENTITY_RUNTIME_STATE_STALE_SECONDS_MIN, Math.min(ENTITY_RUNTIME_STATE_STALE_SECONDS_MAX, Math.round(n)));
         }
         return n;
     }

--- a/backend/index.js
+++ b/backend/index.js
@@ -6322,41 +6322,53 @@ function getActivityThresholds(deviceId, now) {
                 p.then(prefs => {
                     const idleSec = Number(prefs.entity_idle_after_seconds);
                     const sleepMin = Number(prefs.entity_sleep_after_minutes);
+                    const staleSec = Number(prefs.entity_runtime_state_stale_seconds);
                     activityPrefsCache.set(deviceId, {
                         idleAfterMs: (Number.isFinite(idleSec) ? idleSec : 60) * 1000,
                         sleepAfterMs: (Number.isFinite(sleepMin) ? sleepMin : 20) * 60 * 1000,
+                        runtimeStaleMs: (Number.isFinite(staleSec) ? staleSec : 45) * 1000,
                         fetchedAt: Date.now(),
                     });
                 }).catch(() => { /* keep last-known / defaults */ });
             }
         } catch (_) { /* keep last-known / defaults */ }
     }
-    if (cached) return { idleAfterMs: cached.idleAfterMs, sleepAfterMs: cached.sleepAfterMs };
+    if (cached) return {
+        idleAfterMs: cached.idleAfterMs,
+        sleepAfterMs: cached.sleepAfterMs,
+        runtimeStaleMs: cached.runtimeStaleMs,
+    };
     return {
         idleAfterMs: entityActivity.DEFAULT_IDLE_AFTER_MS,
         sleepAfterMs: entityActivity.DEFAULT_SLEEP_AFTER_MS,
+        runtimeStaleMs: entityActivity.DEFAULT_RUNTIME_STALE_MS,
     };
 }
 
 // Apply one deterministic activity evaluation to a single entity (mutates
 // entity.state/message/overlay). Pure decision-making lives in
 // lib/entity-activity.js; this wrapper applies the transition rules.
-function evaluateEntityActivity(entity, now, idleAfterMs, sleepAfterMs) {
-    if (!entity) return;
+function evaluateEntityActivity(entity, now, idleAfterMs, sleepAfterMs, runtimeStaleMs) {
+    if (!entity) return false;
+    const A = entityActivity.ACTIVITY;
+    let changed = false;
 
     // 1. Active expressive overlay → keep showing it (its server TTL guarantees
-    //    it can't get stuck; it reverts below once expired).
+    //    it can't get stuck; it reverts below once expired). An agent-declared
+    //    EXCITED/HAPPY/REVIEW/FAILED celebration/pose ALWAYS wins over the
+    //    runtimeState-derived base for its TTL.
     if (entityActivity.overlayActive(entity, now)) {
         if (entity.state !== entity.overlayState) {
             entity.state = entity.overlayState;
             entity.lastUpdated = now;
+            changed = true;
         }
-        return;
+        return changed;
     }
     const hadOverlay = !!entity.overlayState;
     if (hadOverlay) { entity.overlayState = null; entity.overlayUntil = null; }
 
-    const desired = entityActivity.evaluateActivityState(entity, now, { idleAfterMs, sleepAfterMs });
+    const desired = entityActivity.evaluateActivityState(entity, now, { idleAfterMs, sleepAfterMs, runtimeStaleMs });
     const cur = entity.state;
 
     if (hadOverlay) {
@@ -6366,26 +6378,46 @@ function evaluateEntityActivity(entity, now, idleAfterMs, sleepAfterMs) {
             const msg = entityActivity.defaultMessageForState(desired);
             if (msg) entity.message = msg;
             entity.lastUpdated = now;
+            changed = true;
         }
-        return;
+        return changed;
     }
 
-    // 2. Normal decay/wake. The loop only moves toward IDLE/SLEEPING; the send
-    //    endpoints handle wake-to-ACTIVE. We still wake here if pendingWork/inbound
-    //    flipped the derived state back to ACTIVE while the entity was dormant.
-    if (desired === entityActivity.ACTIVITY.SLEEPING && cur !== entityActivity.ACTIVITY.SLEEPING) {
-        entity.state = entityActivity.ACTIVITY.SLEEPING;
+    // 2. Normal decay/wake + runtime-driven REVIEW/FAILED. The loop never clobbers
+    //    an agent's busy SUB-state (PROCESSING/WORKING/…) down to plain BUSY — it
+    //    only promotes to ACTIVE from a dormant/derived base. REVIEW (stuck) and
+    //    FAILED (crashed) come from a FRESH, authoritative runtimeState, so they
+    //    are applied whenever the derived state differs.
+    if (desired === A.SLEEPING && cur !== A.SLEEPING) {
+        entity.state = A.SLEEPING;
         entity.message = 'Zzz...';
         entity.lastUpdated = now;
-    } else if (desired === entityActivity.ACTIVITY.IDLE && cur !== entityActivity.ACTIVITY.IDLE) {
-        entity.state = entityActivity.ACTIVITY.IDLE;
+        changed = true;
+    } else if (desired === A.IDLE && cur !== A.IDLE) {
+        entity.state = A.IDLE;
         entity.message = 'Waiting...';
         entity.lastUpdated = now;
-    } else if (desired === entityActivity.ACTIVITY.ACTIVE
-        && (cur === entityActivity.ACTIVITY.SLEEPING || cur === entityActivity.ACTIVITY.IDLE)) {
-        entity.state = entityActivity.ACTIVITY.ACTIVE;
+        changed = true;
+    } else if (desired === A.REVIEW && cur !== A.REVIEW) {
+        // runtimeState "stuck" — agent waiting at a confirm/prompt. Preserve the
+        // current bubble text (often the prompt itself); only flip the state.
+        entity.state = A.REVIEW;
         entity.lastUpdated = now;
+        changed = true;
+    } else if (desired === A.FAILED && cur !== A.FAILED) {
+        // runtimeState "crashed"/error. Preserve the bubble text; flip the state.
+        entity.state = A.FAILED;
+        entity.lastUpdated = now;
+        changed = true;
+    } else if (desired === A.ACTIVE
+        && (cur === A.SLEEPING || cur === A.IDLE || cur === A.REVIEW || cur === A.FAILED)) {
+        // Wake back to BUSY from any derived dormant/blocked base (e.g. runtime
+        // flipped stuck→busy, or pendingWork/inbound arrived while idle).
+        entity.state = A.ACTIVE;
+        entity.lastUpdated = now;
+        changed = true;
     }
+    return changed;
 }
 
 // Evaluate every bound entity once. `optsOverride` lets tests force explicit
@@ -6400,10 +6432,32 @@ function runEntityActivityEvaluation(now = Date.now(), optsOverride = null) {
         for (const i of Object.keys(device.entities).map(Number)) {
             const entity = device.entities[i];
             if (!entity || !entity.isBound) continue;
-            // Open assigned kanban card (todo/in_progress) → pendingWork → the
-            // evaluator forbids IDLE/SLEEPING, so a busy bot never shows asleep.
+            // Open assigned kanban card (todo/in_progress) → IDLE FLOOR: the
+            // evaluator forbids SLEEPING (so a bot with work never shows asleep)
+            // but no longer fakes BUSY (Stage 0).
             entity._pendingKanban = !!(openKanban && openKanban.has(entity.entityId));
-            evaluateEntityActivity(entity, now, thresholds.idleAfterMs, thresholds.sleepAfterMs);
+            const changed = evaluateEntityActivity(
+                entity, now, thresholds.idleAfterMs, thresholds.sleepAfterMs, thresholds.runtimeStaleMs);
+            // Push the new activity-derived state to live clients (wallpaper /
+            // dashboard) so heartbeat-driven BUSY/REVIEW/FAILED + idle/sleep decay
+            // are real-time, not only visible on the next /api/entities poll. Emit
+            // ONLY on a real state change (bounded: ≤1 per entity per transition)
+            // and never let an emit error crash the activity loop. For leased_out
+            // entities emit STATE ONLY — the bubble text may be renter chat content
+            // that must not leak to the owner (mirrors the transform emit policy).
+            if (changed && io) {
+                try {
+                    const base = {
+                        deviceId, entityId: entity.entityId,
+                        name: entity.name, character: entity.character,
+                        state: entity.state,
+                        parts: entity.parts, lastUpdated: entity.lastUpdated,
+                        xp: entity.xp || 0, level: entity.level || 1,
+                    };
+                    if (entity.rental_status !== 'leased_out') base.message = entity.message;
+                    io.to(`device:${deviceId}`).emit('entity:update', base);
+                } catch (_) { /* never break the activity loop on an emit error */ }
+            }
         }
     }
 }
@@ -8758,7 +8812,7 @@ app.get('/api/b2b-status', (req, res) => {
  * Body: { deviceId, entityId, botSecret } or { deviceId, entityId, deviceSecret }
  */
 app.post('/api/entity/heartbeat', async (req, res) => {
-    const { deviceId, entityId, botSecret, deviceSecret } = req.body || {};
+    const { deviceId, entityId, botSecret, deviceSecret, runtimeState } = req.body || {};
 
     if (!deviceId) {
         return res.status(400).json({ success: false, message: 'deviceId required' });
@@ -8785,6 +8839,26 @@ app.post('/api/entity/heartbeat', async (req, res) => {
     }
 
     const status = recordEntityHeartbeat(entity);
+
+    // OPTIONAL real-activity signal from the agent's own runtime (Stage 1/2).
+    // Backward-compatible: when `runtimeState` is absent the heartbeat behaves
+    // exactly as before. The value is validated against a fixed allow-list
+    // (busy|stuck|crashed|idle); anything else is ignored (never stamped) so a
+    // bad client can't wedge an entity into an arbitrary state. The activity FSM
+    // (lib/entity-activity.js) only TRUSTS this stamp while it is fresh
+    // (entity_runtime_state_stale_seconds, default 45 s).
+    let runtimeStateAccepted = null;
+    if (runtimeState !== undefined && runtimeState !== null) {
+        const rs = String(runtimeState).trim().toLowerCase();
+        if (entityActivity.RUNTIME_STATES.has(rs)) {
+            const nowMs = Date.now();
+            entity.runtimeState = rs;
+            entity.lastRuntimeStateAt = nowMs;
+            if (rs === 'busy') entity.lastRuntimeBusyAt = nowMs;
+            runtimeStateAccepted = rs;
+        }
+    }
+
     saveData().catch(err => console.error(`[Heartbeat] saveData failed: ${err.message}`));
 
     res.json({
@@ -8793,6 +8867,7 @@ app.post('/api/entity/heartbeat', async (req, res) => {
         daemonConnected: status.daemonConnected,
         lastSeen: status.lastSeen,
         stale: status.stale,
+        runtimeState: runtimeStateAccepted,
     });
 });
 

--- a/backend/lib/entity-activity.js
+++ b/backend/lib/entity-activity.js
@@ -12,12 +12,20 @@
 // the same canonical state every time.
 //
 // Canonical activity states map onto the EXISTING wire CharacterState enum so
-// the Android client needs no change (Stage 3 / separate PR):
-//   ACTIVE   -> 'BUSY'
+// the Android client needs no change (the strings below are all parsed by
+// AgentStatus.fromWireValue — see app/.../data/model/AgentStatus.kt):
+//   ACTIVE   -> 'BUSY'      (running)
 //   IDLE     -> 'IDLE'
 //   SLEEPING -> 'SLEEPING'
+//   REVIEW   -> 'REVIEW'    (agent waiting at a confirm/prompt — purple)
+//   FAILED   -> 'FAILED'    (agent crashed / rate-limited / errored — red)
 //
-// Expressive states (EXCITED/HAPPY/WAVING/JUMPING/REVIEW/FAILED) stay
+// Stage 1/2 (real-activity-driven): the agent runtime reports its OWN live
+// state via the heartbeat (`runtimeState`: busy|stuck|crashed|idle). A FRESH,
+// trusted runtimeState is the PRIMARY signal; when it is absent/stale the
+// evaluator gracefully degrades to the lastSend / kanban-floor heuristics.
+//
+// Expressive states (EXCITED/HAPPY/WAVING/JUMPING/REVIEW/FAILED) ALSO stay
 // agent-declared transient OVERLAYS with a server TTL that reverts to the
 // activity-derived base, so an agent can never leave an entity stuck mid-pose.
 // ============================================================================
@@ -27,6 +35,22 @@ const ACTIVITY = Object.freeze({
     ACTIVE: 'BUSY',
     IDLE: 'IDLE',
     SLEEPING: 'SLEEPING',
+    REVIEW: 'REVIEW',
+    FAILED: 'FAILED',
+});
+
+// Allow-list of agent runtime self-reports accepted on POST /api/entity/heartbeat
+// (Stage 1/2). Anything outside this set is ignored (never stamped) so a bad
+// client can't wedge an entity into an arbitrary state.
+const RUNTIME_STATES = new Set(['busy', 'stuck', 'crashed', 'idle']);
+
+// runtimeState -> canonical activity state (only the "hard override" mappings;
+// 'idle' deliberately has NO hard mapping — it just means "not busy", so the
+// entity falls through to the timestamp/floor heuristics below).
+const RUNTIME_STATE_TO_ACTIVITY = Object.freeze({
+    busy: ACTIVITY.ACTIVE,
+    stuck: ACTIVITY.REVIEW,
+    crashed: ACTIVITY.FAILED,
 });
 
 // Agent-declared busy-family states all map to ACTIVE. Mirrors the
@@ -51,6 +75,9 @@ const OVERLAY_TTL_MS = 30 * 1000;
 // Threshold fallbacks (mirror device-preferences.js DEFAULTS, in canonical units).
 const DEFAULT_IDLE_AFTER_MS = 60 * 1000;        // entity_idle_after_seconds = 60
 const DEFAULT_SLEEP_AFTER_MS = 20 * 60 * 1000;  // entity_sleep_after_minutes = 20
+// How long a heartbeat-reported runtimeState is TRUSTED before it is treated as
+// stale and ignored (mirror device-preferences.js entity_runtime_state_stale_seconds = 45).
+const DEFAULT_RUNTIME_STALE_MS = 45 * 1000;
 
 function isBusyFamilyState(state) {
     return BUSY_FAMILY.has(String(state || '').trim().toUpperCase());
@@ -60,22 +87,48 @@ function isExpressiveState(state) {
     return EXPRESSIVE.has(String(state || '').trim().toUpperCase());
 }
 
-// pendingWork = the entity has unfinished work and MUST stay awake.
+// pendingWork = the entity has LIVE work-in-progress and is genuinely ACTIVE.
 // Sources, cheapest first:
 //   1. unacked inbound in messageQueue — in-process; covers /api/client/speak
 //      AND A2A speakTo (both enqueue here). Drained when the daemon polls.
-//   2. entity._pendingKanban  — OPTIONAL precomputed boolean: any kanban card
-//      in_progress assigned to the entity (DB-backed; see wiring note in index.js).
-//   3. entity._pendingScheduled — OPTIONAL precomputed boolean: any queued
+//   2. entity._pendingScheduled — OPTIONAL precomputed boolean: any queued
 //      scheduled message for the entity (DB-backed; see wiring note in index.js).
-// (2)/(3) are read as already-resolved flags so the 5 s loop never issues a DB
-// query per tick. They default to false when not wired.
+// (2) is read as an already-resolved flag so the 5 s loop never issues a DB
+// query per tick. It defaults to false when not wired.
+//
+// NOTE (Stage 0): entity._pendingKanban (open assigned cards) is DELIBERATELY
+// NOT a pendingWork source any more. Having a card on the board is NOT proof the
+// agent is doing anything right now — treating it as ACTIVE made #1/#5 show a
+// permanent false-BUSY on the wallpaper. Open cards are now only an IDLE FLOOR
+// (see hasKanbanFloor + evaluateActivityState): they keep the entity awake
+// (never SLEEPING) but never fake BUSY.
 function computePendingWork(entity) {
     if (!entity) return false;
     if (Array.isArray(entity.messageQueue) && entity.messageQueue.length > 0) return true;
-    if (entity._pendingKanban === true) return true;
     if (entity._pendingScheduled === true) return true;
     return false;
+}
+
+// IDLE FLOOR signal (Stage 0): the entity has ≥1 OPEN assigned kanban card
+// (todo/in_progress). This forbids SLEEPING (work is outstanding, the bot must
+// stay reachable) but does NOT imply BUSY — an entity with open cards and no
+// real activity is IDLE ("Waiting..."), never "Zzz" and never a fake "running".
+function hasKanbanFloor(entity) {
+    return !!(entity && entity._pendingKanban === true);
+}
+
+// Return the entity's FRESH, trusted runtimeState (lowercased) or null. The
+// self-report is only honored while entity.lastRuntimeStateAt is within
+// staleMs of `now`; a stale (or absent / out-of-allow-list) value returns null
+// so the evaluator falls through to the timestamp/floor heuristics.
+function freshRuntimeState(entity, now, staleMs = DEFAULT_RUNTIME_STALE_MS) {
+    if (!entity) return null;
+    const rt = String(entity.runtimeState || '').trim().toLowerCase();
+    if (!RUNTIME_STATES.has(rt)) return null;
+    const at = Number(entity.lastRuntimeStateAt) || 0;
+    if (!at) return null;
+    if (now - at >= staleMs) return null; // stale → ignore
+    return rt;
 }
 
 // PURE bucketing helper for the kanban pendingWork signal. Given kanban_cards
@@ -108,27 +161,55 @@ function bucketPendingKanban(rows) {
 }
 
 // DETERMINISTIC activity evaluator — NO randomness, NO side effects.
-// Returns a canonical wire state ('BUSY' | 'IDLE' | 'SLEEPING') derived purely
-// from timestamps + pendingWork. Pending work forbids IDLE/SLEEPING.
+// Returns a canonical wire state ('BUSY' | 'REVIEW' | 'FAILED' | 'IDLE' |
+// 'SLEEPING') derived purely from the entity's runtimeState + timestamps + the
+// kanban IDLE floor.
+//
+// Priority (real-activity first, then graceful degradation):
+//   (1) FRESH trusted runtimeState — busy→BUSY, stuck→REVIEW, crashed→FAILED.
+//       (A fresh 'idle' is NOT a hard override; it just means "not busy" and
+//        falls through.) Stale/absent → ignored (graceful degradation).
+//   (2) Recently active grace — last message SEND or last runtime "busy" beat
+//       within idleAfter → BUSY. This is the fallback that keeps #5/#6 (no
+//       busy-probe) working, just less precisely.
+//   (2b) Live work-in-progress (unacked inbound / queued scheduled) → BUSY.
+//   (3) IDLE FLOOR — open assigned kanban cards keep the entity awake (never
+//       SLEEPING) but never fake-BUSY → IDLE.
+//   (4) Past the long inactivity window with nothing pending → SLEEPING.
+//   (5) Otherwise → IDLE.
 function evaluateActivityState(entity, now, opts = {}) {
     const idleAfterMs = Number.isFinite(opts.idleAfterMs) ? opts.idleAfterMs : DEFAULT_IDLE_AFTER_MS;
     const sleepAfterMs = Number.isFinite(opts.sleepAfterMs) ? opts.sleepAfterMs : DEFAULT_SLEEP_AFTER_MS;
+    const runtimeStaleMs = Number.isFinite(opts.runtimeStaleMs) ? opts.runtimeStaleMs : DEFAULT_RUNTIME_STALE_MS;
 
-    // pendingWork → always ACTIVE (IDLE + SLEEPING forbidden while work is open).
+    // (1) PRIMARY: fresh, trusted runtimeState reported by the agent's own runtime.
+    const rt = freshRuntimeState(entity, now, runtimeStaleMs);
+    if (rt && RUNTIME_STATE_TO_ACTIVITY[rt]) return RUNTIME_STATE_TO_ACTIVITY[rt];
+    // rt === 'idle' (or stale/absent) → fall through to the heuristics below.
+
+    // (2) Recently active grace: a delivered message OR a recent runtime "busy"
+    //     heartbeat keeps the entity BUSY for idleAfter (graceful fallback when
+    //     no current/fresh runtimeState is present).
+    const lastSendAt = Number(entity && entity.lastSendAt) || 0;
+    const lastRuntimeBusyAt = Number(entity && entity.lastRuntimeBusyAt) || 0;
+    const lastActiveAnchor = Math.max(lastSendAt, lastRuntimeBusyAt);
+    if (now - lastActiveAnchor < idleAfterMs) return ACTIVITY.ACTIVE;
+
+    // (2b) Live work-in-progress (unacked inbound / queued scheduled send) → BUSY.
     if (computePendingWork(entity)) return ACTIVITY.ACTIVE;
 
-    const lastSendAt = Number(entity && entity.lastSendAt) || 0;
+    // (3) IDLE FLOOR: open assigned cards → never SLEEPING, but only IDLE.
+    if (hasKanbanFloor(entity)) return ACTIVITY.IDLE;
+
     // Sleep anchor falls back to lastUpdated for legacy entities that predate
     // lastActivityAt (loaded from DB without it) so they don't sleep instantly.
     const lastActivityAt = Number(entity && entity.lastActivityAt)
         || Number(entity && entity.lastUpdated) || 0;
 
-    // Recently delivered a message / declared busy → ACTIVE.
-    if (now - lastSendAt < idleAfterMs) return ACTIVITY.ACTIVE;
-
-    // Past the idle grace with no pending work: sleep only after the longer
-    // inactivity window; otherwise IDLE.
+    // (4) Past the long inactivity window with nothing pending → SLEEPING.
     if (now - lastActivityAt >= sleepAfterMs) return ACTIVITY.SLEEPING;
+
+    // (5) Otherwise IDLE.
     return ACTIVITY.IDLE;
 }
 
@@ -150,13 +231,18 @@ module.exports = {
     ACTIVITY,
     BUSY_FAMILY,
     EXPRESSIVE,
+    RUNTIME_STATES,
+    RUNTIME_STATE_TO_ACTIVITY,
     UNFINISHED_KANBAN_STATUSES,
     OVERLAY_TTL_MS,
     DEFAULT_IDLE_AFTER_MS,
     DEFAULT_SLEEP_AFTER_MS,
+    DEFAULT_RUNTIME_STALE_MS,
     isBusyFamilyState,
     isExpressiveState,
     computePendingWork,
+    hasKanbanFloor,
+    freshRuntimeState,
     bucketPendingKanban,
     evaluateActivityState,
     overlayActive,

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1058,6 +1058,18 @@
                        onchange="saveEntitySleepAfterMinutes(this.value)"
                        aria-label="Entity go to sleep after minutes">
             </div>
+            <div class="setting-row">
+                <!-- HELP-KEY: entity_runtime_state_stale_seconds_help -->
+                <div class="setting-row-label">
+                    <span data-i18n="entity_runtime_state_stale_seconds_label">Trust live status for</span>
+                    <small style="display:block;color:var(--text-muted);font-size:11px;" data-i18n="entity_runtime_state_stale_seconds_desc">Seconds a bot's self-reported live status (busy / waiting / error) is trusted before the server falls back to timing rules.</small>
+                </div>
+                <input type="number" id="entityRuntimeStateStaleSeconds" class="policy-input"
+                       min="5" max="600" step="5" value="45"
+                       style="width:110px;text-align:right;"
+                       onchange="saveEntityRuntimeStateStaleSeconds(this.value)"
+                       aria-label="Entity trust live status for seconds">
+            </div>
         </div>
 
         <!-- Owner Rental Roster Card -->
@@ -2968,6 +2980,7 @@
         // ============================================
         const ENTITY_IDLE_AFTER_SECONDS = { MIN: 15, MAX: 3600, DEFAULT: 60 };
         const ENTITY_SLEEP_AFTER_MINUTES = { MIN: 1, MAX: 1440, DEFAULT: 20 };
+        const ENTITY_RUNTIME_STATE_STALE_SECONDS = { MIN: 5, MAX: 600, DEFAULT: 45 };
 
         function clampNumber(value, bounds) {
             const n = parseInt(value, 10);
@@ -2984,6 +2997,10 @@
             if (sleep) sleep.value = String(clampNumber(
                 prefs.entity_sleep_after_minutes != null ? prefs.entity_sleep_after_minutes : ENTITY_SLEEP_AFTER_MINUTES.DEFAULT,
                 ENTITY_SLEEP_AFTER_MINUTES));
+            const stale = document.getElementById('entityRuntimeStateStaleSeconds');
+            if (stale) stale.value = String(clampNumber(
+                prefs.entity_runtime_state_stale_seconds != null ? prefs.entity_runtime_state_stale_seconds : ENTITY_RUNTIME_STATE_STALE_SECONDS.DEFAULT,
+                ENTITY_RUNTIME_STATE_STALE_SECONDS));
         }
 
         async function saveEntityActivityPrefPatch(patch) {
@@ -3002,6 +3019,10 @@
 
         async function saveEntitySleepAfterMinutes(value) {
             await saveEntityActivityPrefPatch({ entity_sleep_after_minutes: clampNumber(value, ENTITY_SLEEP_AFTER_MINUTES) });
+        }
+
+        async function saveEntityRuntimeStateStaleSeconds(value) {
+            await saveEntityActivityPrefPatch({ entity_runtime_state_stale_seconds: clampNumber(value, ENTITY_RUNTIME_STATE_STALE_SECONDS) });
         }
 
         // ============================================

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650425,6 +650425,9 @@ const TRANSLATIONS = {
         "entity_sleep_after_minutes_label": "Go to sleep after",
         "entity_sleep_after_minutes_desc": "Minutes of inactivity (no pending work) before an idle bot falls asleep.",
         "entity_sleep_after_minutes_help": "Minutes of inactivity — with no pending work and no message in the window — before IDLE becomes SLEEPING. Allowed range 1 minute to 1440 (24 hours); default 20.",
+        "entity_runtime_state_stale_seconds_label": "Trust live status for",
+        "entity_runtime_state_stale_seconds_desc": "Seconds a bot's self-reported live status (busy / waiting / error) is trusted before the server falls back to timing rules.",
+        "entity_runtime_state_stale_seconds_help": "Seconds a bot's self-reported live status (busy / stuck / crashed / idle, sent on its heartbeat) is TRUSTED before it is treated as stale and ignored — after which the server falls back to last-message timing and the kanban idle floor. Allowed range 5 seconds to 600 (10 minutes); default 45.",
 
         "kb_toast_moved": "Moved to {col}",
         "kb_toast_archived": "Archived",
@@ -1235510,6 +1235513,9 @@ const TRANSLATIONS = {
         "entity_sleep_after_minutes_label": "睡眠時間",
         "entity_sleep_after_minutes_desc": "閒置夥伴在無活動（且無待辦工作）幾分鐘後進入睡眠。",
         "entity_sleep_after_minutes_help": "在無活動（且無待辦工作、視窗內無訊息）幾分鐘後，由閒置（IDLE）轉為睡眠（SLEEPING）。允許範圍 1 分鐘到 1440 分鐘（24 小時）；預設 20。",
+        "entity_runtime_state_stale_seconds_label": "即時狀態信任時間",
+        "entity_runtime_state_stale_seconds_desc": "夥伴自行回報的即時狀態（忙碌／等待／錯誤）被信任幾秒，逾時後伺服器改用時間規則判定。",
+        "entity_runtime_state_stale_seconds_help": "夥伴在心跳中自行回報的即時狀態（忙碌 busy／卡住 stuck／當機 crashed／閒置 idle）被信任幾秒，逾時即視為過期並忽略——之後伺服器改以最後訊息時間與看板待辦底線（idle floor）判定。允許範圍 5 秒到 600 秒（10 分鐘）；預設 45。",
 
         "kb_toast_moved": "已移到 {col}",
         "kb_toast_archived": "已封存",

--- a/backend/settings-help-keys.json
+++ b/backend/settings-help-keys.json
@@ -40,6 +40,11 @@
       "help_key": "entity_idle_after_seconds_help"
     },
     {
+      "field_key": "entity_runtime_state_stale_seconds",
+      "label_key": "entity_runtime_state_stale_seconds_label",
+      "help_key": "entity_runtime_state_stale_seconds_help"
+    },
+    {
       "field_key": "entity_sleep_after_minutes",
       "label_key": "entity_sleep_after_minutes_label",
       "help_key": "entity_sleep_after_minutes_help"

--- a/backend/tests/jest/entity-activity-endpoints.test.js
+++ b/backend/tests/jest/entity-activity-endpoints.test.js
@@ -143,3 +143,74 @@ test('POST /api/client/speak queues inbound → pendingWork blocks sleep forever
     runEval(farFuture, { idleAfterMs: 1, sleepAfterMs: 1 });
     expect(entity.state).toBe(ACTIVITY.SLEEPING);
 });
+
+// ── (h) Stage 1/2: POST /api/entity/heartbeat stamps runtimeState ──
+test('(h) heartbeat with runtimeState "busy" stamps runtimeState/lastRuntimeBusyAt → BUSY', async () => {
+    const deviceId = 'fsm-dev-hb-busy';
+    const deviceSecret = 'fsm-secret-hb-busy';
+    const botSecret = await bindEntity(deviceId, deviceSecret, 0);
+
+    const entity = devices[deviceId].entities[0];
+    // Make the entity OTHERWISE want to sleep: stale send, no pending, no card.
+    entity.lastSendAt = Date.now() - 60 * 60 * 1000;
+    entity.lastActivityAt = Date.now() - 60 * 60 * 1000;
+
+    const res = await post('/api/entity/heartbeat').send({
+        deviceId, entityId: 0, botSecret, runtimeState: 'busy',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.runtimeState).toBe('busy');           // echoed back
+    expect(entity.runtimeState).toBe('busy');
+    expect(typeof entity.lastRuntimeStateAt).toBe('number');
+    expect(typeof entity.lastRuntimeBusyAt).toBe('number');
+
+    // FAIL-ON-OLD: old heartbeat ignored runtimeState; the stale entity would
+    // sleep. With a fresh runtime busy stamp the evaluator returns BUSY.
+    runEval(Date.now(), { idleAfterMs: 60 * 1000, sleepAfterMs: 20 * 60 * 1000 });
+    expect(entity.state).toBe(ACTIVITY.ACTIVE);
+});
+
+test('heartbeat runtimeState "stuck" → REVIEW; "crashed" → FAILED', async () => {
+    const deviceId = 'fsm-dev-hb-states';
+    const deviceSecret = 'fsm-secret-hb-states';
+    const botSecret = await bindEntity(deviceId, deviceSecret, 0);
+    const entity = devices[deviceId].entities[0];
+    const opts = { idleAfterMs: 60 * 1000, sleepAfterMs: 20 * 60 * 1000 };
+
+    let res = await post('/api/entity/heartbeat').send({ deviceId, entityId: 0, botSecret, runtimeState: 'stuck' });
+    expect(res.status).toBe(200);
+    expect(entity.runtimeState).toBe('stuck');
+    runEval(Date.now(), opts);
+    expect(entity.state).toBe('REVIEW');
+
+    res = await post('/api/entity/heartbeat').send({ deviceId, entityId: 0, botSecret, runtimeState: 'crashed' });
+    expect(res.status).toBe(200);
+    expect(entity.runtimeState).toBe('crashed');
+    runEval(Date.now(), opts);
+    expect(entity.state).toBe('FAILED');
+
+    // recovers: back to busy → BUSY (wakes from FAILED).
+    res = await post('/api/entity/heartbeat').send({ deviceId, entityId: 0, botSecret, runtimeState: 'busy' });
+    expect(res.status).toBe(200);
+    runEval(Date.now(), opts);
+    expect(entity.state).toBe(ACTIVITY.ACTIVE);
+});
+
+test('heartbeat is backward-compatible (no runtimeState) and rejects junk values', async () => {
+    const deviceId = 'fsm-dev-hb-compat';
+    const deviceSecret = 'fsm-secret-hb-compat';
+    const botSecret = await bindEntity(deviceId, deviceSecret, 0);
+    const entity = devices[deviceId].entities[0];
+
+    // No runtimeState → old behavior, nothing stamped.
+    let res = await post('/api/entity/heartbeat').send({ deviceId, entityId: 0, botSecret });
+    expect(res.status).toBe(200);
+    expect(res.body.runtimeState).toBeNull();
+    expect(entity.runtimeState).toBeUndefined();
+
+    // Out-of-allow-list value → ignored (never stamped).
+    res = await post('/api/entity/heartbeat').send({ deviceId, entityId: 0, botSecret, runtimeState: 'pizza' });
+    expect(res.status).toBe(200);
+    expect(res.body.runtimeState).toBeNull();
+    expect(entity.runtimeState).toBeUndefined();
+});

--- a/backend/tests/jest/entity-activity-state-machine.test.js
+++ b/backend/tests/jest/entity-activity-state-machine.test.js
@@ -12,9 +12,19 @@
  *   #2 pendingWork=true → never IDLE/SLEEPING.
  *   #3 inactivity ≥ SLEEP_AFTER + no pending → SLEEPING.
  *
+ * Real-activity redesign (stages 0-2, card_35cb55fc):
+ *   Stage 0 — _pendingKanban is an IDLE FLOOR, not pendingWork: an open assigned
+ *      card → IDLE (awake, never SLEEPING) but NEVER fake-BUSY. Old (#3795)
+ *      returned ACTIVE → permanent false-BUSY on #1/#5 (fail-on-old in (a)).
+ *   Stage 1 — a FRESH, trusted runtimeState "busy" is the PRIMARY BUSY signal;
+ *      absent/stale → graceful fallback to the lastSend/floor heuristics.
+ *   Stage 2 — runtimeState "stuck"→REVIEW, "crashed"→FAILED (existing wire
+ *      CharacterState strings AgentStatus.fromWireValue already parses).
+ *
  * FAIL-ON-OLD: this module (lib/entity-activity.js) does not exist on old code,
  * so the suite hard-fails there; the assertions additionally pin the exact
- * coin-flip failure mode (see the Math.random stub test).
+ * coin-flip failure mode (see the Math.random stub test) and the Stage 0/1/2
+ * behavior changes vs the #3795 baseline.
  */
 
 const activity = require('../../lib/entity-activity');
@@ -114,17 +124,6 @@ describe('entity-activity: pendingWork forbids IDLE/SLEEPING', () => {
         }
     });
 
-    test('precomputed kanban in_progress flag blocks sleep', () => {
-        const entity = makeEntity({
-            lastSendAt: NOW - 60 * 60 * 1000,
-            lastActivityAt: NOW - 60 * 60 * 1000,
-            messageQueue: [],
-            _pendingKanban: true,
-        });
-        expect(activity.computePendingWork(entity)).toBe(true);
-        expect(activity.evaluateActivityState(entity, NOW, OPTS)).toBe(ACTIVITY.ACTIVE);
-    });
-
     test('precomputed queued scheduled-message flag blocks sleep', () => {
         const entity = makeEntity({
             lastSendAt: NOW - 60 * 60 * 1000,
@@ -197,24 +196,29 @@ describe('entity-activity: open kanban assignment forbids sleep (card_52b9032216
         return entity;
     }
 
-    // ── (a) open assigned card + stale + empty queue → ACTIVE, never SLEEPING ──
-    test('(a) bot with an open assigned (in_progress) card is ACTIVE, NOT SLEEPING', () => {
+    // ── (a) Stage 0: open assigned card = IDLE FLOOR — IDLE, never SLEEPING,
+    //    never fake-BUSY (this is the live false-BUSY fix for #1/#5). ──
+    test('(a) open assigned card → IDLE floor (never SLEEPING, never fake-BUSY)', () => {
         const rows = [
             { device_id: DEVICE, status: 'in_progress', archived: false, assigned_bots: [2] },
             { device_id: DEVICE, status: 'todo', archived: false, assigned_bots: [5, 7] },
         ];
         const bot2 = wire(2, rows);
-        // FAIL-ON-OLD: without the kanban signal this entity is SLEEPING…
+        // Without ANY kanban signal this stale, empty-queue entity → SLEEPING.
         expect(activity.evaluateActivityState(makeEntity({ entityId: 2, ...STALE }), NOW, OPTS))
             .toBe(ACTIVITY.SLEEPING);
-        // …with it, the wired entity stays awake.
+        // FAIL-ON-OLD (#3795 wired _pendingKanban as pendingWork → returned ACTIVE
+        // here, i.e. a permanent false-BUSY on the wallpaper). Stage 0: the open
+        // card is now ONLY an IDLE floor → the bot stays awake but shows IDLE.
         expect(bot2._pendingKanban).toBe(true);
-        expect(activity.evaluateActivityState(bot2, NOW, OPTS)).toBe(ACTIVITY.ACTIVE);
+        expect(activity.computePendingWork(bot2)).toBe(false);
+        expect(activity.evaluateActivityState(bot2, NOW, OPTS)).toBe(ACTIVITY.IDLE);
         expect(activity.evaluateActivityState(bot2, NOW, OPTS)).not.toBe(ACTIVITY.SLEEPING);
+        expect(activity.evaluateActivityState(bot2, NOW, OPTS)).not.toBe(ACTIVITY.ACTIVE);
 
-        // a multi-assignee 'todo' card keeps EACH assignee awake.
-        expect(activity.evaluateActivityState(wire(5, rows), NOW, OPTS)).toBe(ACTIVITY.ACTIVE);
-        expect(activity.evaluateActivityState(wire(7, rows), NOW, OPTS)).toBe(ACTIVITY.ACTIVE);
+        // a multi-assignee 'todo' card keeps EACH assignee awake at the IDLE floor.
+        expect(activity.evaluateActivityState(wire(5, rows), NOW, OPTS)).toBe(ACTIVITY.IDLE);
+        expect(activity.evaluateActivityState(wire(7, rows), NOW, OPTS)).toBe(ACTIVITY.IDLE);
     });
 
     // ── (b) no assigned cards + stale → SLEEPING (unchanged) ──
@@ -279,8 +283,161 @@ describe('entity-activity: expressive overlays + state classifiers', () => {
     });
 
     test('canonical activity states map to existing wire CharacterState values', () => {
+        // Every value is a string AgentStatus.fromWireValue already parses
+        // (app/.../data/model/AgentStatus.kt) — no new client art/strings.
         expect(ACTIVITY.ACTIVE).toBe('BUSY');
         expect(ACTIVITY.IDLE).toBe('IDLE');
         expect(ACTIVITY.SLEEPING).toBe('SLEEPING');
+        expect(ACTIVITY.REVIEW).toBe('REVIEW');
+        expect(ACTIVITY.FAILED).toBe('FAILED');
+    });
+});
+
+describe('entity-activity: Stage 1/2 real-activity runtimeState (busy/stuck/crashed/idle)', () => {
+    const STALE_CARD = {
+        // far past SLEEP_AFTER, empty queue, but an OPEN assigned card → without a
+        // runtime signal this would sit at the IDLE floor.
+        lastSendAt: NOW - (SLEEP_AFTER_MS + 10 * 60 * 1000),
+        lastActivityAt: NOW - (SLEEP_AFTER_MS + 10 * 60 * 1000),
+        messageQueue: [],
+        _pendingKanban: true,
+    };
+    // 45s default staleness window is applied when opts.runtimeStaleMs is omitted.
+    const fresh = (now) => now - 10 * 1000;  // stamped 10s ago = fresh
+    const stale = (now) => now - 90 * 1000;  // stamped 90s ago = stale (> 45s)
+
+    // ── (c) fresh runtimeState busy → BUSY regardless of cards ──
+    test('(c) fresh runtimeState "busy" → BUSY even with no cards and a stale lastSend', () => {
+        const entity = makeEntity({
+            lastSendAt: NOW - (SLEEP_AFTER_MS + 60 * 1000), // would otherwise SLEEP
+            lastActivityAt: NOW - (SLEEP_AFTER_MS + 60 * 1000),
+            runtimeState: 'busy',
+            lastRuntimeStateAt: fresh(NOW),
+            lastRuntimeBusyAt: fresh(NOW),
+        });
+        // FAIL-ON-OLD: old evaluator had no runtimeState input → this entity
+        // (stale send, no pending) decayed to SLEEPING. Now it is BUSY.
+        expect(activity.evaluateActivityState(makeEntity({
+            lastSendAt: NOW - (SLEEP_AFTER_MS + 60 * 1000),
+            lastActivityAt: NOW - (SLEEP_AFTER_MS + 60 * 1000),
+        }), NOW, OPTS)).toBe(ACTIVITY.SLEEPING);
+        expect(activity.evaluateActivityState(entity, NOW, OPTS)).toBe(ACTIVITY.ACTIVE);
+    });
+
+    // ── (d) fresh runtimeState stuck → REVIEW ──
+    test('(d) fresh runtimeState "stuck" → REVIEW (agent waiting at a confirm/prompt)', () => {
+        const entity = makeEntity({
+            ...STALE_CARD,
+            runtimeState: 'stuck',
+            lastRuntimeStateAt: fresh(NOW),
+        });
+        // FAIL-ON-OLD: old code only ever returned BUSY/IDLE/SLEEPING — REVIEW is new.
+        expect(activity.evaluateActivityState(entity, NOW, OPTS)).toBe(ACTIVITY.REVIEW);
+        expect(activity.evaluateActivityState(entity, NOW, OPTS)).toBe('REVIEW');
+    });
+
+    // ── (e) fresh runtimeState crashed → FAILED ──
+    test('(e) fresh runtimeState "crashed" → FAILED', () => {
+        const entity = makeEntity({
+            ...STALE_CARD,
+            runtimeState: 'crashed',
+            lastRuntimeStateAt: fresh(NOW),
+        });
+        // FAIL-ON-OLD: FAILED is a new evaluator output.
+        expect(activity.evaluateActivityState(entity, NOW, OPTS)).toBe(ACTIVITY.FAILED);
+        expect(activity.evaluateActivityState(entity, NOW, OPTS)).toBe('FAILED');
+    });
+
+    // ── (f) regression: nothing fresh, no cards → SLEEPING ──
+    test('(f) stale runtimeState + no cards + stale send → SLEEPING (regression)', () => {
+        const entity = makeEntity({
+            lastSendAt: NOW - (SLEEP_AFTER_MS + 60 * 1000),
+            lastActivityAt: NOW - (SLEEP_AFTER_MS + 60 * 1000),
+            runtimeState: 'busy',
+            lastRuntimeStateAt: stale(NOW),       // 90s ago → ignored
+            lastRuntimeBusyAt: NOW - (SLEEP_AFTER_MS + 60 * 1000),
+        });
+        expect(activity.freshRuntimeState(entity, NOW)).toBeNull();
+        expect(activity.evaluateActivityState(entity, NOW, OPTS)).toBe(ACTIVITY.SLEEPING);
+    });
+
+    // ── (g) stale runtimeState → graceful fallback to lastSendAt heuristic ──
+    test('(g) stale runtimeState busy is ignored; lastSendAt grace still applies', () => {
+        // stuck reported 90s ago (stale) but a message was sent 10s ago → the
+        // evaluator ignores the stale runtime and falls back to lastSend → BUSY.
+        const recentSend = makeEntity({
+            lastSendAt: NOW - 10 * 1000,
+            lastActivityAt: NOW - 10 * 1000,
+            runtimeState: 'stuck',
+            lastRuntimeStateAt: stale(NOW),
+        });
+        expect(activity.evaluateActivityState(recentSend, NOW, OPTS)).toBe(ACTIVITY.ACTIVE);
+
+        // same stale runtime but the send is also old + an open card → IDLE floor
+        // (NOT the stale REVIEW, NOT SLEEPING).
+        const oldSend = makeEntity({
+            ...STALE_CARD,
+            runtimeState: 'stuck',
+            lastRuntimeStateAt: stale(NOW),
+        });
+        expect(activity.evaluateActivityState(oldSend, NOW, OPTS)).toBe(ACTIVITY.IDLE);
+    });
+
+    // ── lastRuntimeBusyAt extends the BUSY grace even with no current heartbeat ──
+    test('recent lastRuntimeBusyAt keeps BUSY within idle grace (graceful degradation)', () => {
+        const entity = makeEntity({
+            lastSendAt: NOW - 60 * 60 * 1000,        // sent long ago
+            lastActivityAt: NOW - 60 * 60 * 1000,
+            runtimeState: 'busy',
+            lastRuntimeStateAt: stale(NOW),          // current beat stale → ignored
+            lastRuntimeBusyAt: NOW - 20 * 1000,      // but was busy 20s ago (< idle grace)
+        });
+        expect(activity.freshRuntimeState(entity, NOW)).toBeNull();
+        expect(activity.evaluateActivityState(entity, NOW, OPTS)).toBe(ACTIVITY.ACTIVE);
+    });
+
+    // ── fresh "idle" is NOT a hard override; it falls through to heuristics ──
+    test('fresh runtimeState "idle" falls through to the IDLE floor / sleep logic', () => {
+        const withCard = makeEntity({
+            ...STALE_CARD,
+            runtimeState: 'idle',
+            lastRuntimeStateAt: fresh(NOW),
+            lastRuntimeBusyAt: 0,
+        });
+        expect(activity.evaluateActivityState(withCard, NOW, OPTS)).toBe(ACTIVITY.IDLE);
+
+        const noCard = makeEntity({
+            lastSendAt: NOW - (SLEEP_AFTER_MS + 60 * 1000),
+            lastActivityAt: NOW - (SLEEP_AFTER_MS + 60 * 1000),
+            runtimeState: 'idle',
+            lastRuntimeStateAt: fresh(NOW),
+        });
+        expect(activity.evaluateActivityState(noCard, NOW, OPTS)).toBe(ACTIVITY.SLEEPING);
+    });
+
+    // ── out-of-allow-list runtimeState is ignored ──
+    test('unknown runtimeState value is ignored (treated as absent)', () => {
+        expect(activity.freshRuntimeState({ runtimeState: 'pizza', lastRuntimeStateAt: fresh(NOW) }, NOW)).toBeNull();
+        expect(activity.freshRuntimeState({ runtimeState: 'busy', lastRuntimeStateAt: 0 }, NOW)).toBeNull();
+        expect(activity.freshRuntimeState({}, NOW)).toBeNull();
+        expect(activity.freshRuntimeState(null, NOW)).toBeNull();
+        // normalizes case/whitespace
+        expect(activity.freshRuntimeState({ runtimeState: '  BUSY ', lastRuntimeStateAt: fresh(NOW) }, NOW)).toBe('busy');
+    });
+
+    // ── a custom (shorter) staleness window is honored ──
+    test('runtimeStaleMs opt tightens the trust window', () => {
+        const entity = makeEntity({
+            ...STALE_CARD,
+            runtimeState: 'busy',
+            lastRuntimeStateAt: NOW - 30 * 1000, // 30s ago
+            lastRuntimeBusyAt: NOW - 30 * 1000,
+        });
+        // default 45s window → fresh → BUSY
+        expect(activity.evaluateActivityState(entity, NOW, OPTS)).toBe(ACTIVITY.ACTIVE);
+        // tightened to 20s → 30s-old beat is stale → no current grace either
+        // (lastRuntimeBusyAt 30s > a 20s idle grace) → IDLE floor.
+        expect(activity.evaluateActivityState(entity, NOW, { ...OPTS, idleAfterMs: 20 * 1000, runtimeStaleMs: 20 * 1000 }))
+            .toBe(ACTIVITY.IDLE);
     });
 });


### PR DESCRIPTION
Backend side of the approved wallpaper activity-state redesign (Hank: ③ all 3 stages, 面面俱到). Design: card_35cb55fc. **Do NOT merge — commander #2 reviews + emulator-QAs + merges.**

Goal: the wallpaper entity status reflects the agent's **real dynamic activity**, not "has a card = BUSY". One coherent PR (entity-activity.js + index.js shared across all stages).

## runtimeState contract (for the parallel bridge/sender agent — match EXACTLY)
- Endpoint: existing `POST /api/entity/heartbeat`. New **OPTIONAL** body field `runtimeState` (string) ∈ `"busy" | "stuck" | "crashed" | "idle"`. Absent ⇒ old behavior (backward-compatible).
- Auth unchanged (botSecret OR deviceSecret + deviceId + entityId).
- On a heartbeat carrying a valid `runtimeState`: server stamps `entity.runtimeState=value`, `entity.lastRuntimeStateAt=Date.now()`; if `value==="busy"` also `entity.lastRuntimeBusyAt=Date.now()`. Value is lower-cased + allow-list-validated; junk is ignored (never stamped). Response echoes `runtimeState` (the accepted value or `null`).
- Staleness: a stamped runtimeState is TRUSTED only while `lastRuntimeStateAt` is within `entity_runtime_state_stale_seconds` (default **45s**). Stale ⇒ ignored ⇒ fall through to other signals.

## Evaluator priority (`evaluateActivityState`, PURE)
1. **Fresh trusted runtimeState** — `busy`→BUSY, `stuck`→REVIEW, `crashed`→FAILED. (`idle` is NOT a hard override; falls through.)
2. Recently active grace — `max(lastSendAt, lastRuntimeBusyAt)` within `idleAfterMs` (~60s) → BUSY (graceful fallback for bots with no busy-probe, e.g. #5/#6).
3. Live work-in-progress — unacked `messageQueue` / `_pendingScheduled` → BUSY.
4. **IDLE FLOOR** — `_pendingKanban` (open assigned todo/in_progress card) → IDLE (awake, never SLEEPING) but **never fake-BUSY**. ← Stage 0 fix.
5. Past `sleepAfterMs` with nothing pending → SLEEPING.
6. Else → IDLE.

## Wire-state mapping (existing CharacterState strings — no new art)
`ACTIVITY` → wire: ACTIVE→`BUSY`, IDLE→`IDLE`, SLEEPING→`SLEEPING`, **REVIEW→`REVIEW`**, **FAILED→`FAILED`**. All five are parsed by `AgentStatus.fromWireValue` (app/.../data/model/AgentStatus.kt:129-152: `review`→REVIEW purple, `failed`→FAILED red, `busy/active`→BUSY). `entity.state` IS the wire value (emitted via `entity:update` / `/api/entities`). Agent-declared EXCITED/HAPPY transform overlays still pass through (TTL overlay wins over the derived base — verified by existing overlay test).

The 5s activity loop now emits `entity:update` on a **real state change** (bounded ≤1/transition, try/caught, leased_out = state-only to avoid renter-chat leak) so heartbeat-driven BUSY/REVIEW/FAILED are real-time, not only visible on the next poll.

**Deferred (documented):** EXCITED-on-inbound — would flash on every peer/noise inbound; left out deliberately, easy to add later if wanted.

## Prefs
+ `entity_runtime_state_stale_seconds` (default 45, clamp [5,600]). Settings UI field in the existing 實體活動與睡眠 card + en/zh i18n (label/desc/help) + HELP-KEY annotation + settings-help-keys.json entry. Reuses existing `entity_idle_after_seconds` / `entity_sleep_after_minutes`.

## Fail-on-old proof / tests (面面俱到)
`backend/tests/jest/entity-activity-state-machine.test.js` + `entity-activity-endpoints.test.js`:
- (a) open card + stale + no runtime-busy → **IDLE** (asserts #3795 baseline returned ACTIVE → fail-on-old)
- (b) open card past sleepAfter → IDLE floor, never SLEEPING
- (c) fresh runtimeState busy → BUSY regardless of cards (old: SLEEPING)
- (d) stuck → REVIEW · (e) crashed → FAILED (new outputs old code can't produce)
- (f) all-stale + no cards → SLEEPING (regression)
- (g) stale runtimeState → graceful fallback to lastSend/floor
- (h) `POST /api/entity/heartbeat` stamps runtimeState/lastRuntimeStateAt/lastRuntimeBusyAt; junk + no-field backward-compat
- plus lastRuntimeBusyAt grace, fresh-idle fall-through, custom stale window.

Status: **35/35 green** (both activity suites); device-preferences/settings-help/settings-manifest/settings-action-request 79/79 green; `node -c` clean on all touched JS; settings-help invariant green; en+zh i18n hard-gate green.

## Emulator QA checklist for #2 (verify each state live)
Prereq: admin-login the app + set ClawWallpaperService live (skills emulator-admin-login / emulator-set-wallpaper). Drive heartbeats with the bound entity's botSecret:
- **BUSY**: `POST /api/entity/heartbeat {deviceId,entityId,botSecret,runtimeState:"busy"}` → within ~5s wallpaper shows running/busy. Stop heartbeating → after `entity_idle_after_seconds` → IDLE.
- **REVIEW (purple)**: heartbeat `runtimeState:"stuck"` → REVIEW pose.
- **FAILED (red)**: heartbeat `runtimeState:"crashed"` → FAILED pose.
- **IDLE floor (Stage 0 / the headline fix)**: give the entity an open todo/in_progress card, send NO heartbeat and no recent message → must show **IDLE "Waiting..."**, NOT BUSY and NOT SLEEPING. (Old behavior = stuck BUSY.)
- **SLEEPING**: no card, no heartbeat, idle past `entity_sleep_after_minutes` → Zzz.
- **Backward-compat**: heartbeat with NO `runtimeState` → response `runtimeState:null`, state unaffected (pre-existing daemons keep working).
- **Recovery**: stuck→REVIEW then busy→BUSY wakes correctly.
- **Pref**: settings.html → 實體活動與睡眠 → "Trust live status for" field saves; lowering it shortens the trust window.

Refs card_35cb55fc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBmn5NeYXxoWMYX6QPx2mt