### PR TITLE
fix(portal-a11y): aria-labels + keyboard operability sweep (weekly audit, card_5431b300)

### DIFF
--- a/backend/public/portal/admin.html
+++ b/backend/public/portal/admin.html
@@ -808,7 +808,7 @@
 
 <body>
     <!-- AI Support Chat Widget -->
-    <button class="ai-chat-fab" onclick="toggleAIChat()">🤖</button>
+    <button class="ai-chat-fab" onclick="toggleAIChat()" aria-label="Open AI assistant">🤖</button>
     <div class="ai-chat-panel" id="aiChatPanel">
         <div class="ai-chat-header">
             <h3>🤖 AI Support Tester</h3>

--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -714,7 +714,7 @@
             <div class="header-actions">
                 <div class="search-bar">
                     <span>&#x1F50D;</span>
-                    <input type="text" id="searchInput" placeholder="Search cards..." data-i18n-placeholder="cardholder_search">
+                    <input type="text" id="searchInput" placeholder="Search cards..." data-i18n-placeholder="cardholder_search" aria-label="Search cards">
                 </div>
             </div>
         </div>
@@ -1311,7 +1311,7 @@
                         <h3>${escapeHtml(card.name || card.publicCode)}</h3>
                         <span class="agent-code" onclick="copyCode('${escapeAttr(card.publicCode)}')">${escapeHtml(card.publicCode)}</span>
                     </div>
-                    <button class="modal-close" onclick="closeDetail()">&#x2715;</button>
+                    <button class="modal-close" onclick="closeDetail()" aria-label="${t('cardholder_close', 'Close')}">&#x2715;</button>
                 </div>
 
                 <div class="modal-section">
@@ -1419,7 +1419,7 @@
                         ${card.isFriend ? `<span class="friend-badge">${t('cardholder_friend', 'Friend')}</span>` : ''}
                         ${card.blocked ? `<span style="display:inline-block; margin-left:8px; font-size:12px; background:var(--danger); color:#fff; padding:1px 6px; border-radius:4px;">${t('cardholder_blocked_label', 'Blocked')}</span>` : ''}
                     </div>
-                    <button class="modal-close" onclick="closeDetail()">&#x2715;</button>
+                    <button class="modal-close" onclick="closeDetail()" aria-label="${t('cardholder_close', 'Close')}">&#x2715;</button>
                 </div>
 
                 <div class="modal-tabs">

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3933,7 +3933,7 @@
         <div class="modal-box">
             <div class="r2-modal-header">
                 <div class="modal-title" data-i18n="chat_cloud_drive_title">&#x1F4C1; Cloud Drive</div>
-                <button onclick="closeR2FilesPanel()" style="background:none;border:none;font-size:18px;cursor:pointer;color:var(--text-muted);line-height:1;">&#x2715;</button>
+                <button onclick="closeR2FilesPanel()" aria-label="Close" style="background:none;border:none;font-size:18px;cursor:pointer;color:var(--text-muted);line-height:1;">&#x2715;</button>
             </div>
             <div id="r2UsageText" style="font-size:12px;color:var(--text-muted);">載入中...</div>
             <div class="r2-usage-bar"><div class="r2-usage-fill" id="r2UsageFill" style="width:0%"></div></div>
@@ -6518,7 +6518,7 @@
                     const durStr = Math.floor(seconds / 60) + ':' + String(seconds % 60).padStart(2, '0');
                     mediaHtml = `
                         <div class="chat-voice" data-src="${escapeHtml(msg.media_url)}">
-                            <button class="voice-play-btn" onclick="toggleVoice(this)">&#9654;</button>
+                            <button class="voice-play-btn" onclick="toggleVoice(this)" aria-label="Play voice message">&#9654;</button>
                             <div class="voice-progress" onclick="seekVoice(event, this)"><div class="voice-progress-fill"></div></div>
                             <span class="voice-duration">${durStr}</span>
                         </div>`;

--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -1139,7 +1139,7 @@
     <div class="modal-overlay" id="detailModal" onclick="if(event.target===this)closeDetail()">
         <div style="position:relative;max-width:560px;width:100%;max-height:75vh;">
             <div class="modal-content" id="detailContent" style="max-height:75vh;overflow-y:auto;border-radius:16px;">
-                <button class="modal-close" onclick="closeDetail()">✕</button>
+                <button class="modal-close" aria-label="Close" onclick="closeDetail()">✕</button>
                 <!-- Rendered by JS -->
             </div>
             <!-- gradient now inside modal-content as sticky div -->
@@ -1761,7 +1761,7 @@
             }
 
             content.innerHTML = `
-                <button class="modal-close" onclick="closeDetail()">✕</button>
+                <button class="modal-close" aria-label="Close" onclick="closeDetail()">✕</button>
                 <div class="detail-header">
                     <div class="detail-avatar">${botAvatarHtml(resolveBotAvatar(bot), 72, entityIdForPublicCode(bot.publicCode))}</div>
                     <div class="detail-name">${esc(bot.name)}</div>
@@ -1916,7 +1916,7 @@
                     : `<div style="margin:12px 20px 0;padding:12px;border-radius:12px;background:#f3f4f6;border:1px solid #d1d5db;color:#4b5563;font-size:13px;line-height:1.45;">⏸ ${ttt('listing_soft_paused_visitor_banner','This bot is temporarily unavailable while the owner fixes health checks. The page remains available, but renting is disabled for now.')}${softPauseEta ? `<div>${ttt('mp_est_total','Estimated')}: ${esc(softPauseEta)}</div>` : ''}</div>`)
                 : '';
             content.innerHTML = `
-                <button class="modal-close" onclick="closeDetail()">\u2715</button>
+                <button class="modal-close" aria-label="Close" onclick="closeDetail()">\u2715</button>
                 <div class="detail-header">
                     <div class="detail-avatar">${botAvatarHtml(resolveBotAvatar({ petdxAvatarUrl: l.petdx_avatar_url, avatar: l.avatar_url }), 72, l.owner_entity_id)}</div>
                     <div class="detail-name">${esc(l.title)}</div>

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -2268,7 +2268,7 @@
 
         <!-- Add Entity Section -->
         <div class="card" id="addEntityCard">
-            <div class="add-entity-header" onclick="toggleAddEntity()">
+            <div class="add-entity-header" onclick="toggleAddEntity()" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleAddEntity()}">
                 <div class="card-title" style="margin-bottom:0;" data-i18n="dash_add_entity">
                     Add Entity
                 </div>
@@ -2313,7 +2313,7 @@
 
                 <!-- EClaw Channel Promotion -->
                 <div class="channel-promo" id="channelPromo">
-                    <div class="channel-promo-header" onclick="toggleChannelPromo()">
+                    <div class="channel-promo-header" onclick="toggleChannelPromo()" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleChannelPromo()}">
                         <span class="channel-promo-icon">⚡</span>
                         <span data-i18n="dash_channel_promo">Try EClaw Channel? More native, faster</span>
                         <span class="channel-promo-arrow" id="channelPromoArrow">›</span>
@@ -2437,7 +2437,7 @@
 
         <!-- Official Borrow Section -->
         <div class="card" id="borrowCard">
-            <div class="add-entity-header" onclick="toggleBorrow()">
+            <div class="add-entity-header" onclick="toggleBorrow()" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleBorrow()}">
                 <div class="card-title" style="margin-bottom:0;">
                     <span data-i18n="borrow_title">Official Bot Rental</span>
                     <span class="beta-badge">BETA</span>

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -2268,7 +2268,7 @@
 
         <!-- Add Entity Section -->
         <div class="card" id="addEntityCard">
-            <div class="add-entity-header" onclick="toggleAddEntity()" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleAddEntity()}">
+            <div class="add-entity-header" onclick="toggleAddEntity()" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
                 <div class="card-title" style="margin-bottom:0;" data-i18n="dash_add_entity">
                     Add Entity
                 </div>
@@ -2313,7 +2313,7 @@
 
                 <!-- EClaw Channel Promotion -->
                 <div class="channel-promo" id="channelPromo">
-                    <div class="channel-promo-header" onclick="toggleChannelPromo()" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleChannelPromo()}">
+                    <div class="channel-promo-header" onclick="toggleChannelPromo()" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
                         <span class="channel-promo-icon">⚡</span>
                         <span data-i18n="dash_channel_promo">Try EClaw Channel? More native, faster</span>
                         <span class="channel-promo-arrow" id="channelPromoArrow">›</span>
@@ -2437,7 +2437,7 @@
 
         <!-- Official Borrow Section -->
         <div class="card" id="borrowCard">
-            <div class="add-entity-header" onclick="toggleBorrow()" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleBorrow()}">
+            <div class="add-entity-header" onclick="toggleBorrow()" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
                 <div class="card-title" style="margin-bottom:0;">
                     <span data-i18n="borrow_title">Official Bot Rental</span>
                     <span class="beta-badge">BETA</span>

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -709,7 +709,7 @@
 
         <!-- Folder Filter Bar -->
         <div class="folder-filter-bar" id="folderFilterBar">
