### PR TITLE
fix(portal): 需要你 inbox scrolls tall items — owner couldn't scroll to read (flex-shrink:0)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -383,6 +383,14 @@
             background: rgba(127,127,127,0.10); border: 1px solid var(--card-border, #333355);
             grid-template-columns: minmax(0, 1fr);
             box-sizing: border-box; min-width: 0; max-width: 100%; overflow: hidden;
+            /* Items live in a flex-column, max-height, overflow-y:auto inbox body.
+               With the default flex-shrink:1 a tall item (e.g. a decision with a
+               long prompt + options + reply previews) gets COMPRESSED to fit the
+               body, then overflow:hidden clips its lower content — so nothing
+               overflows the body and it never scrolls (card_*: owner couldn't
+               scroll the 需要你 inbox to read a tall item). flex-shrink:0 keeps
+               each item at its natural height so the body overflows → scrolls. */
+            flex-shrink: 0;
         }
         .action-request-item > * { min-width: 0; max-width: 100%; }
         .action-request-meta { overflow-wrap: anywhere; }

--- a/backend/tests/jest/chat-inbox-item-scroll.test.js
+++ b/backend/tests/jest/chat-inbox-item-scroll.test.js
@@ -1,0 +1,56 @@
+/**
+ * Static invariant — 需要你 (action-request) inbox must scroll tall items.
+ *
+ * Bug: the inbox body is `display:flex; flex-direction:column; max-height:…;
+ * overflow-y:auto`. Its `.action-request-item` children had the default
+ * `flex-shrink:1`, so a TALL item (a decision with a long prompt + options +
+ * reply previews) was COMPRESSED to fit the body, then `overflow:hidden`
+ * clipped its lower content. Because the compressed item no longer overflowed
+ * the body, the body never showed a scrollbar → the owner could not scroll the
+ * inbox to read the item ("無法在需要你收件夾內往上滑動… 看不到下面的字").
+ *
+ * Fix: `.action-request-item { flex-shrink: 0 }` keeps each item at its natural
+ * height, so the body overflows and scrolls (verified live on prod: item grew
+ * 248→552px, body scrollHeight 321→625 > clientHeight 321 = scrollable).
+ *
+ * node testEnv → assert the CSS rules statically (same style as the sibling
+ * chat-action-request-*.test.js files).
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const chatHtml = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html'),
+    'utf8'
+);
+
+// Isolate the `.action-request-item { … }` rule block (the first bare-selector
+// rule, not the `.action-request-item.in-consensus` / `> *` variants).
+function ruleBlock(selector) {
+    const re = new RegExp(selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*\\{([^}]*)\\}');
+    const m = chatHtml.match(re);
+    return m ? m[1] : null;
+}
+
+describe('需要你 inbox — tall items keep natural height so the body scrolls', () => {
+    test('.action-request-item does not shrink (flex-shrink: 0)', () => {
+        const block = ruleBlock('.action-request-item');
+        expect(block).not.toBeNull();
+        expect(block).toMatch(/flex-shrink:\s*0/);
+    });
+
+    test('.action-request-item still clamps horizontally (overflow:hidden + max-width) — fix did not regress the x-axis guard', () => {
+        const block = ruleBlock('.action-request-item');
+        expect(block).toMatch(/overflow:\s*hidden/);
+        expect(block).toMatch(/max-width:\s*100%/);
+    });
+
+    test('the inbox body is the scroll container (overflow-y:auto + a max-height)', () => {
+        const block = ruleBlock('.action-request-inbox-body');
+        expect(block).not.toBeNull();
+        expect(block).toMatch(/overflow-y:\s*auto/);
+        expect(block).toMatch(/max-height:/);
+    });
+});


### PR DESCRIPTION
## Problem (owner-reported, live)
「我現在無法在需要你收件夾內往上滑動了 所以看不到下面的字」 — a tall action-request item couldn't be scrolled; its lower content was unreachable.

## Root cause
The inbox body is `display:flex; flex-direction:column; max-height:…; overflow-y:auto`. `.action-request-item` kept the default **`flex-shrink:1`**, so a tall item (a decision with a long prompt + 3 options + reply previews — e.g. the current Leg-2 negotiation card) was **compressed** to fit the body, and `overflow:hidden` then **clipped** its lower content. Because the compressed item no longer overflowed the body, the body **never showed a scrollbar** → nothing to scroll.

Measured live on prod (390×844): item `clientHeight 246` vs `scrollHeight 445` (clipped), body `scrollHeight 321 == clientHeight 321` (not scrollable).

## Fix
`.action-request-item { flex-shrink: 0 }` — keeps each item at its natural height so the body overflows and scrolls. Horizontal `overflow:hidden` / `max-width:100%` clamp preserved.

**Verified live** (injected the rule on prod before the PR): item **248→552px**, body **scrollHeight 321→625** > clientHeight 321 = **scrollable**.

Regression from the batch-reply work (#3854) that made decision items tall enough to trip the latent flex-shrink compression.

## Test
`chat-inbox-item-scroll.test.js` (3) — `flex-shrink:0` present, x-axis clamp not regressed, body is the `overflow-y:auto` + `max-height` scroll container. **Fail-on-old**: the flex-shrink assertion fails on origin/main. Inbox siblings (`chat-action-request-inbox`, `…-batch-resolve`): **33/33** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)