### PR TITLE
fix(card-holder): don't gate card rendering behind avatar preload (stuck loading)

### DIFF
--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -848,21 +848,37 @@
         // ── Data loading ──
         async function loadAllData() {
             await Promise.all([loadMyCards(), loadRecent(), loadCollected(), loadFriendRequests()]);
-            // Preload petdx companion descriptors for my own cards so the
-            // avatar canvases mount on first paint. Other-bot cards don't
-            // have a local entityId, so they keep the legacy emoji/img path.
+
+            // Render the cards NOW. Card rendering must NEVER be gated behind
+            // avatar preload (card_415faf19): a single entity whose
+            // /api/companion/current hangs would leave the un-guarded
+            // `await preload()` pending forever → rebuildContent() never runs →
+            // the page sticks on "Loading cards…". This was reproducible on the
+            // admin account (many entities) while ordinary accounts loaded fine.
+            rebuildContent();
+
+            // Progressive avatar enhancement — best-effort, must never block or
+            // throw up the page. Bounded by a timeout so a hung companion fetch
+            // can't stall the mount; autoMount runs after rebuildContent has
+            // created the canvas placeholders.
             if (window.AvatarPetdx && currentUser && currentUser.deviceSecret) {
                 const myEntityIds = myCards.map(c => c.entityId).filter(Boolean);
                 if (myEntityIds.length) {
-                    await window.AvatarPetdx.preload({
-                        deviceId: currentUser.deviceId,
-                        deviceSecret: currentUser.deviceSecret,
-                        entityIds: myEntityIds
-                    });
-                    window.AvatarPetdx.autoMount();
+                    try {
+                        await Promise.race([
+                            window.AvatarPetdx.preload({
+                                deviceId: currentUser.deviceId,
+                                deviceSecret: currentUser.deviceSecret,
+                                entityIds: myEntityIds
+                            }),
+                            new Promise(resolve => setTimeout(resolve, 8000)),
+                        ]);
+                        window.AvatarPetdx.autoMount();
+                    } catch (err) {
+                        console.warn('[card-holder] avatar preload/mount failed (non-fatal):', err && err.message);
+                    }
                 }
             }
-            rebuildContent();
         }
 
         async function loadFriendRequests() {


### PR DESCRIPTION
## Symptom
card-holder.html sticks on **"Loading cards…"** on the admin account.

## Root cause
`loadAllData()` runs `rebuildContent()` (which clears the loading state and renders cards) **only after** `await AvatarPetdx.preload(...)`. `preload` is `Promise.all(entityIds.map(fetchOne))`; each `fetchOne` is reject-safe but a **hung** `/api/companion/current` (never settles) leaves the un-guarded `await` pending forever → `rebuildContent()` never runs → stuck loading.

Verified via Playwright that ordinary accounts load fine ("6 cards shown", companion calls ~364ms), so it presented as admin-specific (the admin has many entities → higher odds one companion fetch stalls).

## Fix
- Call `rebuildContent()` **immediately** after the contact loads — card rendering never needs avatars.
- Move avatar preload/mount to best-effort **progressive enhancement**: bounded by an 8s `Promise.race` timeout + `try/catch`, so a hung/failed companion fetch can never freeze the page. Avatars mount when they arrive.

## Test
Static portal HTML timing fix (no jest). Post-deploy: card list renders regardless of avatar-fetch state; verified the normal path still shows cards + avatars via Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN