### PR TITLE
fix(avatar): card-holder my-cards emoji fallback + exam wrong-entity avatar (card_55e811b8, card_cea91e58)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -14862,7 +14862,14 @@ app.get('/api/contacts/my-cards', async (req, res) => {
             isPublic: !!ent.isPublic
         });
     }
-    res.json({ success: true, cards });
+    // card_55e811b8: my-cards was the ONLY card-holder path that never enriched
+    // rows with petdxAvatarUrl (recent/search/cross-device all do), so when the
+    // canvas sprite descriptor fails to resolve the front-end had no URL fallback
+    // and dropped straight to the emoji — the recurring "avatar missing smart-
+    // partner appearance" bug. Give my-cards the same same-origin proxy URL
+    // safety net as the other paths.
+    const enrichedCards = await enrichCardHolderEntriesWithPetdx(cards);
+    res.json({ success: true, cards: enrichedCards });
 });
 
 /**

--- a/backend/public/arena/exam.html
+++ b/backend/public/arena/exam.html
@@ -590,7 +590,16 @@
                     const data = await res.json();
                     const bound = (data.entities || []).filter(e => e && e.isBound !== false);
                     if (!bound.length) return;
-                    entityId = Number(bound[0].entityId || bound[0].id);
+                    // card_cea91e58: bind to the ACTIVE session entity, not bound[0].
+                    // Picking bound[0] always showed the first entity (#1)'s
+                    // companion even when a different entity (e.g. #2) was the one
+                    // actually taking the exam. Use the shared active-entity key
+                    // (petdx-browser's eclaw_petdex_active_entity_id); fall back to
+                    // bound[0] only when it's unset or no longer bound.
+                    let activeId = NaN;
+                    try { activeId = Number(localStorage.getItem('eclaw_petdex_active_entity_id')); } catch (_) { /* private mode */ }
+                    const chosen = (Number.isFinite(activeId) && bound.find(e => Number(e.entityId || e.id) === activeId)) || bound[0];
+                    entityId = Number(chosen.entityId || chosen.id);
                 } catch (_) { return; }
                 if (!Number.isFinite(entityId)) return;
 

