### PR TITLE
feat(action-requests): 計畫E ratify-loop adjustable params + default-ON (card_c3d48c4607ee753b2c98e04b)

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -66,6 +66,16 @@ let timeoutSweepTimer = null;
 // auto-resolved by silence reuses the 24h (1440-min) timeout default.
 const MAX_RATIFY_RETRIES = 2;
 const RATIFY_DEFAULT_GRACE_MINUTES = 1440;
+// 計畫E adjustable params (card_c3d48c4607ee753b2c98e04b). The N-cap and the
+// silence grace are device prefs (action_request_ratify_max_attempts /
+// action_request_ratify_grace_minutes). These bounds are the worker-side
+// DEFENSIVE re-clamp so a junk/out-of-range pref can never disable the cap or
+// make the auto-ratify timer fire too eagerly. The cap default reuses
+// MAX_RATIFY_RETRIES; the grace default reuses RATIFY_DEFAULT_GRACE_MINUTES.
+const RATIFY_MAX_ATTEMPTS_MIN = 1;
+const RATIFY_MAX_ATTEMPTS_MAX = 5;
+const RATIFY_GRACE_MINUTES_MIN = 60;     // never auto-ratify faster than 1h
+const RATIFY_GRACE_MINUTES_MAX = 10080;  // 7 days
 
 // ══════════════════════════════════════════════════════════════════════════
 // 需要你 NEGOTIATION / CONSENSUS WORKFLOW (owner-approved build)
@@ -102,6 +112,14 @@ function clampSynthGraceMinutes(raw) {
 }
 function clampMinEntities(raw) {
     return clampInt(raw, CONSENSUS_MIN_ENTITIES_DEFAULT, CONSENSUS_MIN_ENTITIES_MIN, CONSENSUS_MIN_ENTITIES_MAX);
+}
+// 計畫E adjustable params (card_c3d48c4607ee753b2c98e04b). Defensive runtime
+// re-clamp of the two ratify tunables; junk/undefined → the safe default.
+function clampRatifyMaxAttempts(raw) {
+    return clampInt(raw, MAX_RATIFY_RETRIES, RATIFY_MAX_ATTEMPTS_MIN, RATIFY_MAX_ATTEMPTS_MAX);
+}
+function clampRatifyGraceMinutes(raw) {
+    return clampInt(raw, RATIFY_DEFAULT_GRACE_MINUTES, RATIFY_GRACE_MINUTES_MIN, RATIFY_GRACE_MINUTES_MAX);
 }
 
 // Count entities bound on a device (the N in the k/N vote progress + the
@@ -423,7 +441,11 @@ function ratifyInputFrom(prompt, ratify) {
 // silence-grace window in the worker); a hold clears it.
 //   - mode='default_agree' ONLY when classifyRatifyMode says so AND prior arms < N
 //   - any predicate hold, classifier veto, or retry-cap → mode='hold'
-async function recomputeRatifyMode(client, requestId, prompt, ratify, nowMs) {
+// The N-cap is now a device pref (action_request_ratify_max_attempts): the caller
+// passes `maxAttempts`, defensively re-clamped here ([1,5], junk/undefined →
+// MAX_RATIFY_RETRIES) so an out-of-range pref can never widen or disable the cap.
+async function recomputeRatifyMode(client, requestId, prompt, ratify, nowMs, maxAttempts) {
+    const cap = clampRatifyMaxAttempts(maxAttempts);
     const r = (ratify && typeof ratify === 'object') ? { ...ratify } : {};
     const verdict = classifyRatifyMode(ratifyInputFrom(prompt, r));
     let mode = verdict.mode;
@@ -443,12 +465,12 @@ async function recomputeRatifyMode(client, requestId, prompt, ratify, nowMs) {
         priorArms = (c.rows[0] && c.rows[0].n) || 0;
     } catch (_) {
         // Fail-closed: if we cannot establish the count, do not arm.
-        priorArms = MAX_RATIFY_RETRIES;
+        priorArms = cap;
         holdReasons.push('retry_count_unavailable');
     }
-    if (mode === 'default_agree' && priorArms >= MAX_RATIFY_RETRIES) {
+    if (mode === 'default_agree' && priorArms >= cap) {
         mode = 'hold';
-        holdReasons.push(`retry_cap_reached:${priorArms}/${MAX_RATIFY_RETRIES}`);
+        holdReasons.push(`retry_cap_reached:${priorArms}/${cap}`);
     }
 
     r.mode = mode;
@@ -955,14 +977,19 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
     // skipped by 'keep' and not blocked by the decision_context pin (which keeps
     // every OTHER owner-decision row waiting for Hank).
     //
-    // Stacked safety: dark-default-off; matches ratify.mode==='default_agree'
-    // EXACTLY; re-derives the verdict at fire time; the N-cap already capped how
-    // many times it could be armed (PUT handler); grace anchored to armedAt.
+    // Stacked safety: the worker enable-gate is the ONLY thing default-ON changes
+    // (card_c3d48c4607ee753b2c98e04b) — WHAT may auto-ratify is unchanged. It still
+    // matches ratify.mode==='default_agree' EXACTLY; re-derives the fail-closed
+    // verdict at fire time; the N-cap already capped how many times it could be
+    // armed (PUT handler); grace anchored to armedAt.
     // ══════════════════════════════════════════════════════════════════════
     async function runRatifyPass(deviceId, prefs, device) {
-        if (!prefs || prefs.action_request_ratify_enabled !== true) return; // dark launch
-        const graceRaw = prefs.action_request_ratify_grace_minutes;
-        const graceMin = Number.isFinite(Number(graceRaw)) ? Number(graceRaw) : RATIFY_DEFAULT_GRACE_MINUTES;
+        // default-ON (card_c3d48c4607ee753b2c98e04b): an UNSET/true pref RUNS the
+        // pass; only an explicit `false` disables it. (Was dark-launch:
+        // enabled !== true ⇒ skip.) This flips WHETHER the worker runs, never the
+        // fail-closed green-light predicate below that gates WHAT it may resolve.
+        if (prefs && prefs.action_request_ratify_enabled === false) return;
+        const graceMin = clampRatifyGraceMinutes(prefs && prefs.action_request_ratify_grace_minutes);
         const graceMs = graceMin * 60 * 1000;
         const nowMs = Date.now();
 
@@ -1679,7 +1706,14 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
                 try { dcObj = JSON.parse(decisionContextNew); } catch (_) { dcObj = null; }
                 if (dcObj && dcObj.ratify && typeof dcObj.ratify === 'object' && dcObj.ratify.planE === true) {
                     const nowMs = Date.now();
-                    dcObj.ratify = await recomputeRatifyMode(client, id, before.prompt, dcObj.ratify, nowMs);
+                    // N-cap from the device pref (clamped inside recomputeRatifyMode);
+                    // a prefs read failure → undefined → safe default cap.
+                    let ratifyPrefs = {};
+                    try { ratifyPrefs = (await readDevicePrefs(deviceId)) || {}; } catch (_) { ratifyPrefs = {}; }
+                    dcObj.ratify = await recomputeRatifyMode(
+                        client, id, before.prompt, dcObj.ratify, nowMs,
+                        ratifyPrefs.action_request_ratify_max_attempts,
+                    );
                     decisionContextNew = JSON.stringify(dcObj);
                     // Re-check the 8KB cap after the server stamp (holdReasons grow it).
                     if (decisionContextNew.length > 8192) {
@@ -1810,6 +1844,10 @@ module.exports.initAgentActionRequestsDatabase = initAgentActionRequestsDatabase
 module.exports.recomputeRatifyMode = recomputeRatifyMode;
 module.exports.ratifyInputFrom = ratifyInputFrom;
 module.exports.MAX_RATIFY_RETRIES = MAX_RATIFY_RETRIES;
+// 計畫E adjustable params (card_c3d48c4607ee753b2c98e04b): defensive clamps for
+// the two ratify tunables — exported for unit tests.
+module.exports.clampRatifyMaxAttempts = clampRatifyMaxAttempts;
+module.exports.clampRatifyGraceMinutes = clampRatifyGraceMinutes;
 // 需要你 negotiation: pure helpers exported for unit testing without a pool.
 module.exports.isNegotiable = isNegotiable;
 module.exports.tallyVotes = tallyVotes;

--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -68,17 +68,26 @@ const DEFAULTS = {
     // Deadline (minutes) after which the policy above fires. Default 1440 (24h).
     // Clamped to [5, 43200] (5 min .. 30 days).
     action_request_timeout_minutes: 1440,
-    // 計畫E ratify-loop (card_e9d01b6e). DARK-LAUNCH master switch: when true, the
-    // worker's independent ratify pass may passively default-agree (silence ⇒ the
-    // agent's server-armed decided option ships) on requests whose
-    // decision_context.ratify.mode was recomputed to 'default_agree'. DEFAULT FALSE
-    // — flipping it on in prod is the OWNER's decision; everything else (build /
-    // merge) ships dark. Consumed by runRatifyPass in agent-action-requests.js.
-    action_request_ratify_enabled: false,
+    // 計畫E ratify-loop. Master switch for the worker's independent ratify pass:
+    // when on, the pass may passively default-agree (silence ⇒ the agent's
+    // server-armed decided option ships) on requests whose
+    // decision_context.ratify.mode was recomputed to 'default_agree'.
+    // ⚠️ DEFAULT-ON (card_c3d48c4607ee753b2c98e04b) — a GLOBAL flip from the prior
+    // dark-launch DEFAULT FALSE. An UNSET pref now ENABLES the pass; only an
+    // explicit `false` disables it. WHAT may auto-ratify is unchanged (the
+    // fail-closed green-light predicate in runRatifyPass still gates every row).
+    // Consumed by runRatifyPass in agent-action-requests.js.
+    action_request_ratify_enabled: true,
     // Silence grace (minutes) before an armed default_agree ratify auto-resolves,
     // anchored to when it was armed (decision_context.ratify.armedAt), not emit
-    // time. Default 1440 (24h); clamped [5, 43200] like the timeout deadline.
+    // time. Default 1440 (24h); persistence clamps [5, 43200] like the timeout
+    // deadline; the worker re-clamps [60, 10080] defensively.
     action_request_ratify_grace_minutes: 1440,
+    // 計畫E adjustable N-cap (card_c3d48c4607ee753b2c98e04b). Server-enforced max
+    // number of armed default_agree rounds per request (audit-trail reconstructed,
+    // not agent self-report). Default 2; clamped [1, 5]. Consumed by
+    // recomputeRatifyMode (agent-action-requests.js).
+    action_request_ratify_max_attempts: 2,
     // 需要你 negotiation workflow (owner-approved build). When the timeout policy is
     // 'consensus', a 需要你 item with options>=2 (+ enough bound entities) opens a
     // bot-to-bot negotiation round: entities vote, the task-owner entity synthesizes
@@ -114,6 +123,11 @@ const ENTITY_RUNTIME_STATE_STALE_SECONDS_MAX = 600;
 const ACTION_REQUEST_TIMEOUT_POLICIES = new Set(['keep', 'auto_dismiss', 'safe_default', 'consensus']);
 const ACTION_REQUEST_TIMEOUT_MINUTES_MIN = 5;
 const ACTION_REQUEST_TIMEOUT_MINUTES_MAX = 43200; // 30 days
+
+// 計畫E adjustable N-cap (card_c3d48c4607ee753b2c98e04b): max armed default_agree
+// rounds per request. Persistence clamp [1,5]; invalid → default 2.
+const ACTION_REQUEST_RATIFY_MAX_ATTEMPTS_MIN = 1;
+const ACTION_REQUEST_RATIFY_MAX_ATTEMPTS_MAX = 5;
 
 // 需要你 negotiation tunables (clamp ranges; defaults live in DEFAULTS above).
 const CONSENSUS_WINDOW_MIN_MIN = 1;
@@ -156,6 +170,12 @@ function coerceValue(key, raw) {
         const n = parseInt(raw, 10);
         if (!Number.isFinite(n)) return def;
         return Math.max(ACTION_REQUEST_TIMEOUT_MINUTES_MIN, Math.min(ACTION_REQUEST_TIMEOUT_MINUTES_MAX, n));
+    }
+    // 計畫E adjustable N-cap — parseInt-style coercion + clamp [1,5]; junk → default 2.
+    if (key === 'action_request_ratify_max_attempts') {
+        const n = parseInt(raw, 10);
+        if (!Number.isFinite(n)) return def;
+        return Math.max(ACTION_REQUEST_RATIFY_MAX_ATTEMPTS_MIN, Math.min(ACTION_REQUEST_RATIFY_MAX_ATTEMPTS_MAX, n));
     }
     // 需要你 negotiation tunables — parseInt-style coercion + per-key clamp; junk → default.
     if (key === 'consensus_window_minutes') {

--- a/backend/tests/jest/owner-decision-action-request.test.js
+++ b/backend/tests/jest/owner-decision-action-request.test.js
@@ -36,9 +36,13 @@ beforeAll(() => {
     app = express();
     app.use(express.json());
     // Inject getDevicePrefs so the timeout worker never touches device-preferences.
+    // action_request_ratify_enabled:false isolates this suite from the (now
+    // default-ON, card_c3d48c4607ee753b2c98e04b) ratify pass — this file tests the
+    // timeout/owner-decision pinning path, whose positional query mocks assume the
+    // ratify pass issues no SELECT.
     mod = require('../../agent-action-requests')(devices, {
         serverLog: () => {},
-        getDevicePrefs: () => ({ action_request_timeout_policy: 'auto_dismiss', action_request_timeout_minutes: 1 }),
+        getDevicePrefs: () => ({ action_request_timeout_policy: 'auto_dismiss', action_request_timeout_minutes: 1, action_request_ratify_enabled: false }),
     });
     app.use('/api/action-requests', mod.router);
 });

--- a/backend/tests/jest/ratify-loop-wiring.test.js
+++ b/backend/tests/jest/ratify-loop-wiring.test.js
@@ -88,6 +88,34 @@ describe('recomputeRatifyMode — server-authoritative mode + audit-trail N-cap'
         expect(out.mode).toBe('default_agree');
     });
 
+    // 計畫E adjustable N-cap (card_c3d48c4607ee753b2c98e04b): the cap is now a device
+    // pref passed as maxAttempts (clamped [1,5]). FAILS on old code (hardcoded 2).
+    test('N-cap honors the pref: cap=1 ⇒ 1 prior arm already holds', async () => {
+        const out = await recomputeRatifyMode(clientWithArms(1), UUID, 'tweak copy', cleanRatify(), 1700, 1);
+        expect(out.mode).toBe('hold');
+        expect(out.holdReasons.join(';')).toMatch(/retry_cap_reached:1\/1/);
+    });
+
+    test('N-cap honors the pref: cap=4 ⇒ 3 prior arms still permits default_agree', async () => {
+        const out = await recomputeRatifyMode(clientWithArms(3), UUID, 'tweak copy', cleanRatify(), 1700, 4);
+        expect(out.mode).toBe('default_agree');
+    });
+
+    test('N-cap pref clamped: junk maxAttempts → default cap 2; out-of-range high → 5', async () => {
+        const junk = await recomputeRatifyMode(clientWithArms(MAX_RATIFY_RETRIES), UUID, 'tweak copy', cleanRatify(), 1700, 'nonsense');
+        expect(junk.mode).toBe('hold'); // junk → cap 2; 2 prior arms ⇒ hold
+        const high = await recomputeRatifyMode(clientWithArms(4), UUID, 'tweak copy', cleanRatify(), 1700, 99);
+        expect(high.mode).toBe('default_agree'); // 99 clamped to 5; 4 prior < 5
+    });
+
+    test('fail-closed retry-count-unavailable uses the (clamped) pref cap, not the const', async () => {
+        const client = { query: jest.fn().mockRejectedValue(new Error('db down')) };
+        const out = await recomputeRatifyMode(client, UUID, 'tweak copy', cleanRatify(), 1700, 4);
+        expect(out.mode).toBe('hold');
+        expect(out.priorArms).toBe(4); // fail-closed: priorArms set to the cap (4), not 2
+        expect(out.holdReasons.join(';')).toMatch(/retry_count_unavailable/);
+    });
+
     test('fail-closed when the audit count query throws (count unavailable ⇒ hold)', async () => {
         const client = { query: jest.fn().mockRejectedValue(new Error('db down')) };
         const out = await recomputeRatifyMode(client, UUID, 'tweak copy', cleanRatify(), 1700);
@@ -140,13 +168,25 @@ function ratifyRow(over = {}, ratifyOver = {}) {
 }
 
 describe('runRatifyPass via enforceActionRequestTimeouts — dark launch + fire-time fail-closed', () => {
-    test('DARK LAUNCH: ratify_enabled unset ⇒ no ratify query at all (device scan only, policy=keep)', async () => {
+    // 計畫E default-ON (card_c3d48c4607ee753b2c98e04b): an UNSET pref now RUNS the
+    // ratify pass (it issues the candidate SELECT). FAILS on old dark-launch code
+    // (which returned before querying when ratify_enabled !== true).
+    test('DEFAULT-ON: ratify_enabled UNSET ⇒ the ratify pass RUNS (candidate SELECT issued, no auto-write on empty)', async () => {
         const { mod } = buildModule({ prefs: { action_request_timeout_policy: 'keep' } });
+        mockPoolQuery.mockResolvedValueOnce({ rows: [{ device_id: deviceId }] }); // scan; candidate SELECT → default empty rows
+        await mod.enforceActionRequestTimeouts();
+        expect(mockPoolQuery.mock.calls[0][0]).toMatch(/SELECT DISTINCT device_id/);
+        // default-ON: the ratify candidate SELECT DID run (was skipped under dark-launch)
+        expect(mockPoolQuery.mock.calls.find(c => /ratify,planE/.test(c[0]))).toBeDefined();
+        // nothing to resolve (no candidate rows) ⇒ no auto-act write
+        expect(mockPoolQuery.mock.calls.filter(c => /UPDATE agent_action_requests/.test(c[0]))).toHaveLength(0);
+    });
+
+    // Explicit OFF is the ONLY way to disable the worker post-flip.
+    test('EXPLICIT OFF: ratify_enabled=false ⇒ no ratify query at all (device scan only, policy=keep)', async () => {
+        const { mod } = buildModule({ prefs: { action_request_ratify_enabled: false, action_request_timeout_policy: 'keep' } });
         mockPoolQuery.mockResolvedValueOnce({ rows: [{ device_id: deviceId }] }); // scan
         await mod.enforceActionRequestTimeouts();
-        // dark launch: the ratify pass returned before querying (no ratify SELECT)
-        // and keep skipped every auto-act write. (The policy-independent negotiation
-        // advance pass may issue marker SELECTs, but writes nothing here.)
         expect(mockPoolQuery.mock.calls[0][0]).toMatch(/SELECT DISTINCT device_id/);
         expect(mockPoolQuery.mock.calls.find(c => /ratify,planE/.test(c[0]))).toBeUndefined();
         expect(mockPoolQuery.mock.calls.filter(c => /UPDATE agent_action_requests/.test(c[0]))).toHaveLength(0);
@@ -214,9 +254,11 @@ describe('runRatifyPass via enforceActionRequestTimeouts — dark launch + fire-
 describe('device-preferences: ratify pref coercion (dark-launch safe)', () => {
     const devicePrefs = require('../../device-preferences');
 
-    test('DEFAULTS: ratify disabled + 1440-min grace', () => {
-        expect(devicePrefs.DEFAULTS.action_request_ratify_enabled).toBe(false);
+    // ⚠️ default-ON global flip (card_c3d48c4607ee753b2c98e04b): was `false`.
+    test('DEFAULTS: ratify DEFAULT-ON + 1440-min grace + 2 max-attempts', () => {
+        expect(devicePrefs.DEFAULTS.action_request_ratify_enabled).toBe(true);
         expect(devicePrefs.DEFAULTS.action_request_ratify_grace_minutes).toBe(1440);
+        expect(devicePrefs.DEFAULTS.action_request_ratify_max_attempts).toBe(2);
     });
 
     test('action_request_ratify_enabled string-safe: only true/`true` enable; `false`/junk stay off', async () => {
@@ -243,5 +285,50 @@ describe('device-preferences: ratify pref coercion (dark-launch safe)', () => {
             await devicePrefs.updatePrefs(deviceId, { action_request_ratify_grace_minutes: input });
             expect(readBack().action_request_ratify_grace_minutes).toBe(expected);
         }
+    });
+
+    // 計畫E adjustable N-cap (card_c3d48c4607ee753b2c98e04b): GET/PUT round-trip of the
+    // new pref through the persistence coercion. FAILS on old code (key not in DEFAULTS
+    // ⇒ updatePrefs filters it out ⇒ readBack has no such key).
+    test('action_request_ratify_max_attempts clamps [1,5]; invalid → 2', async () => {
+        const written = [];
+        const stubPool = { query: jest.fn((sql, params) => { written.push({ sql, params }); return Promise.resolve({ rows: [] }); }) };
+        await devicePrefs.initTable(stubPool);
+        const readBack = () => JSON.parse(written[written.length - 1].params[1]);
+        const cases = [[1, 1], [5, 5], [0, 1], [99, 5], [3, 3], ['4', 4], ['oops', 2], [null, 2]];
+        for (const [input, expected] of cases) {
+            written.length = 0;
+            await devicePrefs.updatePrefs(deviceId, { action_request_ratify_max_attempts: input });
+            expect(readBack().action_request_ratify_max_attempts).toBe(expected);
+        }
+    });
+});
+
+// ───────────────────────── worker-side defensive clamps ─────────────────────────
+// 計畫E adjustable params (card_c3d48c4607ee753b2c98e04b): the worker re-clamps both
+// tunables so a junk/out-of-range pref can never disable the N-cap or fire the timer
+// too eagerly. FAILS on old code (these exports did not exist).
+describe('agent-action-requests: ratify tunable clamps', () => {
+    const { clampRatifyMaxAttempts, clampRatifyGraceMinutes } = factory;
+
+    test('clampRatifyMaxAttempts: [1,5], junk/undefined → default 2', () => {
+        expect(clampRatifyMaxAttempts(1)).toBe(1);
+        expect(clampRatifyMaxAttempts(5)).toBe(5);
+        expect(clampRatifyMaxAttempts(0)).toBe(1);    // below floor → clamp up
+        expect(clampRatifyMaxAttempts(99)).toBe(5);   // above ceiling → clamp down
+        expect(clampRatifyMaxAttempts('3')).toBe(3);
+        expect(clampRatifyMaxAttempts('junk')).toBe(2);
+        expect(clampRatifyMaxAttempts(undefined)).toBe(2);
+        expect(clampRatifyMaxAttempts(null)).toBe(2);
+    });
+
+    test('clampRatifyGraceMinutes: [60,10080], junk/undefined → default 1440', () => {
+        expect(clampRatifyGraceMinutes(60)).toBe(60);
+        expect(clampRatifyGraceMinutes(10080)).toBe(10080);
+        expect(clampRatifyGraceMinutes(1)).toBe(60);        // below floor → 1h floor
+        expect(clampRatifyGraceMinutes(99999)).toBe(10080); // above ceiling → 7d cap
+        expect(clampRatifyGraceMinutes('120')).toBe(120);
+        expect(clampRatifyGraceMinutes('junk')).toBe(1440);
+        expect(clampRatifyGraceMinutes(undefined)).toBe(1440);
     });
 });


### PR DESCRIPTION
## 計畫E ratify-loop — adjustable params + default-ON

Backend for `card_c3d48c4607ee753b2c98e04b`. Makes the 計畫E ratify-loop tunables adjustable and flips the worker's enable default from dark-launch **OFF → ON**.

### 🛑 BLOCKED ON OWNER SIGN-OFF — DO NOT MERGE YET
This PR contains a **global default flip**: `DEFAULTS.action_request_ratify_enabled` `false → true`, and the worker guard changes to "explicit `false` disables; unset/true runs". After merge+deploy, **every device that has not explicitly turned ratify OFF will have the passive default-agree worker pass ENABLED**. That is the owner's call. Please confirm before this is merged. Everything else in the PR is additive and safe to ship; the flip is the one behavior change.

### What changed (backend only)
1. **New pref `action_request_ratify_max_attempts`** (default `2`, clamp `[1,5]`). The N-cap in `recomputeRatifyMode` now comes from `clampRatifyMaxAttempts(prefs.action_request_ratify_max_attempts)` (passed from the PUT handler) instead of the hardcoded `2`. The audit-count fetch failure path still **fail-closes** (priorArms set to the cap → hold).
2. **Grace clamp** `clampRatifyGraceMinutes` (default `1440`, `[60, 10080]`) — worker-side defensive re-clamp of `action_request_ratify_grace_minutes` so a junk pref can't fire the timer too eagerly. (Persistence layer keeps its existing `[5,43200]` clamp; the worker floor is the stricter, fail-safe one.)
3. **default-ON flip (the only behavior change)**: `DEFAULTS.action_request_ratify_enabled` `false → true`; worker guard now `if (prefs && prefs.action_request_ratify_enabled === false) return;`.
4. **device-preferences GET/PUT passthrough** for all three keys (`action_request_ratify_enabled`, `action_request_ratify_grace_minutes`, `action_request_ratify_max_attempts`) via `DEFAULTS` + `coerceValue`.

### SAFETY — unchanged, byte-for-byte
`default-ON` only changes **whether** the worker runs, never **what** it may auto-ratify. The fail-closed green-light predicate (`ratify-reversibility.js`, reversible-allowlist + PR + diff/path scan + classifier-not-veto), the classifier VETO-only behavior, the irreversible→HOLD rule, and the **fire-time green-light re-check** in `runRatifyPass` are untouched. `ratify-reversibility.js` is not in the diff.

### Files
- `backend/agent-action-requests.js` — clamp fns + consts, N-cap wired to pref, default-ON guard, worker grace clamp, exports.
- `backend/device-preferences.js` — DEFAULTS flip + new pref + coerce clamp.
- `backend/tests/jest/ratify-loop-wiring.test.js` — new/updated tests.
- `backend/tests/jest/owner-decision-action-request.test.js` — explicitly sets `action_request_ratify_enabled:false` to isolate its positional query mocks from the now-default-ON ratify pass.

### Tests (fail-on-old) + CI
- N-cap honors the pref (cap=1 holds at 1 prior arm; cap=4 permits at 3; junk→2; high→5); fail-closed uses the clamped cap.
- default-ON: unset → ratify pass RUNS (candidate SELECT issued); explicit false → no ratify query.
- DEFAULTS assert flipped to `true` + max_attempts `2`.
- `clampRatifyMaxAttempts` / `clampRatifyGraceMinutes` bounds; `action_request_ratify_max_attempts` persistence round-trip `[1,5]`.
- **Full backend jest: 418 suites / 5865 pass (17 skipped), ESLint 0 errors locally.**

### Follow-up (out of scope here)
- `settings.html` "Ratify retry cap" input is still a read-only display of the constant; making it editable + i18n is a separate UI card (route to #6 per UI-review rule). A concurrent agent appears to be building that surface.
- `chat.html:4187` has a now-stale "default OFF" comment (display-only badge gate, not touched to keep this PR backend-pure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtwWX6BCQRxvWEBkecdcq2