### PR TITLE
fix(portal): mobile destructive bottom-sheet pads safe-area-inset-bottom

### DIFF
--- a/backend/public/portal/shared/style.css
+++ b/backend/public/portal/shared/style.css
@@ -1233,7 +1233,10 @@ a:hover { text-decoration: underline; }
 
     /* Dialog — mobile bottom-sheet */
     .dialog-overlay { align-items: flex-end; }
-    .dialog { padding: 16px; min-width: auto; max-height: 85vh; max-height: 85dvh; border-radius: var(--radius) var(--radius) 0 0; width: 100%; max-width: 100%; }
+    /* Bottom-sheet hugs the screen bottom, so the bottommost (destructive) action
+       can fall under the home-indicator / gesture bar on notched devices. Pad the
+       sheet bottom by the safe-area inset (floored at the normal 16px). */
+    .dialog { padding: 16px; padding-bottom: max(16px, env(safe-area-inset-bottom)); min-width: auto; max-height: 85vh; max-height: 85dvh; border-radius: var(--radius) var(--radius) 0 0; width: 100%; max-width: 100%; }
     .dialog-actions { flex-direction: column; }
     .dialog-actions .btn { width: 100%; justify-content: center; }
 

--- a/backend/tests/jest/dialog-mobile-safe-area.test.js
+++ b/backend/tests/jest/dialog-mobile-safe-area.test.js
@@ -1,0 +1,38 @@
+/**
+ * Regression guard for the mobile destructive-confirm bottom-sheet safe-area inset.
+ *
+ * Card: card_9eaab012ab5c5eb71489be62 (destructive-modals daily E2E Phase-2 finding,
+ * parent card_d6eb7b8892b6380bb37d0931).
+ *
+ * The shared showConfirm() dialog becomes a bottom-sheet on mobile
+ * (`@media (max-width: 768px)`, `.dialog-overlay{align-items:flex-end}`), so its
+ * bottommost element — the destructive primary action — sits flush against the
+ * screen bottom. Without `env(safe-area-inset-bottom)` padding it overlaps the
+ * iPhone home-indicator / Android gesture bar on notched devices. Playwright's
+ * 0px-inset headless viewport cannot catch this, so this static CSS guard keeps
+ * the fix from silently regressing.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const cssPath = path.join(__dirname, '..', '..', 'public', 'portal', 'shared', 'style.css');
+const css = fs.readFileSync(cssPath, 'utf8');
+
+// The mobile bottom-sheet rules live right after this stable marker comment.
+const MARKER = '/* Dialog — mobile bottom-sheet */';
+
+describe('mobile destructive bottom-sheet — safe-area-inset-bottom guard', () => {
+    test('the mobile bottom-sheet section exists', () => {
+        expect(css).toContain(MARKER);
+    });
+
+    test('the mobile .dialog rule pads its bottom by the safe-area inset', () => {
+        const seg = css.split(MARKER)[1] || '';
+        const dialogRule = (seg.match(/\.dialog\s*\{[^}]*\}/) || [''])[0];
+        expect(dialogRule).not.toBe('');
+        // floor at the normal 16px, grow to the device safe-area inset
+        expect(dialogRule).toMatch(/padding-bottom:\s*max\(\s*16px\s*,\s*env\(safe-area-inset-bottom\)\s*\)/);
+    });
+});


### PR DESCRIPTION
Closes the destructive-modals daily E2E Phase-2 finding (card_9eaab012, parent card_d6eb7b8892b6380bb37d0931).

**Problem:** the shared `showConfirm()` dialog becomes a bottom-sheet on mobile (`@media (max-width:768px)`, `.dialog-overlay{align-items:flex-end}`). The bottommost element — the destructive primary button — sits flush to the screen bottom with only `padding:16px` and no safe-area inset, so it overlaps the iPhone home-indicator / Android gesture bar on notched devices (measured 21px to edge on 390×844, < ~34px indicator zone). Playwright's 0px-inset headless viewport passes the in-viewport check, so this slipped Phase 1.

**Fix:** mobile `.dialog` rule → `padding-bottom: max(16px, env(safe-area-inset-bottom))`.

**Guard:** `backend/tests/jest/dialog-mobile-safe-area.test.js` asserts the rule references the inset (fails on old CSS, passes on fix) so the regression can't silently return.

CSS + test only; no behavior change on non-notched devices (floor stays 16px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)