### PR TITLE
feat(action-requests): owner-decision DELIVERY — push-on-create + morning digest + no bot-vote flood

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -151,11 +151,27 @@ function optionLabel(o) {
 // (3) device has >= consensus_min_entities bound entities; (4) status='pending'
 // AND consensus_triggered_at IS NULL. decision_context does NOT block opening —
 // owner-only items DO deliberate; the owner-veto applies only at DISPOSITION.
+// An OWNER-decision request (decision_context.ownerOnly === true) is for Hank to
+// resolve in the 需要你 inbox — it must NOT open a bot-to-bot consensus round.
+// (Opening one buzzed every bound entity with a vote prompt the instant such an
+// item was created — the flood Hank flagged.) decision_context arrives as a jsonb
+// object off a DB row, but tolerate a raw string. (DELIVERY fix — owner reminders.)
+function isOwnerOnlyDecision(decisionContext) {
+    if (decisionContext == null) return false;
+    let dc = decisionContext;
+    if (typeof dc === 'string') {
+        try { dc = JSON.parse(dc); } catch (_) { return false; }
+    }
+    return !!(dc && typeof dc === 'object' && dc.ownerOnly === true);
+}
+
 function isNegotiable(row, prefs, boundEntityCount) {
     if (!row || !prefs) return false;
     if (prefs.action_request_timeout_policy !== 'consensus') return false;
     if (row.status !== 'pending') return false;
     if (row.consensus_triggered_at != null) return false;
+    // Owner decisions wait for Hank, never a bot vote (DELIVERY fix).
+    if (isOwnerOnlyDecision(row.decision_context)) return false;
     const opts = row.options;
     if (!Array.isArray(opts) || opts.length < 2) return false;
     if (Number(boundEntityCount) < clampMinEntities(prefs.consensus_min_entities)) return false;
@@ -362,6 +378,24 @@ async function initAgentActionRequestsDatabase() {
     } catch (err) {
         console.error('[AgentActionRequests] votes table migration skipped:', err.message);
     }
+
+    // ── Idempotent: owner-decision morning-digest dedup (DELIVERY fix) ──
+    // One digest per (device, device-local-date). The 5-min sweep fires up to 12×
+    // inside the digest hour and may run on multiple instances; the PK makes the
+    // "send today's digest" decision win exactly once per day per device.
+    try {
+        await pool.query(
+            `CREATE TABLE IF NOT EXISTS owner_decision_digest_sent (
+                device_id TEXT NOT NULL,
+                sent_date TEXT NOT NULL,
+                sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                item_count INTEGER DEFAULT NULL,
+                CONSTRAINT owner_digest_pk PRIMARY KEY (device_id, sent_date)
+            )`
+        );
+    } catch (err) {
+        console.error('[AgentActionRequests] owner_decision_digest_sent migration skipped:', err.message);
+    }
 }
 
 // ── Helpers ──
@@ -512,7 +546,7 @@ function rowToApi(row) {
 /**
  * Factory. Matches the kanban/scheduled-messages module style so index.js wires it the same way.
  */
-module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, getDevicePrefs } = {}) {
+module.exports = function (devices, { pushToBot, unifiedPush, notifyDevice, serverLog, io, getDevicePrefs } = {}) {
     const router = express.Router();
 
     // How the worker reads a device's timeout policy + minutes. Defaults to the
@@ -885,6 +919,38 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
         );
         const row = result.rows[0];
         emitChanged(deviceId, 'emitted', row.id, row.from_entity_id);
+        // OWNER-DECISION PUSH (DELIVERY fix): an ownerOnly item must actively REACH
+        // Hank's device (socket + Web Push + FCM fan-out via notifyDevice), not just
+        // sit in a collapsed inbox where it died silently. Gated on
+        // decision_context.ownerOnly so bot-to-bot requests never buzz the owner's
+        // phone, and on an opt-out pref. Best-effort: a push error must NEVER fail
+        // request creation (fully wrapped).
+        if (typeof notifyDevice === 'function' && isOwnerOnlyDecision(decisionContext)) {
+            try {
+                let prefsPush = {};
+                try { prefsPush = (await readDevicePrefs(deviceId)) || {}; } catch (_) { prefsPush = {}; }
+                if (prefsPush.owner_decision_push_enabled !== false) {
+                    let dc = decisionContext;
+                    if (typeof dc === 'string') { try { dc = JSON.parse(dc); } catch (_) { dc = null; } }
+                    Promise.resolve(notifyDevice(deviceId, {
+                        type: 'owner_decision',
+                        category: 'action_request',
+                        title: '需要你拍板',
+                        body: prompt,
+                        link: '/',
+                        metadata: {
+                            kind: 'owner_decision_created',
+                            requestId: row.id,
+                            relatedCardId: relatedCardId != null ? relatedCardId : null,
+                            recommendedOptionIndex: (dc && typeof dc === 'object') ? dc.recommendedOptionIndex : undefined,
+                        },
+                    })).catch((e) => log('error', `owner-decision push failed id=${row.id}: ${e.message}`, { deviceId }));
+                    log('info', `owner-decision push id=${row.id}`, { deviceId });
+                }
+            } catch (e) {
+                log('error', `owner-decision push wrap failed id=${row.id}: ${e.message}`, { deviceId });
+            }
+        }
         // ON-ARRIVAL negotiation open (需要你 negotiation): best-effort, AFTER the
         // committed INSERT + 'emitted'. A prefs/push error here must NOT fail request
         // creation — fully wrapped in try/catch. Only fires when isNegotiable (device
@@ -1038,6 +1104,102 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
         }
     }
 