-            <div class="folder-chip active" data-folder="all" onclick="setFolderFilter('all')" data-i18n="files_folder_all">All</div>
+            <div class="folder-chip active" data-folder="all" onclick="setFolderFilter('all')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();setFolderFilter('all')}" role="button" tabindex="0" data-i18n="files_folder_all">All</div>
             <!-- dynamic folder chips + add button rendered by JS -->
         </div>
 

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -709,7 +709,7 @@
 
         <!-- Folder Filter Bar -->
         <div class="folder-filter-bar" id="folderFilterBar">
-            <div class="folder-chip active" data-folder="all" onclick="setFolderFilter('all')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();setFolderFilter('all')}" role="button" tabindex="0" data-i18n="files_folder_all">All</div>
+            <div class="folder-chip active" data-folder="all" onclick="setFolderFilter('all')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}" role="button" tabindex="0" data-i18n="files_folder_all">All</div>
             <!-- dynamic folder chips + add button rendered by JS -->
         </div>
 

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -5225,7 +5225,7 @@ platforms:
             <div class="faq-toolbar">
                 <div class="faq-search">
                     <span>🔍</span>
-                    <input type="text" id="faqSearchInput" data-i18n="faq_search_placeholder" placeholder="搜尋常見問題..." maxlength="100" oninput="filterFaq()">
+                    <input type="text" id="faqSearchInput" aria-label="Search FAQ" data-i18n="faq_search_placeholder" placeholder="搜尋常見問題..." maxlength="100" oninput="filterFaq()">
                 </div>
                 <div class="faq-chips">
                     <button class="faq-chip active" data-faq-cat="all" onclick="setFaqCat('all',this)" data-i18n="faq_chip_all">全部</button>
@@ -5343,7 +5343,7 @@ platforms:
                 <div class="rn-hero-title" data-i18n="rn_hero_title">Release Notes</div>
                 <div class="rn-hero-subtitle" data-i18n="rn_hero_subtitle">What's new in EClawbot — features, improvements, and fixes across the platform.</div>
                 <div style="margin-top:12px;display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
-                    <input type="text" id="rnSearch" data-i18n="rn_search_placeholder" placeholder="Search versions..." style="padding:8px 12px;border-radius:8px;border:1px solid var(--card-border);background:var(--card-bg);color:var(--text);font-size:13px;width:200px;">
+                    <input type="text" id="rnSearch" aria-label="Search versions" data-i18n="rn_search_placeholder" placeholder="Search versions..." style="padding:8px 12px;border-radius:8px;border:1px solid var(--card-border);background:var(--card-bg);color:var(--text);font-size:13px;width:200px;">
                     <select id="rnFilter" style="padding:8px 12px;border-radius:8px;border:1px solid var(--card-border);background:var(--card-bg);color:var(--text);font-size:13px;">
                         <option value="all" data-i18n="rn_filter_all">All</option>
                         <option value="Features" data-i18n="rn_filter_features">Features</option>
@@ -5459,7 +5459,7 @@ platforms:
                         <option value="risk" data-i18n="crl_kind_risk">Risk</option>
                         <option value="todo" data-i18n="crl_kind_todo">TODO</option>
                     </select>
-                    <input type="text" id="crlSearch" data-i18n="crl_search_placeholder" placeholder="Search records..." style="padding:8px 12px;border-radius:8px;border:1px solid var(--card-border);background:var(--card-bg);color:var(--text);font-size:13px;width:180px;">
+                    <input type="text" id="crlSearch" aria-label="Search records" data-i18n="crl_search_placeholder" placeholder="Search records..." style="padding:8px 12px;border-radius:8px;border:1px solid var(--card-border);background:var(--card-bg);color:var(--text);font-size:13px;width:180px;">
                     <span id="crlCount" style="color:var(--text-secondary);font-size:13px;"></span>
                 </div>
             </div>

--- a/backend/public/portal/invite.html
+++ b/backend/public/portal/invite.html
@@ -450,7 +450,7 @@
         <div class="inv-section">
             <h3 data-i18n="inv_redeem_title">Have an Invite Code?</h3>
             <div class="inv-redeem">
-                <input id="redeemInput" placeholder="ABCDEF" maxlength="8">
+                <input id="redeemInput" placeholder="ABCDEF" maxlength="8" aria-label="Invite code">
                 <button onclick="redeemCode()" data-i18n="inv_redeem_btn">Redeem</button>
             </div>
         </div>

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -836,7 +836,7 @@
 
         <!-- ⚡ Automation Collapse Section -->
         <div class="kb-automation" id="kbAutomation" style="display:none">
