### PR TITLE
fix(avatar): shared renderAvatarHtml URL branch had no onerror → 破圖 across ~10 portal pages (card_430579ee)

### DIFF
--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -238,8 +238,20 @@ function renderAvatarHtml(avatar, size, entityId, opts) {
             + 'background-image:url(' + _escAttr(avatar) + ');background-repeat:no-repeat;'
             + 'background-size:800% 900%;background-position:0 0;"></div>';
     } else if (isAvatarUrl(avatar)) {
-        inner = '<img src="' + avatar + '" class="entity-avatar-img"' + eidAttr +
-            ' style="width:' + size + 'px;height:' + size + 'px;" alt="avatar" loading="lazy">';
+        // card_430579ee: wrap the <img> so a load FAILURE (404 / expired R2 URL /
+        // Chrome net::ERR_BLOCKED_BY_ORB on an external petdx sprite) degrades to
+        // the emoji fallback instead of the browser's broken-image glyph. Before,
+        // this plain <img> had no onerror, so avatar failures showed 破圖 across
+        // every portal surface that renders via this shared helper (~10 pages).
+        // eidAttr lives on the wrapper so click delegates still resolve entityId;
+        // _escAttr hardens the (previously raw) URL against attribute breakout.
+        inner = '<span class="entity-avatar-imgwrap"' + eidAttr
+            + ' style="display:inline-block;width:' + size + 'px;height:' + size + 'px;'
+            + 'line-height:' + size + 'px;text-align:center;font-size:' + Math.round(size * 0.7) + 'px;">'
+            + '<img src="' + _escAttr(avatar) + '" class="entity-avatar-img"'
+            + ' style="width:' + size + 'px;height:' + size + 'px;" alt="avatar" loading="lazy"'
+            + ' onerror="this.onerror=null;var p=this.parentNode;if(p){p.className=&quot;entity-avatar-emoji&quot;;p.textContent=&quot;\u{1F99E}&quot;;}">'
+            + '</span>';
     } else if (entityId != null) {
         // Emoji fallback — wrap in a span so the click delegate can resolve entityId.
         inner = '<span class="entity-avatar-emoji"' + eidAttr + '>' + (avatar || '\u{1F99E}') + '</span>';

--- a/backend/tests/jest/portal-entity-avatar-resolver.test.js
+++ b/backend/tests/jest/portal-entity-avatar-resolver.test.js
@@ -90,6 +90,20 @@ describe('portal entity-utils — Phase 0 petdx-aware resolver chain', () => {
         expect(ctx.renderAvatarHtml(ctx.getAvatarForEntity(1), 20, 1)).toContain('src="' + PETDX_LOBSTER_URL + '"');
     });
 
+    test('card_430579ee: URL-avatar <img> carries an onerror fallback (no bare broken-image glyph across portal pages)', () => {
+        const ctx = loadResolver();
+        ctx.updateEntityMaps([{ entityId: 1, character: 'LOBSTER', avatar: null,
+            petdxAvatarUrl: PETDX_LOBSTER_URL }]);
+        const html = ctx.renderAvatarHtml(ctx.getAvatarForEntity(1), 20, 1);
+        // FAIL-ON-OLD: the plain <img> branch had NO onerror, so a 404 / expired R2
+        // URL / ORB-block showed the browser's broken-image glyph (破圖) on ~10 pages.
+        expect(html).toMatch(/<img[^>]*onerror=/);
+        // the failure degrades to the emoji (a signal), not a broken image
+        expect(html).toContain(LOBSTER);
+        // the wrapper keeps data-entity-id so click delegates still resolve entityId
+        expect(html).toMatch(/data-entity-id="1"/);
+    });
+
     test('default-emoji avatar dropped from _entityAvatarMap (§0.4 invariant) so petdx wins', () => {
         const ctx = loadResolver();
         // Stale entity carries the lobster emoji as its "avatar" — must NOT beat petdxAvatarUrl


### PR DESCRIPTION
## Found proactively (not by Hank)
The anti-pattern audit — launched after Hank asked *"why do you always wait for me to find problems?"* — surfaced this before he hit it. The shared `renderAvatarHtml()` URL branch (`entity-utils.js`) emitted a plain `<img>` with **no onerror** and a **raw (unescaped) src**. Any avatar URL that 404s / expires (R2) / is ORB-blocked (external petdx sprite, `net::ERR_BLOCKED_BY_ORB`) showed the browser's broken-image glyph (破圖) on **every** portal surface that renders via this shared helper: community, marketplace, share-chat, dashboard, chat, kanban, mission, settings, files, card-holder (~10 pages).

## Fix
Wrap the `<img>` in a span (carrying `data-entity-id` so click delegates still resolve the entity) with an `onerror` that degrades to the emoji fallback — a signal, not a broken image — and `_escAttr`-harden the previously-raw URL.

## Test
`portal-entity-avatar-resolver.test.js`: URL-avatar render must carry `onerror` + degrade to emoji + keep `data-entity-id` (FAILS on the old no-onerror `<img>`). 20/20 in-suite; 58/58 sibling avatar tests unaffected.

## Follow-up
Routing external upstream petdx sprite URLs (needs_recovery companions) through the same-origin `/api/petdx` proxy is a separate data-repair item on card_430579ee; this change already makes those degrade to emoji instead of 破圖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)