### PR TITLE
fix(ai-support): never surface upstream auth/API errors to users + proxy env-token precedence

### DIFF
--- a/backend/ai-support-sanitize.js
+++ b/backend/ai-support-sanitize.js
@@ -1,0 +1,74 @@
+// ── AI Support proxy-response sanitizer ─────────────────────────────
+// Extracted from ai-support.js so it is unit-testable (card_747b9500).
+//
+// Two failure classes are caught here before a proxy answer reaches a user:
+//  1. Raw CLI session JSON leaking through as the "answer" (pre-existing).
+//  2. Plain-text upstream auth/API errors leaking through verbatim, e.g.
+//     "Failed to authenticate. API Error: 401 Invalid authentication credentials"
+//     (2026-07-02 incident: claude-cli-proxy OAuth credential expired and the
+//     CLI's error text was served to portal users as a normal chat reply).
+
+const UNAVAILABLE_MESSAGE = 'Sorry, the AI assistant is temporarily unavailable. Please try again shortly.';
+
+// Upstream error shapes that must never be shown to a user verbatim.
+// Kept deliberately narrow: matches CLI/provider auth+API error phrasing,
+// not ordinary sentences that merely mention "authentication" in prose.
+const UPSTREAM_ERROR_PATTERNS = [
+    /failed to authenticate\b/i,                       // Claude CLI auth failure prefix
+    /\bAPI Error:\s*\d{3}\b/i,                         // "API Error: 401 ..." / any HTTP code
+    /invalid authentication credentials/i,             // credentials-file 401 message
+    /invalid bearer token/i,                           // env-token 401 message
+    /invalid x-api-key/i,                              // API-key 401 message
+    /oauth token (?:has )?(?:expired|been revoked)/i,  // OAuth session expiry
+    /\bauthentication_error\b/i,                       // Anthropic error type literal
+    /please run \/login\b/i,                           // CLI re-login instruction
+];
+
+function isUpstreamErrorText(text) {
+    if (!text || typeof text !== 'string') return false;
+    return UPSTREAM_ERROR_PATTERNS.some((re) => re.test(text));
+}
+
+function sanitizeProxyResponse(responseText, opts = {}) {
+    if (!responseText || typeof responseText !== 'string') {
+        return responseText || 'Sorry, I could not generate a response. Please try again.';
+    }
+
+    // Proxy explicitly flagged the run as an error — never surface raw text.
+    if (opts.isError === true) {
+        console.warn('[AI Chat] Proxy flagged is_error, sanitizing response');
+        return UNAVAILABLE_MESSAGE;
+    }
+
+    const trimmed = responseText.trim();
+    // Detect raw JSON session results
+    if (trimmed.startsWith('{') && trimmed.includes('"type"')) {
+        try {
+            const parsed = JSON.parse(trimmed);
+            if (parsed.type === 'result' || parsed.subtype || parsed.session_id) {
+                console.warn(`[AI Chat] Raw session JSON detected (subtype: ${parsed.subtype}), sanitizing`);
+                if (parsed.result_text) {
+                    return parsed.result_text;
+                } else if (parsed.subtype === 'error_max_turns') {
+                    return 'Sorry, this question was too complex for me to fully analyze. Could you try asking a more specific question?';
+                } else if (parsed.subtype === 'error_tool_execution') {
+                    return 'I encountered an error while looking into your issue. Please try again.';
+                } else {
+                    return 'Sorry, I was unable to process your request. Please try rephrasing your question.';
+                }
+            }
+        } catch (_) {
+            // Not valid JSON, leave as-is
+        }
+    }
+
+    // Plain-text upstream auth/API error leaking through as the "answer"
+    if (isUpstreamErrorText(trimmed)) {
+        console.error(`[AI Chat] Upstream error text sanitized (never shown to user): ${trimmed.slice(0, 120)}`);
+        return UNAVAILABLE_MESSAGE;
+    }
+
+    return responseText;
+}
+
+module.exports = { sanitizeProxyResponse, isUpstreamErrorText, UNAVAILABLE_MESSAGE };

--- a/backend/ai-support.js
+++ b/backend/ai-support.js
@@ -5,6 +5,7 @@
 // ============================================
 const express = require('express');
 const safeEqual = require('./safe-equal');
+const { sanitizeProxyResponse } = require('./ai-support-sanitize');
 
 // Lazy-load Anthropic client (only when ANTHROPIC_API_KEY is set)
 let _anthropicClient = null;
@@ -852,38 +853,10 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
 
     const toolHandlers = buildToolHandlers();
 
