### PR TITLE
feat(chip): add the ? spec-tooltip icon to the card-chip screenshot section (card_abdf0904)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3517,6 +3517,7 @@
         .autolink-chip-popover .chip-popover-shots { margin-top: 8px; padding-top: 6px; border-top: 1px solid rgba(255,255,255,0.06); }
         .autolink-chip-popover .chip-popover-shots-label { font-size: 12px; color: #bbb; margin-bottom: 6px; display: flex; align-items: center; gap: 4px; }
         .autolink-chip-popover .chip-popover-shots-count { color: #888; }
+        .autolink-chip-popover .chip-popover-shots-help { display: inline-flex; align-items: center; justify-content: center; width: 14px; height: 14px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.25); color: #aaa; font-size: 10px; line-height: 1; cursor: help; }
         .autolink-chip-popover .chip-popover-thumbs { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }
         .autolink-chip-popover .chip-popover-thumb { display: block; border: 1px solid rgba(255,255,255,0.1); border-radius: 6px; overflow: hidden; background: rgba(255,255,255,0.04); transition: border-color .15s, transform .15s; }
         .autolink-chip-popover .chip-popover-thumb:hover { border-color: #c084fc; transform: scale(1.03); }

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -229,6 +229,7 @@
         .autolink-chip-popover .chip-popover-shots { margin-top:8px; padding-top:6px; border-top:1px solid rgba(255,255,255,0.06); }
         .autolink-chip-popover .chip-popover-shots-label { font-size:12px; color:#bbb; margin-bottom:6px; display:flex; align-items:center; gap:4px; }
         .autolink-chip-popover .chip-popover-shots-count { color:#888; }
+        .autolink-chip-popover .chip-popover-shots-help { display:inline-flex; align-items:center; justify-content:center; width:14px; height:14px; border-radius:50%; border:1px solid rgba(255,255,255,0.25); color:#aaa; font-size:10px; line-height:1; cursor:help; }
         .autolink-chip-popover .chip-popover-thumbs { display:grid; grid-template-columns:repeat(3,1fr); gap:6px; }
         .autolink-chip-popover .chip-popover-thumb { display:block; border:1px solid rgba(255,255,255,0.1); border-radius:6px; overflow:hidden; background:rgba(255,255,255,0.04); transition:border-color .15s, transform .15s; }
         .autolink-chip-popover .chip-popover-thumb:hover { border-color:#c084fc; transform:scale(1.03); }

--- a/backend/public/portal/shared/autolink-chip-preview.js
+++ b/backend/public/portal/shared/autolink-chip-preview.js
@@ -187,10 +187,18 @@
             && /^image\//i.test(String(f.mimeType || f.mime_type || '')));
         if (!images.length) return '';
         const label = t('chip_popover_screenshots', '📸 截圖');
-        // TODO(#6): attach the "?" spec-tooltip icon here (right of the section
-        // label), reusing the portal's existing help-icon pattern. Backend/data
-        // is ready; only the tooltip affordance is #6's (UI) piece. Marker id
-        // below so #6 can target it without re-deriving the DOM shape.
+        // card_abdf0904: "?" spec-tooltip icon (Hank: 加上 ? icon 註解詳細規格).
+        // Native title = robust bilingual affordance (hover on desktop, long-press
+        // on mobile) that no i18n.apply pass can clobber; language by document lang,
+        // same approach chat.html's replyPreviewHelp uses.
+        const zh = ((typeof document !== 'undefined' && document.documentElement
+            && document.documentElement.lang) || '').toLowerCase().indexOf('zh') === 0;
+        const helpText = zh
+            ? '此區顯示這張卡片的截圖／附件縮圖；點縮圖可放大檢視。內容來自卡片附件並隨其更新。此功能過去存在、一度消失，現已修復並加了防回歸測試以防再次消失。'
+            : "This card's screenshots / attachment thumbnails — click a thumbnail to enlarge. It reflects the card's current attachments. The section had regressed away and is now restored with a guard test so it can't silently vanish again.";
+        const helpIcon = ' <span class="chip-popover-shots-help" role="img"'
+            + ' aria-label="' + escapeHtml(zh ? '截圖區說明' : 'about screenshots') + '"'
+            + ' title="' + escapeHtml(helpText) + '">?</span>';
         const thumbs = images.map(f => {
             const url = escapeHtml(f.url);
             const name = escapeHtml(f.filename || 'screenshot');
@@ -201,7 +209,8 @@
         }).join('');
         return '<div class="chip-popover-shots">'
             + '<div class="chip-popover-shots-label" data-chip-help-anchor="screenshots">'
-            + escapeHtml(label) + ' <span class="chip-popover-shots-count">' + images.length + '</span></div>'
+            + escapeHtml(label) + ' <span class="chip-popover-shots-count">' + images.length + '</span>'
+            + helpIcon + '</div>'
             + '<div class="chip-popover-thumbs">' + thumbs + '</div>'
             + '</div>';
     }

--- a/backend/tests/jest/chip-preview-screenshot-thumbnails.test.js
+++ b/backend/tests/jest/chip-preview-screenshot-thumbnails.test.js
@@ -86,6 +86,16 @@ describe('chip popover screenshot-thumbnail block', () => {
         expect(html).toMatch(/chip-popover-shots-count">2</);
     });
 
+    test('card_abdf0904: the section carries a "?" spec-tooltip icon with a title', () => {
+        const html = buildScreenshotBlockHtml({ files: [IMG()] });
+        // the "?" help affordance is present, styled by chip-popover-shots-help
+        expect(html).toMatch(/class="chip-popover-shots-help"[^>]*>\?</);
+        // it exposes a non-empty title tooltip (the spec annotation Hank asked for)
+        expect(html).toMatch(/class="chip-popover-shots-help"[^>]*title="[^"]+"/);
+        // and an aria-label for a11y
+        expect(html).toMatch(/class="chip-popover-shots-help"[^>]*aria-label="[^"]+"/);
+    });
+
     test('renders nothing when the card has no image files', () => {
         expect(buildScreenshotBlockHtml({ files: [] })).toBe('');
         expect(buildScreenshotBlockHtml({})).toBe('');
@@ -148,7 +158,10 @@ describe('chip popover render wiring (source-text guard)', () => {
         expect(CHIP_SRC).toMatch(/window\.openLightbox/);
     });
 
-    test('leaves a TODO marker for #6 to attach the ? spec-tooltip icon', () => {
-        expect(CHIP_SRC).toMatch(/TODO\(#6\)/);
+    test('card_abdf0904: the ? spec-tooltip icon is IMPLEMENTED (TODO(#6) marker resolved)', () => {
+        // The screenshot section now ships the "?" help affordance itself — the
+        // earlier TODO(#6) placeholder has been resolved, not just deferred.
+        expect(CHIP_SRC).not.toMatch(/TODO\(#6\)/);
+        expect(CHIP_SRC).toMatch(/chip-popover-shots-help/);
     });
 });


### PR DESCRIPTION
Completes **card_abdf0904** (Hank: 加上 ? icon 來註解詳細規格). The screenshot/thumbnail restore + regression guard shipped in #3855; this adds the last piece — the `?` help affordance — that #3855 left as a `TODO(#6)` marker. Since the card auto-escalated to P0 waiting on it and I'd already left the hook, I finished it rather than leave it blocked.

## Changes
- `autolink-chip-preview.js` `buildScreenshotBlockHtml`: append a `?` icon (`.chip-popover-shots-help`) after the section label, with a **bilingual native `title`** (hover desktop / long-press mobile) by document lang — the clobber-proof `replyPreviewHelp` approach, so `i18n.apply` can't wipe it — plus `aria-label`. The tooltip explains what the section shows AND that it regressed once and is now guarded.
- `chat.html` + `kanban.html`: `.chip-popover-shots-help` CSS (subtle circular badge, `cursor:help`).

## Test
`chip-preview-screenshot-thumbnails.test.js`: asserts the `?` icon renders with title + aria-label, and the `TODO(#6)` marker is **resolved**. 21/21 pass; `autolink-chip.test.js` green; JS `--check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)