### PR TITLE
fix(audit): eliminate recurring weekly compliance false-positives (card_e4c6d43f)

### DIFF
--- a/backend/agent-improvement/audit-rules.js
+++ b/backend/agent-improvement/audit-rules.js
@@ -36,6 +36,7 @@
 const TEST_PATH_HINTS = Object.freeze([
     '/tests/', '/test/', '__tests__', '.test.js', '.spec.js',
     '/fixtures/', '/migrations/', // migrations may legitimately reference example IDs
+    'test_',          // root-level legacy test scripts (test_multi_tenant.js etc.)
 ]);
 const HANK_HEX_DEVICE = '480def4c-2183-4d8e-afd0-b131ae89adcc';
 const HANK_HEX_REGEX = new RegExp(HANK_HEX_DEVICE, 'g');
@@ -309,7 +310,7 @@ function ctxInputPlaceholderNoLabel(idx, lines) {
     return true;
 }
 
-const CONFIRM_REF = /showConfirm|confirm\s*\(|window\.confirm|data-confirm|confirm-overlay|confirmDialog/i;
+const CONFIRM_REF = /showConfirm|confirm\s*\(|window\.confirm|data-confirm|confirm-overlay|confirmDialog|confirmCheck|\.checked\b/i; // +checkbox-gate (delete-account confirmCheck)
 // A SERVER mutation only — an HTTP write. Deliberately NOT `.delete(`/`.destroy(`
 // which match JS Set/Map.delete() and teardown helpers (false positives like
 // `mySet.delete(id)` / `widget.destroy()`), not data loss on the backend.
@@ -433,7 +434,7 @@ const RULES = [
         title: 'Hank\'s deviceId UUID hardcoded in source',
         rationale: 'EClawbot must work for any user. Hardcoding the test device UUID into shipped code makes the feature single-tenant.',
         pattern: HANK_HEX_REGEX,
-        allowFiles: TEST_PATH_HINTS.slice(),
+        allowFiles: TEST_PATH_HINTS.concat(['compliance-scan']), // scripts/compliance-scan.js DEFINES the literal to detect it (self-ref)
     },
     {
         id: 'hardcoded-users-hank-path',
@@ -442,7 +443,7 @@ const RULES = [
         title: 'Absolute path under /Users/hank/ in shipped code',
         rationale: 'Paths under one developer\'s home directory will not resolve on production or another contributor\'s laptop.',
         pattern: /\/Users\/hank\//,
-        allowFiles: ['/scripts/dev', '/.local/', '/docs/'],
+        allowFiles: TEST_PATH_HINTS.concat(['/scripts/dev', '/.local/', '/docs/', 'compliance-scan']), // + tests + scanner self-ref (rule descriptions / fixtures)
     },
     {
         id: 'hardcoded-entity-id-comparison',
@@ -463,7 +464,7 @@ const RULES = [
         // letter and a digit — that is the publicCode shape (e.g. tbwb9e, 3xa3h4).
         // Lookaheads keep us from false-firing on '401', '256kb', plain words, or
         // long hashes (the earlier `[a-z0-9]*\d[a-z0-9]*` matched all of those).
-        pattern: /['"`](?=[a-z0-9]{6}['"`])(?=[a-z0-9]*[a-z])(?=[a-z0-9]*\d)[a-z0-9]{6}['"`]/,
+        pattern: /['"`](?!0x)(?=[a-z0-9]{6}['"`])(?=[a-z0-9]*[a-z])(?=[a-z0-9]*\d)[a-z0-9]{6}['"`]/, // (?!0x) drops hex literals like '0xf3a4'
         filePathFilter: (p) => /\.(js|ts)$/.test(p) && !/\.test\./.test(p),
         // Words with the publicCode shape (6 alnum, letter+digit) that are NOT
         // publicCodes — encodings, hash algos, mime fragments. Without this

--- a/backend/tests/jest/audit-rules.test.js
+++ b/backend/tests/jest/audit-rules.test.js
@@ -488,3 +488,31 @@ describe('audit-rules — R7 focus-style-removed', () => {
             'operability-focus-style-removed', PCSS)).toBe(false);
     });
 });
+
+describe('audit-rules — false-positive exemptions (card_e4c6d43f weekly-noise reduction)', () => {
+    const fires = (fp, text, rid) => audit.scanText(fp, text).some(r => r.ruleId === rid);
+
+    test('scanner self-ref: compliance-scan.js exempt from hardcoded-hank-device-id (still fires in product code)', () => {
+        const t = "const HANKS_DEVICE_ID = '480def4c-2183-4d8e-afd0-b131ae89adcc';";
+        expect(fires('backend/scripts/compliance-scan.js', t, 'hardcoded-hank-device-id')).toBe(false);
+        expect(fires('backend/index.js', t, 'hardcoded-hank-device-id')).toBe(true);
+    });
+
+    test('scanner self-ref + tests exempt from hardcoded-users-hank-path (still fires in product code)', () => {
+        const t = 'const p = "/Users/hank/Desktop/foo";';
+        expect(fires('backend/scripts/compliance-scan.js', t, 'hardcoded-users-hank-path')).toBe(false);
+        expect(fires('backend/tests/jest/compliance-scan.test.js', t, 'hardcoded-users-hank-path')).toBe(false);
+        expect(fires('backend/index.js', t, 'hardcoded-users-hank-path')).toBe(true);
+    });
+
+    test('root-level test_*.js exempt from hardcoded-entity-id-comparison (still fires in product code)', () => {
+        const t = 'const e1 = entities.find(e => e.entityId === 1);';
+        expect(fires('backend/test_multi_tenant.js', t, 'hardcoded-entity-id-comparison')).toBe(false);
+        expect(fires('backend/router.js', t, 'hardcoded-entity-id-comparison')).toBe(true);
+    });
+
+    test('public-code regex drops 0x-hex literals but keeps real publicCode shape', () => {
+        expect(fires('backend/interview-arena.js', "const x = '0xf3a4';", 'hardcoded-public-code-literal')).toBe(false);
+        expect(fires('backend/svc.js', "const code = 'tbwb9e';", 'hardcoded-public-code-literal')).toBe(true);
+    });
+});


### PR DESCRIPTION
## What
The weekly `audit-run.js` compliance sweep was emitting 4 rule groups that were **100% false positives** every week — scanner self-references, test fixtures, and a hex literal. This tightens the exemptions so they report **0 hits** (re-run verified) without weakening real detection.

### Changes (`audit-rules.js`)
- **`TEST_PATH_HINTS`** += `'test_'` → root-level legacy test scripts (`test_multi_tenant.js`) are exempt from `hardcoded-entity-id-comparison`.
- **`hardcoded-hank-device-id`** / **`hardcoded-users-hank-path`** → exempt `compliance-scan` (the legacy scanner `scripts/compliance-scan.js` *defines* these literals to detect them; its `.test.js` fixture too). `users-hank-path` also now inherits `TEST_PATH_HINTS`.
- **`hardcoded-public-code-literal`** → add `(?!0x)` lookahead: drops hex literals like `'0xf3a4'` (interview-arena content) while still matching the real publicCode shape (`'tbwb9e'`).
- **`destructive-no-confirm` (`CONFIRM_REF`)** → recognize checkbox-gate confirms (`confirmCheck` / `.checked`) so `delete-account.html` (which gates deletion behind a confirm checkbox) no longer false-fires.

### Verification
- `node agent-improvement/audit-run.js --json` → **hardcoded-hank-device-id / users-hank-path / entity-id-comparison / public-code-literal all = 0**; destructive-no-confirm drops the `deleteAccount` false positive (removeBot + clearNudge remain — separate cross-function / low-risk cases).
- `audit-rules.test.js` **70/70 pass** — 4 new cases assert the exemptions AND positive regression guards (the rules STILL fire on real product-code violations).

Kills ~6 recurring noise findings per weekly cron. Spec: card_e4c6d43f3912db57c3382c08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015G18VarYZdEUPEmkXvVLHa