+    // ══════════════════════════════════════════════════════════════════════
+    // OWNER-DECISION MORNING DIGEST (DELIVERY fix)
+    // ──────────────────────────────────────────────────────────────────────
+    // Once per day, on/after the configured digest hour (device-local), if the
+    // device still has pending ownerOnly items, push ONE summary to the owner's
+    // device (notifyDevice → socket + Web Push + FCM fan-out). Without this an
+    // owner-decision created overnight would sit unseen in a collapsed inbox.
+    // Idempotent per (device, local-date) via owner_decision_digest_sent.
+    //   opt-out: owner_decision_digest_enabled === false
+    //   hour:    owner_decision_digest_hour (0..23, default 8)
+    //   tz:      owner_decision_digest_tz   (IANA, default 'Asia/Taipei')
+    // Never resolves or mutates requests; failure-isolated by the caller.
+    // ══════════════════════════════════════════════════════════════════════
+    function localDateAndHour(tz) {
+        try {
+            const parts = new Intl.DateTimeFormat('en-CA', {
+                timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
+                hour: '2-digit', hour12: false,
+            }).formatToParts(new Date());
+            const get = (t) => (parts.find(p => p.type === t) || {}).value;
+            let hour = parseInt(get('hour'), 10);
+            if (hour === 24) hour = 0; // some ICU builds emit '24' at midnight
+            return { date: `${get('year')}-${get('month')}-${get('day')}`, hour };
+        } catch (_) {
+            const d = new Date(); // bad tz → server-local fallback
+            return { date: d.toISOString().slice(0, 10), hour: d.getHours() };
+        }
+    }
+
+    async function runOwnerDigestPass(deviceId, prefs, device) {
+        if (prefs && prefs.owner_decision_digest_enabled === false) return;
+        if (typeof notifyDevice !== 'function') return;
+
+        const tz = (prefs && typeof prefs.owner_decision_digest_tz === 'string' && prefs.owner_decision_digest_tz)
+            || 'Asia/Taipei';
+        const hourPref = Number(prefs && prefs.owner_decision_digest_hour);
+        const digestHour = Number.isFinite(hourPref) ? Math.min(23, Math.max(0, Math.trunc(hourPref))) : 8;
+        const { date: localDate, hour: localHour } = localDateAndHour(tz);
+        if (localHour < digestHour) return; // not yet the morning window
+
+        let items = [];
+        try {
+            const r = await pool.query(
+                `SELECT id, prompt FROM agent_action_requests
+                  WHERE device_id = $1 AND status = 'pending'
+                    AND decision_context ->> 'ownerOnly' = 'true'
+                  ORDER BY created_at ASC LIMIT 50`,
+                [deviceId]
+            );
+            items = r.rows || [];
+        } catch (err) {
+            log('error', `owner digest query failed: ${err.message}`, { deviceId });
+            return;
+        }
+        if (items.length === 0) return;
+
+        // Win the once-per-day race (multi-instance safe): only the inserter sends.
+        let won = false;
+        try {
+            const ins = await pool.query(
+                `INSERT INTO owner_decision_digest_sent (device_id, sent_date, item_count)
+                 VALUES ($1, $2, $3)
+                 ON CONFLICT (device_id, sent_date) DO NOTHING
+                 RETURNING device_id`,
+                [deviceId, localDate, items.length]
+            );
+            won = (ins.rowCount || 0) > 0;
+        } catch (err) {
+            log('error', `owner digest dedup insert failed: ${err.message}`, { deviceId });
+            return;
+        }
+        if (!won) return;
+
+        const n = items.length;
+        const preview = items.slice(0, 3)
+            .map(it => `• ${String(it.prompt || '').replace(/\s+/g, ' ').slice(0, 60)}`)
+            .join('\n');
+        try {
+            await notifyDevice(deviceId, {
+                type: 'owner_decision_digest',
+                category: 'action_request',
+                title: `需要你：${n} 項待拍板`,
+                body: preview + (n > 3 ? `\n…還有 ${n - 3} 項` : ''),
+                link: '/',
+                metadata: {
+                    kind: 'owner_decision_digest',
+                    count: n,
+                    requestIds: items.map(it => it.id),
+                },
+            });
+            log('info', `owner digest sent device=${deviceId} count=${n} date=${localDate}`, { deviceId });
+        } catch (err) {
+            log('error', `owner digest push failed: ${err.message}`, { deviceId });
+        }
+    }
+
     async function enforceActionRequestTimeouts() {
         let deviceIds = [];
         try {
@@ -1069,6 +1231,12 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
                 // finish even if the device is now on 'keep'. Failure-isolated.
                 try { await advanceNegotiations(deviceId, prefs, device); }
                 catch (e) { console.error(`[AgentActionRequests] negotiation advance failed device=${deviceId}:`, e.message); }
+
+                // OWNER-DECISION MORNING DIGEST (DELIVERY fix): runs BEFORE the keep
+                // gate so default-policy ('keep') devices — i.e. almost everyone —
+                // still get their once-a-day reminder of pending owner decisions.
+                try { await runOwnerDigestPass(deviceId, prefs, device); }
+                catch (e) { console.error(`[AgentActionRequests] owner digest pass failed device=${deviceId}:`, e.message); }
 
                 const policy = prefs.action_request_timeout_policy || 'keep';
                 if (policy === 'keep') continue; // default: never auto-act
@@ -1821,6 +1989,9 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
         // Timeout-policy worker (card_ce0d685b). Exported so tests + an external
         // scheduler can invoke a sweep directly.
         enforceActionRequestTimeouts,
+        // Owner-decision morning digest (DELIVERY fix). Exported for direct test
+        // invocation of the once-per-day reminder pass.
+        runOwnerDigestPass,
         // Shared create path (子3) so the kanban move-hook can auto-surface an
         // owner-only review/blocked card into this inbox via the SAME INSERT +
         // 'emitted' socket emit the HTTP route uses. Caller validates inputs.
@@ -1843,6 +2014,11 @@ module.exports.initAgentActionRequestsDatabase = initAgentActionRequestsDatabase
 // recompute (fail-closed mode + audit-trail N-cap) and its input builder.
 module.exports.recomputeRatifyMode = recomputeRatifyMode;
 module.exports.ratifyInputFrom = ratifyInputFrom;
+// DELIVERY fix: exported for unit tests — the ownerOnly predicate that both
+// suppresses bot consensus on owner decisions and gates the owner-device push,
+// and the negotiability gate it feeds.
+module.exports.isOwnerOnlyDecision = isOwnerOnlyDecision;
+module.exports.isNegotiable = isNegotiable;
 module.exports.MAX_RATIFY_RETRIES = MAX_RATIFY_RETRIES;
 // 計畫E adjustable params (card_c3d48c4607ee753b2c98e04b): defensive clamps for
 // the two ratify tunables — exported for unit tests.

--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -111,6 +111,19 @@ const DEFAULTS = {
     //   before it is treated as stale and ignored (the evaluator then falls back
     //   to lastSend / kanban-floor heuristics). Default 45; clamped [5, 600].
     entity_runtime_state_stale_seconds: 45,
+    // Owner-decision DELIVERY reminders (DELIVERY fix — Hank: "eclaw 應該也要提醒？").
+    // An ownerOnly 需要你 item now (a) pushes the owner device the instant it is
+    // created, and (b) is summarized in a once-a-day morning digest, so owner
+    // decisions stop dying silently in a collapsed inbox. All default ON (opt-out).
+    // Consumed by createActionRequest + runOwnerDigestPass (agent-action-requests.js).
+    //   owner_decision_push_enabled    — push on creation of an ownerOnly item.
+    //   owner_decision_digest_enabled  — send the once-a-day pending-decisions digest.
+    //   owner_decision_digest_hour     — device-local hour [0,23] on/after which the digest fires. Default 8.
+    //   owner_decision_digest_tz       — IANA tz the hour is evaluated in. Default 'Asia/Taipei'.
+    owner_decision_push_enabled: true,
+    owner_decision_digest_enabled: true,
+    owner_decision_digest_hour: 8,
+    owner_decision_digest_tz: 'Asia/Taipei',
 };
 
 const ENTITY_IDLE_AFTER_SECONDS_MIN = 15;
@@ -159,9 +172,12 @@ function coerceValue(key, raw) {
     // (a bare `!!raw` would coerce the string 'false' to true — wrong for an API
     // that may serialize the flag as a query/JSON string).
     if (key === 'kanban_auto_escalate_enabled' || key === 'kanban_auto_escalate_skip_automation'
-        || key === 'action_request_ratify_enabled') {
+        || key === 'action_request_ratify_enabled'
+        || key === 'owner_decision_push_enabled' || key === 'owner_decision_digest_enabled') {
         // 計畫E: ratify master switch — same string-safe boolean coercion (a bare
         // `!!raw` would turn the string 'false' true, fail-OPEN for an auto-merge gate).
+        // Owner-decision reminder toggles ride the same string-safe path so 'false'
+        // from the settings API actually disables the push/digest (DELIVERY fix).
         return raw === true || raw === 'true';
     }
     if (typeof def === 'boolean') return !!raw;
@@ -207,6 +223,8 @@ function coerceValue(key, raw) {
         if (key === 'entity_runtime_state_stale_seconds') {
             return Math.max(ENTITY_RUNTIME_STATE_STALE_SECONDS_MIN, Math.min(ENTITY_RUNTIME_STATE_STALE_SECONDS_MAX, Math.round(n)));
         }
+        // Owner-decision digest hour clamps to a valid hour-of-day [0,23] (DELIVERY fix).
+        if (key === 'owner_decision_digest_hour') return Math.max(0, Math.min(23, Math.round(n)));
         return n;
     }
     if (key === 'kanban_nudge_priority_mode') {
@@ -214,6 +232,14 @@ function coerceValue(key, raw) {
     }
     if (key === 'action_request_timeout_policy') {
         return ACTION_REQUEST_TIMEOUT_POLICIES.has(raw) ? raw : def;
+    }
+    // Owner-decision digest tz: accept only a string Intl recognizes as an IANA
+    // zone, else fall back to the default (DELIVERY fix). Guards against a typo
+    // silently shifting everyone's digest hour or throwing in the worker.
+    if (key === 'owner_decision_digest_tz') {
+        if (typeof raw !== 'string' || !raw) return def;
+        try { new Intl.DateTimeFormat('en-US', { timeZone: raw }); return raw; }
+        catch (_) { return def; }
     }
     if (key === 'kanban_nudge_statuses') {
         if (!Array.isArray(raw)) return [...def];

--- a/backend/index.js
+++ b/backend/index.js
@@ -2007,6 +2007,7 @@ try {
     agentActionRequestsModule = require('./agent-action-requests')(devices, {
         pushToBot,
         unifiedPush,
+        notifyDevice, // owner-device push for ownerOnly action requests (DELIVERY fix): socket + Web Push + FCM fan-out
         serverLog,
         io, // real-time inbox push: emits 'action_request:changed' to device:<id> (card_8151054f)
     });

--- a/backend/tests/jest/owner-decision-push-digest.test.js
+++ b/backend/tests/jest/owner-decision-push-digest.test.js
@@ -1,0 +1,193 @@
+/**
+ * Tests for the OWNER-DECISION DELIVERY fix (Hank: "eclaw 應該也要提醒？" — owner
+ * decisions were created in the 需要你 inbox but never pushed, so they died
+ * silently in a collapsed inbox; and ownerOnly items wrongly opened a bot-to-bot
+ * consensus round that flooded every entity).
+ *
+ * Three behaviours, pg mocked:
+ *   1. isOwnerOnlyDecision / isNegotiable — an ownerOnly request is NOT negotiable
+ *      (no bot consensus round opens for it).
+ *   2. createActionRequest — an ownerOnly request pushes to the owner device
+ *      (notifyDevice fan-out: socket + Web Push + FCM); a non-owner request and a
+ *      push-disabled device do NOT.
+ *   3. runOwnerDigestPass — once-per-day morning digest of pending ownerOnly
+ *      items; the dedup PK makes it fire exactly once per (device, local-date).
+ */
+
+const mockPoolQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockPoolQuery,
+        connect: jest.fn().mockResolvedValue({ query: mockPoolQuery, release: jest.fn() }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const factory = require('../../agent-action-requests');
+const {
+    isOwnerOnlyDecision,
+    isNegotiable,
+} = factory;
+
+const deviceId = 'dev-1';
+const UUID = '11111111-2222-3333-4444-555555555555';
+
+function buildModule({ prefs = {}, notifyDevice } = {}) {
+    const emitToRoom = jest.fn();
+    const io = { to: jest.fn(() => ({ emit: emitToRoom })) };
+    const getDevicePrefs = jest.fn().mockResolvedValue(prefs);
+    const dev = {
+        [deviceId]: {
+            deviceSecret: 'sek',
+            entities: {
+                1: { isBound: true, botSecret: 'bot-1', bindingType: 'channel' },
+                2: { isBound: true, botSecret: 'bot-2', bindingType: 'channel' },
+            },
+        },
+    };
+    const mod = factory(dev, {
+        serverLog: () => {}, io, getDevicePrefs,
+        unifiedPush: jest.fn().mockResolvedValue({}), pushToBot: jest.fn().mockResolvedValue({}),
+        notifyDevice,
+    });
+    return { mod, io, getDevicePrefs };
+}
+
+afterEach(() => { mockPoolQuery.mockReset(); mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 }); });
+
+// ───────────────────────── 1. predicate / negotiability ─────────────────────────
+describe('isOwnerOnlyDecision', () => {
+    test('true only for an object/JSON with ownerOnly===true', () => {
+        expect(isOwnerOnlyDecision({ ownerOnly: true })).toBe(true);
+        expect(isOwnerOnlyDecision(JSON.stringify({ ownerOnly: true, x: 1 }))).toBe(true);
+        expect(isOwnerOnlyDecision({ ownerOnly: false })).toBe(false);
+        expect(isOwnerOnlyDecision({})).toBe(false);
+        expect(isOwnerOnlyDecision(null)).toBe(false);
+        expect(isOwnerOnlyDecision('not json')).toBe(false);
+        expect(isOwnerOnlyDecision('{"ownerOnly":1}')).toBe(false); // truthy-but-not-true
+    });
+});
+
+describe('isNegotiable: ownerOnly never opens a bot consensus round', () => {
+    const consensusPrefs = { action_request_timeout_policy: 'consensus', consensus_min_entities: 2 };
+    const baseRow = { status: 'pending', consensus_triggered_at: null, options: ['A', 'B'] };
+
+    test('a normal options request IS negotiable', () => {
+        expect(isNegotiable({ ...baseRow, decision_context: null }, consensusPrefs, 2)).toBe(true);
+    });
+    test('an ownerOnly request is NOT negotiable (even with options + consensus policy)', () => {
+        expect(isNegotiable({ ...baseRow, decision_context: { ownerOnly: true } }, consensusPrefs, 2)).toBe(false);
+    });
+    test('ownerOnly as a jsonb string is also not negotiable', () => {
+        expect(isNegotiable({ ...baseRow, decision_context: '{"ownerOnly":true}' }, consensusPrefs, 2)).toBe(false);
+    });
+});
+
+// ───────────────────────── 2. push-on-create ─────────────────────────
+describe('createActionRequest: owner-device push', () => {
+    function insertedRow(decision_context) {
+        return {
+            id: UUID, device_id: deviceId, from_entity_id: 1, anchor_message_id: null,
+            type: 'decision', prompt: '要不要合併 PR #123?', options: ['合', '不合'],
+            status: 'pending', answer: null, created_at: new Date('2026-06-30T00:00:00Z'),
+            resolved_at: null, consensus_triggered_at: null, decision_context,
+        };
+    }
+
+    test('ownerOnly request → notifyDevice called once with owner_decision metadata', async () => {
+        const notifyDevice = jest.fn().mockResolvedValue(undefined);
+        const { mod } = buildModule({ prefs: {}, notifyDevice });
+        mockPoolQuery.mockResolvedValueOnce({ rows: [insertedRow({ ownerOnly: true })] }); // the INSERT
+
+        await mod.createActionRequest({
+            deviceId, fromEntityId: 1, type: 'decision', prompt: '要不要合併 PR #123?',
+            options: ['合', '不合'], decisionContext: { ownerOnly: true, recommendedOptionIndex: 0 },
+        });
+        // allow the fire-and-forget push microtask to settle
+        await Promise.resolve();
+
+        expect(notifyDevice).toHaveBeenCalledTimes(1);
+        const [dId, notif] = notifyDevice.mock.calls[0];
+        expect(dId).toBe(deviceId);
+        expect(notif.category).toBe('action_request');
+        expect(notif.metadata.kind).toBe('owner_decision_created');
+        expect(notif.metadata.requestId).toBe(UUID);
+    });
+
+    test('non-owner request → notifyDevice NOT called', async () => {
+        const notifyDevice = jest.fn().mockResolvedValue(undefined);
+        const { mod } = buildModule({ prefs: {}, notifyDevice });
+        mockPoolQuery.mockResolvedValueOnce({ rows: [insertedRow(null)] });
+
+        await mod.createActionRequest({
+            deviceId, fromEntityId: 1, type: 'decision', prompt: 'bot question', options: ['A', 'B'],
+        });
+        await Promise.resolve();
+        expect(notifyDevice).not.toHaveBeenCalled();
+    });
+
+    test('opt-out (owner_decision_push_enabled=false) → notifyDevice NOT called', async () => {
+        const notifyDevice = jest.fn().mockResolvedValue(undefined);
+        const { mod } = buildModule({ prefs: { owner_decision_push_enabled: false }, notifyDevice });
+        mockPoolQuery.mockResolvedValueOnce({ rows: [insertedRow({ ownerOnly: true })] });
+
+        await mod.createActionRequest({
+            deviceId, fromEntityId: 1, type: 'decision', prompt: 'owner q',
+            options: ['合', '不合'], decisionContext: { ownerOnly: true },
+        });
+        await Promise.resolve();
+        expect(notifyDevice).not.toHaveBeenCalled();
+    });
+});
+
+// ───────────────────────── 3. morning digest ─────────────────────────
+describe('runOwnerDigestPass: once-per-day owner reminder', () => {
+    // digest_hour:0 makes the morning-window gate always open regardless of the
+    // real wall-clock the test runs at.
+    const digestPrefs = { owner_decision_digest_hour: 0 };
+
+    test('pending ownerOnly items → notifyDevice digest sent when dedup-insert wins', async () => {
+        const notifyDevice = jest.fn().mockResolvedValue(undefined);
+        const { mod } = buildModule({ prefs: digestPrefs, notifyDevice });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ id: UUID, prompt: '要不要合併 PR' }, { id: 'x', prompt: 'petdx ②' }] }) // SELECT
+            .mockResolvedValueOnce({ rows: [{ device_id: deviceId }], rowCount: 1 }); // INSERT won
+
+        await mod.runOwnerDigestPass(deviceId, digestPrefs, {});
+
+        expect(notifyDevice).toHaveBeenCalledTimes(1);
+        const [, notif] = notifyDevice.mock.calls[0];
+        expect(notif.metadata.kind).toBe('owner_decision_digest');
+        expect(notif.metadata.count).toBe(2);
+        expect(notif.title).toContain('2');
+    });
+
+    test('dedup-insert loses (already sent today) → NO second digest', async () => {
+        const notifyDevice = jest.fn().mockResolvedValue(undefined);
+        const { mod } = buildModule({ prefs: digestPrefs, notifyDevice });
+        mockPoolQuery
+            .mockResolvedValueOnce({ rows: [{ id: UUID, prompt: 'owner q' }] }) // SELECT
+            .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // INSERT conflict → lost
+
+        await mod.runOwnerDigestPass(deviceId, digestPrefs, {});
+        expect(notifyDevice).not.toHaveBeenCalled();
+    });
+
+    test('no pending ownerOnly items → no digest, no dedup insert', async () => {
+        const notifyDevice = jest.fn().mockResolvedValue(undefined);
+        const { mod } = buildModule({ prefs: digestPrefs, notifyDevice });
+        mockPoolQuery.mockResolvedValueOnce({ rows: [] }); // SELECT empty
+
+        await mod.runOwnerDigestPass(deviceId, digestPrefs, {});
+        expect(notifyDevice).not.toHaveBeenCalled();
+        expect(mockPoolQuery).toHaveBeenCalledTimes(1); // SELECT only, no INSERT
+    });
+
+    test('opt-out (owner_decision_digest_enabled=false) → no query, no digest', async () => {
+        const notifyDevice = jest.fn().mockResolvedValue(undefined);
+        const { mod } = buildModule({ prefs: {}, notifyDevice });
+        await mod.runOwnerDigestPass(deviceId, { owner_decision_digest_enabled: false }, {});
+        expect(notifyDevice).not.toHaveBeenCalled();
+        expect(mockPoolQuery).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Why
Hank this morning: 「之前要你改善 workflow 讓要我拍板的進需要你收件夾…我早上應該要看到」 + 「eclaw 應該也要提醒？」

The 需要你 inbox **captured** owner decisions but never **delivered** them:
- `createActionRequest` only emitted a portal socket — **no push**. An owner decision created overnight sat unseen in a collapsed inbox.
- An `ownerOnly` item with options wrongly **opened a bot-to-bot consensus round**, flooding every entity (#1/#4/#5/#6) with a vote prompt for a decision that is Hank's alone.

## What (all additive, gated, default-on opt-out)
1. **ownerOnly skips negotiation** — `isNegotiable()` returns false for `decision_context.ownerOnly === true`, so owner decisions wait for Hank and never trigger a bot vote (kills the flood). New `isOwnerOnlyDecision()` predicate.
2. **push-on-create** — `createActionRequest()` fires `notifyDevice` (socket + Web Push + **FCM fan-out via `device_fcm_tokens`**, the multi-device path from PR #3808) for ownerOnly items. Gated on `decision_context.ownerOnly` (no bot-to-bot phone spam) + opt-out pref `owner_decision_push_enabled`. Best-effort: a push error never fails request creation.
3. **morning digest** — `runOwnerDigestPass()` in the existing 5-min sweep (runs **before** the `keep` gate so default-policy devices still get it) sends **one** summary per day of pending ownerOnly items, deduped per `(device, local-date)` via `owner_decision_digest_sent` (PK ⇒ once/day, multi-instance safe). Prefs: `owner_decision_digest_enabled`, `owner_decision_digest_hour` (default 8), `owner_decision_digest_tz` (default `Asia/Taipei`).

`notifyDevice` wired into the action-requests module deps in `index.js`. New prefs added to `device-preferences` DEFAULTS + string-safe boolean / hour-clamp / IANA-tz coercion (so the opt-outs are actually settable via the settings API).

## FCM targeting (Hank asked to verify first)
Verified at code level: `notifyDevice → sendFcm → getDeviceFcmTokens` **fans out to every registered token and prunes dead tokens per-row** — the PR #3808 multi-device fix, no clobber. Not live-fired to avoid buzzing Hank's phone in CI.

## Tests
- New `tests/jest/owner-decision-push-digest.test.js` — 11 tests (predicate, negotiation-skip, push gating incl. opt-out, digest once-per-day + dedup-loss + empty + opt-out).
- No regression: existing action-request/owner-decision suites (218) + prefs/settings batch (300) green.

## Rollout
Default-on (opt-out) but **nothing pushes until this merges + deploys**. Reversible per-device via the new prefs. PR is for Hank's review — not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)