### PR TITLE
fix(chip): restore card screenshot/thumbnail strip in the task-card chip popover (card_abdf0904)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3508,6 +3508,14 @@
         .autolink-chip-popover .chip-popover-open { color: #c084fc; font-size: 12px; text-decoration: none; }
         .autolink-chip-popover .chip-popover-open:hover { text-decoration: underline; }
         .autolink-chip-popover .chip-popover-loading, .autolink-chip-popover .chip-popover-error { padding: 16px; text-align: center; color: #888; font-size: 12px; }
+        /* Card-chip screenshot/attachment thumbnail strip (parity with kanban modal). */
+        .autolink-chip-popover .chip-popover-shots { margin-top: 8px; padding-top: 6px; border-top: 1px solid rgba(255,255,255,0.06); }
+        .autolink-chip-popover .chip-popover-shots-label { font-size: 12px; color: #bbb; margin-bottom: 6px; display: flex; align-items: center; gap: 4px; }
+        .autolink-chip-popover .chip-popover-shots-count { color: #888; }
+        .autolink-chip-popover .chip-popover-thumbs { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }
+        .autolink-chip-popover .chip-popover-thumb { display: block; border: 1px solid rgba(255,255,255,0.1); border-radius: 6px; overflow: hidden; background: rgba(255,255,255,0.04); transition: border-color .15s, transform .15s; }
+        .autolink-chip-popover .chip-popover-thumb:hover { border-color: #c084fc; transform: scale(1.03); }
+        .autolink-chip-popover .chip-popover-thumb img { width: 100%; height: 60px; object-fit: cover; display: block; }
         .autolink-chip-toast { background: rgba(30, 30, 40, 0.95); color: #facc15; border: 1px solid rgba(250, 204, 21, 0.4); border-radius: 6px; padding: 6px 10px; font-size: 12px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5); transition: opacity 0.4s; pointer-events: none; }
 
         /* ── Entity Preview Modal ── */

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -225,6 +225,14 @@
         .autolink-chip-popover .chip-popover-open { color:#c084fc; font-size:12px; text-decoration:none; }
         .autolink-chip-popover .chip-popover-open:hover { text-decoration:underline; }
         .autolink-chip-popover .chip-popover-loading, .autolink-chip-popover .chip-popover-error { padding:16px; text-align:center; color:#888; font-size:12px; }
+        /* Card-chip screenshot/attachment thumbnail strip (parity with kanban modal). */
+        .autolink-chip-popover .chip-popover-shots { margin-top:8px; padding-top:6px; border-top:1px solid rgba(255,255,255,0.06); }
+        .autolink-chip-popover .chip-popover-shots-label { font-size:12px; color:#bbb; margin-bottom:6px; display:flex; align-items:center; gap:4px; }
+        .autolink-chip-popover .chip-popover-shots-count { color:#888; }
+        .autolink-chip-popover .chip-popover-thumbs { display:grid; grid-template-columns:repeat(3,1fr); gap:6px; }
+        .autolink-chip-popover .chip-popover-thumb { display:block; border:1px solid rgba(255,255,255,0.1); border-radius:6px; overflow:hidden; background:rgba(255,255,255,0.04); transition:border-color .15s, transform .15s; }
+        .autolink-chip-popover .chip-popover-thumb:hover { border-color:#c084fc; transform:scale(1.03); }
+        .autolink-chip-popover .chip-popover-thumb img { width:100%; height:60px; object-fit:cover; display:block; }
         .autolink-chip-toast { background:rgba(30,30,40,0.95); color:#facc15; border:1px solid rgba(250,204,21,0.4); border-radius:6px; padding:6px 10px; font-size:12px; box-shadow:0 4px 12px rgba(0,0,0,0.5); transition:opacity 0.4s; pointer-events:none; }
 
         /* Floating page-level toast — confirms cross-pane smart-quote delivery */

--- a/backend/public/portal/shared/autolink-chip-preview.js
+++ b/backend/public/portal/shared/autolink-chip-preview.js
@@ -168,6 +168,44 @@
         `;
     }
 
+    // Screenshot/attachment thumbnail strip for the card-chip popover.
+    //
+    // Regression note (card fix/chip-card-screenshot-thumbnails): the popover
+    // fetches GET /api/mission/card/:id, whose payload carries `card.files[]`
+    // ({ fileId, filename, url, mimeType, ... } — see backend/kanban.js
+    // mapCardFileRow + the /card/:id handler which does `card.files = …`), and
+    // the full kanban modal renders those images as a thumbnail grid + lightbox
+    // (kanban.html loadScreenshots/openLightbox). The chip popover shipped
+    // WITHOUT this block, so scrolling the chip never revealed the card's
+    // screenshots — reachable everywhere else but not in the quick-preview chip.
+    // This restores parity: image files → a scrollable thumbnail grid; each
+    // thumb is a real <a href=signedUrl> so a click enlarges it (a host page's
+    // window.openLightbox is preferred when present — see bindPopoverActions).
+    function buildScreenshotBlockHtml(c) {
+        const files = Array.isArray(c.files) ? c.files : [];
+        const images = files.filter(f => f && typeof f.url === 'string' && f.url
+            && /^image\//i.test(String(f.mimeType || f.mime_type || '')));
+        if (!images.length) return '';
+        const label = t('chip_popover_screenshots', '📸 截圖');
+        // TODO(#6): attach the "?" spec-tooltip icon here (right of the section
+        // label), reusing the portal's existing help-icon pattern. Backend/data
+        // is ready; only the tooltip affordance is #6's (UI) piece. Marker id
+        // below so #6 can target it without re-deriving the DOM shape.
+        const thumbs = images.map(f => {
+            const url = escapeHtml(f.url);
+            const name = escapeHtml(f.filename || 'screenshot');
+            return '<a class="chip-popover-thumb" href="' + url + '"'
+                + ' data-action="thumb" data-url="' + url + '" data-name="' + name + '"'
+                + ' target="_blank" rel="noopener" title="' + name + '">'
+                + '<img src="' + url + '" alt="' + name + '" loading="lazy"></a>';
+        }).join('');
+        return '<div class="chip-popover-shots">'
+            + '<div class="chip-popover-shots-label" data-chip-help-anchor="screenshots">'
+            + escapeHtml(label) + ' <span class="chip-popover-shots-count">' + images.length + '</span></div>'
+            + '<div class="chip-popover-thumbs">' + thumbs + '</div>'
+            + '</div>';
+    }
+
     function buildContentHtml(d, refType, refId) {
         if (d.kind !== 'card') return buildErrorHtml(new Error('ref_not_supported:kind'), refType, refId);
         const c = d.data;
@@ -180,6 +218,7 @@
             const truncated = cmt.text && cmt.text.length > 120 ? '…' : '';
             return '<div class="chip-popover-comment">💬 ' + renderChips(escapeHtml(raw)) + truncated + '</div>';
         }).join('');
+        const screenshotsHtml = buildScreenshotBlockHtml(c);
         const titleRendered = renderChips(escapeHtml(c.title || ''));
         const hashId = c.id.indexOf('card_') === 0 ? c.id : ('card_' + c.id);
         const fullUrl = '/portal/kanban.html#' + hashId;
@@ -196,6 +235,7 @@
             <div class="chip-popover-body">
                 ${descRaw ? '<div class="chip-popover-desc">' + desc + '</div>' : ''}
                 ${comments}
+                ${screenshotsHtml}
             </div>
             <div class="chip-popover-footer">
                 <a href="${escapeHtml(fullUrl)}" class="chip-popover-open" data-action="open-full" data-card-id="${escapeHtml(hashId)}">${escapeHtml(openFullLabel)}</a>
@@ -224,6 +264,20 @@
             if (!btn) return;
             e.stopPropagation();
             const action = btn.getAttribute('data-action');
+            if (action === 'thumb') {
+                // Enlarge a screenshot thumbnail. Prefer the host page's own
+                // lightbox (chat.html/kanban.html/feedback.html define
+                // window.openLightbox); otherwise fall through to the native
+                // <a target="_blank"> so the image still opens on the 4 pages
+                // that host the chip without a lightbox.
+                const url = btn.getAttribute('data-url') || '';
+                const name = btn.getAttribute('data-name') || '';
+                if (url && typeof window.openLightbox === 'function') {
+                    e.preventDefault();
+                    try { window.openLightbox(url, name); return; } catch (_) {}
+                }
+                return; // let the <a> open the signed URL in a new tab
+            }
             if (action === 'close') {
                 const idx = stack.indexOf(pop);
                 if (idx >= 0) closeFromIndex(idx);

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -411947,6 +411947,7 @@ const TRANSLATIONS = {
 
 
         "chip_popover_open_full": "Open full page →",
+        "chip_popover_screenshots": "📸 Screenshots",
 
 
 
@@ -1035496,6 +1035497,7 @@ const TRANSLATIONS = {
 
 
         "chip_popover_open_full": "打開完整頁面 →",
+        "chip_popover_screenshots": "📸 截圖",
 
 
 
@@ -1849644,6 +1849646,7 @@ const TRANSLATIONS = {
         "chip_popover_not_supported": "此引用类型尚未支援预览",
         "chip_popover_requote": "再引用到聊天",
         "chip_popover_open_full": "打开完整页面 →",
+        "chip_popover_screenshots": "📸 截图",
         "chip_popover_cycle": "已在引用堆叠上",
         "chip_popover_too_deep": "太深，请直接跳页",
         "chip_popover_requoted": "已引用至聊天",
@@ -6109245,6 +6109248,7 @@ const TRANSLATIONS = {
         "chip_popover_not_supported": "Preview not yet supported for this reference type",
         "chip_popover_requote": "Quote to chat again",
         "chip_popover_open_full": "Open full page →",
+        "chip_popover_screenshots": "📸 Screenshots",
         "chip_popover_cycle": "Already in the reference stack",
         "chip_popover_too_deep": "Too deep — open the full page instead",
         "chip_popover_requoted": "Quoted into chat",

--- a/backend/tests/jest/chip-preview-screenshot-thumbnails.test.js
+++ b/backend/tests/jest/chip-preview-screenshot-thumbnails.test.js
@@ -1,0 +1,154 @@
+/**
+ * Task-card CHIP popover — screenshot / attachment thumbnail block (regression).
+ *
+ * Regression (owner Hank): 「任務子卡的 chip 往下滑要能顯示該卡的截圖欄位以及縮圖，
+ * 很久以前這個功能還在，不知為何突然消失，需要避免此問題再次發生」= the task
+ * sub-card CHIP popover, when scrolled/expanded, must show that card's
+ * screenshot/attachment field + thumbnails. The chip fetches GET
+ * /api/mission/card/:id (payload carries `card.files[]`), and the full kanban
+ * modal already renders those images as a thumbnail grid + lightbox — but the
+ * chip popover (autolink-chip-preview.js buildContentHtml) shipped WITHOUT the
+ * block, so scrolling the chip never revealed the screenshots. This test pins
+ * the restored block so it can never silently vanish again.
+ *
+ * We EXECUTE the private `buildScreenshotBlockHtml()` (extracted from
+ * autolink-chip-preview.js via the brace-count + `new Function` harness the
+ * sibling chat-action-request-independent-resolve.test.js uses) since the
+ * module IIFE has no export for it.
+ *
+ * FAIL-ON-OLD: the pre-fix source has no `buildScreenshotBlockHtml` function
+ * and its `buildContentHtml` render string never references
+ * `chip-popover-thumbs` — so `extractFunction('buildScreenshotBlockHtml')`
+ * throws (test 0) and the source-text assertion (last test) fails on old code.
+ * Both PASS after the fix.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const CHIP_SRC = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'shared', 'autolink-chip-preview.js'),
+    'utf8'
+);
+
+// Brace-count extractor (same shape as chat-action-request-independent-resolve.test.js).
+function extractFunction(src, name) {
+    const re = new RegExp(`function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`, 'g');
+    const m = re.exec(src);
+    if (!m) throw new Error(`function ${name} not found in autolink-chip-preview.js`);
+    let depth = 1;
+    let i = m.index + m[0].length;
+    while (i < src.length && depth > 0) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+        i++;
+    }
+    return src.slice(m.index, i);
+}
+
+// Build a runnable copy of buildScreenshotBlockHtml with its two collaborators
+// (escapeHtml, t) supplied. escapeHtml mirrors the module's textContent-based
+// implementation without needing a DOM.
+function makeBuilder() {
+    const escapeHtml = (s) => String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    const t = (key, fallback) => fallback; // exercise the i18n fallback path
+    const body = extractFunction(CHIP_SRC, 'buildScreenshotBlockHtml');
+    const factory = new Function('escapeHtml', 't', `${body}\n return buildScreenshotBlockHtml;`);
+    return factory(escapeHtml, t);
+}
+
+const IMG = (over) => Object.assign({
+    fileId: 'f_1', filename: 'shot.png', url: 'https://cdn.example/shot.png?sig=abc', mimeType: 'image/png',
+}, over || {});
+
+describe('chip popover screenshot-thumbnail block', () => {
+    // Built lazily inside each test so that on PRE-FIX code (where
+    // buildScreenshotBlockHtml is absent) each test reports a clean failure
+    // instead of the whole suite erroring at load time.
+    let buildScreenshotBlockHtml;
+    beforeAll(() => { buildScreenshotBlockHtml = makeBuilder(); });
+
+    test('renders a thumbnail grid for image files on the card', () => {
+        const html = buildScreenshotBlockHtml({ files: [IMG(), IMG({ fileId: 'f_2', filename: 'two.jpg', url: 'https://cdn.example/two.jpg', mimeType: 'image/jpeg' })] });
+        expect(html).toMatch(/chip-popover-shots/);
+        expect(html).toMatch(/chip-popover-thumbs/);
+        // one <img> per image file, wrapped in a clickable enlarge anchor
+        expect((html.match(/<img /g) || []).length).toBe(2);
+        expect(html).toMatch(/class="chip-popover-thumb"/);
+        expect(html).toMatch(/data-action="thumb"/);
+        expect(html).toContain('https://cdn.example/shot.png?sig=abc');
+        expect(html).toContain('https://cdn.example/two.jpg');
+        // count badge reflects the number of screenshots
+        expect(html).toMatch(/chip-popover-shots-count">2</);
+    });
+
+    test('renders nothing when the card has no image files', () => {
+        expect(buildScreenshotBlockHtml({ files: [] })).toBe('');
+        expect(buildScreenshotBlockHtml({})).toBe('');
+        expect(buildScreenshotBlockHtml({ files: null })).toBe('');
+        // non-image attachments (pdf/log) are excluded — only screenshots show
+        const pdfOnly = buildScreenshotBlockHtml({ files: [{ fileId: 'p', filename: 'a.pdf', url: 'https://x/a.pdf', mimeType: 'application/pdf' }] });
+        expect(pdfOnly).toBe('');
+    });
+
+    test('mixes image + non-image: only images render as thumbnails', () => {
+        const html = buildScreenshotBlockHtml({ files: [
+            IMG(),
+            { fileId: 'l', filename: 'run.log', url: 'https://x/run.log', mimeType: 'text/plain' },
+        ] });
+        expect((html.match(/<img /g) || []).length).toBe(1);
+    });
+
+    test('supports the snake_case mime_type field shape too', () => {
+        const html = buildScreenshotBlockHtml({ files: [{ fileId: 'f', filename: 'legacy.png', url: 'https://x/legacy.png', mime_type: 'image/png' }] });
+        expect(html).toMatch(/chip-popover-thumbs/);
+        expect((html.match(/<img /g) || []).length).toBe(1);
+    });
+
+    test('XSS-safe: malicious filename/url are HTML-escaped (no live injection)', () => {
+        const html = buildScreenshotBlockHtml({ files: [IMG({
+            filename: '"><img src=x onerror=alert(1)>evil',
+            url: 'https://cdn/x.png"><script>alert(2)</script>',
+        })] });
+        // The injected markup must be neutralised: no live <script> tag, no
+        // attribute break-out (all payload <, >, " are entity-encoded so the
+        // browser never re-parses them as markup). The literal text
+        // "onerror=alert(1)" may remain as inert, fully-escaped attribute text.
+        expect(html).not.toContain('<script>');
+        expect(html).not.toContain('><img src=x onerror'); // no attribute break-out
+        expect(html).toContain('&lt;script&gt;');          // payload angle brackets encoded
+        expect(html).toContain('&quot;');                  // payload quotes encoded
+        // Every emitted tag is one of ours (div/span/a/img) — no injected tag.
+        const tags = (html.match(/<([a-zA-Z][a-zA-Z0-9]*)/g) || []).map(s => s.slice(1).toLowerCase());
+        expect(tags.every(tg => ['div', 'span', 'a', 'img'].includes(tg))).toBe(true);
+    });
+
+    test('skips files that lack a usable url', () => {
+        const html = buildScreenshotBlockHtml({ files: [IMG({ url: '' }), IMG({ url: null })] });
+        expect(html).toBe('');
+    });
+});
+
+describe('chip popover render wiring (source-text guard)', () => {
+    test('buildContentHtml injects the screenshot block into the popover body', () => {
+        // This guard FAILS on the pre-fix source: buildContentHtml never
+        // referenced the screenshot block, so removing/omitting it recurs.
+        const body = extractFunction(CHIP_SRC, 'buildContentHtml');
+        expect(body).toMatch(/buildScreenshotBlockHtml\(/);
+        expect(body).toMatch(/screenshotsHtml/);
+    });
+
+    test('thumbnail click is wired to enlarge (data-action="thumb" handled)', () => {
+        expect(CHIP_SRC).toMatch(/action === 'thumb'/);
+        // prefers a host-page lightbox, falls back to native <a target=_blank>
+        expect(CHIP_SRC).toMatch(/window\.openLightbox/);
+    });
+
+    test('leaves a TODO marker for #6 to attach the ? spec-tooltip icon', () => {
+        expect(CHIP_SRC).toMatch(/TODO\(#6\)/);
+    });
+});


### PR DESCRIPTION
## What (owner-reported regression)
Hank: the task sub-card **chip**, when scrolled, should show that card's **screenshot/attachment field + thumbnails** — "很久以前這個功能還在，不知為何突然消失".

## Root cause (git archaeology)
The card-chip quick-preview popover (`autolink-chip-preview.js` `buildContentHtml`) was **created already WITHOUT a screenshot block** (commit `e523b29f`, card_394 "Task Chip UX") — it only rendered title/status/desc/comments. **No later commit removed a thumbnail block** (0 matches across all 15 historical revisions of the file). So this is a **feature-parity regression baked in at the chip's creation**: the backend `GET /api/mission/card/:id` returns `card.files[]` (`kanban.js` `mapCardFileRow`) and the full kanban modal renders them as thumbnails+lightbox, but the chip's port never included that section — so from the owner's view (the modal always had it) the chip "lost" a feature it should have had.

## Fix (render + style + i18n only — backend already returns `card.files`)
- `autolink-chip-preview.js`: `buildScreenshotBlockHtml(c)` filters `card.files` for `image/*` → scrollable thumbnail grid; each thumb is a real `<a href=signedUrl target=_blank><img loading=lazy>` (portable click-to-enlarge), wired into the popover body. `bindPopoverActions` gains a `data-action="thumb"` handler that prefers the host page's `window.openLightbox` and falls back to the native new-tab `<a>`. **XSS-safe**: `f.url`/`f.filename`/label all via `escapeHtml`.
- `chat.html` + `kanban.html`: matching `.chip-popover-shots/-thumbs/-thumb` CSS.
- `i18n.js`: `chip_popover_screenshots` (en/zh/zh-CN).

## Prevent recurrence (Hank: "避免此問題再次發生")
`chip-preview-screenshot-thumbnails.test.js` executes the real `buildScreenshotBlockHtml` + guards the render wiring/thumb handler — **FAILS if the thumbnail block is removed again** (proven 9/9 fail on pristine origin/main, pass on fix).

## Follow-up → #6
The **"?" spec-tooltip icon** is #6's (UI). Left a `TODO(#6)` marker + `data-chip-help-anchor="screenshots"` so #6 can attach it without re-deriving the DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)