-            <div class="kb-auto-header" id="autoHeader" onclick="toggleAutomation()" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleAutomation()}">
+            <div class="kb-auto-header" id="autoHeader" onclick="toggleAutomation()" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
                 <h3>⚡ <span data-i18n="kb_auto_title">Automations</span> <span class="kb-auto-count" id="autoCount">0</span>
                     <span class="kb-auto-view-toggle" onclick="event.stopPropagation()">
                         <button class="kb-auto-view-btn" data-view="grid" onclick="switchAutoView('grid')" data-i18n-title="kb_auto_view_grid" title="Grid" aria-label="Grid">☰</button>

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -836,7 +836,7 @@
 
         <!-- ⚡ Automation Collapse Section -->
         <div class="kb-automation" id="kbAutomation" style="display:none">
-            <div class="kb-auto-header" id="autoHeader" onclick="toggleAutomation()">
+            <div class="kb-auto-header" id="autoHeader" onclick="toggleAutomation()" role="button" tabindex="0" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleAutomation()}">
                 <h3>⚡ <span data-i18n="kb_auto_title">Automations</span> <span class="kb-auto-count" id="autoCount">0</span>
                     <span class="kb-auto-view-toggle" onclick="event.stopPropagation()">
                         <button class="kb-auto-view-btn" data-view="grid" onclick="switchAutoView('grid')" data-i18n-title="kb_auto_view_grid" title="Grid" aria-label="Grid">☰</button>
@@ -2908,7 +2908,7 @@
                             <option value="supports">supports</option>
                             <option value="contradicts">contradicts</option>
                         </select>
-                        <input id="cardLinkTarget" placeholder="target card id" style="min-width:180px;flex:1">
+                        <input id="cardLinkTarget" placeholder="target card id" aria-label="Target card id" style="min-width:180px;flex:1">
                         <button class="kb-move-btn" onclick="addCardLink('${cardId}')">Add link</button>
                     </div>
                     ${renderCardLinkRows(cardId, 'Outgoing', outgoing, 'outgoing')}
@@ -4068,7 +4068,7 @@
                     <label style="display:block;font-size:13px;margin:10px 0 4px">Reason <span style="color:#f66">*</span></label>
                     <textarea id="kbReopenReason" rows="4" placeholder="e.g. validation failed; artifact missing; regression reported" style="width:100%;padding:8px;border-radius:8px;background:var(--bg-secondary,#222);color:inherit;border:1px solid var(--border-color,#444);resize:vertical"></textarea>
                     <label style="display:flex;gap:8px;align-items:center;margin-top:10px;font-size:13px"><input id="kbReopenPrFlag" type="checkbox"> Requires PR rework</label>
-                    <input id="kbReopenPrNumber" placeholder="New PR number or URL (optional until final Done)" style="width:100%;margin-top:6px;padding:8px;border-radius:8px;background:var(--bg-secondary,#222);color:inherit;border:1px solid var(--border-color,#444)">
+                    <input id="kbReopenPrNumber" placeholder="New PR number or URL (optional until final Done)" aria-label="New PR number or URL" style="width:100%;margin-top:6px;padding:8px;border-radius:8px;background:var(--bg-secondary,#222);color:inherit;border:1px solid var(--border-color,#444)">
                     <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:14px">
                         <button class="btn btn-ghost" onclick="closeReopenDialog()">Cancel</button>
                         <button class="btn btn-primary" onclick="submitReopenCard('${cardId}')">Reopen</button>

--- a/backend/public/portal/marketplace.html
+++ b/backend/public/portal/marketplace.html
@@ -645,7 +645,7 @@
         </section>
 
         <section class="mp-toolbar" aria-label="Marketplace filters">
-            <input class="mp-field" id="searchInput" type="search" placeholder="Search bots..." data-i18n-placeholder="mp_search_placeholder" maxlength="100">
+            <input class="mp-field" id="searchInput" type="search" placeholder="Search bots..." data-i18n-placeholder="mp_search_placeholder" aria-label="Search bots" maxlength="100">
             <select class="mp-select" id="sortSelect" aria-label="Sort listings">
                 <option value="rating" data-i18n="mp_sort_rating">Top Rated</option>
                 <option value="newest" data-i18n="mp_sort_newest">Newest</option>

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -1700,7 +1700,7 @@
             const catAttr = esc(cat);
             return `<div class="cat-folder" data-section="${section}" data-category="${catAttr}"
                         ondragover="onDropZoneDragOver(event)" ondragleave="onDropZoneDragLeave(event)" ondrop="onCatDrop(event)">
-                <div class="cat-header" onclick="handleCatHeaderClick(this)">
+                <div class="cat-header" role="button" tabindex="0" onclick="handleCatHeaderClick(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();handleCatHeaderClick(this)}">
                     <span class="cat-chevron ${expanded ? 'open' : ''}">&#9654;</span>
                     <span class="cat-name">${esc(cat)}</span>
                     <span class="cat-count">(${count})</span>

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -1700,7 +1700,7 @@
             const catAttr = esc(cat);
             return `<div class="cat-folder" data-section="${section}" data-category="${catAttr}"
                         ondragover="onDropZoneDragOver(event)" ondragleave="onDropZoneDragLeave(event)" ondrop="onCatDrop(event)">
-                <div class="cat-header" role="button" tabindex="0" onclick="handleCatHeaderClick(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();handleCatHeaderClick(this)}">
+                <div class="cat-header" role="button" tabindex="0" onclick="handleCatHeaderClick(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
                     <span class="cat-chevron ${expanded ? 'open' : ''}">&#9654;</span>
                     <span class="cat-name">${esc(cat)}</span>
                     <span class="cat-count">(${count})</span>

--- a/backend/public/portal/petdx-browser.html
+++ b/backend/public/portal/petdx-browser.html
@@ -200,7 +200,7 @@
         <select id="entity-selector" class="entity-selector" title="切換要更換伙伴的對象 / Switch which entity's companion you're changing">
             <option value="">🖥️ 全裝置 / Device-wide</option>
         </select>
-        <input id="search" class="search" type="search" placeholder="搜尋伙伴名稱或描述 / Search…" autocomplete="off">
+        <input id="search" class="search" type="search" placeholder="搜尋伙伴名稱或描述 / Search…" autocomplete="off" aria-label="搜尋伙伴名稱或描述 / Search companions">
     </div>
     <div class="filters" id="filters"></div>
 </div>

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1216,7 +1216,7 @@
 
         <!-- Notifications Card -->
         <div class="card">
-            <div class="notif-header" role="button" tabindex="0" onclick="toggleNotifSection()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleNotifSection()}">
+            <div class="notif-header" role="button" tabindex="0" onclick="toggleNotifSection()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
                 <div class="card-title" style="margin-bottom:0;">
                     <span>🔔 <span data-i18n="notif_settings_title">Notifications</span></span>
                 </div>
@@ -1240,7 +1240,7 @@
 
         <!-- Developer Section (collapsible) -->
         <div class="card">
-            <div class="notif-header" role="button" tabindex="0" onclick="toggleDeveloperSection()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleDeveloperSection()}">
+            <div class="notif-header" role="button" tabindex="0" onclick="toggleDeveloperSection()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
                 <div class="card-title" style="margin-bottom:0;">
                     <span>🛠️ <span data-i18n="developer_section_title">Developer</span></span>
                 </div>
@@ -1735,7 +1735,7 @@
         <!-- card_01417648: explicit empty-state with ? icon explains why the wallet
              row can look empty for a globe-user device (no account yet). The
              help-icon click/hover surfaces the concrete next step. -->
-        <div class="card" id="walletCard" style="cursor:pointer;" role="button" tabindex="0" onclick="(window.SmartRouter&&window.SmartRouter.navigate('wallet'))||(window.location.href='wallet.html')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();(window.SmartRouter&&window.SmartRouter.navigate('wallet'))||(window.location.href='wallet.html')}">
+        <div class="card" id="walletCard" style="cursor:pointer;" role="button" tabindex="0" onclick="(window.SmartRouter&&window.SmartRouter.navigate('wallet'))||(window.location.href='wallet.html')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
             <div class="card-title" style="display:flex;align-items:center;gap:8px;">
                 <span>💎 <span data-i18n="nav_wallet">Wallet</span></span>
                 <span class="help-icon" data-help-content-key="settings_wallet_section_help" tabindex="0" onclick="event.stopPropagation();"></span>
@@ -1758,7 +1758,7 @@
              (card_411522dac74b0e193bd306d3). -->
 
         <!-- Invite Card -->
