### PR TITLE
feat(mission): single-note delete gets an undo toast (parity with bulk) (card_3ffe8415)

### DIFF
--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -2305,12 +2305,24 @@
         }
 
         async function deleteNote(id) {
-            const note = dashboard.notes.find(n => n.id === id);
-            const itemName = note ? (note.title || note.id) : id;
+            const removedIdx = dashboard.notes.findIndex(n => n.id === id);
+            if (removedIdx === -1) return;
+            const note = dashboard.notes[removedIdx];
+            const itemName = note.title || note.id;
             if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, confirmText: i18n.t('common_delete'), danger: true })) {
+                const removed = note;
                 dashboard.notes = dashboard.notes.filter(n => n.id !== id);
                 markChanged();
                 renderNotes();
+                // card_3ffe8415: single-note delete now offers a ~6s undo toast, the
+                // same safety net bulk delete already had. Confirm PREVENTS mis-taps,
+                // undo RECOVERS from them (Material/HIG) — the two are complementary,
+                // and it was inconsistent that only bulk had the recoverable net.
+                showUndoToast(i18n.t('mc_note_deleted') || 'Note deleted', () => {
+                    dashboard.notes.splice(Math.min(removedIdx, dashboard.notes.length), 0, removed);
+                    markChanged();
+                    renderNotes();
+                });
             }
         }
 
@@ -2323,14 +2335,10 @@
             menu.style.top = e.clientY + 'px';
 
             menu.querySelector('.context-menu-item').onclick = async () => {
-                const note = dashboard.notes.find(n => n.id === id);
-                const itemName = note ? (note.title || note.id) : id;
-                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, confirmText: i18n.t('common_delete'), danger: true })) {
-                    dashboard.notes = dashboard.notes.filter(n => n.id !== id);
-                    markChanged();
-                    renderNotes();
-                }
                 menu.style.display = 'none';
+                // card_3ffe8415: route through deleteNote so this path also gets the
+                // confirm + undo-toast safety net (was a duplicated no-undo delete).
+                await deleteNote(id);
             };
 
             setTimeout(() => document.addEventListener('click', () => menu.style.display = 'none', { once: true }), 10);

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -10722,6 +10722,7 @@ const TRANSLATIONS = {
 
 
         "mc_bulk_undo": "Undo",
+        "mc_note_deleted": "Note deleted",
 
 
 
@@ -661178,6 +661179,7 @@ const TRANSLATIONS = {
 
 
         "mc_bulk_undo": "復原",
+        "mc_note_deleted": "便箋已刪除",
 
 
 
@@ -1659108,6 +1659110,7 @@ const TRANSLATIONS = {
 
 
         "mc_bulk_undo": "复原",
+        "mc_note_deleted": "便签已删除",
 
 
 
@@ -6105979,6 +6105982,7 @@ const TRANSLATIONS = {
         "mc_confirm_delete_category": "Delete this category? Items will become uncategorized.",
         "mc_bulk_cancel": "Cancel",
         "mc_bulk_undo": "Undo",
+        "mc_note_deleted": "Note deleted",
         "mc_bulk_clearing": "Clearing...",
         "mc_bulk_cleared": "{count} items cleared",
         "mc_bulk_restoring": "Restoring...",

--- a/backend/tests/jest/mission-single-delete-undo.test.js
+++ b/backend/tests/jest/mission-single-delete-undo.test.js
@@ -1,0 +1,86 @@
+/**
+ * card_3ffe8415: single-note delete must offer an UNDO toast (parity with bulk).
+ *
+ * Before: deleteNote() confirmed then permanently filtered the note out — bulk
+ * delete had a ~6s undo safety net, single delete had none (inconsistent; a mis-tap
+ * was unrecoverable). This EXECUTES the real deleteNote() extracted from
+ * mission.html (same new Function harness as the chat-action-request tests) and
+ * pins: on confirm it removes the note AND calls showUndoToast, and the undo
+ * callback restores the note at its original index.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const html = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'mission.html'), 'utf8'
+);
+
+function extractFunction(name) {
+    const re = new RegExp(`(?:async\\s+)?function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`, 'g');
+    const m = re.exec(html);
+    if (!m) throw new Error(`function ${name} not found in mission.html`);
+    let depth = 1, i = m.index + m[0].length;
+    while (i < html.length && depth > 0) {
+        const ch = html[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+        i++;
+    }
+    return html.slice(m.index, i);
+}
+
+function makeHarness({ confirm = true } = {}) {
+    const dashboard = { notes: [
+        { id: 'n1', title: 'first' },
+        { id: 'n2', title: 'second' },
+        { id: 'n3', title: 'third' },
+    ] };
+    const calls = { markChanged: 0, renderNotes: 0, undoToasts: [] };
+    const showConfirm = jest.fn(async () => confirm);
+    const markChanged = () => { calls.markChanged++; };
+    const renderNotes = () => { calls.renderNotes++; };
+    const showUndoToast = (msg, undoFn) => { calls.undoToasts.push({ msg, undoFn }); };
+    const i18n = { t: (k) => k };
+
+    const factory = new Function(
+        'dashboard', 'showConfirm', 'markChanged', 'renderNotes', 'showUndoToast', 'i18n', 'Math',
+        `${extractFunction('deleteNote')}\n return deleteNote;`
+    );
+    const deleteNote = factory(dashboard, showConfirm, markChanged, renderNotes, showUndoToast, i18n, Math);
+    return { deleteNote, dashboard, calls, showConfirm };
+}
+
+describe('mission single-note delete — undo toast (card_3ffe8415)', () => {
+    it('removes the note AND offers an undo toast on confirm (FAIL-ON-OLD: no showUndoToast call)', async () => {
+        const h = makeHarness({ confirm: true });
+        await h.deleteNote('n2');
+        expect(h.dashboard.notes.map(n => n.id)).toEqual(['n1', 'n3']);   // removed
+        expect(h.calls.undoToasts).toHaveLength(1);                        // FAIL-ON-OLD: was 0
+        expect(typeof h.calls.undoToasts[0].undoFn).toBe('function');
+    });
+
+    it('the undo callback restores the deleted note at its ORIGINAL index', async () => {
+        const h = makeHarness({ confirm: true });
+        await h.deleteNote('n2');                    // remove the middle note
+        h.calls.undoToasts[0].undoFn();              // user clicks Undo
+        expect(h.dashboard.notes.map(n => n.id)).toEqual(['n1', 'n2', 'n3']);  // back in place
+        expect(h.dashboard.notes[1]).toMatchObject({ id: 'n2', title: 'second' });
+    });
+
+    it('cancelling the confirm deletes nothing and shows no undo toast', async () => {
+        const h = makeHarness({ confirm: false });
+        await h.deleteNote('n2');
+        expect(h.dashboard.notes.map(n => n.id)).toEqual(['n1', 'n2', 'n3']);
+        expect(h.calls.undoToasts).toHaveLength(0);
+    });
+
+    it('deleting an unknown id is a no-op (no toast, no throw)', async () => {
+        const h = makeHarness({ confirm: true });
+        await h.deleteNote('nope');
+        expect(h.dashboard.notes).toHaveLength(3);
+        expect(h.calls.undoToasts).toHaveLength(0);
+        expect(h.showConfirm).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## What
Found by the destructive-modals daily E2E. mission.html already had a ~6s undo-toast safety net (`showUndoToast`), but **only bulk delete used it** — single `deleteNote()` confirmed then permanently removed the note with **no undo**, so a mis-tap was unrecoverable. Confirm PREVENTS mis-taps; undo RECOVERS from them (Material/HIG) — complementary, and it was inconsistent that only bulk had the net.

## Changes (`mission.html`)
- `deleteNote()`: after removing the note, reuse the existing `showUndoToast()` with an undo callback that splices the note back at its **original index**. No new infra.
- The context-menu delete path (`showNoteMenu`) was a duplicated no-undo delete → routed through `deleteNote()` so it also gets confirm + undo (dedup).
- i18n: `mc_note_deleted` (EN/ZH/zh-CN); Undo button reuses `mc_bulk_undo`.

## Test — `mission-single-delete-undo.test.js`
Executes the real extracted `deleteNote()`: confirm → removed + `showUndoToast` called (**FAIL-ON-OLD**: 0 undo toasts); undo restores the note at its original index; cancel deletes nothing; unknown id no-ops. **4/4 pass**; i18n-syntax 12/12.

## Scope note
This covers single **note** delete (the reported inconsistency). `deleteNotePage` (whole note-page) and kanban single-card archive are separate delete surfaces — a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)