### PR TITLE
fix(push): multi-device APNs tokens + admin-broadcast fan-out (FCM clobber siblings, card_9435d8da)

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -331,6 +331,35 @@ async function createTables() {
         `, [Date.now()]);
         console.log('[Push] DB migration: device_fcm_tokens multi-token table ensured + backfilled');
 
+        // Multi-device APNs tokens (push clobber fix — sibling of device_fcm_tokens, 2026-06-29).
+        // `devices.apns_token` has the identical single-column clobber as fcm_token had: a
+        // user with an iPhone AND an iPad sharing one deviceId would have the second device's
+        // APNs token OVERWRITE the first, so only the last-registered iOS device could ever
+        // receive a native push. Mirror the FCM fix with one row per (device_id, token).
+        // NOTE: there is currently NO APNs SEND path in the backend (apns_token is write-only:
+        // registered + read by the diagnostic status endpoint, never sent to). This table +
+        // upsert is preventive parity so that WHENEVER a native APNs sender is built it is
+        // already clobber-safe — it MUST read getDeviceApnsTokens() and delete only single
+        // dead-token rows, never the whole device. Backfill the legacy column so nothing regresses.
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS device_apns_tokens (
+                device_id   TEXT   NOT NULL,
+                token       TEXT   NOT NULL,
+                platform    TEXT   NOT NULL DEFAULT 'apns',
+                updated_at  BIGINT,
+                PRIMARY KEY (device_id, token)
+            )
+        `);
+        await client.query(`
+            CREATE INDEX IF NOT EXISTS idx_device_apns_tokens_device ON device_apns_tokens(device_id)
+        `);
+        await client.query(`
+            INSERT INTO device_apns_tokens (device_id, token, platform, updated_at)
+            SELECT device_id, apns_token, 'apns', $1 FROM devices WHERE apns_token IS NOT NULL
+            ON CONFLICT (device_id, token) DO NOTHING
+        `, [Date.now()]);
+        console.log('[Push] DB migration: device_apns_tokens multi-token table ensured + backfilled');
+
         // Official bot bindings (free bot multi-device tracking)
         await client.query(`
             CREATE TABLE IF NOT EXISTS official_bot_bindings (

--- a/backend/index.js
+++ b/backend/index.js
@@ -5371,16 +5371,21 @@ app.post('/api/admin/push-update', adminAuth, adminCheck, async (req, res) => {
     const targetVersion = version || LATEST_APP_VERSION;
     const notes = releaseNotes || `Version ${targetVersion} is now available!`;
 
-    // Collect all FCM tokens from in-memory devices
+    // Collect EVERY FCM token per device (multi-device fix 2026-06-29). A single deviceId can
+    // have several physical devices registered (phone + emulator + …). The old code took only
+    // device.fcmToken — the single in-memory latest token — so a multi-device user got the
+    // update push on just ONE device: the exact single-token clobber PR #3808 fixed for
+    // sendFcm, still latent here. Reuse getDeviceFcmTokens to fan out to all of them.
     const tokens = [];
-    const deviceIds = [];
-    for (const deviceId in devices) {
-        const device = devices[deviceId];
-        if (device.fcmToken) {
-            tokens.push(device.fcmToken);
-            deviceIds.push(deviceId);
+    const tokenMeta = []; // parallel to tokens: { deviceId, token } → a stale token deletes only its own row
+    const deviceIdList = Object.keys(devices);
+    const perDeviceTokens = await Promise.all(deviceIdList.map(id => getDeviceFcmTokens(id)));
+    deviceIdList.forEach((deviceId, i) => {
+        for (const token of perDeviceTokens[i]) {
+            tokens.push(token);
+            tokenMeta.push({ deviceId, token });
         }
-    }
+    });
 
     if (tokens.length === 0) {
         return res.json({ success: true, sent: 0, failed: 0, total: 0, message: 'No devices with FCM tokens' });
@@ -5393,7 +5398,7 @@ app.post('/api/admin/push-update', adminAuth, adminCheck, async (req, res) => {
     // Send via Firebase sendEachForMulticast (batches of 500)
     for (let i = 0; i < tokens.length; i += 500) {
         const batch = tokens.slice(i, i + 500);
-        const batchDeviceIds = deviceIds.slice(i, i + 500);
+        const batchMeta = tokenMeta.slice(i, i + 500);
         try {
             const response = await firebaseAdmin.messaging().sendEachForMulticast({
                 tokens: batch,
@@ -5416,14 +5421,17 @@ app.post('/api/admin/push-update', adminAuth, adminCheck, async (req, res) => {
             successCount += response.successCount;
             failureCount += response.failureCount;
 
-            // Clean up stale tokens
+            // Clean up stale tokens — delete only THIS dead token's row, never the whole
+            // device (that would wipe a multi-device user's other live tokens = the clobber
+            // bug again). Mirror sendFcm's per-row cleanup.
             response.responses.forEach((resp, idx) => {
                 if (!resp.success && resp.error?.code === 'messaging/registration-token-not-registered') {
-                    const staleDeviceId = batchDeviceIds[idx];
-                    if (devices[staleDeviceId]) {
+                    const { deviceId: staleDeviceId, token: staleToken } = batchMeta[idx];
+                    chatPool.query('DELETE FROM device_fcm_tokens WHERE device_id = $1 AND token = $2', [staleDeviceId, staleToken]).catch(() => {});
+                    if (devices[staleDeviceId]?.fcmToken === staleToken) {
                         delete devices[staleDeviceId].fcmToken;
+                        chatPool.query('UPDATE devices SET fcm_token = NULL WHERE device_id = $1', [staleDeviceId]).catch(() => {});
                     }
-                    chatPool.query('UPDATE devices SET fcm_token = NULL WHERE device_id = $1', [staleDeviceId]).catch(() => {});
                     staleTokensCleaned++;
                 }
             });
@@ -21955,10 +21963,20 @@ app.post('/api/device/fcm-token', (req, res) => {
     const changed = prevToken !== resolvedToken;
 
     if (resolvedPlatform === 'apns') {
-        // iOS APNs token
+        // iOS APNs token. Keep the legacy single column = latest token for backward compat,
+        // AND upsert into device_apns_tokens so an iPhone + iPad (or any two iOS devices)
+        // sharing one deviceId each keep their own token instead of clobbering one another —
+        // the same multi-device fix applied to FCM. (No native APNs sender exists yet; this
+        // makes storage clobber-safe ahead of one being built. 2026-06-29.)
         device.apnsToken = resolvedToken;
         chatPool.query('ALTER TABLE devices ADD COLUMN IF NOT EXISTS apns_token TEXT').catch(() => {});
         chatPool.query('UPDATE devices SET apns_token = $1 WHERE device_id = $2', [resolvedToken, deviceId]).catch(() => {});
+        chatPool.query(
+            `INSERT INTO device_apns_tokens (device_id, token, platform, updated_at)
+             VALUES ($1, $2, 'apns', $3)
+             ON CONFLICT (device_id, token) DO UPDATE SET updated_at = EXCLUDED.updated_at`,
+            [deviceId, resolvedToken, Date.now()]
+        ).catch(() => {});
         serverLog('info', 'fcm_token', `APNs token registered`, { deviceId, metadata: { prevPrefix, newPrefix, changed, platform: 'apns' } });
     } else {
         // Android FCM token (default). Keep the legacy single column = latest token for
@@ -21983,7 +22001,7 @@ app.post('/api/device/fcm-token', (req, res) => {
 // Read-only FCM/APNs registration status. Diagnostic for "no notifications
 // despite enabled" — lets the device owner check whether the token even made
 // it to the backend without exposing the token itself.
-app.get('/api/device/fcm-status', (req, res) => {
+app.get('/api/device/fcm-status', async (req, res) => {
     const { deviceId, deviceSecret } = req.query;
     if (!deviceId || !deviceSecret) {
         return res.status(400).json({ success: false, error: 'deviceId and deviceSecret required' });
@@ -21994,11 +22012,16 @@ app.get('/api/device/fcm-status', (req, res) => {
     }
     const fcm = device.fcmToken || null;
     const apns = device.apnsToken || null;
+    // tokenCount > 1 means multiple physical devices on this deviceId now coexist — which
+    // was impossible under the old single-column schema (they clobbered each other). It is
+    // the at-a-glance "is the multi-device push fix actually working?" signal.
+    const fcmTokens = await getDeviceFcmTokens(deviceId);
+    const apnsTokens = await getDeviceApnsTokens(deviceId);
     res.json({
         success: true,
         firebaseAdminInitialized: !!firebaseAdmin,
-        fcm: { registered: !!fcm, prefix: fcm ? fcm.slice(0, 12) : null },
-        apns: { registered: !!apns, prefix: apns ? apns.slice(0, 12) : null }
+        fcm: { registered: !!fcm, prefix: fcm ? fcm.slice(0, 12) : null, tokenCount: fcmTokens.length },
+        apns: { registered: !!apns, prefix: apns ? apns.slice(0, 12) : null, tokenCount: apnsTokens.length }
     });
 });
 
@@ -22040,6 +22063,27 @@ async function getDeviceFcmTokens(deviceId) {
         for (const row of r.rows) if (row.token) set.add(row.token);
     } catch (e) {
         serverLog('warn', 'fcm_send', `device_fcm_tokens read failed, using in-mem only: ${e.message}`, { deviceId });
+    }
+    return [...set];
+}
+
+// Gather ALL live APNs tokens for a device — sibling of getDeviceFcmTokens (2026-06-29).
+// There is NO native APNs sender wired up yet (apns_token is currently write-only). This
+// helper exists so that whoever builds the iOS native push path fans out to every iOS
+// device on a shared deviceId from day one, and — like sendFcm — deletes only a single
+// dead-token row on failure, never the whole device (re-introducing the clobber bug).
+async function getDeviceApnsTokens(deviceId) {
+    const set = new Set();
+    const inMem = devices[deviceId]?.apnsToken;
+    if (inMem) set.add(inMem);
+    try {
+        const r = await chatPool.query(
+            "SELECT token FROM device_apns_tokens WHERE device_id = $1 AND platform = 'apns'",
+            [deviceId]
+        );
+        for (const row of r.rows) if (row.token) set.add(row.token);
+    } catch (e) {
+        serverLog('warn', 'fcm_send', `device_apns_tokens read failed, using in-mem only: ${e.message}`, { deviceId });
     }
     return [...set];
 }

--- a/backend/tests/jest/multi-apns-token-and-admin-broadcast.test.js
+++ b/backend/tests/jest/multi-apns-token-and-admin-broadcast.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * Regression: multi-device push clobber — siblings of the FCM fix (PR #3808, 2026-06-29).
+ *
+ * PR #3808 fixed the single-column `devices.fcm_token` clobber (phone + emulator sharing one
+ * deviceId overwrote each other's token, so only the last got pushes) with a multi-row
+ * `device_fcm_tokens` table + sendFcm fan-out. The follow-up audit (card_9435d8da) found two
+ * siblings of the SAME bug that #3808 did not touch:
+ *
+ *   1) APNs — `devices.apns_token` is the identical single column. An iPhone + iPad on one
+ *      deviceId clobber each other. There is NO native APNs SEND path yet (apns_token is
+ *      write-only: registered + read by the diagnostic endpoint), so this is PREVENTIVE
+ *      storage parity: a multi-row device_apns_tokens table + register upsert + a
+ *      getDeviceApnsTokens() helper, so whoever later builds the iOS sender is clobber-safe.
+ *
+ *   2) /api/admin/push-update — the app-update broadcast collected a SINGLE device.fcmToken
+ *      per device, so a multi-device user got the update push on only one device. Fixed to
+ *      fan out via getDeviceFcmTokens and to delete only a single dead-token ROW on a stale
+ *      token (never the whole device — that would re-introduce the clobber).
+ *
+ * Style: static source-grep, matching multi-fcm-token.test.js (index.js / db.js need a live
+ * pg pool, so structural invariants are pinned by source assertion). A refactor that
+ * re-introduces single-token clobber on either path fails here.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const indexSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'index.js'), 'utf8');
+const dbSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'db.js'), 'utf8');
+
+describe('multi-device APNs token: schema + backfill (db.js)', () => {
+    test('device_apns_tokens table is created with a (device_id, token) primary key', () => {
+        expect(dbSrc).toMatch(/CREATE TABLE IF NOT EXISTS device_apns_tokens/);
+        // the PK clause appears for both fcm + apns tables; assert it exists at least twice
+        const pks = dbSrc.match(/PRIMARY KEY\s*\(device_id,\s*token\)/g) || [];
+        expect(pks.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('legacy single-column apns_token is backfilled into the multi-row table', () => {
+        expect(dbSrc).toMatch(/INSERT INTO device_apns_tokens[\s\S]*SELECT device_id, apns_token[\s\S]*FROM devices WHERE apns_token IS NOT NULL/);
+        expect(dbSrc).toMatch(/INSERT INTO device_apns_tokens[\s\S]*ON CONFLICT \(device_id, token\) DO NOTHING/);
+    });
+});
+
+describe('multi-device APNs token: registration upserts a row (POST /api/device/fcm-token)', () => {
+    test('the apns branch upserts into device_apns_tokens (not only the single column)', () => {
+        const handlerIdx = indexSrc.indexOf("app.post('/api/device/fcm-token'");
+        expect(handlerIdx).toBeGreaterThan(-1);
+        const handler = indexSrc.slice(handlerIdx, handlerIdx + 3500);
+        // within the apns branch specifically
+        const apnsBranchIdx = handler.indexOf("resolvedPlatform === 'apns'");
+        expect(apnsBranchIdx).toBeGreaterThan(-1);
+        const apnsBranch = handler.slice(apnsBranchIdx, apnsBranchIdx + 1200);
+        expect(apnsBranch).toMatch(/INSERT INTO device_apns_tokens[\s\S]*ON CONFLICT \(device_id, token\) DO UPDATE/);
+    });
+});
+
+describe('multi-device APNs token: getDeviceApnsTokens helper', () => {
+    const gIdx = indexSrc.indexOf('async function getDeviceApnsTokens(deviceId)');
+    const g = gIdx > -1 ? indexSrc.slice(gIdx, gIdx + 900) : '';
+
+    test('getDeviceApnsTokens unions in-memory apnsToken + device_apns_tokens rows, deduped', () => {
+        expect(gIdx).toBeGreaterThan(-1);
+        expect(g).toMatch(/new Set\(\)/);
+        expect(g).toMatch(/devices\[deviceId\]\?\.apnsToken/);
+        expect(g).toMatch(/SELECT token FROM device_apns_tokens WHERE device_id = \$1/);
+    });
+});
+
+describe('admin push-update broadcast: fans out to all of a device\'s tokens (POST /api/admin/push-update)', () => {
+    const hIdx = indexSrc.indexOf("app.post('/api/admin/push-update'");
+    const handler = hIdx > -1 ? indexSrc.slice(hIdx, hIdx + 3500) : '';
+
+    test('handler exists', () => {
+        expect(hIdx).toBeGreaterThan(-1);
+    });
+
+    test('collects tokens via getDeviceFcmTokens, not a single device.fcmToken per device', () => {
+        expect(handler).toMatch(/getDeviceFcmTokens/);
+        // the old single-token collection (tokens.push(device.fcmToken)) must be gone
+        expect(handler).not.toMatch(/tokens\.push\(device\.fcmToken\)/);
+    });
+
+    test('keeps a (deviceId, token) meta parallel array so cleanup can target one row', () => {
+        expect(handler).toMatch(/tokenMeta/);
+    });
+
+    test('a stale token deletes ONLY its own row, never the whole device (no re-clobber)', () => {
+        expect(handler).toMatch(/registration-token-not-registered/);
+        expect(handler).toMatch(/DELETE FROM device_fcm_tokens WHERE device_id = \$1 AND token = \$2/);
+        // guarded clear of the in-memory single column only when it equals the dead token
+        expect(handler).toMatch(/devices\[staleDeviceId\]\?\.fcmToken === staleToken/);
+    });
+});


### PR DESCRIPTION
## What & why

Follow-up audit to **PR #3808** (multi-device FCM tokens — stop phone/emulator clobbering). Hank asked (card_9435d8da): *"順便調查 EClaw 是不是有其他漏掉『一個 device 多個 token』的類似問題"*. Three sub-agents swept the schema vs `origin/main`. Two siblings of the **same single-value clobber** were found that #3808 did not touch — both fixed here, mechanically mirroring the #3808 pattern.

### 1) APNs — `devices.apns_token` single-column clobber (preventive parity)
Identical bug to FCM: an iPhone + iPad (or any two iOS devices) sharing one `deviceId` each register an APNs token under the **same single column** → the second `UPDATE` overwrites the first, so only the last-registered iOS device could ever receive a native push.

- New multi-row `device_apns_tokens` table (`PRIMARY KEY (device_id, token)`) + index + backfill of the legacy column.
- The `apns` branch of `POST /api/device/fcm-token` now **upserts a row** (`ON CONFLICT DO UPDATE`), keeping the legacy column for back-compat.
- New `getDeviceApnsTokens(deviceId)` union helper (in-mem + table rows, deduped), the sibling of `getDeviceFcmTokens`.

> ⚠️ **There is currently NO native APNs sender in the backend** — `apns_token` is write-only (registered + read by the diagnostic endpoint; `notifyDevice` calls only `sendWebPush` + `sendFcm`, no `sendApns`). So this is **preventive storage parity**: the clobber is dormant today and would only bite the moment an iOS push path ships. Whoever builds that sender **must** read `getDeviceApnsTokens` and delete only single dead-token rows (never the whole device), exactly like `sendFcm`. Building the actual APNs delivery path needs an APNs auth key/provider and is a separate product decision — intentionally **not** in this PR.

### 2) `/api/admin/push-update` — broadcast read-side gap (active fix)
The app-update broadcast collected a **single `device.fcmToken`** per device — the multi-row read-side gap #3808 left behind — so a multi-device user got the update push on only one device.

- Now fans out via `getDeviceFcmTokens` across **all** of a device's tokens.
- Stale-token cleanup deletes only the **single dead-token row** (`DELETE FROM device_fcm_tokens WHERE device_id=$1 AND token=$2`), and clears the in-mem single column only when it equals the dead token — never wiping the device (which would re-introduce the clobber).

### Bonus
`GET /api/device/fcm-status` now reports per-platform `tokenCount` — `>1` means multiple physical devices now coexist (impossible under the old schema), the at-a-glance "is the multi-device fix working?" signal. (Also the real consumer for `getDeviceApnsTokens`.)

## Audit result (full per-device/per-entity single-value sweep)
The **only** remaining active same-class clobber is APNs (above). Everything else is correct:
- **Correct single-value by design** (security rotation / genuinely 1:1): `device_secret`, `entities.bot_secret`, session JWT, `official_bot_bindings.session_key`, `device_vars` vault, `channel_accounts` creds, `discord_bots.bot_token`, `entities.webhook`.
- **Already multi-row** (reference design): `push_subscriptions`, `device_fcm_tokens`, `official_bot_bindings`, `agent_card_holder`, `scheduled_messages.target_entity_ids`.
- **Latent LOW-MED** (defer until product needs): `discord_bots.guild_id` (multi-guild), `entities.channel_account_id`, `official_bots.assigned_*` (staleness, not data-loss — `official_bot_bindings` is authoritative).
- **Separate milder bug → follow-up card** (not in this PR): `channel_accounts UNIQUE(device_id)` survives on **fresh DBs** because the `DROP CONSTRAINT` migration runs before the `CREATE TABLE`; a 2nd channel account then **fails loud** (unique violation, 500) rather than silently clobbering. Inverse problem (multi-account intent blocked), fail-closed.

## Tests
- New `backend/tests/jest/multi-apns-token-and-admin-broadcast.test.js` (8 tests, source-grep style matching `multi-fcm-token.test.js`): APNs table+backfill, register upsert, `getDeviceApnsTokens` union, admin-broadcast fan-out + per-row stale cleanup, and a regression assert that the old `tokens.push(device.fcmToken)` single collection is gone.
- Full backend jest suite: **5882 passed**, 0 failures. `eslint index.js db.js` clean. `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)