-        <div class="card" style="cursor:pointer;" role="button" tabindex="0" onclick="(window.SmartRouter&&window.SmartRouter.navigate('invite'))||(window.location.href='invite.html')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();(window.SmartRouter&&window.SmartRouter.navigate('invite'))||(window.location.href='invite.html')}">
+        <div class="card" style="cursor:pointer;" role="button" tabindex="0" onclick="(window.SmartRouter&&window.SmartRouter.navigate('invite'))||(window.location.href='invite.html')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
             <div class="card-title">
                 <span>🎁 <span data-i18n="nav_invite">Invite Friends</span></span>
             </div>
@@ -1766,7 +1766,7 @@
         </div>
 
         <!-- Files Card (moved from nav) -->
-        <div class="card" style="cursor:pointer;" role="button" tabindex="0" onclick="(window.SmartRouter&&window.SmartRouter.navigate('files'))||(window.location.href='files.html')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();(window.SmartRouter&&window.SmartRouter.navigate('files'))||(window.location.href='files.html')}">
+        <div class="card" style="cursor:pointer;" role="button" tabindex="0" onclick="(window.SmartRouter&&window.SmartRouter.navigate('files'))||(window.location.href='files.html')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
             <div class="card-title">
                 <span>📁 <span data-i18n="nav_files">Files</span></span>
             </div>
@@ -1774,7 +1774,7 @@
         </div>
 
         <!-- Companion Card (Phase C: Petdx UIUX integration; see docs/specs/petdx-uiux-spec-amendment-2026-06-05-phase-C-settings-integration.md) -->
-        <div class="card" style="cursor:pointer;" role="button" tabindex="0" onclick="(window.SmartRouter&&window.SmartRouter.navigate('petdx'))||(window.location.href='petdx-browser.html')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();(window.SmartRouter&&window.SmartRouter.navigate('petdx'))||(window.location.href='petdx-browser.html')}">
+        <div class="card" style="cursor:pointer;" role="button" tabindex="0" onclick="(window.SmartRouter&&window.SmartRouter.navigate('petdx'))||(window.location.href='petdx-browser.html')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
             <div class="card-title">
                 <span>🐾 <span data-i18n="nav_companion">Companion</span></span>
             </div>
@@ -1784,7 +1784,7 @@
         <!-- Feedback Card -->
         <div class="card">
             <div class="feedback-header">
-                <div class="feedback-body" role="button" tabindex="0" onclick="showFeedbackDialog()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();showFeedbackDialog()}">
+                <div class="feedback-body" role="button" tabindex="0" onclick="showFeedbackDialog()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}">
                     <div class="card-title">
                         <span>💬 <span data-i18n="settings_feedback_title">Feedback</span></span>
                     </div>

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1216,7 +1216,7 @@
 
         <!-- Notifications Card -->
         <div class="card">
-            <div class="notif-header" onclick="toggleNotifSection()">
+            <div class="notif-header" role="button" tabindex="0" onclick="toggleNotifSection()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleNotifSection()}">
                 <div class="card-title" style="margin-bottom:0;">
                     <span>🔔 <span data-i18n="notif_settings_title">Notifications</span></span>
                 </div>
@@ -1240,7 +1240,7 @@
 
         <!-- Developer Section (collapsible) -->
         <div class="card">
-            <div class="notif-header" onclick="toggleDeveloperSection()">
+            <div class="notif-header" role="button" tabindex="0" onclick="toggleDeveloperSection()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleDeveloperSection()}">
                 <div class="card-title" style="margin-bottom:0;">
                     <span>🛠️ <span data-i18n="developer_section_title">Developer</span></span>
                 </div>
@@ -1735,7 +1735,7 @@
         <!-- card_01417648: explicit empty-state with ? icon explains why the wallet
              row can look empty for a globe-user device (no account yet). The
              help-icon click/hover surfaces the concrete next step. -->
-        <div class="card" id="walletCard" style="cursor:pointer;" onclick="(window.SmartRouter&&window.SmartRouter.navigate('wallet'))||(window.location.href='wallet.html')">
+        <div class="card" id="walletCard" style="cursor:pointer;" role="button" tabindex="0" onclick="(window.SmartRouter&&window.SmartRouter.navigate('wallet'))||(window.location.href='wallet.html')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();(window.SmartRouter&&window.SmartRouter.navigate('wallet'))||(window.location.href='wallet.html')}">
             <div class="card-title" style="display:flex;align-items:center;gap:8px;">
                 <span>💎 <span data-i18n="nav_wallet">Wallet</span></span>
                 <span class="help-icon" data-help-content-key="settings_wallet_section_help" tabindex="0" onclick="event.stopPropagation();"></span>
@@ -1758,7 +1758,7 @@
              (card_411522dac74b0e193bd306d3). -->
 
         <!-- Invite Card -->
-        <div class="card" style="cursor:pointer;" onclick="(window.SmartRouter&&window.SmartRouter.navigate('invite'))||(window.location.href='invite.html')">
+        <div class="card" style="cursor:pointer;" role="button" tabindex="0" onclick="(window.SmartRouter&&window.SmartRouter.navigate('invite'))||(window.location.href='invite.html')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();(window.SmartRouter&&window.SmartRouter.navigate('invite'))||(window.location.href='invite.html')}">
             <div class="card-title">
                 <span>🎁 <span data-i18n="nav_invite">Invite Friends</span></span>
             </div>
@@ -1766,7 +1766,7 @@
         </div>
 
         <!-- Files Card (moved from nav) -->
-        <div class="card" style="cursor:pointer;" onclick="(window.SmartRouter&&window.SmartRouter.navigate('files'))||(window.location.href='files.html')">
+        <div class="card" style="cursor:pointer;" role="button" tabindex="0" onclick="(window.SmartRouter&&window.SmartRouter.navigate('files'))||(window.location.href='files.html')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();(window.SmartRouter&&window.SmartRouter.navigate('files'))||(window.location.href='files.html')}">
             <div class="card-title">
                 <span>📁 <span data-i18n="nav_files">Files</span></span>
             </div>
@@ -1774,7 +1774,7 @@
         </div>
 
         <!-- Companion Card (Phase C: Petdx UIUX integration; see docs/specs/petdx-uiux-spec-amendment-2026-06-05-phase-C-settings-integration.md) -->
-        <div class="card" style="cursor:pointer;" onclick="(window.SmartRouter&&window.SmartRouter.navigate('petdx'))||(window.location.href='petdx-browser.html')">
+        <div class="card" style="cursor:pointer;" role="button" tabindex="0" onclick="(window.SmartRouter&&window.SmartRouter.navigate('petdx'))||(window.location.href='petdx-browser.html')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();(window.SmartRouter&&window.SmartRouter.navigate('petdx'))||(window.location.href='petdx-browser.html')}">
             <div class="card-title">
                 <span>🐾 <span data-i18n="nav_companion">Companion</span></span>
             </div>
@@ -1784,7 +1784,7 @@
         <!-- Feedback Card -->
         <div class="card">
             <div class="feedback-header">
-                <div class="feedback-body" onclick="showFeedbackDialog()">
+                <div class="feedback-body" role="button" tabindex="0" onclick="showFeedbackDialog()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();showFeedbackDialog()}">
                     <div class="card-title">
                         <span>💬 <span data-i18n="settings_feedback_title">Feedback</span></span>
                     </div>

--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -261,7 +261,7 @@
 
         <!-- Input -->
         <div class="input-bar">
-            <input type="text" id="msgInput" data-i18n-placeholder="sc_placeholder" placeholder="Type a message..." maxlength="5000" autocomplete="off">
+            <input type="text" id="msgInput" aria-label="Type a message" data-i18n-placeholder="sc_placeholder" placeholder="Type a message..." maxlength="5000" autocomplete="off">
             <button id="sendBtn" onclick="handleSend()" data-i18n="sc_send">Send</button>
         </div>
 