-    // ── Sanitize raw Claude CLI session JSON ─────
-    // The proxy sometimes returns raw Claude CLI session output (e.g. {"type":"result","subtype":"error_max_turns",...})
-    // instead of clean text. Detect and replace with user-friendly message.
-    function sanitizeProxyResponse(responseText) {
-        if (!responseText || typeof responseText !== 'string') {
-            return responseText || 'Sorry, I could not generate a response. Please try again.';
-        }
-
-        const trimmed = responseText.trim();
-        // Detect raw JSON session results
-        if (trimmed.startsWith('{') && trimmed.includes('"type"')) {
-            try {
-                const parsed = JSON.parse(trimmed);
-                if (parsed.type === 'result' || parsed.subtype || parsed.session_id) {
-                    console.warn(`[AI Chat] Raw session JSON detected (subtype: ${parsed.subtype}), sanitizing`);
-                    if (parsed.result_text) {
-                        return parsed.result_text;
-                    } else if (parsed.subtype === 'error_max_turns') {
-                        return 'Sorry, this question was too complex for me to fully analyze. Could you try asking a more specific question?';
-                    } else if (parsed.subtype === 'error_tool_execution') {
-                        return 'I encountered an error while looking into your issue. Please try again.';
-                    } else {
-                        return 'Sorry, I was unable to process your request. Please try rephrasing your question.';
-                    }
-                }
-            } catch (_) {
-                // Not valid JSON, leave as-is
-            }
-        }
-
-        return responseText;
-    }
+    // ── Sanitize proxy responses ─────
+    // Raw CLI session JSON *and* plain-text upstream auth/API errors must never
+    // reach a user verbatim. Logic lives in ./ai-support-sanitize (unit-tested);
+    // see card_747b9500 (2026-07-02 "Failed to authenticate. API Error: 401" leak).
 
     // ── Log Query to DB ─────────────────────────
     function logSupportQuery(deviceId, entityId, result) {

--- a/backend/tests/jest/ai-support-sanitize.test.js
+++ b/backend/tests/jest/ai-support-sanitize.test.js
@@ -1,0 +1,82 @@
+/**
+ * AI Support — proxy response sanitizer (card_747b9500)
+ *
+ * Regression: 2026-07-02 the claude-cli-proxy's OAuth credential expired and
+ * the CLI's raw error text — "Failed to authenticate. API Error: 401 Invalid
+ * authentication credentials" — was served to portal users as a normal AI
+ * customer-support reply. These tests FAIL on the pre-fix sanitizer (which
+ * only intercepted raw session JSON) and PASS with ai-support-sanitize.js.
+ */
+
+const {
+    sanitizeProxyResponse,
+    isUpstreamErrorText,
+    UNAVAILABLE_MESSAGE,
+} = require('../../ai-support-sanitize');
+
+describe('sanitizeProxyResponse — upstream auth/API error passthrough (the 2026-07-02 incident)', () => {
+    const incidentLiteral = 'Failed to authenticate. API Error: 401 Invalid authentication credentials';
+
+    test('the exact incident string is replaced with the friendly unavailable message', () => {
+        expect(sanitizeProxyResponse(incidentLiteral)).toBe(UNAVAILABLE_MESSAGE);
+    });
+
+    test.each([
+        ['env-token variant', 'Failed to authenticate. API Error: 401 Invalid bearer token'],
+        ['api-key variant', 'API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}'],
+        ['oauth expiry variant', 'OAuth token has expired. Please run /login to re-authenticate.'],
+        ['bare api error with other status', 'API Error: 529 Overloaded'],
+    ])('%s never reaches the user verbatim', (_label, raw) => {
+        expect(sanitizeProxyResponse(raw)).toBe(UNAVAILABLE_MESSAGE);
+    });
+
+    test('is_error flag from the proxy sanitizes regardless of text', () => {
+        expect(sanitizeProxyResponse('anything at all', { isError: true })).toBe(UNAVAILABLE_MESSAGE);
+    });
+
+    test('ordinary prose mentioning authentication is NOT sanitized', () => {
+        const benign = 'To fix webhook authentication, re-read your gateway token and retry the register call.';
+        expect(sanitizeProxyResponse(benign)).toBe(benign);
+    });
+
+    test('a normal helpful answer passes through untouched', () => {
+        const answer = 'Your device is bound correctly. Try restarting the app and the wallpaper will reload.';
+        expect(sanitizeProxyResponse(answer)).toBe(answer);
+    });
+});
+
+describe('sanitizeProxyResponse — pre-existing raw session JSON behavior is preserved', () => {
+    test('result_text is extracted from raw session JSON', () => {
+        const raw = JSON.stringify({ type: 'result', subtype: 'success', result_text: 'Here is the answer.' });
+        expect(sanitizeProxyResponse(raw)).toBe('Here is the answer.');
+    });
+
+    test('error_max_turns maps to the too-complex message', () => {
+        const raw = JSON.stringify({ type: 'result', subtype: 'error_max_turns' });
+        expect(sanitizeProxyResponse(raw)).toMatch(/too complex/i);
+    });
+
+    test('error_tool_execution maps to the retry message', () => {
+        const raw = JSON.stringify({ type: 'result', subtype: 'error_tool_execution' });
+        expect(sanitizeProxyResponse(raw)).toMatch(/try again/i);
+    });
+
+    test('empty/null input yields the could-not-generate fallback', () => {
+        expect(sanitizeProxyResponse('')).toMatch(/could not generate/i);
+        expect(sanitizeProxyResponse(null)).toMatch(/could not generate/i);
+    });
+});
+
+describe('isUpstreamErrorText', () => {
+    test('detects all incident-class strings', () => {
+        expect(isUpstreamErrorText('Failed to authenticate. API Error: 401 Invalid authentication credentials')).toBe(true);
+        expect(isUpstreamErrorText('failed to authenticate')).toBe(true);
+        expect(isUpstreamErrorText('API Error: 401 Invalid bearer token')).toBe(true);
+    });
+
+    test('does not flag normal answers', () => {
+        expect(isUpstreamErrorText('Everything looks healthy — 7/7 endpoints returned 200.')).toBe(false);
+        expect(isUpstreamErrorText('')).toBe(false);
+        expect(isUpstreamErrorText(null)).toBe(false);
+    });
+});

--- a/claude-cli-proxy/proxy.py
+++ b/claude-cli-proxy/proxy.py
@@ -883,11 +883,33 @@ def restore_claude_config():
             pass
 
 
+# ── Env token is the single source of truth for CLI auth ────
+def enforce_env_token_auth():
+    """When CLAUDE_CODE_OAUTH_TOKEN is set on the service, retire any stored
+    credentials file left on the volume by a past `claude login`. The CLI
+    prefers the stored (possibly expired) session over the env token, which
+    made env-token rotation a silent no-op — every run kept failing with
+    "401 Invalid authentication credentials" (card_747b9500, 2026-07-02).
+    The stale file is renamed (not deleted) so a rollback is possible."""
+    if not os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
+        return
+    home = Path(os.environ.get("HOME", "/root"))
+    creds = home / ".claude" / ".credentials.json"
+    if creds.exists():
+        try:
+            retired = creds.with_name(f".credentials.json.retired.{int(time.time())}")
+            creds.rename(retired)
+            log.info(f"[Startup] CLAUDE_CODE_OAUTH_TOKEN set — retired stored credentials file to {retired.name}")
+        except Exception as e:
+            log.warning(f"[Startup] Could not retire stored credentials file: {e}")
+
+
 # ── App Lifespan ─────────────────────────────
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
     restore_claude_config()
+    enforce_env_token_auth()
 
     # Write DB config for child processes
     if DATABASE_URL:


### PR DESCRIPTION
## Incident (card_747b9500, 2026-07-02)
AI customer support replied to users with raw upstream error text:
`Failed to authenticate. API Error: 401 Invalid authentication credentials`

Root cause chain:
1. claude-cli-proxy's stored OAuth credential (Railway volume) expired → every CLI run 401s.
2. The CLI's error text flows back as a normal `response` (no is_error on the complete event).
3. `sanitizeProxyResponse` only intercepted raw session JSON — plain-text errors passed straight to users.
4. Bonus finding: setting `CLAUDE_CODE_OAUTH_TOKEN` on the service was a silent no-op — the CLI prefers the stored (stale) credentials file over the env token.

## Fix
- **backend**: extract `sanitizeProxyResponse` → `ai-support-sanitize.js` (unit-testable) + upstream-error text guard → users see the friendly unavailable message instead. Both call sites (`/chat` sync + submit/poll worker) share it.
- **proxy**: startup `enforce_env_token_auth()` — when `CLAUDE_CODE_OAUTH_TOKEN` is set, the stored credentials file is retired (renamed, reversible) so env rotation actually works.
- **tests**: `ai-support-sanitize.test.js` — exact incident literal + 4 variants + is_error flag + benign-prose non-flagging + preserved JSON-session behavior (30/30 green incl. existing ai-support suites).

## Note
Token renewal itself is owner-action (all vault CLAUDE_CODE_OAUTH_TOKEN* are stale — 需要你 request b62852c7 pending). This PR makes the failure invisible to users and the rotation path reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN