### PR TITLE
fix(kanban): route bot completion reports to dispatcher, not fail-safe to human

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -44,6 +44,7 @@ const safeEqual = require('./safe-equal');
 const extractCreds = require('./extract-creds');
 const { newCardId } = require('./entity-id');
 const { tKanban, statusLabel } = require('./i18n/kanban-notifications');
+const { buildDispatcherRoutingDirective } = require('./lib/kanban-dispatcher-routing');
 const devicePrefs = require('./device-preferences');
 const { emit: emitKanbanEvent } = require('./lib/kanban-events');
 const { resolveEntityHostDevice } = require('./lib/per-device-cron');
@@ -629,7 +630,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         // assuming the card's own device hosts it. Default false keeps every other
         // caller (once-triggers, manual notifies) on the legacy local-only path.
         // See backend/lib/per-device-cron.js + card_1ce50de359411f0d0947399f.
-        const { description, cardId, perDeviceCron = false } = options;
+        const { description, cardId, perDeviceCron = false, dispatcherEntityId } = options;
         if (!pushToChannelCallback && !pushToEntity && !pushToBot) {
             console.warn('[Kanban] No push callback available — notifications will not be delivered');
             return;
@@ -667,6 +668,29 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         const commentBlock = latestComment
             ? `\n\n[LATEST COMMENT]\n${latestComment}\n[/LATEST COMMENT]`
             : '';
+
+        // ── Dispatcher routing hint (card_e9379868) ──
+        // A kanban notification is a SYSTEM event with no sender entity, so when an
+        // assigned bot replies "task done" in chat, the central router finds no
+        // speakTo/@mention/senderHint and fail-safes the message to a human — the
+        // DISPATCHER (the commander who assigned the card) never receives it and
+        // cannot verify/close the card. Fix: tell the bot exactly who to route its
+        // completion report to. The dispatcher entity lives on the card's own device
+        // (deviceId), so resolve its publicCode here (once) and hand the recipient
+        // both the same-device @#N token and the cross-device @publicCode token
+        // (recipient may be hosted on another device under per-device cron).
+        let dispatcherMeta = null;
+        const dispId = Number(dispatcherEntityId);
+        if (dispId && dispId > 0) {
+            const dispEntity = devices?.[deviceId]?.entities?.[dispId];
+            if (dispEntity?.publicCode) {
+                dispatcherMeta = { entityId: dispId, publicCode: dispEntity.publicCode };
+            } else {
+                // Still emit the @#N token even if publicCode is unavailable — a
+                // same-device reply routes on @#N alone.
+                dispatcherMeta = { entityId: dispId, publicCode: null };
+            }
+        }
 
         for (const eid of entityIds) {
             try {
@@ -755,9 +779,17 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                       `A card left unmoved keeps re-nudging and auto-escalating.`
                     : '';
 
-                // Hints + lifecycle directive travel together so the obligation
-                // sits right next to the Move card command in every push path.
-                const missionBlock = kanbanHints + lifecycleDirective;
+                // ── Dispatcher routing directive (card_e9379868) ──
+                // Tells the assigned bot who to address so its completion report
+                // routes back to the dispatcher instead of fail-safing to a human.
+                const routingDirective = buildDispatcherRoutingDirective({
+                    dispatcherMeta, recipientEntityId: eid, cardId,
+                });
+
+                // Hints + lifecycle + routing directives travel together so the
+                // obligation and the reply-routing target sit right next to the
+                // Move card command in every push path.
+                const missionBlock = kanbanHints + lifecycleDirective + routingDirective;
 
                 // ── 3. Build full message with description ──
                 const descBlock = description
@@ -1336,7 +1368,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     title: title.trim(),
                     status: statusLabel(lang, cardStatus)
                 });
-                notifyEntities(deviceId, bots, msg, { description, cardId: card.id });
+                notifyEntities(deviceId, bots, msg, { description, cardId: card.id, dispatcherEntityId: createdBy });
             }
 
             if (awardEntityXP) {
@@ -2294,6 +2326,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                         notifyEntities(deviceId, newlyAdded, msg, {
                             description: updated.description,
                             cardId: updated.id,
+                            dispatcherEntityId: updated.created_by,
                         });
                     }
                 } catch (notifyErr) {
@@ -2546,7 +2579,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     from: statusLabel(lang, oldStatus),
                     to: statusLabel(lang, newStatus)
                 });
-                notifyEntities(deviceId, bots, msg, { description: card.description, cardId });
+                notifyEntities(deviceId, bots, msg, { description: card.description, cardId, dispatcherEntityId: card.created_by });
             }
 
             // Notify reviewer on /move → review (card_dfb65748c14680560c7bb873).