--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -1128,7 +1128,11 @@
 
         // ── My Card rendering ──
         function renderMyCardHtml(c) {
-            const avatar = c.avatar || '\u{1F99E}';
+            // card_55e811b8: prefer the same-origin petdx proxy URL (now enriched
+            // onto my-cards rows) so the real smart-partner sprite shows via the
+            // canvas/URL path; emoji is the last resort only when no companion
+            // exists — no more silent instant-fallback to a default glyph.
+            const avatar = c.petdxAvatarUrl || c.avatar || '\u{1F99E}';
             const ac = c.agentCard || {};
             let html = `<div class="card-item" onclick="showMyCardDetail('${escapeAttr(c.publicCode)}')">
                 <div class="card-row">
@@ -1317,7 +1321,8 @@
             if (!card) return;
 
             const ac = card.agentCard || {};
-            const avatar = card.avatar || '\u{1F99E}';
+            // card_55e811b8: same as the list view — prefer the enriched proxy URL.
+            const avatar = card.petdxAvatarUrl || card.avatar || '\u{1F99E}';
 
             const content = document.getElementById('detailContent');
             content.innerHTML = `

--- a/backend/tests/jest/card-holder-avatar-enrichment-static.test.js
+++ b/backend/tests/jest/card-holder-avatar-enrichment-static.test.js
@@ -1,0 +1,59 @@
+/**
+ * Regression guard for the recurring (5+ times) card-holder avatar bug
+ * (card_55e811b8) + the exam wrong-entity avatar (card_cea91e58).
+ *
+ * STRUCTURAL cause: /api/contacts/my-cards was the ONLY card-holder read path that
+ * never enriched rows with petdxAvatarUrl (recent/search/cross-device all do), so
+ * when the canvas sprite descriptor failed the front-end had no URL fallback and
+ * dropped straight to the emoji. Prior fixes patched other rows and left my-cards
+ * fragile — hence the recurrence. These are SOURCE assertions (like
+ * mention-ux-static.test.js) that fail if the enrichment / URL-precedence / active-
+ * entity binding is ever removed again.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const read = (p) => fs.readFileSync(path.join(__dirname, '..', '..', p), 'utf8');
+
+describe('card-holder my-cards must enrich rows with petdxAvatarUrl (index.js)', () => {
+    const idx = read('index.js');
+
+    it('the /api/contacts/my-cards handler calls enrichCardHolderEntriesWithPetdx before responding', () => {
+        const start = idx.indexOf("'/api/contacts/my-cards'");
+        expect(start).toBeGreaterThan(-1);
+        // scan the handler body up to the next route registration
+        const nextRoute = idx.indexOf("app.get('/api/contacts/recent'", start);
+        const body = idx.slice(start, nextRoute > 0 ? nextRoute : start + 4000);
+        // FAIL-ON-OLD: old my-cards did `res.json({ success: true, cards })` with no enrich.
+        expect(body).toMatch(/enrichCardHolderEntriesWithPetdx\(\s*cards\s*\)/);
+        // and the response must send the enriched list, not the raw one
+        expect(body).toMatch(/cards:\s*enrichedCards/);
+    });
+});
+
+describe('card-holder.html prefers the enriched proxy URL before the emoji fallback', () => {
+    const html = read('public/portal/card-holder.html');
+
+    it('the my-cards LIST view uses petdxAvatarUrl precedence', () => {
+        expect(html).toMatch(/const avatar = c\.petdxAvatarUrl \|\| c\.avatar \|\|/);
+    });
+
+    it('the my-cards DETAIL view uses petdxAvatarUrl precedence', () => {
+        expect(html).toMatch(/const avatar = card\.petdxAvatarUrl \|\| card\.avatar \|\|/);
+    });
+});
+
+describe('exam.html binds the top-right avatar to the ACTIVE entity, not bound[0]', () => {
+    const html = read('public/arena/exam.html');
+
+    it('uses the shared active-entity localStorage key and only falls back to bound[0]', () => {
+        expect(html).toContain('eclaw_petdex_active_entity_id');
+        // the active-entity find must be present (fallback to bound[0] is fine)
+        expect(html).toMatch(/bound\.find\(e => Number\(e\.entityId \|\| e\.id\) === activeId\)/);
+        // FAIL-ON-OLD: old code did `entityId = Number(bound[0].entityId || bound[0].id)`
+        // as the ONLY selection — assert it's no longer the sole binding.
+        expect(html).not.toMatch(/if \(!bound\.length\) return;\s*\n\s*entityId = Number\(bound\[0\]/);
+    });
+});


### PR DESCRIPTION
## Two recurring avatar bugs from Hank's interview

### card_55e811b8 — card-holder shows emoji not the smart-partner sprite (recurred 5+ times)
**Structural root cause**: `/api/contacts/my-cards` was the **only** card-holder read path that never enriched rows with `petdxAvatarUrl` — `recent`/`search`/cross-device all call `enrichCardHolderEntriesWithPetdx`; my-cards returned `cards` raw. So my-cards had only the canvas sprite-descriptor path and **no URL safety net**; when the descriptor didn't resolve (no companion / procedural default / ORB-blocked upstream sprite URL) the front-end dropped **straight to emoji**. Prior fixes patched cross-device rows and assumed my-cards was "already correct" → recurrence.
- **index.js**: enrich my-cards with `enrichCardHolderEntriesWithPetdx` (adds the same-origin `/api/petdx` proxy URL, which already defeats `ERR_BLOCKED_BY_ORB`).
- **card-holder.html**: list + detail prefer `petdxAvatarUrl || avatar || emoji` — real sprite via canvas/URL, emoji only when there's genuinely no companion.

### card_cea91e58 — exam top-right avatar shows the wrong entity (#1 while #2 active)
Root cause: exam.html picked `bound[0]` (first bound entity = #1), not the active session entity. Fix: select via the shared `eclaw_petdex_active_entity_id` key (same one petdx-browser uses), fall back to `bound[0]` only when unset/unbound.

## Prevent recurrence
`card-holder-avatar-enrichment-static.test.js` (source-level) asserts: my-cards calls the enrich + responds enriched; list & detail use the `petdxAvatarUrl` precedence; exam binds to the active-entity key not `bound[0]` alone. **FAILS if any is removed again.** 4/4 pass; `card-holder.test.js` 21/21 unaffected.

## Follow-ups → #6
- Leaderboard mobile overflow (card_e1695548).
- Leaderboard avatars + click-to-card (card_cea91e58 enhance).
- Data repair: companions still `needs_recovery=true` (upstream sprite URL not yet R2-backfilled) — separate item; these fixes make even those degrade to a URL `<img>`/emoji, not a broken canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)