### PR TITLE
fix(kanban): stale-card escalations reach a supervisor, not only the stuck assignee (card_3ce0080a)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -3850,11 +3850,11 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
 
             if (escalationAllowed) {
                 if (elapsedMs >= blockAfterMs && card.status !== 'blocked' && sinceLast > intervalMs) {
-                    await fireBlockEscalation(card, filterNudgeStoppedRecipients(buildEscalationRecipients(card)));
+                    await fireBlockEscalation(card, filterNudgeStoppedRecipients(await buildEscalationRecipients(card)));
                     continue;
                 }
                 if (elapsedMs >= escalateAfterMs && sinceLast > intervalMs) {
-                    const fired = await fireLevelTwoEscalation(card, filterNudgeStoppedRecipients(buildEscalationRecipients(card)));
+                    const fired = await fireLevelTwoEscalation(card, filterNudgeStoppedRecipients(await buildEscalationRecipients(card)));
                     if (fired) continue;
                 }
             }
@@ -3987,14 +3987,66 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         }
     }
 
-    function buildEscalationRecipients(card) {
+    // Commander-class entities, ordered by preference (#2 commander, then #1
+    // deputy). Mirrors REOPEN_SUPERVISOR_ENTITY_IDS — the platform already treats
+    // #1/#2 as supervisors. Used as the fallback escalation target when no reviewer
+    // is set and no org chart is configured.
+    const ESCALATION_SUPERVISOR_ENTITY_IDS = [2, 1];
+
+    /**
+     * Resolve the supervisor an escalation should also reach, so a stuck
+     * subordinate's card doesn't just re-nudge the STUCK assignee forever with no
+     * commander ever intervening (card_3ce0080a). Preference:
+     *   1. org-chart superior of the (first) assignee, if a hierarchy is configured
+     *   2. fallback: a bound commander-class entity (#2 then #1) that isn't itself
+     *      an assignee
+     * Returns an entity id (number) or null. Never returns an assignee.
+     */
+    async function resolveEscalationSupervisor(card, bots) {
+        const assignees = new Set(bots.map(Number));
+        // (1) org-chart superior
+        if (orgChart && bots.length > 0) {
+            try {
+                const orgData = await orgChart.getOrgChart(card.device_id);
+                const sup = orgData && orgData.hierarchy
+                    ? orgChart.getSuperior(orgData.hierarchy, Number(bots[0]))
+                    : null;
+                if (typeof sup === 'number' && !assignees.has(sup)) {
+                    const device = devices[card.device_id];
+                    if (device && device.entities && device.entities[sup] && device.entities[sup].isBound) {
+                        return sup;
+                    }
+                }
+            } catch (err) {
+                // non-fatal: fall through to the commander fallback
+                if (serverLog) serverLog('warn', 'kanban', `[Escalation] org-chart superior lookup failed: ${err.message}`, { deviceId: card.device_id });
+            }
+        }
+        // (2) commander-class fallback
+        const device = devices[card.device_id];
+        if (device && device.entities) {
+            for (const cid of ESCALATION_SUPERVISOR_ENTITY_IDS) {
+                if (assignees.has(cid)) continue;
+                if (device.entities[cid] && device.entities[cid].isBound) return cid;
+            }
+        }
+        return null;
+    }
+
+    async function buildEscalationRecipients(card) {
         const config = card.config || {};
         const esc = config.escalationPolicy || {};
         const notifyEntityId = esc.notifyEntityId || card.reviewer_entity_id;
         const bots = Array.isArray(card.assigned_bots) ? card.assigned_bots : [];
+        // Supervisor visibility (card_3ce0080a): without this, a card whose
+        // reviewer_entity_id is null escalates ONLY to its assignees, so a blocked
+        // subordinate's card re-nudges the stuck bot indefinitely and burns its
+        // tokens with no commander in the loop. Add a resolved supervisor to L2/L3/
+        // P0 escalation recipients (not routine L1 nudges).
+        const supervisorId = await resolveEscalationSupervisor(card, bots);
         const seen = new Set();
         const out = [];
-        for (const id of [notifyEntityId, ...bots]) {
+        for (const id of [notifyEntityId, supervisorId, ...bots]) {
             if (id == null) continue;
             const key = String(id);
             if (seen.has(key)) continue;
@@ -4006,7 +4058,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
 
     async function fireBlockEscalation(card, recipientIds = null) {
         const elapsedHrs = Math.round((Date.now() - new Date(card.status_changed_at).getTime()) / 3600000 * 10) / 10;
-        const recipients = Array.isArray(recipientIds) ? recipientIds : buildEscalationRecipients(card);
+        const recipients = Array.isArray(recipientIds) ? recipientIds : await buildEscalationRecipients(card);
         // Severity gate (card_22ab8c3b path #2, sibling of PR #3564):
         // P0 cards are "fix now, supervisor's attention". Auto-moving them to
         // `blocked` hides them from the active board and clears the in_progress
@@ -4045,7 +4097,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
 
     async function fireLevelTwoEscalation(card, recipientIds = null) {
         const elapsedHrs = Math.round((Date.now() - new Date(card.status_changed_at).getTime()) / 3600000 * 10) / 10;
-        const recipients = Array.isArray(recipientIds) ? recipientIds : buildEscalationRecipients(card);
+        const recipients = Array.isArray(recipientIds) ? recipientIds : await buildEscalationRecipients(card);
         // Severity gate (card_22ab8c3b path #2): P3 cards in `backlog` are
         // design-first drafts awaiting launch — they sit there on purpose and
         // must NOT be silently bumped to P2 by clock alone. Skip L2; the L1

--- a/backend/tests/jest/kanban-escalate-to-supervisor.test.js
+++ b/backend/tests/jest/kanban-escalate-to-supervisor.test.js
@@ -1,0 +1,194 @@
+'use strict';
+
+/**
+ * Regression test — supervisor-visibility on stale-card escalation
+ * (card_3ce0080a).
+ *
+ * Root cause it pins: buildEscalationRecipients used to return
+ * [reviewer_entity_id, ...assigned_bots]. When a card has NO reviewer set
+ * (reviewer_entity_id === null — the common case for a directly-assigned
+ * subordinate card), escalations reached ONLY the assignees. So when a
+ * subordinate (e.g. #6) got stuck/blocked, the stale-nudge worker just
+ * re-nudged the STUCK bot forever and no commander ever intervened — burning
+ * the assignee's tokens. (This is the exact card_83bbe7ed incident: reviewer
+ * was null, assigned=[6], so every L2/L3/P0 escalation notified only #6.)
+ *
+ * Fix: resolveEscalationSupervisor() adds a supervisor to L2/L3/P0 escalation
+ * recipients — the org-chart superior of the assignee if a hierarchy is
+ * configured, else a bound commander-class entity (#2 then #1) that isn't
+ * itself an assignee.
+ *
+ * Style mirrors kanban-stall-severity-gate.test.js: extractFunctionBody +
+ * new Function behavioural smoke, plus source-grep invariants.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const kanbanSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'kanban.js'),
+    'utf8'
+);
+
+function extractFunctionBody(src, signature) {
+    const start = src.indexOf(signature);
+    if (start === -1) throw new Error(`function not found: ${signature}`);
+    const open = src.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) return src.slice(open, i + 1);
+        }
+    }
+    throw new Error(`unterminated function: ${signature}`);
+}
+
+// ---- Rebuild the two functions in isolation ------------------------------
+
+const resolveSrc = extractFunctionBody(
+    kanbanSrc,
+    'async function resolveEscalationSupervisor(card, bots)'
+);
+const buildSrc = extractFunctionBody(
+    kanbanSrc,
+    'async function buildEscalationRecipients(card)'
+);
+
+const makeResolve = (deps) =>
+    // eslint-disable-next-line no-new-func
+    new Function(
+        'orgChart', 'devices', 'serverLog', 'ESCALATION_SUPERVISOR_ENTITY_IDS',
+        `return async function resolveEscalationSupervisor(card, bots) ${resolveSrc}`
+    )(deps.orgChart, deps.devices, deps.serverLog, [2, 1]);
+
+const makeBuild = (resolveStub) =>
+    // eslint-disable-next-line no-new-func
+    new Function(
+        'resolveEscalationSupervisor',
+        `return async function buildEscalationRecipients(card) ${buildSrc}`
+    )(resolveStub);
+
+function boundDevice(boundIds) {
+    const entities = {};
+    for (const id of boundIds) entities[id] = { isBound: true };
+    return { entities };
+}
+
+describe('resolveEscalationSupervisor — behavioural', () => {
+    test('card_83bbe7ed incident: no org chart, assigned=[6], #2 bound → returns #2 (commander fallback)', async () => {
+        const resolve = makeResolve({
+            orgChart: { getOrgChart: async () => ({ hierarchy: {} }), getSuperior: () => null },
+            devices: { dev1: boundDevice([1, 2, 6]) },
+            serverLog: () => {},
+        });
+        const sup = await resolve({ device_id: 'dev1' }, [6]);
+        expect(sup).toBe(2);
+    });
+
+    test('org-chart superior wins when a hierarchy is configured (#6 → #3 bound)', async () => {
+        const resolve = makeResolve({
+            orgChart: {
+                getOrgChart: async () => ({ hierarchy: { USER: [3], 3: [6] } }),
+                getSuperior: (h, id) => (id === 6 ? 3 : 'USER'),
+            },
+            devices: { dev1: boundDevice([1, 2, 3, 6]) },
+            serverLog: () => {},
+        });
+        const sup = await resolve({ device_id: 'dev1' }, [6]);
+        expect(sup).toBe(3);
+    });
+
+    test('never returns an assignee: org-chart superior that is itself assigned → falls back to commander', async () => {
+        const resolve = makeResolve({
+            orgChart: {
+                getOrgChart: async () => ({ hierarchy: { USER: [6], 6: [7] } }),
+                getSuperior: () => 6, // superior is also in bots
+            },
+            devices: { dev1: boundDevice([1, 2, 6, 7]) },
+            serverLog: () => {},
+        });
+        const sup = await resolve({ device_id: 'dev1' }, [6, 7]);
+        expect(sup).toBe(2); // #6 excluded (assignee), commander fallback #2
+    });
+
+    test('commander is the assignee: #2 working its own card → does not self-escalate, tries #1', async () => {
+        const resolve = makeResolve({
+            orgChart: { getOrgChart: async () => ({ hierarchy: {} }), getSuperior: () => null },
+            devices: { dev1: boundDevice([1, 2]) },
+            serverLog: () => {},
+        });
+        const sup = await resolve({ device_id: 'dev1' }, [2]);
+        expect(sup).toBe(1); // #2 is the assignee → deputy #1
+    });
+
+    test('no bound commander → returns null (no phantom recipient)', async () => {
+        const resolve = makeResolve({
+            orgChart: { getOrgChart: async () => ({ hierarchy: {} }), getSuperior: () => null },
+            devices: { dev1: boundDevice([6]) }, // neither #1 nor #2 bound
+            serverLog: () => {},
+        });
+        const sup = await resolve({ device_id: 'dev1' }, [6]);
+        expect(sup).toBeNull();
+    });
+
+    test('org-chart lookup throws → non-fatal, falls back to commander', async () => {
+        const resolve = makeResolve({
+            orgChart: { getOrgChart: async () => { throw new Error('db down'); }, getSuperior: () => null },
+            devices: { dev1: boundDevice([2, 6]) },
+            serverLog: () => {},
+        });
+        const sup = await resolve({ device_id: 'dev1' }, [6]);
+        expect(sup).toBe(2);
+    });
+});
+
+describe('buildEscalationRecipients — supervisor is included', () => {
+    test('reviewer=null, assigned=[6], supervisor #2 → recipients include #2 (the fix)', async () => {
+        const build = makeBuild(async () => 2);
+        const out = await build({ reviewer_entity_id: null, assigned_bots: [6], config: {} });
+        expect(out).toContain(2);      // commander now in the loop
+        expect(out).toContain(6);      // assignee still notified
+        expect(out.indexOf(2)).toBeLessThan(out.indexOf(6)); // supervisor ordered before assignees
+    });
+
+    test('explicit reviewer preserved and deduped against supervisor', async () => {
+        const build = makeBuild(async () => 2);
+        const out = await build({ reviewer_entity_id: 2, assigned_bots: [6], config: {} });
+        expect(out.filter((x) => x === 2).length).toBe(1); // no dup
+        expect(out).toEqual([2, 6]);
+    });
+
+    test('no supervisor resolved (null) → legacy behavior, assignees only', async () => {
+        const build = makeBuild(async () => null);
+        const out = await build({ reviewer_entity_id: null, assigned_bots: [6], config: {} });
+        expect(out).toEqual([6]);
+    });
+});
+
+describe('source invariants', () => {
+    test('buildEscalationRecipients is async and threads supervisorId into the recipient list', () => {
+        expect(kanbanSrc).toMatch(/async function buildEscalationRecipients\(card\)/);
+        expect(buildSrc).toMatch(/resolveEscalationSupervisor\(card, bots\)/);
+        expect(buildSrc).toMatch(/\[notifyEntityId, supervisorId, \.\.\.bots\]/);
+    });
+
+    test('all call sites await buildEscalationRecipients (no sync leftovers)', () => {
+        const syncCalls = kanbanSrc
+            .split('\n')
+            .filter((l) => /buildEscalationRecipients\(card\)/.test(l))
+            .filter((l) => !/await buildEscalationRecipients\(card\)/.test(l))
+            .filter((l) => !/async function buildEscalationRecipients/.test(l));
+        expect(syncCalls).toEqual([]);
+    });
+
+    test('commander fallback uses the #2-before-#1 ordering constant', () => {
+        expect(kanbanSrc).toMatch(/ESCALATION_SUPERVISOR_ENTITY_IDS\s*=\s*\[2,\s*1\]/);
+    });
+
+    test('supervisor is never an assignee (guard present)', () => {
+        expect(resolveSrc).toMatch(/assignees\.has/);
+    });
+});

--- a/backend/tests/jest/kanban-nudge-stop-mode.test.js
+++ b/backend/tests/jest/kanban-nudge-stop-mode.test.js
@@ -57,8 +57,11 @@ describe('kanban nudge stop-mode preferences', () => {
 
         expect(body).toMatch(/function filterNudgeStoppedRecipients\(ids\)/);
         expect(body).toMatch(/if \(effectiveFor\(n\)\.stopMode\) continue/);
-        expect(body).toMatch(/fireBlockEscalation\(card, filterNudgeStoppedRecipients\(buildEscalationRecipients\(card\)\)\)/);
-        expect(body).toMatch(/fireLevelTwoEscalation\(card, filterNudgeStoppedRecipients\(buildEscalationRecipients\(card\)\)\)/);
+        // buildEscalationRecipients became async (card_3ce0080a: resolves a
+        // supervisor via org-chart / commander fallback) — the recipient list is
+        // still wrapped by filterNudgeStoppedRecipients, now with an await.
+        expect(body).toMatch(/fireBlockEscalation\(card, filterNudgeStoppedRecipients\(await buildEscalationRecipients\(card\)\)\)/);
+        expect(body).toMatch(/fireLevelTwoEscalation\(card, filterNudgeStoppedRecipients\(await buildEscalationRecipients\(card\)\)\)/);
     });
 
     test('nudge delivery helpers accept filtered recipient lists and record only those recipients', () => {
@@ -69,8 +72,8 @@ describe('kanban nudge stop-mode preferences', () => {
         expect(l1).toMatch(/const bots = Array\.isArray\(recipientIds\) \? recipientIds : \(card\.assigned_bots \|\| \[\]\)/);
         expect(l1).toMatch(/notifyEntities\(card\.device_id, bots/);
         expect(l1).toMatch(/recordEntityNudge\(card\.device_id, bots\)/);
-        expect(l2).toMatch(/const recipients = Array\.isArray\(recipientIds\) \? recipientIds : buildEscalationRecipients\(card\)/);
-        expect(l3).toMatch(/const recipients = Array\.isArray\(recipientIds\) \? recipientIds : buildEscalationRecipients\(card\)/);
+        expect(l2).toMatch(/const recipients = Array\.isArray\(recipientIds\) \? recipientIds : await buildEscalationRecipients\(card\)/);
+        expect(l3).toMatch(/const recipients = Array\.isArray\(recipientIds\) \? recipientIds : await buildEscalationRecipients\(card\)/);
     });
 });
 


### PR DESCRIPTION
## The incident (Hank's accountability demand)
A subordinate (#6) got stuck on card_83bbe7ed (Computer Use denied → couldn't finish), posted its blocker on the card, and the stale-nudge worker **re-nudged #6 hourly forever** — burning its tokens — while the commander (#2) never saw it and never intervened.

## Root cause
`buildEscalationRecipients(card)` returned `[reviewer_entity_id, ...assigned_bots]`. card_83bbe7ed had **`reviewer_entity_id = null`**, assigned `[6]` → every L2/L3/P0 escalation notified **only #6** (the stuck assignee). No structural path put a supervisor in the loop.

## Fix
New `resolveEscalationSupervisor(card, bots)`, threaded into `buildEscalationRecipients` (now async):
1. **org-chart superior** of the assignee, if a hierarchy is configured (reuses the existing `orgChart.getSuperior` already used for reviewer auto-set);
2. **fallback**: a *bound* commander-class entity (**#2 then #1**, mirroring the existing `REOPEN_SUPERVISOR_ENTITY_IDS = {1,2}` convention) that isn't itself an assignee.

Guarantees a stuck subordinate's escalation reaches a commander so they can intervene / take over / unblock — instead of the board hammering the stuck bot.

### Blast radius (deliberately narrow)
- Fires **only on genuine stalls** (L2 escalate >6h, L3 block >12h, P0-stalled) — **not** routine L1 nudges.
- **No-op when no supervisor is bound** (returns `null` → legacy behavior, assignees only). Users without `#1/#2` bound and without an org chart see **zero change**.
- Never returns an assignee (a commander working its own card doesn't self-escalate; falls through to #1).
- org-chart lookup failure is non-fatal (falls back to commander).

## Tests
`backend/tests/jest/kanban-escalate-to-supervisor.test.js` (13) — extract-and-run harness (same style as kanban-stall-severity-gate):
- commander fallback (the exact incident: reviewer=null, assigned=[6], #2 bound → #2)
- org-chart superior wins when configured
- never-an-assignee guard
- #2-is-assignee → escalates to #1
- no-bound-commander → null (no phantom recipient)
- org-chart throws → falls back to commander
- `buildEscalationRecipients` includes the supervisor + dedups an explicit reviewer
- **fail-on-old**: suite errors on origin/main (`resolveEscalationSupervisor` absent)

Full `jest tests/jest/kanban`: **416 passed**. ESLint clean. Updated 2 nudge-stop-mode source-grep assertions for the added `await`.

This is part of the card_3ce0080a systemic remediation (the other legs: #6→#2 per-message routing delivery; tool-permission pre-check before dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)