### PR TITLE
fix(portal): keep destructive Confirm out of the phone thumb zone (card_3267470a)

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -243,6 +243,23 @@ function _eclawEnsureDialogAnimStyle() {
 @media (prefers-reduced-motion: reduce) {
     .eclaw-confirm-overlay,
     .eclaw-confirm-dialog { animation: none; }
+}
+/* Destructive-confirm thumb-zone guard (card_3267470a): on narrow (phone)
+   viewports the actions stack full-width vertically, which puts the LAST DOM
+   button — the destructive Confirm — at the very bottom, i.e. the easiest
+   single-thumb target, directly under Cancel. column-reverse flips only the
+   VISUAL order so the safe Cancel sits in the bottom thumb zone and the
+   destructive button is above it. DOM order is untouched, so tab order, the
+   focus trap, safe-default-focus (Cancel) and Esc all keep working exactly as
+   before. Scoped to danger dialogs + phone width, so desktop (side-by-side
+   row) is unaffected. */
+@media (max-width: 480px) {
+    .eclaw-confirm-dialog.eclaw-confirm-danger .dialog-actions {
+        display: flex;
+        flex-direction: column-reverse;
+        gap: 8px;
+    }
+    .eclaw-confirm-dialog.eclaw-confirm-danger .dialog-actions > .btn { width: 100%; }
 }`;
     document.head.appendChild(style);
 }
@@ -279,7 +296,7 @@ function showConfirm({ message, title, confirmText, cancelText, danger, itemName
         const itemStrip = (danger && itemName)
             ? `<div class="eclaw-confirm-item" style="margin:8px 0 0;padding:8px 12px;background:var(--bg-secondary, rgba(0,0,0,0.04));border-left:3px solid var(--danger, #e53e3e);border-radius:4px;font-weight:600;color:var(--text);word-break:break-word">${_escHtml(itemName)}</div>`
             : '';
-        overlay.innerHTML = `<div class="dialog eclaw-confirm-dialog" ${dialogAria} ${_ECLAW_DIALOG_SHADOW_STYLE}>
+        overlay.innerHTML = `<div class="dialog eclaw-confirm-dialog${danger ? ' eclaw-confirm-danger' : ''}" ${dialogAria} ${_ECLAW_DIALOG_SHADOW_STYLE}>
             ${title ? `<div class="dialog-title" id="${titleId}">${_escHtml(title)}</div>` : ''}
             <div class="dialog-body"><p id="${messageId}" style="margin:0;line-height:1.6;color:var(--text-secondary)">${_escHtml(message)}</p>${itemStrip}</div>
             <div class="dialog-actions">

--- a/backend/tests/jest/showConfirm-destructive-thumb-zone.test.js
+++ b/backend/tests/jest/showConfirm-destructive-thumb-zone.test.js
@@ -1,0 +1,81 @@
+/**
+ * Static invariant test — destructive-confirm thumb-zone guard.
+ *
+ * Card: card_3267470a (P3) — on phone viewports the shared `showConfirm(danger)`
+ * actions stack full-width vertically, putting the LAST DOM button (the
+ * destructive Confirm) at the very bottom = the easiest single-thumb target,
+ * directly under Cancel → mis-tap-delete risk.
+ *
+ * Fix (CSS-only, visual reorder): danger dialogs get an `eclaw-confirm-danger`
+ * marker class, and the injected <style> flips ONLY the visual order on phone
+ * width via `flex-direction: column-reverse` so the safe Cancel sits in the
+ * bottom thumb zone and the destructive button is above it. DOM order is
+ * untouched, so tab order / focus trap / safe-default-focus (Cancel) / Esc are
+ * all preserved. Scoped to `.eclaw-confirm-danger` + `max-width:480px`, so
+ * non-danger dialogs and desktop (side-by-side row) are unaffected.
+ *
+ * jest.config.js is testEnvironment:'node' → grep the source like the sibling
+ * showConfirm-*.test.js files.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const apiJs = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'shared', 'api.js'),
+    'utf8'
+);
+
+const styleBlock = (apiJs.match(/_eclawEnsureDialogAnimStyle[\s\S]*?document\.head\.appendChild\(style\)/) || [''])[0];
+
+describe('showConfirm — destructive thumb-zone guard (card_3267470a)', () => {
+    test('danger dialogs carry an eclaw-confirm-danger marker class; non-danger do not', () => {
+        // Marker is appended to the dialog className ONLY when danger is true.
+        expect(apiJs).toMatch(/eclaw-confirm-dialog\$\{danger\s*\?\s*['"] eclaw-confirm-danger['"]\s*:\s*['"]['"]\}/);
+    });
+
+    test('injected CSS reorders ONLY danger dialogs on phone width (column-reverse)', () => {
+        expect(styleBlock).not.toBe('');
+        // A phone-width media query.
+        expect(styleBlock).toMatch(/@media\s*\(\s*max-width:\s*480px\s*\)/);
+        // The reorder rule is scoped to the danger marker + the actions row.
+        expect(styleBlock).toMatch(
+            /\.eclaw-confirm-dialog\.eclaw-confirm-danger\s+\.dialog-actions\s*\{[^}]*flex-direction:\s*column-reverse/
+        );
+    });
+
+    test('the reorder is scoped — it never targets non-danger or desktop', () => {
+        // Extract the phone media block and assert the reorder rule inside it is
+        // gated by .eclaw-confirm-danger (not a bare .dialog-actions that would
+        // hit every dialog).
+        const mq = styleBlock.match(/@media\s*\(\s*max-width:\s*480px\s*\)\s*\{([\s\S]*?)\}\s*`/);
+        expect(mq).not.toBeNull();
+        const body = mq[1];
+        expect(body).toMatch(/column-reverse/);
+        // Every column-reverse rule in the block must be qualified by the danger class.
+        const reverseRules = body.match(/[^}]*column-reverse[^}]*\{?/g) || [];
+        // Simpler + robust: there is no column-reverse selector that omits the danger marker.
+        expect(body).not.toMatch(/(^|[},])\s*\.dialog-actions\s*\{[^}]*column-reverse/);
+        expect(body).toMatch(/\.eclaw-confirm-danger\s+\.dialog-actions/);
+    });
+
+    test('CSS-only: DOM/tab order unchanged — Cancel button still precedes Confirm in markup', () => {
+        // The whole point: reorder is VISUAL. In the DOM, cancel must still be
+        // authored before ok so tab order + focus trap logic (Cancel first
+        // tabbable, OK last) keep working.
+        const cancelIdx = apiJs.indexOf('eclaw-confirm-cancel');
+        const okIdx = apiJs.indexOf('eclaw-confirm-ok');
+        expect(cancelIdx).toBeGreaterThan(-1);
+        expect(okIdx).toBeGreaterThan(-1);
+        expect(cancelIdx).toBeLessThan(okIdx);
+    });
+
+    test('a11y contract untouched (no regression): safe-default-focus stays on Cancel for danger', () => {
+        // danger → focus the cancel button (unchanged by the CSS fix).
+        expect(apiJs).toMatch(/const\s+safeBtnSel\s*=\s*danger\s*\?\s*['"]\.eclaw-confirm-cancel['"]/);
+        expect(apiJs).toMatch(/role="alertdialog"/);
+        expect(apiJs).toMatch(/if\s*\(\s*e\.key\s*===\s*['"]Escape['"]\s*\)\s*cleanup\(\s*false\s*\)/);
+        expect(apiJs).toMatch(/btn-danger/);
+    });
+});


### PR DESCRIPTION
## Problem
On phone viewports the shared `showConfirm(danger)` actions stack full-width vertically. Measured at 390×844: Cancel t=731–775, **⚠ Delete t=783–827** — the destructive (irreversible) button lands at the very bottom = the easiest single-thumb target, directly **under** Cancel. safe-default-focus is already on Cancel, but the visual/touch target wasn't guarded → one-handed mis-tap-delete risk.

## Fix (CSS-only, visual reorder)
- Danger dialogs get an `eclaw-confirm-danger` marker class.
- The injected `<style>` flips **only the visual order** on `max-width:480px`:
  ```css
  @media (max-width: 480px) {
    .eclaw-confirm-dialog.eclaw-confirm-danger .dialog-actions {
      display: flex; flex-direction: column-reverse; gap: 8px;
    }
  }
  ```
  → the safe **Cancel** now sits in the bottom thumb zone; the destructive button is above it.

**DOM order is untouched** (Cancel authored before OK), so tab order, the focus trap (Cancel first tabbable / OK last), safe-default-focus (Cancel) and Esc all behave exactly as before. Scoped to `.eclaw-confirm-danger` + phone width, so **non-danger dialogs and desktop (side-by-side row) are unaffected**.

Satisfies the card's acceptance: mobile destructive button not in the bottom single-thumb zone; desktop unaffected; a11y (safe-default-focus / Esc / focus-trap) preserved.

## Test
`backend/tests/jest/showConfirm-destructive-thumb-zone.test.js` (5) — marker only when danger; scoped `column-reverse` rule present and never hits a bare `.dialog-actions` or desktop; DOM order Cancel-before-OK preserved (CSS-only); a11y contract intact. Sibling `showConfirm-*` suites: **27/27** green. ESLint clean.

## Scope
#2 owns the `showConfirm` logic (this reorder — the standard HIG/Material mitigation). Visual polish (stronger separation / color) is left to #6 as a follow-up once #6→#2 routing (card_3ce0080a Leg 2) is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)