--- a/backend/lib/kanban-dispatcher-routing.js
+++ b/backend/lib/kanban-dispatcher-routing.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Kanban dispatcher routing hint (card_e9379868).
+ *
+ * A kanban notification is a SYSTEM event with no sender entity. When an
+ * assigned bot replies "task done" in chat, the central router finds no
+ * speakTo / @mention / senderHint and fail-safes the reply to a human — the
+ * DISPATCHER (the commander who assigned the card) never receives it and
+ * cannot verify/close the card (Hank 2026-07-02: a #6 completion report
+ * routed to the human instead of #2). This builds an explicit routing
+ * directive that tells the bot exactly who to address so its report reaches
+ * the dispatcher.
+ *
+ * Pure + side-effect-free so it is unit-testable without a live pg pool
+ * (the kanban module otherwise requires one).
+ *
+ * @param {object} p
+ * @param {{entityId:number, publicCode:(string|null)}|null} p.dispatcherMeta
+ *        The card dispatcher, resolved on the card's own device. null when
+ *        unknown (system/cron-spawned cards with created_by=0).
+ * @param {number} p.recipientEntityId  The entity being notified.
+ * @param {string} [p.cardId]           Card id, for the comment instruction.
+ * @returns {string} The directive block (leading with \n\n) or '' when no
+ *        directive should be emitted.
+ */
+function buildDispatcherRoutingDirective({ dispatcherMeta, recipientEntityId, cardId } = {}) {
+    if (!dispatcherMeta) return '';
+    const dispId = Number(dispatcherMeta.entityId);
+    if (!Number.isFinite(dispId) || dispId <= 0) return '';
+    // A card creator assigned to their own card needs no self-routing.
+    if (dispId === Number(recipientEntityId)) return '';
+
+    const tokens = [`@#${dispId}`];
+    if (dispatcherMeta.publicCode) tokens.push(`@${dispatcherMeta.publicCode}`);
+
+    return (
+        `\n\n[ROUTING — WHERE YOUR REPLY GOES]\n` +
+        `This task was dispatched by #${dispId}. A plain chat reply to a kanban ` +
+        `notification has NO sender to route back to and fail-safes to a human — the ` +
+        `dispatcher never sees it. To report progress/completion so #${dispId} actually ` +
+        `receives it, do EITHER:\n` +
+        `• PREFERRED: POST a comment on card ${cardId || 'this card'} + move its status ` +
+        `(the dispatcher is notified automatically), or\n` +
+        `• if you must reply in chat, START the message with ${tokens.join(' or ')} ` +
+        `so it routes to the dispatcher.`
+    );
+}
+
+module.exports = { buildDispatcherRoutingDirective };

--- a/backend/tests/jest/kanban-dispatcher-routing.test.js
+++ b/backend/tests/jest/kanban-dispatcher-routing.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+/**
+ * card_e9379868 — kanban dispatcher routing hint.
+ *
+ * Regression: a kanban notification is a SYSTEM event with no sender entity,
+ * so an assigned bot's chat reply ("task done") fail-safes to a human and the
+ * DISPATCHER never receives it (2026-07-02: #6's completion report for
+ * card_2b0cffd6 routed to Hank, not #2). These tests exercise the directive
+ * builder that fixes it: they FAIL on pre-fix code (no directive at all) and
+ * PASS once the dispatcher hint is emitted.
+ */
+
+const {
+    buildDispatcherRoutingDirective,
+} = require('../../lib/kanban-dispatcher-routing');
+
+describe('buildDispatcherRoutingDirective', () => {
+    test('emits both same-device @#N and cross-device @publicCode tokens', () => {
+        const out = buildDispatcherRoutingDirective({
+            dispatcherMeta: { entityId: 2, publicCode: 'abc123' },
+            recipientEntityId: 6,
+            cardId: 'card_x',
+        });
+        expect(out).toMatch(/\[ROUTING — WHERE YOUR REPLY GOES\]/);
+        expect(out).toMatch(/dispatched by #2/);
+        expect(out).toContain('@#2');
+        expect(out).toContain('@abc123');
+        expect(out).toContain('card_x');
+    });
+
+    test('the exact incident shape (#6 notified, dispatcher #2) gets a route back to #2', () => {
+        const out = buildDispatcherRoutingDirective({
+            dispatcherMeta: { entityId: 2, publicCode: 'lobbb2' },
+            recipientEntityId: 6,
+            cardId: 'card_2b0cffd6',
+        });
+        expect(out).toContain('@#2');
+        expect(out).toContain('card_2b0cffd6');
+        // Preferred path is card comment + move (reaches dispatcher automatically).
+        expect(out).toMatch(/POST a comment/i);
+    });
+
+    test('falls back to @#N only when publicCode is unavailable', () => {
+        const out = buildDispatcherRoutingDirective({
+            dispatcherMeta: { entityId: 2, publicCode: null },
+            recipientEntityId: 6,
+            cardId: 'card_x',
+        });
+        expect(out).toContain('@#2');
+        expect(out).not.toMatch(/@[a-z0-9]{6}\b/); // no publicCode token
+    });
+
+    test('emits NOTHING when the recipient IS the dispatcher (self-assigned card)', () => {
+        const out = buildDispatcherRoutingDirective({
+            dispatcherMeta: { entityId: 2, publicCode: 'abc123' },
+            recipientEntityId: 2,
+            cardId: 'card_x',
+        });
+        expect(out).toBe('');
+    });
+
+    test('emits NOTHING for system/cron cards (no dispatcher / created_by=0)', () => {
+        expect(buildDispatcherRoutingDirective({ dispatcherMeta: null, recipientEntityId: 6 })).toBe('');
+        expect(buildDispatcherRoutingDirective({ dispatcherMeta: { entityId: 0, publicCode: null }, recipientEntityId: 6 })).toBe('');
+        expect(buildDispatcherRoutingDirective({})).toBe('');
+    });
+});
+
+describe('kanban.js wiring (dispatcherEntityId threaded through all dispatch sites)', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(path.join(__dirname, '..', '..', 'kanban.js'), 'utf8');
+
+    test('notifyEntities destructures dispatcherEntityId and resolves dispatcherMeta', () => {
+        expect(src).toMatch(/dispatcherEntityId\s*\}\s*=\s*options/);
+        expect(src).toMatch(/dispatcherMeta/);
+        expect(src).toMatch(/buildDispatcherRoutingDirective\(/);
+    });
+
+    test('all three dispatch callers pass dispatcherEntityId', () => {
+        // create dispatch (createdBy), move/reassign (card.created_by), edit-add (updated.created_by)
+        expect(src).toMatch(/dispatcherEntityId:\s*createdBy/);
+        expect(src).toMatch(/dispatcherEntityId:\s*card\.created_by/);
+        expect(src).toMatch(/dispatcherEntityId:\s*updated\.created_by/);
+    });
+});

--- a/backend/tests/jest/kanban-nudge-lifecycle-directive.test.js
+++ b/backend/tests/jest/kanban-nudge-lifecycle-directive.test.js
@@ -48,7 +48,9 @@ describe('kanban notify → task-lifecycle directive (card_c0819f4e)', () => {
     });
 
     test('hints + directive are combined into one missionBlock', () => {
-        expect(kanbanSrc).toMatch(/const missionBlock = kanbanHints \+ lifecycleDirective;/);
+        // card_e9379868 appended the dispatcher routingDirective to the same block
+        // so the reply-routing target ships alongside the lifecycle obligation.
+        expect(kanbanSrc).toMatch(/const missionBlock = kanbanHints \+ lifecycleDirective \+ routingDirective;/);
     });
 
     test('ALL three push paths ship missionBlock (channel / webhook / legacy), not bare kanbanHints', () => {


### PR DESCRIPTION
## Problem (card_e9379868, P0)
A kanban notification is a **system event with no sender entity**. When an assigned bot replies "task done" in chat, the central router finds no speakTo/@mention/senderHint → fail-safes to a human. The **dispatcher** (commander who assigned the card) never receives it and can't verify/close.

Live incident 2026-07-02: #6's completion report for card_2b0cffd6 routed to Hank, not to #2 (dispatcher). #2's chat scope never saw it.

## Fix
- `notifyEntities` accepts `options.dispatcherEntityId`, resolves that entity's publicCode on the card's own device, and injects a **[ROUTING — WHERE YOUR REPLY GOES]** directive: (preferred) comment + move the card (dispatcher auto-notified via the card_cc20541e path), or prefix a chat reply with `@#N` / `@publicCode`.
- All 3 dispatch sites pass `dispatcherEntityId = card creator`: create, move/reassign, edit-add.
- Extracted to `lib/kanban-dispatcher-routing.js` (pure, unit-testable — the kanban module needs a live pg pool).
- Suppressed when recipient IS the dispatcher (self-assigned) and for system/cron cards (created_by=0). Existing un-@'d fail-safe-to-human for non-task chatter is unchanged.

## Tests
- `backend/tests/jest/kanban-dispatcher-routing.test.js` — 7/7: incident shape (#6→#2), both tokens, publicCode fallback, self-assign & system-card suppression, + wiring grep for all 3 callers.
- Existing `kanban-done-device-push-wiring` + `per-device-cron-wiring` 17/17 unregressed. ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN