### PR TITLE
fix(push): multi-device FCM tokens — stop phone/emulator clobbering (45h notification outage)

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -305,6 +305,32 @@ async function createTables() {
         `);
         console.log('[Push] DB migration: fcm_token + apns_token columns ensured on devices table');
 
+        // Multi-device FCM tokens (push notification clobber fix, 2026-06-29).
+        // The legacy single devices.fcm_token column means MULTIPLE physical devices
+        // sharing one deviceId (e.g. owner's phone + a desktop emulator) each register
+        // their token under the same deviceId and OVERWRITE each other — only the
+        // last-registered device receives pushes. Mirror the multi-row push_subscriptions
+        // design: one row per (device_id, token) so notifyDevice can fan out to ALL of a
+        // device's tokens. Backfill the current single-column token so no device regresses.
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS device_fcm_tokens (
+                device_id   TEXT   NOT NULL,
+                token       TEXT   NOT NULL,
+                platform    TEXT   NOT NULL DEFAULT 'fcm',
+                updated_at  BIGINT,
+                PRIMARY KEY (device_id, token)
+            )
+        `);
+        await client.query(`
+            CREATE INDEX IF NOT EXISTS idx_device_fcm_tokens_device ON device_fcm_tokens(device_id)
+        `);
+        await client.query(`
+            INSERT INTO device_fcm_tokens (device_id, token, platform, updated_at)
+            SELECT device_id, fcm_token, 'fcm', $1 FROM devices WHERE fcm_token IS NOT NULL
+            ON CONFLICT (device_id, token) DO NOTHING
+        `, [Date.now()]);
+        console.log('[Push] DB migration: device_fcm_tokens multi-token table ensured + backfilled');
+
         // Official bot bindings (free bot multi-device tracking)
         await client.query(`
             CREATE TABLE IF NOT EXISTS official_bot_bindings (

--- a/backend/index.js
+++ b/backend/index.js
@@ -21961,10 +21961,19 @@ app.post('/api/device/fcm-token', (req, res) => {
         chatPool.query('UPDATE devices SET apns_token = $1 WHERE device_id = $2', [resolvedToken, deviceId]).catch(() => {});
         serverLog('info', 'fcm_token', `APNs token registered`, { deviceId, metadata: { prevPrefix, newPrefix, changed, platform: 'apns' } });
     } else {
-        // Android FCM token (default)
+        // Android FCM token (default). Keep the legacy single column = latest token for
+        // backward compat, AND upsert into device_fcm_tokens so multiple physical devices
+        // on the same deviceId (phone + emulator + …) each keep their own token and ALL
+        // receive pushes instead of clobbering one another (multi-device fix 2026-06-29).
         device.fcmToken = resolvedToken;
         chatPool.query('ALTER TABLE devices ADD COLUMN IF NOT EXISTS fcm_token TEXT').catch(() => {});
         chatPool.query('UPDATE devices SET fcm_token = $1 WHERE device_id = $2', [resolvedToken, deviceId]).catch(() => {});
+        chatPool.query(
+            `INSERT INTO device_fcm_tokens (device_id, token, platform, updated_at)
+             VALUES ($1, $2, 'fcm', $3)
+             ON CONFLICT (device_id, token) DO UPDATE SET updated_at = EXCLUDED.updated_at`,
+            [deviceId, resolvedToken, Date.now()]
+        ).catch(() => {});
         serverLog('info', 'fcm_token', `FCM token registered`, { deviceId, metadata: { prevPrefix, newPrefix, changed, platform: 'fcm' } });
     }
 
@@ -22014,47 +22023,76 @@ try {
     console.warn('[FCM] Firebase Admin init FAILED:', e.message);
 }
 
+// Gather ALL live FCM tokens for a device (multi-device fix 2026-06-29): the union of
+// the in-memory latest token and every row in device_fcm_tokens, deduped. This is why a
+// push reaches the owner's phone AND their emulator/second device instead of only the
+// last one to register. Falls back to the in-memory token alone if the table query fails
+// (e.g. first boot before migration) so delivery never regresses.
+async function getDeviceFcmTokens(deviceId) {
+    const set = new Set();
+    const inMem = devices[deviceId]?.fcmToken;
+    if (inMem) set.add(inMem);
+    try {
+        const r = await chatPool.query(
+            "SELECT token FROM device_fcm_tokens WHERE device_id = $1 AND platform = 'fcm'",
+            [deviceId]
+        );
+        for (const row of r.rows) if (row.token) set.add(row.token);
+    } catch (e) {
+        serverLog('warn', 'fcm_send', `device_fcm_tokens read failed, using in-mem only: ${e.message}`, { deviceId });
+    }
+    return [...set];
+}
+
 async function sendFcm(deviceId, notif) {
     if (!firebaseAdmin) {
         serverLog('warn', 'fcm_send', 'skip: firebaseAdmin not initialized', { deviceId, metadata: { category: notif?.category } });
         return false;
     }
-    const device = devices[deviceId];
-    const token = device?.fcmToken;
-    if (!token) {
-        serverLog('warn', 'fcm_send', 'skip: no fcmToken for device', { deviceId, metadata: { deviceExists: !!device, category: notif?.category } });
+    const tokens = await getDeviceFcmTokens(deviceId);
+    if (tokens.length === 0) {
+        serverLog('warn', 'fcm_send', 'skip: no fcmToken for device', { deviceId, metadata: { deviceExists: !!devices[deviceId], category: notif?.category } });
         return false;
     }
-    const tokenPrefix = token.slice(0, 12);
     // Silent categories handled by the app's FCM service (start TtsService,
     // fetch GPS, etc). Sending an android.notification for these would make
     // the OS display a visible tray notification when the app is killed.
     const silent = notif.category === 'tts' || notif.category === 'location_request';
-    const fcmMessage = {
-        token,
-        data: notifModule.buildFcmNotificationData(notif),
-        android: { priority: 'high' }
-    };
-    if (!silent) {
-        fcmMessage.android.notification = {
-            title: notif.title || '',
-            body: notif.body || '',
-            channelId: 'eclaw_chat',
-            sound: 'default'
+    let anyOk = false;
+    // Fan out to EVERY registered device sharing this deviceId.
+    for (const token of tokens) {
+        const tokenPrefix = token.slice(0, 12);
+        const fcmMessage = {
+            token,
+            data: notifModule.buildFcmNotificationData(notif),
+            android: { priority: 'high' }
         };
-    }
-    try {
-        const resp = await firebaseAdmin.messaging().send(fcmMessage);
-        serverLog('info', 'fcm_send', 'sent OK', { deviceId, metadata: { tokenPrefix, category: notif?.category, messageId: resp } });
-        return true;
-    } catch (e) {
-        if (e.code === 'messaging/registration-token-not-registered') {
-            delete devices[deviceId]?.fcmToken;
-            chatPool.query('UPDATE devices SET fcm_token = NULL WHERE device_id = $1', [deviceId]).catch(() => {});
+        if (!silent) {
+            fcmMessage.android.notification = {
+                title: notif.title || '',
+                body: notif.body || '',
+                channelId: 'eclaw_chat',
+                sound: 'default'
+            };
         }
-        serverLog('error', 'fcm_send', `send failed: ${e.message}`, { deviceId, metadata: { tokenPrefix, code: e.code } });
-        return false;
+        try {
+            const resp = await firebaseAdmin.messaging().send(fcmMessage);
+            serverLog('info', 'fcm_send', 'sent OK', { deviceId, metadata: { tokenPrefix, category: notif?.category, messageId: resp } });
+            anyOk = true;
+        } catch (e) {
+            if (e.code === 'messaging/registration-token-not-registered') {
+                // Delete only THIS dead token's row — never the whole device (would
+                // wipe the other live devices' tokens, the original clobber bug).
+                chatPool.query('DELETE FROM device_fcm_tokens WHERE device_id = $1 AND token = $2', [deviceId, token]).catch(() => {});
+                if (devices[deviceId]?.fcmToken === token) {
+                    delete devices[deviceId].fcmToken;
+                    chatPool.query('UPDATE devices SET fcm_token = NULL WHERE device_id = $1', [deviceId]).catch(() => {});
+                }
+            }
+            serverLog('error', 'fcm_send', `send failed: ${e.message}`, { deviceId, metadata: { tokenPrefix, code: e.code } });
+        }
     }
+    return anyOk;
 }
 
 // ── Schedule API Routes removed — migrated to Kanban ──

--- a/backend/tests/jest/multi-fcm-token.test.js
+++ b/backend/tests/jest/multi-fcm-token.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * Regression: multi-device FCM token fan-out (push clobber fix, 2026-06-29).
+ *
+ * Root cause (emulator E2E, #2): the legacy single `devices.fcm_token` column
+ * means MULTIPLE physical devices sharing one deviceId (owner's phone + a
+ * desktop emulator + …) each register their token under the same deviceId and
+ * OVERWRITE each other — only the last-registered device receives pushes. The
+ * owner's "任務完成通知 45 小時前就沒了" was exactly this: a desktop emulator
+ * clobbered the phone's token. The pipeline itself was healthy (the emulator
+ * DID receive a test card-done push).
+ *
+ * Fix: a multi-row `device_fcm_tokens` table (mirrors push_subscriptions),
+ * register UPSERTs a row, and sendFcm fans out to EVERY token for the device,
+ * deleting only a single dead token row on
+ * `messaging/registration-token-not-registered` (never the whole device).
+ *
+ * Style: static source-grep, matching kanban-done-device-push-wiring.test.js
+ * (index.js / db.js require a live pg pool, so structural invariants are pinned
+ * by source assertion). A refactor that re-introduces single-token clobber
+ * fails here.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const indexSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'index.js'), 'utf8');
+const dbSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'db.js'), 'utf8');
+
+describe('multi-device FCM token: schema + backfill (db.js)', () => {
+    test('device_fcm_tokens table is created with a (device_id, token) primary key', () => {
+        expect(dbSrc).toMatch(/CREATE TABLE IF NOT EXISTS device_fcm_tokens/);
+        expect(dbSrc).toMatch(/PRIMARY KEY\s*\(device_id,\s*token\)/);
+    });
+
+    test('legacy single-column tokens are backfilled into the multi-row table', () => {
+        expect(dbSrc).toMatch(/INSERT INTO device_fcm_tokens[\s\S]*SELECT device_id, fcm_token[\s\S]*FROM devices WHERE fcm_token IS NOT NULL/);
+        expect(dbSrc).toMatch(/ON CONFLICT \(device_id, token\) DO NOTHING/);
+    });
+});
+
+describe('multi-device FCM token: registration upserts a row (POST /api/device/fcm-token)', () => {
+    test('the FCM register branch upserts into device_fcm_tokens (does not only overwrite the single column)', () => {
+        const handlerIdx = indexSrc.indexOf("app.post('/api/device/fcm-token'");
+        expect(handlerIdx).toBeGreaterThan(-1);
+        const handler = indexSrc.slice(handlerIdx, handlerIdx + 3000);
+        expect(handler).toMatch(/INSERT INTO device_fcm_tokens[\s\S]*ON CONFLICT \(device_id, token\) DO UPDATE/);
+    });
+});
+
+describe('multi-device FCM token: sendFcm fans out to all tokens', () => {
+    const fnIdx = indexSrc.indexOf('async function sendFcm(deviceId, notif)');
+    const fn = fnIdx > -1 ? indexSrc.slice(fnIdx, fnIdx + 2500) : '';
+
+    test('sendFcm gathers ALL tokens via getDeviceFcmTokens (not a single device.fcmToken)', () => {
+        expect(fnIdx).toBeGreaterThan(-1);
+        expect(fn).toMatch(/getDeviceFcmTokens\(deviceId\)/);
+        // it must iterate the token set, not send to a single token
+        expect(fn).toMatch(/for\s*\(const token of tokens\)/);
+    });
+
+    test('getDeviceFcmTokens unions in-memory token + device_fcm_tokens rows, deduped', () => {
+        const gIdx = indexSrc.indexOf('async function getDeviceFcmTokens(deviceId)');
+        expect(gIdx).toBeGreaterThan(-1);
+        const g = indexSrc.slice(gIdx, gIdx + 900);
+        expect(g).toMatch(/new Set\(\)/);
+        expect(g).toMatch(/SELECT token FROM device_fcm_tokens WHERE device_id = \$1/);
+    });
+
+    test('a dead token deletes ONLY its own row, never the whole device (no re-clobber)', () => {
+        expect(fn).toMatch(/registration-token-not-registered/);
+        expect(fn).toMatch(/DELETE FROM device_fcm_tokens WHERE device_id = \$1 AND token = \$2/);
+    });
+});


### PR DESCRIPTION
## Root cause (emulator E2E confirmed)
The single `devices.fcm_token` column means **multiple physical devices sharing one deviceId** (owner's phone + a desktop emulator) each register their FCM token under the same deviceId and **overwrite each other** — only the last-registered device gets pushes. This is the owner's "任務完成通知 45 小時前就沒了": a desktop emulator running the app this session clobbered the phone's token.

**The pipeline is healthy** — a test card-done push WAS delivered to the emulator (`✅ 任務完成`). The bug is purely token storage.

## Fix (mirrors the multi-row `push_subscriptions` web-push design)
- **db.js**: new `device_fcm_tokens` table (PK `(device_id, token)`) + idempotent backfill of existing tokens.
- **POST /api/device/fcm-token**: keep legacy column = latest (back-compat) **and** upsert a per-device-per-token row.
- **sendFcm**: `getDeviceFcmTokens()` unions in-memory + table rows (deduped), fans out to **every** token; a dead token deletes **only its own row**, never the whole device.
- **test**: static-source invariants so a refactor can't re-introduce single-token clobber.

After this, the owner's phone **and** emulator **and** any second device all receive pushes.

⚠️ Folds into the broader 需要你 notification work (Layer 1+2 push-on-create / SLA / zero-subs detection) — separate follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)