### PR TITLE
fix(a11y): showConfirm Enter activates focused Confirm button (card_d2506588)

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -308,11 +308,20 @@ function showConfirm({ message, title, confirmText, cancelText, danger, itemName
         }
         const _keyHandler = (e) => {
             if (e.key === 'Escape') cleanup(false);
-            // For destructive confirms Enter dismisses (= cancel) so an
-            // accidental keypress on a focused Cancel button still resolves
-            // false. Non-danger confirms keep the original Enter=confirm
-            // ergonomics so OK-flow dialogs still feel snappy.
-            if (e.key === 'Enter') cleanup(!danger ? true : false);
+            // Enter semantics (WAI-ARIA APG: a focused button reacts to Enter
+            // and Space identically). Non-danger: Enter confirms. Danger: Enter
+            // confirms ONLY when the Confirm button is focused (fall through to
+            // its native click → cleanup(true), matching Space); when focus is
+            // on Cancel or anywhere else — including the safe default focus — a
+            // stray Enter still cancels.
+            if (e.key === 'Enter') {
+                if (!danger) {
+                    cleanup(true);
+                } else if (document.activeElement !== overlay.querySelector('.eclaw-confirm-ok')) {
+                    cleanup(false);
+                }
+                // danger + Confirm focused → native button activation confirms
+            }
             // Focus trap: keep Tab / Shift+Tab cycling among the two buttons so
             // focus cannot escape onto background elements while the modal is
             // open. Cancel is the first tabbable, OK is the last.

--- a/backend/tests/jest/showConfirm-danger-default-focus.test.js
+++ b/backend/tests/jest/showConfirm-danger-default-focus.test.js
@@ -31,11 +31,18 @@ describe('showConfirm — destructive-modal safe default focus', () => {
         );
     });
 
-    test('Enter on a destructive confirm does NOT commit', () => {
-        // Enter handler must skip cleanup(true) when danger is set. The
-        // previous unconditional `cleanup(true)` shipped destructive ops on
-        // any keyboard-focused Enter, which violated the safety invariant.
-        expect(apiJs).toMatch(/if\s*\(\s*e\.key\s*===\s*['"]Enter['"]\s*\)\s*cleanup\(\s*!danger/);
+    test('Enter on a destructive confirm commits ONLY when Confirm is focused (stray Enter cancels)', () => {
+        // WAI-ARIA APG: a focused button reacts to Enter and Space identically.
+        // Danger Enter falls through to the Confirm button's native activation
+        // ONLY when it is the active element; when focus is on Cancel or the
+        // safe default, a stray Enter still resolves false. The danger branch
+        // must therefore guard cleanup(false) on the "not the OK button" check
+        // and must NOT unconditionally cleanup(true). Behaviour verified live
+        // via Playwright (Enter@Confirm->true, Enter@Cancel->false, Space@Confirm->true);
+        // card_d2506588cee92488f50cbe5e.
+        expect(apiJs).toMatch(
+            /document\.activeElement\s*!==\s*overlay\.querySelector\(\s*['"]\.eclaw-confirm-ok['"]\s*\)[\s\S]{0,80}cleanup\(\s*false\s*\)/
+        );
     });
 
     test('Esc still cancels regardless of danger flag', () => {
@@ -45,12 +52,7 @@ describe('showConfirm — destructive-modal safe default focus', () => {
     });
 
     test('non-danger confirm keeps Enter=confirm ergonomics', () => {
-        // The fix must preserve the snappy OK-flow for non-destructive
-        // dialogs — Enter should still resolve true when danger is falsy.
-        // We assert via the same `cleanup(!danger ? true : false)` expression
-        // — when danger is false, the inner ternary evaluates to true.
-        const enterLine = apiJs.match(/e\.key\s*===\s*['"]Enter['"][^;]*;?/);
-        expect(enterLine).not.toBeNull();
-        expect(enterLine[0]).toMatch(/!danger\s*\?\s*true\s*:\s*false/);
+        // Non-destructive dialogs keep the snappy OK-flow: Enter resolves true.
+        expect(apiJs).toMatch(/if\s*\(\s*!danger\s*\)\s*\{\s*cleanup\(\s*true\s*\)\s*;?\s*\}/);
     });
 });


### PR DESCRIPTION
## What
A Phase-2 finding from the destructive-modals daily E2E: on a **danger** `showConfirm()`, the document-level keydown handler intercepted **Enter** and always resolved *cancel* — regardless of which button was focused. So a keyboard user who Tabbed to **Confirm** and pressed Enter was silently cancelled; only **Space** or a mouse click could confirm. That violates WAI-ARIA APG (a focused button should react to Enter and Space identically).

## Fix (option A from the card — the ARIA-correct one)
The danger Enter branch now resolves cancel **only when focus is NOT on the Confirm button**. When Confirm is focused, the handler does nothing and the event falls through to the button's **native activation** (`click` → `cleanup(true)`), matching Space. The safety default is untouched: initial focus is **Cancel**, so a stray Enter still cancels.

```js
if (e.key === 'Enter') {
    if (!danger) { cleanup(true); }
    else if (document.activeElement !== overlay.querySelector('.eclaw-confirm-ok')) { cleanup(false); }
    // danger + Confirm focused → native button activation confirms
}
```

## Verification (live, real keypresses via Playwright)
- Enter @ Confirm → **confirm (true)** ✓  (was: cancel)
- Enter @ Cancel → **cancel (false)** ✓  (stray Enter safety preserved)
- Space @ Confirm → **confirm (true)** ✓  (Enter now matches Space)
- Esc → cancel (unchanged); focus trap (Tab/Shift+Tab) unchanged.
- `showConfirm-danger-default-focus.test.js` updated to lock the new invariant — 4/4 pass (the 2 prior assertions locked the old "Enter never commits" shape).

Parent: card_0fd45da40bd718b277ce97ef · card_d2506588cee92488f50cbe5e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015G18VarYZdEUPEmkXvVLHa