### PR TITLE
feat(kanban): task-load census in stale nudges

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -4130,6 +4130,56 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         return true;
     }
 
+    /**
+     * Build a compact one-line "task-load census" for a single entity — how many
+     * OPEN cards it is currently an assignee on, grouped by status, plus the age
+     * of its oldest open card. Prepended to stale nudges (waiting-state awareness,
+     * owner Hank) so the recipient agent is always reminded of its TOTAL
+     * outstanding workload, not just the one card being nudged. Backend-enforced:
+     * the server computes and injects this, the agent doesn't have to remember.
+     *
+     * Returns '' when the entity has no open cards (so the caller emits no census
+     * line) or on any DB error — a census failure must never break the nudge.
+     */
+    async function buildEntityTaskCensus(deviceId, entityId) {
+        try {
+            // Open statuses only — exclude done/backlog/archived (mirrors the
+            // census columns below). assigned_bots is a jsonb array of entity
+            // ids; `@> to_jsonb($n::int)` is the containment filter used
+            // elsewhere in this file (e.g. lines ~4296/4529).
+            const res = await pool.query(
+                `SELECT status, status_changed_at
+                   FROM kanban_cards
+                  WHERE device_id = $1
+                    AND archived = false
+                    AND status IN ('todo','in_progress','review','blocked')
+                    AND assigned_bots @> to_jsonb($2::int)`,
+                [deviceId, Number(entityId)]
+            );
+            const counts = { todo: 0, in_progress: 0, review: 0, blocked: 0 };
+            let oldest = null;
+            for (const row of res.rows) {
+                if (counts[row.status] === undefined) continue;
+                counts[row.status]++;
+                if (row.status_changed_at) {
+                    const t = new Date(row.status_changed_at).getTime();
+                    if (!Number.isNaN(t) && (oldest === null || t < oldest)) oldest = t;
+                }
+            }
+            const total = counts.todo + counts.in_progress + counts.review + counts.blocked;
+            if (total === 0) return '';
+            let staleSeg = '';
+            if (oldest !== null) {
+                const hrs = Math.round((Date.now() - oldest) / 3600000 * 10) / 10;
+                staleSeg = `｜最舊停留${hrs}h`;
+            }
+            return `【#${entityId} 未完成｜待辦${counts.todo}·進行中${counts.in_progress}·審查${counts.review}·封鎖${counts.blocked}${staleSeg}】收到請先盤點：完成的移 done、卡住的升級`;
+        } catch (err) {
+            if (serverLog) serverLog('warn', 'kanban', `[Census] task-load census failed for #${entityId}: ${err.message}`, { deviceId });
+            return '';
+        }
+    }
+
     async function fireLevelOneNudge(card, recipientIds = null) {
         const bots = Array.isArray(recipientIds) ? recipientIds : (card.assigned_bots || []);
         const cardStatusLabel = STATUS_LABELS[card.status] || card.status;
@@ -4149,7 +4199,15 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 status: statusLabel(lang, card.status),
                 hours: elapsedHrs
             });
-            notifyEntities(card.device_id, bots, msg, { description: card.description, cardId: card.id });
+            // Personalize per recipient: each bot gets a census of ITS OWN open
+            // cards prepended, so notifyEntities is called once per bot. If the
+            // census is empty (no open cards / query error) send msg alone with
+            // no stray leading newline.
+            for (const bid of bots) {
+                const censusLine = await buildEntityTaskCensus(card.device_id, bid);
+                const finalMsg = censusLine ? (censusLine + '\n' + msg) : msg;
+                notifyEntities(card.device_id, [bid], finalMsg, { description: card.description, cardId: card.id });
+            }
             await recordEntityNudge(card.device_id, bots);
         }
         console.log(`[Kanban] Nudged card ${card.id} (${card.title}) — ${elapsedHrs}h in ${card.status}`);

--- a/backend/tests/jest/kanban-nudge-stop-mode.test.js
+++ b/backend/tests/jest/kanban-nudge-stop-mode.test.js
@@ -70,7 +70,10 @@ describe('kanban nudge stop-mode preferences', () => {
         const l3 = extractFunctionBody(kanbanSrc, 'async function fireBlockEscalation(card, recipientIds = null)');
 
         expect(l1).toMatch(/const bots = Array\.isArray\(recipientIds\) \? recipientIds : \(card\.assigned_bots \|\| \[\]\)/);
-        expect(l1).toMatch(/notifyEntities\(card\.device_id, bots/);
+        // fireLevelOneNudge now notifies PER-BOT so it can prepend a per-entity
+        // task-load census (feat/kanban-nudge-task-census) — the notify target is
+        // a single-id array [bid] inside a loop, not the whole `bots` list.
+        expect(l1).toMatch(/notifyEntities\(card\.device_id, \[bid\], finalMsg/);
         expect(l1).toMatch(/recordEntityNudge\(card\.device_id, bots\)/);
         expect(l2).toMatch(/const recipients = Array\.isArray\(recipientIds\) \? recipientIds : await buildEscalationRecipients\(card\)/);
         expect(l3).toMatch(/const recipients = Array\.isArray\(recipientIds\) \? recipientIds : await buildEscalationRecipients\(card\)/);

--- a/backend/tests/jest/kanban-nudge-task-census.test.js
+++ b/backend/tests/jest/kanban-nudge-task-census.test.js
@@ -1,0 +1,231 @@
+'use strict';
+
+/**
+ * Regression test — per-entity task-load census prepended to stale nudges
+ * (feat/kanban-nudge-task-census; owner Hank).
+ *
+ * When the kanban L1 stale nudge fires, the server prepends a compact one-line
+ * census of the RECIPIENT entity's OWN open cards, so the agent receiving the
+ * nudge is aware of its TOTAL outstanding workload (not just the one nudged
+ * card). Backend-enforced — the census is injected server-side, not something
+ * the agent has to remember.
+ *
+ * Mix of source-grep invariants (fail on origin/main which has no census) plus
+ * Function-constructor behavioural smokes for buildEntityTaskCensus and the
+ * per-bot fireLevelOneNudge loop.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const kanbanSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'kanban.js'),
+    'utf8'
+);
+
+function extractFunctionBody(src, signature) {
+    const start = src.indexOf(signature);
+    if (start === -1) throw new Error(`function not found: ${signature}`);
+    const open = src.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) return src.slice(open, i + 1);
+        }
+    }
+    throw new Error(`unterminated function: ${signature}`);
+}
+
+describe('buildEntityTaskCensus — source invariants', () => {
+    test('helper exists and is async', () => {
+        // Fails on origin/main — the helper does not exist there.
+        expect(kanbanSrc).toMatch(/async function buildEntityTaskCensus\(deviceId, entityId\)/);
+    });
+
+    test('source carries the census format + reconcile instruction', () => {
+        expect(kanbanSrc).toContain('未完成');
+        expect(kanbanSrc).toContain('待辦');
+        expect(kanbanSrc).toContain('進行中');
+        expect(kanbanSrc).toContain('審查');
+        expect(kanbanSrc).toContain('封鎖');
+        expect(kanbanSrc).toContain('最舊停留');
+        expect(kanbanSrc).toContain('完成的移 done');
+        expect(kanbanSrc).toContain('卡住的升級');
+    });
+
+    test('census query targets open statuses only (excludes done/backlog/archived)', () => {
+        const body = extractFunctionBody(
+            kanbanSrc,
+            'async function buildEntityTaskCensus(deviceId, entityId)'
+        );
+        expect(body).toMatch(/status IN \('todo','in_progress','review','blocked'\)/);
+        expect(body).toMatch(/archived = false/);
+        expect(body).toMatch(/assigned_bots @> to_jsonb\(\$2::int\)/);
+        // Never throws — census failure must not break the nudge.
+        expect(body).toMatch(/try \{/);
+        expect(body).toMatch(/catch \(err\)/);
+    });
+});
+
+describe('buildEntityTaskCensus — behavioural', () => {
+    const src = extractFunctionBody(
+        kanbanSrc,
+        'async function buildEntityTaskCensus(deviceId, entityId)'
+    );
+
+    const make = (deps) =>
+        // eslint-disable-next-line no-new-func
+        new Function(
+            'pool', 'serverLog',
+            `return async function buildEntityTaskCensus(deviceId, entityId) ${src}`
+        )(deps.pool, deps.serverLog);
+
+    function makePool(rows) {
+        return { query: async () => ({ rows }) };
+    }
+
+    test('groups counts correctly by status', async () => {
+        const now = Date.now();
+        const rows = [
+            { status: 'todo', status_changed_at: new Date(now - 1 * 3600e3).toISOString() },
+            { status: 'todo', status_changed_at: new Date(now - 2 * 3600e3).toISOString() },
+            { status: 'in_progress', status_changed_at: new Date(now - 3 * 3600e3).toISOString() },
+            { status: 'review', status_changed_at: new Date(now - 4 * 3600e3).toISOString() },
+            { status: 'blocked', status_changed_at: new Date(now - 5 * 3600e3).toISOString() },
+            { status: 'blocked', status_changed_at: new Date(now - 6 * 3600e3).toISOString() },
+        ];
+        const fn = make({ pool: makePool(rows), serverLog: () => {} });
+        const line = await fn('dev1', 4);
+        // 待辦2·進行中1·審查1·封鎖2
+        expect(line).toContain('【#4 未完成');
+        expect(line).toContain('待辦2');
+        expect(line).toContain('進行中1');
+        expect(line).toContain('審查1');
+        expect(line).toContain('封鎖2');
+        // oldest is the blocked card at now-6h.
+        expect(line).toContain('最舊停留6h');
+        expect(line).toContain('完成的移 done');
+    });
+
+    test('total 0 → returns empty string (no census line)', async () => {
+        const fn = make({ pool: makePool([]), serverLog: () => {} });
+        expect(await fn('dev1', 4)).toBe('');
+    });
+
+    test('DB error → returns empty string, never throws', async () => {
+        const errPool = { query: async () => { throw new Error('boom'); } };
+        let logged = false;
+        const fn = make({ pool: errPool, serverLog: () => { logged = true; } });
+        await expect(fn('dev1', 4)).resolves.toBe('');
+        expect(logged).toBe(true);
+    });
+
+    test('oldest null (no status_changed_at) → omits 最舊停留 segment but still counts', async () => {
+        const rows = [
+            { status: 'todo', status_changed_at: null },
+            { status: 'review', status_changed_at: null },
+        ];
+        const fn = make({ pool: makePool(rows), serverLog: () => {} });
+        const line = await fn('dev1', 2);
+        expect(line).toContain('待辦1');
+        expect(line).toContain('審查1');
+        expect(line).not.toContain('最舊停留');
+    });
+
+    test('rounds oldest-stale hours to 1 decimal', async () => {
+        const now = Date.now();
+        const rows = [
+            { status: 'in_progress', status_changed_at: new Date(now - 5.25 * 3600e3).toISOString() },
+        ];
+        const fn = make({ pool: makePool(rows), serverLog: () => {} });
+        const line = await fn('dev1', 3);
+        expect(line).toMatch(/最舊停留5\.[23]h/); // ~5.25 rounds to 5.2/5.3 depending on tick
+    });
+});
+
+describe('fireLevelOneNudge — per-bot census prepend', () => {
+    const src = extractFunctionBody(
+        kanbanSrc,
+        'async function fireLevelOneNudge(card, recipientIds = null)'
+    );
+
+    const make = (deps) =>
+        // eslint-disable-next-line no-new-func
+        new Function(
+            'STATUS_LABELS', 'addSystemComment', 'pool', 'getDeviceLanguage',
+            'tKanban', 'statusLabel', 'notifyEntities', 'recordEntityNudge',
+            'buildEntityTaskCensus', 'console',
+            `return async function fireLevelOneNudge(card, recipientIds = null) ${src}`
+        )(
+            deps.STATUS_LABELS, deps.addSystemComment, deps.pool, deps.getDeviceLanguage,
+            deps.tKanban, deps.statusLabel, deps.notifyEntities, deps.recordEntityNudge,
+            deps.buildEntityTaskCensus, deps.console
+        );
+
+    function makeDeps(censusFor) {
+        const notifies = [];
+        const recorded = [];
+        return {
+            notifies, recorded,
+            STATUS_LABELS: { in_progress: 'In Progress' },
+            addSystemComment: async () => {},
+            pool: { query: async () => ({ rows: [] }) },
+            getDeviceLanguage: async () => 'zh',
+            tKanban: () => 'NUDGE_BODY',
+            statusLabel: () => 'In Progress',
+            notifyEntities: (deviceId, recipients, msg, extra) => { notifies.push({ deviceId, recipients, msg, extra }); },
+            recordEntityNudge: async (deviceId, bots) => { recorded.push({ deviceId, bots }); },
+            buildEntityTaskCensus: async (deviceId, bid) => censusFor(bid),
+            console: { log: () => {} },
+        };
+    }
+
+    function makeCard() {
+        return {
+            id: 'card_test_x',
+            device_id: 'dev1',
+            title: 'test card',
+            status: 'in_progress',
+            description: 'desc',
+            status_changed_at: new Date(Date.now() - 4 * 3600e3).toISOString(),
+        };
+    }
+
+    test('notifyEntities is called once PER bot, message starts with that bot census', async () => {
+        const deps = makeDeps((bid) => `CENSUS_FOR_${bid}`);
+        const fn = make(deps);
+        await fn(makeCard(), [1, 2]);
+        expect(deps.notifies.length).toBe(2);
+        // Each call targets a single-id array.
+        expect(deps.notifies[0].recipients).toEqual([1]);
+        expect(deps.notifies[1].recipients).toEqual([2]);
+        // Message STARTS WITH the per-bot census line.
+        expect(deps.notifies[0].msg.startsWith('CENSUS_FOR_1\n')).toBe(true);
+        expect(deps.notifies[1].msg.startsWith('CENSUS_FOR_2\n')).toBe(true);
+        // Body still present after the census.
+        expect(deps.notifies[0].msg).toContain('NUDGE_BODY');
+        // recordEntityNudge still records the FULL list once.
+        expect(deps.recorded.length).toBe(1);
+        expect(deps.recorded[0].bots).toEqual([1, 2]);
+    });
+
+    test('empty census → message has NO leading newline', async () => {
+        const deps = makeDeps(() => '');
+        const fn = make(deps);
+        await fn(makeCard(), [7]);
+        expect(deps.notifies.length).toBe(1);
+        expect(deps.notifies[0].msg).toBe('NUDGE_BODY');
+        expect(deps.notifies[0].msg.startsWith('\n')).toBe(false);
+    });
+
+    test('mixed: one bot has census, one does not', async () => {
+        const deps = makeDeps((bid) => (bid === 1 ? 'CENSUS_1' : ''));
+        const fn = make(deps);
+        await fn(makeCard(), [1, 2]);
+        expect(deps.notifies[0].msg).toBe('CENSUS_1\nNUDGE_BODY');
+        expect(deps.notifies[1].msg).toBe('NUDGE_BODY');
+    });
+});


### PR DESCRIPTION
## Problem
Kanban stale-card nudges fire **card-by-card**. The nudged agent sees only the single card being nudged, with **no visibility into its total outstanding workload** — so it chips at one card while the rest of its queue silently piles up (and keeps re-nudging).

## Fix
When the L1 stale nudge fires, the server now **prepends a compact one-line "task-load census"** of the *recipient entity's own* open cards to that entity's nudge message. Backend-enforced — the census is computed and injected server-side in `fireLevelOneNudge`, not something the agent has to remember. Owner: Hank.

New helper `buildEntityTaskCensus(deviceId, entityId)`:
- Counts the entity's **open** cards (`todo`/`in_progress`/`review`/`blocked`; excludes `done`/`backlog`/`archived`) via the `assigned_bots @> to_jsonb($n::int)` containment filter already used elsewhere in this file.
- Computes the oldest open card's stale-hours (1 decimal).
- Returns `''` on no open cards **or any DB error** (wrapped in try/catch — a census failure must never break the nudge → the nudge still sends without a census line, no stray leading newline).

Census format shipped:
```
【#<id> 未完成｜待辦<todo>·進行中<in_progress>·審查<review>·封鎖<blocked>｜最舊停留<h>h】收到請先盤點：完成的移 done、卡住的升級
```

`fireLevelOneNudge` now notifies **per-bot** (each recipient gets its own census prepended); `recordEntityNudge` still records the full recipient list once. Kept `addSystemComment` + the `last_stale_nudge_at` UPDATE unchanged.

## Tests
- New `backend/tests/jest/kanban-nudge-task-census.test.js` (11 tests): source-grep invariants (fail on origin/main — helper + `未完成` format don't exist there) + behavioural smokes for `buildEntityTaskCensus` (status grouping, total-0→`''`, DB-error→`''` never-throw, oldest-null omits stale segment, hour rounding) and the per-bot `fireLevelOneNudge` loop (per-bot notify, message starts with that bot's census, empty-census→no leading newline, mixed).
- Updated `kanban-nudge-stop-mode.test.js` source-grep for the new per-bot `notifyEntities(card.device_id, [bid], finalMsg…)` call shape.
- Full kanban jest suite: **39 suites / 427 tests green**. `npx eslint kanban.js`: 0 errors (1 pre-existing unrelated warning).

## Scope
Phase-1 of the waiting-state / total-load awareness work: this covers the L1 stale nudge only (the most frequent touchpoint). Later phases can extend the census to L2/L3 escalations and other agent-facing surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN