### PR TITLE
fix(channel): allow many channel_accounts per device on fresh DBs (card_4d9786fc)

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -541,7 +541,15 @@ async function createTables() {
                 ON device_vars_audit (device_id, created_at DESC)
         `);
 
-        // Channel accounts (OpenClaw channel plugin integration)
+        // Channel accounts (OpenClaw channel plugin integration).
+        // A device is meant to have MANY channel accounts (one per plugin) — row identity is
+        // `channel_api_key UNIQUE` (a fresh key is generated per /provision). Do NOT declare
+        // UNIQUE(device_id): the original schema had it, and the idempotent DROP CONSTRAINT
+        // migration above (channel_accounts_device_id_key) removes it from EXISTING DBs — but
+        // that DROP runs *before* this CREATE, so on a FRESH DB (table not yet present) the
+        // drop is a no-op and a re-declared UNIQUE(device_id) here would survive forever,
+        // making a 2nd /provision fail-loud with a unique violation (audit spinoff card_4d9786fc).
+        // Omitting it here fixes fresh DBs; the DROP above still cleans up legacy DBs.
         await client.query(`
             CREATE TABLE IF NOT EXISTS channel_accounts (
                 id SERIAL PRIMARY KEY,
@@ -552,8 +560,7 @@ async function createTables() {
                 callback_token TEXT,
                 status TEXT DEFAULT 'active',
                 created_at BIGINT NOT NULL,
-                updated_at BIGINT NOT NULL,
-                UNIQUE(device_id)
+                updated_at BIGINT NOT NULL
             )
         `);
         await client.query(`CREATE INDEX IF NOT EXISTS idx_channel_api_key ON channel_accounts(channel_api_key)`);

--- a/backend/tests/jest/channel-accounts-multi-per-device.test.js
+++ b/backend/tests/jest/channel-accounts-multi-per-device.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/**
+ * Regression: channel_accounts must allow MANY accounts per device (audit spinoff card_4d9786fc).
+ *
+ * Bug: createTables() runs the idempotent `DROP CONSTRAINT channel_accounts_device_id_key`
+ * migration BEFORE `CREATE TABLE channel_accounts (... UNIQUE(device_id))`. On a FRESH DB the
+ * table does not exist when the DROP runs, so the DROP is a no-op; the CREATE then re-adds
+ * UNIQUE(device_id) and it survives forever. A device's 2nd /provision then fails LOUD with a
+ * unique violation (createChannelAccount is a plain INSERT → returns null → 500), even though
+ * the schema's own comment says "Allow multiple channel accounts per device (each plugin gets
+ * its own account)".
+ *
+ * Fix: do NOT declare UNIQUE(device_id) in the CREATE TABLE. Row identity is `channel_api_key
+ * UNIQUE` (a fresh key per provision). The DROP migration stays for legacy DBs that still have
+ * the constraint. This source-grep pins the invariant: re-introducing the device_id unique
+ * constraint in the table definition fails here.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const dbSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'db.js'), 'utf8');
+
+function channelAccountsCreateBlock() {
+    const start = dbSrc.indexOf('CREATE TABLE IF NOT EXISTS channel_accounts');
+    expect(start).toBeGreaterThan(-1);
+    // up to the closing of the CREATE TABLE statement
+    const end = dbSrc.indexOf(')\n        `', start);
+    return dbSrc.slice(start, end > start ? end : start + 600);
+}
+
+describe('channel_accounts: many-per-device (no UNIQUE(device_id) in CREATE TABLE)', () => {
+    test('the CREATE TABLE channel_accounts block does NOT declare UNIQUE(device_id)', () => {
+        const block = channelAccountsCreateBlock();
+        expect(block).not.toMatch(/UNIQUE\s*\(\s*device_id\s*\)/);
+    });
+
+    test('row identity is still preserved by channel_api_key UNIQUE', () => {
+        const block = channelAccountsCreateBlock();
+        expect(block).toMatch(/channel_api_key\s+TEXT\s+NOT NULL\s+UNIQUE/);
+    });
+
+    test('the legacy DROP CONSTRAINT migration is retained for existing DBs', () => {
+        expect(dbSrc).toMatch(/DROP CONSTRAINT channel_accounts_device_id_key/);
+        // and it must remain guarded by an existence check (idempotent)
+        expect(dbSrc).toMatch(/constraint_name = 'channel_accounts_device_id_key'/);
+    });
+});


### PR DESCRIPTION
## What & why
Audit spinoff of **card_9435d8da** (the "one-device-many-token" sweep). Not the same class as the FCM/APNs token clobber — this one is **fail-loud, fresh-DB only**.

`createTables()` runs the idempotent `DROP CONSTRAINT channel_accounts_device_id_key` migration **before** `CREATE TABLE channel_accounts (... UNIQUE(device_id))`. On a fresh DB the table doesn't exist when the DROP runs → no-op; the CREATE then re-adds `UNIQUE(device_id)` and it survives forever. A device's **2nd** `/provision` then fails loud (unique violation → `createChannelAccount` returns `null` → `500 Failed to create channel account`), directly contradicting the schema's own comment: *"Allow multiple channel accounts per device (each plugin gets its own account)."*

## Fix
Drop `UNIQUE(device_id)` from the `CREATE TABLE`. Row identity is already preserved by `channel_api_key TEXT NOT NULL UNIQUE` (a fresh key is generated per `/provision`), so no extra grain is needed and `createChannelAccount` needs no `ON CONFLICT`. The existing idempotent DROP migration is **retained** so legacy DBs that still carry the constraint get cleaned up.

- Fresh DB: table created without the constraint → multi-account works immediately.
- Legacy DB with the constraint: DROP migration removes it (unchanged behavior).
- Legacy DB already dropped: DROP is a guarded no-op.

## Test
`backend/tests/jest/channel-accounts-multi-per-device.test.js` (3 source-grep tests): no `UNIQUE(device_id)` in the CREATE block, `channel_api_key UNIQUE` retained, legacy DROP migration retained. Fails on pre-fix code. `node --check` + `eslint db.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)