@@ -1535,10 +1535,10 @@
         dialog.innerHTML = `<div style="background:var(--card);border:1px solid rgba(255,255,255,0.1);border-radius:16px;padding:24px;max-width:380px;width:100%">
             <h3 style="margin:0 0 4px">🛒 ${escapeHtml(name)}</h3>
             <p style="color:var(--primary);font-weight:700;margin:0 0 16px">${escapeHtml(price)}</p>
-            <input id="od-name" data-i18n-placeholder="sc_order_name" placeholder="Name" style="width:100%;padding:10px;margin:4px 0;background:var(--bg);color:var(--text);border:1px solid rgba(255,255,255,0.15);border-radius:8px" required>
-            <input id="od-phone" data-i18n-placeholder="sc_order_phone" placeholder="Phone" style="width:100%;padding:10px;margin:4px 0;background:var(--bg);color:var(--text);border:1px solid rgba(255,255,255,0.15);border-radius:8px" required>
-            <input id="od-email" placeholder="Email" type="email" style="width:100%;padding:10px;margin:4px 0;background:var(--bg);color:var(--text);border:1px solid rgba(255,255,255,0.15);border-radius:8px">
-            <input id="od-addr" data-i18n-placeholder="sc_order_address" placeholder="Shipping address" style="width:100%;padding:10px;margin:4px 0;background:var(--bg);color:var(--text);border:1px solid rgba(255,255,255,0.15);border-radius:8px">
+            <input id="od-name" aria-label="Name" data-i18n-placeholder="sc_order_name" placeholder="Name" style="width:100%;padding:10px;margin:4px 0;background:var(--bg);color:var(--text);border:1px solid rgba(255,255,255,0.15);border-radius:8px" required>
+            <input id="od-phone" aria-label="Phone" data-i18n-placeholder="sc_order_phone" placeholder="Phone" style="width:100%;padding:10px;margin:4px 0;background:var(--bg);color:var(--text);border:1px solid rgba(255,255,255,0.15);border-radius:8px" required>
+            <input id="od-email" aria-label="Email" placeholder="Email" type="email" style="width:100%;padding:10px;margin:4px 0;background:var(--bg);color:var(--text);border:1px solid rgba(255,255,255,0.15);border-radius:8px">
+            <input id="od-addr" aria-label="Shipping address" data-i18n-placeholder="sc_order_address" placeholder="Shipping address" style="width:100%;padding:10px;margin:4px 0;background:var(--bg);color:var(--text);border:1px solid rgba(255,255,255,0.15);border-radius:8px">
             <div style="display:flex;gap:8px;margin-top:12px">
                 <button onclick="document.getElementById('orderDialog').remove()" data-i18n="sc_order_cancel" style="flex:1;padding:10px;background:rgba(255,255,255,0.1);color:var(--text);border:none;border-radius:8px;cursor:pointer">Cancel</button>
                 <button id="od-submit" onclick="submitOrder(this)" data-i18n="sc_order_confirm" style="flex:1;padding:10px;background:var(--primary);color:#fff;border:none;border-radius:8px;cursor:pointer;font-weight:600">Confirm Order</button>

--- a/backend/public/portal/shared/ai-chat.js
+++ b/backend/public/portal/shared/ai-chat.js
@@ -177,7 +177,7 @@
                 </button>
                 <textarea id="aiChatInput" class="ai-chat-input" rows="1"
                           placeholder="Ask a question..." maxlength="2000"></textarea>
-                <button id="aiChatSend" class="ai-chat-send-btn" disabled>
+                <button id="aiChatSend" class="ai-chat-send-btn" aria-label="Send message" disabled>
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <line x1="22" y1="2" x2="11" y2="13"></line>
                         <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>


### PR DESCRIPTION
## What
Weekly operability/a11y audit (`audit-run.js`, card_5431b300) surfaced 50 hits across the portal. After excluding demo/dev pages and verified false positives, this PR fixes **34 genuine a11y gaps** — **additive accessibility semantics only**, zero layout/style/behavior change.

### Fixes (15 files)
- **input-no-label** → `aria-label` on placeholder-only inputs: card-holder search, info ×3 (FAQ/release-notes/change-log search), invite code, kanban (cardLinkTarget/reopenPr), marketplace search, petdx-browser search, share-chat ×5 (msg + order name/phone/email/address)
- **icon-button-no-aria** → `aria-label` on icon-only buttons: admin AI fab (🤖), card-holder/community/chat close (✕) ×6, voice play (▶), ai-chat send
- **div-onclick-no-keyboard** → `role="button" tabindex="0"` + Enter/Space `onkeydown` mirroring the existing `onclick`: dashboard ×3 (collapsible headers), files folder-chip, kanban auto-header, mission cat-header, settings ×7 (collapsible headers + nav cards + feedback)

### Skipped (verified false positives / by-design — not regressions)
- analytics `#pathInput` — already wrapped in a `<label>`
- kanban `#funnelSearch` / `#funnelTag` — already carry `data-i18n-aria-label`
- delete-account `deleteAccount` — already gated by a `confirmCheck` checkbox
- admin `removeBot` — already gated by the `confirmRemoveBot` overlay (adding `showConfirm` would double-confirm)
- settings `clearKanbanNudgeEntityOverride` — low-risk, reversible (clears a pref override)

### Deferred to #6 design review (content/interaction decisions, not pure semantics)
- 2 empty-state CTAs (dashboard "No project activity today", feedback "No feedback yet") — wording is a design call
- chat voice-progress bar — needs a proper `role="slider"` + arrow-key stepping (current onclick reads `clientX`, so a button+Enter can't seek)

### Verification
- Generated via a per-file multi-agent sweep; each change reviewed in the staged diff (all additive attributes; onkeydown handlers faithfully replicate the existing onclick; quote nesting valid).
- Line-ending (CRLF) churn in unrelated files was deliberately excluded from the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015G18VarYZdEUPEmkXvVLHa