### PR TITLE
fix(chat/inbox): 需要你 sequential replies — stage one item at a time, don't discard (card_6a5cc9bb)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -7689,6 +7689,15 @@
         function focusActionRequestReply(requestId, optionIndex = null) {
             const request = getActionRequestById(requestId);
             if (!request) return;
+            // card_6a5cc9bb: the 需要你 inbox is a per-item decision surface, not a
+            // multi-quote target — at most ONE action-request may be staged for reply
+            // at a time. Clicking "Reply"/an option on an inbox item REPLACES any
+            // previously-staged inbox item (regular chat quotes still accumulate,
+            // card_277c80f5). Without this, staging A then B then Send hit the
+            // uniq.length>1 guard in resolveActionRequestReplyContexts and resolved
+            // NEITHER item — the owner "無法連續處理多個問題" (PR #3787 turned the old
+            // "one answer resolves both" into "one answer resolves neither").
+            clearStagedActionRequestReplies();
             openActionRequestAnchor(request);
             const entityId = Number(request.fromEntityId);
             const entityName = Number.isFinite(entityId) && typeof getEntityDisplayName === 'function'
@@ -7699,10 +7708,18 @@
             if (optionIndex !== null && Array.isArray(request.options) && request.options[optionIndex] !== undefined) {
                 const input = document.getElementById('messageInput');
                 if (input) {
-                    input.value = String(request.options[optionIndex]);
+                    // card_6a5cc9bb Failure Mode 2 ("回覆被覆蓋掉"): don't silently clobber
+                    // owner-typed free text. Auto-fill the option only when the composer
+                    // is empty or still holds a prior auto-filled option (so switching
+                    // between options works, but a typed answer is never destroyed).
+                    const optText = String(request.options[optionIndex]);
+                    if (!input.value.trim() || input.value === lastAutoFilledOptionValue) {
+                        input.value = optText;
+                        lastAutoFilledOptionValue = optText;
+                        input.style.height = 'auto';
+                        input.style.height = Math.min(input.scrollHeight, 120) + 'px';
+                    }
                     input.focus();
-                    input.style.height = 'auto';
-                    input.style.height = Math.min(input.scrollHeight, 120) + 'px';
                 }
             }
         }
@@ -8277,11 +8294,29 @@
         // appends instead of overwriting, with no cap. sendMessage emits one
         // "↩ …" line per entry so the recipient entity receives ALL of them.
         let replyContexts = [];
+        // card_6a5cc9bb Failure Mode 2: the last option string we auto-filled into
+        // the composer. Lets focusActionRequestReply tell "text the owner typed"
+        // (never clobber) from "text we auto-filled from an option" (safe to replace
+        // when switching options). Reset on clear/send.
+        let lastAutoFilledOptionValue = '';
         // Smart receiver auto-select — entityIds we auto-toggled-on for the
         // current reply contexts. Cleared on reply clear, on send, and when
         // the user manually changes a checkbox (the hint badge belongs to
         // the auto-toggle, so a manual toggle revokes it).
         const autoToggledReceiverEntities = new Set();
+
+        // card_6a5cc9bb: drop every staged ACTION-REQUEST reply context (those bound
+        // to a requestId), leaving regular chat quotes untouched. Enforces the
+        // one-inbox-item-at-a-time invariant so a Send resolves exactly the item the
+        // owner is currently answering — never a stale sibling, never zero items.
+        function clearStagedActionRequestReplies() {
+            const before = replyContexts.length;
+            replyContexts = replyContexts.filter(rc => !rc.requestId);
+            if (replyContexts.length !== before) {
+                renderReplyPreviews();
+                recomputeAutoReceivers();
+            }
+        }
 
         function handleReplyBtn(btn) {
             const msgId = btn.dataset.msgId;
@@ -8380,6 +8415,7 @@
 
         function clearReplyContext() {
             replyContexts = [];
+            lastAutoFilledOptionValue = '';
             renderReplyPreviews();
             clearAllReceiverHints();
             autoToggledReceiverEntities.clear();

--- a/backend/tests/jest/chat-action-request-sequential-resolve.test.js
+++ b/backend/tests/jest/chat-action-request-sequential-resolve.test.js
@@ -1,0 +1,176 @@
+/**
+ * 需要你 inbox SEQUENTIAL replies — the owner must be able to answer several inbox
+ * items one after another (card_6a5cc9bb).
+ *
+ * Bug (Hank, twice): "我要連續回覆處理多個問題但是會被覆蓋掉,導致我無法連續處理".
+ * The inbox has NO per-item reply state — every "Reply"/option click feeds one
+ * shared, ACCUMULATING `replyContexts` array. Staging item A then item B left
+ * [A, B]; one Send then hit the uniq.length>1 guard in
+ * resolveActionRequestReplyContexts and resolved NEITHER (PR #3787 turned the old
+ * "one answer resolves both" into "one answer resolves neither"). Fix:
+ * focusActionRequestReply() now REPLACES any previously-staged action-request
+ * context (clearStagedActionRequestReplies) so exactly one inbox item is staged at
+ * a time, while regular chat quotes (card_277c80f5) still accumulate.
+ *
+ * Also pins Failure Mode 2 ("回覆被覆蓋掉"): an option auto-fill must not clobber
+ * owner-typed free text.
+ *
+ * EXECUTES the real functions extracted from chat.html (no module export — same
+ * brace-count + `new Function` harness as chat-action-request-independent-resolve).
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const chatHtml = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html'), 'utf8'
+);
+
+function extractFunction(name) {
+    const re = new RegExp(`(?:async\\s+)?function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`, 'g');
+    const m = re.exec(chatHtml);
+    if (!m) throw new Error(`function ${name} not found in chat.html`);
+    let depth = 1;
+    let i = m.index + m[0].length;
+    while (i < chatHtml.length && depth > 0) {
+        const ch = chatHtml[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+        i++;
+    }
+    return chatHtml.slice(m.index, i);
+}
+
+const REQ_A = 'aaaaaaaa-0000-4000-8000-000000000001';
+const REQ_B = 'bbbbbbbb-0000-4000-8000-000000000002';
+
+function makeInput() {
+    return { value: '', scrollHeight: 0, style: {}, focus() {} };
+}
+
+function makeHarness() {
+    const apiCall = jest.fn(async () => ({ success: true }));
+    const showToast = jest.fn();
+    const loadActionRequests = jest.fn(async () => {});
+    const currentUser = { deviceId: 'dev-1', deviceSecret: 'sec-1' };
+    const i18n = { t: (k) => k };
+    const input = makeInput();
+    const documentStub = { getElementById: (id) => (id === 'messageInput' ? input : null) };
+    const requests = {
+        [REQ_A]: { id: REQ_A, fromEntityId: 4, prompt: 'A?', anchorMessageId: 'anchor-a', options: ['A-opt-0', 'A-opt-1'] },
+        [REQ_B]: { id: REQ_B, fromEntityId: 5, prompt: 'B?', anchorMessageId: 'anchor-b', options: ['B-opt-0', 'B-opt-1'] },
+    };
+
+    const preamble = `
+        let replyContexts = [];
+        let lastAutoFilledOptionValue = '';
+        const normalizeChatMessageId = (v) => (v == null ? '' : String(v));
+        const stripReplyQuotePrefix = (t) => (t == null ? '' : String(t));
+        const openActionRequestAnchor = () => {};
+        const renderReplyPreviews = () => {};
+        const recomputeAutoReceivers = () => {};
+        const clearAllReceiverHints = () => {};
+        const autoToggledReceiverEntities = new Set();
+        const getEntityDisplayName = (id) => '#' + id;
+        const getActionRequestById = (id) => __REQUESTS__[id] || null;
+        const actionRequestMeta = (request) => ({
+            kind: 'chat-entity',
+            entityId: Number(request.fromEntityId),
+            actionRequest: { requestId: request.id, anchorMessageId: request.anchorMessageId || null }
+        });
+    `;
+
+    const factory = new Function(
+        'apiCall', 'showToast', 'loadActionRequests', 'currentUser', 'i18n', 'console', 'document', '__REQUESTS__',
+        `${preamble}
+         ${extractFunction('addReplyContext')}
+         ${extractFunction('clearStagedActionRequestReplies')}
+         ${extractFunction('collectActionRequestReplyContexts')}
+         ${extractFunction('clearReplyContext')}
+         ${extractFunction('focusActionRequestReply')}
+         ${extractFunction('resolveActionRequestReplyContexts')}
+         return {
+             addReplyContext, clearStagedActionRequestReplies, collectActionRequestReplyContexts,
+             clearReplyContext, focusActionRequestReply, resolveActionRequestReplyContexts,
+             getReplyContexts: () => replyContexts.slice(),
+         };`
+    );
+    const api = factory(apiCall, showToast, loadActionRequests, currentUser, i18n, console, documentStub, requests);
+    return { ...api, apiCall, showToast, input };
+}
+
+const resolvePosts = (apiCall) =>
+    apiCall.mock.calls.filter(([method, url]) => method === 'POST' && /\/api\/action-requests\/.+\/resolve$/.test(url));
+
+describe('需要你 inbox — sequential replies (card_6a5cc9bb)', () => {
+    it('staging item B after item A REPLACES A — one Send resolves exactly B', async () => {
+        const h = makeHarness();
+        h.focusActionRequestReply(REQ_A);              // owner clicks Reply on A
+        h.focusActionRequestReply(REQ_B);              // then clicks Reply on B (to answer it)
+        const staged = h.getReplyContexts().filter(rc => rc.requestId);
+        expect(staged.map(rc => rc.requestId)).toEqual([REQ_B]);   // FAIL-ON-OLD: was [A, B]
+
+        await h.resolveActionRequestReplyContexts(h.collectActionRequestReplyContexts(), 'answer for B');
+        const posts = resolvePosts(h.apiCall);
+        expect(posts).toHaveLength(1);                              // FAIL-ON-OLD: was 0 (uniq>1 → resolve none)
+        expect(posts[0][1]).toBe(`/api/action-requests/${REQ_B}/resolve`);
+        expect(posts[0][2].answer.text).toBe('answer for B');
+        expect(h.showToast).not.toHaveBeenCalledWith('action_request_one_at_a_time', 'error');
+    });
+
+    it('full consecutive flow: answer A → Send, then answer B → Send, each resolves independently', async () => {
+        const h = makeHarness();
+
+        h.focusActionRequestReply(REQ_A);
+        await h.resolveActionRequestReplyContexts(h.collectActionRequestReplyContexts(), 'ans A');
+        h.clearReplyContext();                          // sendMessage clears staged contexts
+
+        h.focusActionRequestReply(REQ_B);
+        await h.resolveActionRequestReplyContexts(h.collectActionRequestReplyContexts(), 'ans B');
+
+        const posts = resolvePosts(h.apiCall);
+        expect(posts).toHaveLength(2);
+        expect(posts[0][1]).toBe(`/api/action-requests/${REQ_A}/resolve`);
+        expect(posts[0][2].answer.text).toBe('ans A');
+        expect(posts[1][1]).toBe(`/api/action-requests/${REQ_B}/resolve`);
+        expect(posts[1][2].answer.text).toBe('ans B');
+    });
+
+    it('regular chat quotes are preserved when an inbox item is staged (multi-quote card_277c80f5 intact)', () => {
+        const h = makeHarness();
+        h.addReplyContext('msg-100', 'Alice', 'a normal quoted message', { kind: 'chat-system' });
+        h.focusActionRequestReply(REQ_A);
+        const ctxs = h.getReplyContexts();
+        expect(ctxs.some(rc => rc.msgId === 'msg-100' && !rc.requestId)).toBe(true);  // quote survives
+        expect(ctxs.filter(rc => rc.requestId).map(rc => rc.requestId)).toEqual([REQ_A]);
+        h.focusActionRequestReply(REQ_B);   // switching inbox items still keeps the quote
+        const ctxs2 = h.getReplyContexts();
+        expect(ctxs2.some(rc => rc.msgId === 'msg-100' && !rc.requestId)).toBe(true);
+        expect(ctxs2.filter(rc => rc.requestId).map(rc => rc.requestId)).toEqual([REQ_B]);
+    });
+
+    describe('option auto-fill guard — Failure Mode 2 ("回覆被覆蓋掉")', () => {
+        it('fills the option text into an empty composer', () => {
+            const h = makeHarness();
+            h.focusActionRequestReply(REQ_A, 0);
+            expect(h.input.value).toBe('A-opt-0');
+        });
+
+        it('switching options replaces a prior AUTO-FILLED option', () => {
+            const h = makeHarness();
+            h.focusActionRequestReply(REQ_A, 0);
+            expect(h.input.value).toBe('A-opt-0');
+            h.focusActionRequestReply(REQ_A, 1);        // change your mind
+            expect(h.input.value).toBe('A-opt-1');
+        });
+
+        it('does NOT clobber owner-typed free text with an option', () => {
+            const h = makeHarness();
+            h.focusActionRequestReply(REQ_A);           // plain Reply, no option
+            h.input.value = 'my carefully typed answer';  // owner types
+            h.focusActionRequestReply(REQ_B, 0);        // clicks an option on B
+            expect(h.input.value).toBe('my carefully typed answer');   // preserved
+        });
+    });
+});


### PR DESCRIPTION
## Problem (Hank, reported twice — P1, blocks owner workflow)
「我要連續回覆處理多個問題但是會被覆蓋掉,導致我無法連續處理」+ 「之前開卡 report 過類似問題 (card_2cfe0586) 但遲遲沒修」.

The 需要你 inbox has **no per-item reply state** — every "Reply"/option click feeds ONE shared, *accumulating* `replyContexts` array. Staging item A then item B leaves `[A, B]`; a single Send then trips the `uniq.length>1` guard in `resolveActionRequestReplyContexts` and resolves **NEITHER** item. PR #3787 (card_2cfe0586) fixed *"one answer resolves both"* but converted it into *"one answer resolves neither"* — still the owner's exact "被覆蓋 / 無法連續處理" symptom.

Diagnosed by executing the real extracted functions: stage A, stage B, one answer → **0 resolve POSTs** + `action_request_one_at_a_time` toast. **Backend is correctly id-scoped — frontend-only fix.**

## Fix (`backend/public/portal/chat.html`)
- `focusActionRequestReply()` now calls **`clearStagedActionRequestReplies()`** first → clicking Reply/an option on an inbox item **replaces** any previously-staged inbox item. Regular chat quotes (multi-quote, card_277c80f5) still accumulate untouched. Exactly one inbox item is staged at a time → each Send resolves the item being answered. A→Send→resolves A; B→Send→resolves B.
- **Failure Mode 2 ("回覆被覆蓋掉")**: option auto-fill no longer clobbers owner-typed free text — fills only when composer is empty or still holds a prior auto-filled option (switching options still works; a typed answer is never destroyed). Tracked via `lastAutoFilledOptionValue`, reset on clear/send.

## Test — `chat-action-request-sequential-resolve.test.js`
Executes the real functions (`new Function` brace-count harness, same as the sibling independent-resolve test).
- **FAIL-ON-OLD** (verified by temporarily disabling the fix): stage A then B → accumulates `[A,B]` → 0 resolve POSTs + one-at-a-time toast.
- **PASS-ON-FIX**: staging B replaces A → 1 resolve POST to B with its own text; full consecutive A→Send→B→Send resolves each independently; multi-quote preserved; option-clobber guard pinned.
- **5 suites / 73 tests green** (all chat-action-request).

## Out of scope → #6
The "任務子卡 chip 彈框" half of card_6a5cc9bb is UI-design → routed to #6 (feedback_uiux_design_discuss_with_6). This PR is the reply-state logic fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)