### PR TITLE
feat(inbox): waiting-state surfacer (dark-launch, default off)

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -927,6 +927,31 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
         return upd.rows || [];
     }
 
+    // Waiting-state surfacer lifecycle (phases 2-3 of card_76b073959c279d6204d9fd42):
+    // dismiss ONLY the SURFACER-created pending item(s) for a card — rows whose
+    // decision_context.surfacer === true. This is STRICTLY NARROWER than
+    // dismissActionRequestsForCard (which dismisses every owner-decision row,
+    // decision_context IS NOT NULL): the surfacer must NEVER touch the move-hook's
+    // owner-decision rows nor any ordinary action-request. Same 'dismissed' socket
+    // contract so the inbox live-refreshes. Device-scoped; throws only on DB error
+    // (the kanban caller wraps it in try/catch).
+    async function dismissSurfacerActionRequestsForCard(deviceId, cardId) {
+        if (!deviceId || !cardId) return [];
+        const upd = await pool.query(
+            `UPDATE agent_action_requests
+                SET status = 'dismissed', resolved_at = NOW()
+              WHERE device_id = $1 AND related_card_id = $2
+                AND status = 'pending'
+                AND (decision_context #>> '{surfacer}') = 'true'
+            RETURNING *`,
+            [deviceId, cardId]
+        );
+        for (const row of (upd.rows || [])) {
+            emitChanged(deviceId, 'dismissed', row.id, row.from_entity_id);
+        }
+        return upd.rows || [];
+    }
+
     // ══════════════════════════════════════════════════════════════════════
     // TIMEOUT-POLICY WORKER (card_ce0d685b)
     // ──────────────────────────────────────────────────────────────────────
@@ -1829,6 +1854,11 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
         // review/blocked to auto-dismiss its pending owner-decision request(s) +
         // emit the 'dismissed' socket event.
         dismissActionRequestsForCard,
+        // Waiting-state surfacer lifecycle (phases 2-3 of card_76b073959c279d6204d9fd42):
+        // NARROWER dismiss that only touches surfacer rows (decision_context.surfacer
+        // === true), so the surfacer never dismisses the move-hook's owner-decision
+        // rows or ordinary action-requests. Injected into kanban.js.
+        dismissSurfacerActionRequestsForCard,
         // 需要你 negotiation: exported for direct test invocation of the engine.
         openNegotiationRound,
         advanceNegotiations,

--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -111,6 +111,16 @@ const DEFAULTS = {
     //   before it is treated as stale and ignored (the evaluator then falls back
     //   to lastSend / kanban-floor heuristics). Default 45; clamped [5, 600].
     entity_runtime_state_stale_seconds: 45,
+    // Waiting-state surfacer (phases 2-3 of card_76b073959c279d6204d9fd42).
+    // DARK-LAUNCH: DEFAULT FALSE. When true, the kanban worker's stale-scan pass
+    // also runs a "waiting-state surfacer" that auto-opens a 需要你 inbox item for
+    // every card genuinely WAITING ON THE OWNER (blocked with an owner-only
+    // reason / review + ownerOnly / explicit config.waitingOn='owner' /
+    // in_progress with an explicit [await-owner] marker), and auto-dismisses that
+    // item when the wait clears. Strictly de-duplicated (≤1 surfacer item/card).
+    // Until explicitly enabled, the surfacer is a complete no-op — nothing
+    // changes for anyone. Consumed by surfaceOwnerWaitingStates in kanban.js.
+    waiting_state_surfacer_enabled: false,
 };
 
 const ENTITY_IDLE_AFTER_SECONDS_MIN = 15;
@@ -159,9 +169,12 @@ function coerceValue(key, raw) {
     // (a bare `!!raw` would coerce the string 'false' to true — wrong for an API
     // that may serialize the flag as a query/JSON string).
     if (key === 'kanban_auto_escalate_enabled' || key === 'kanban_auto_escalate_skip_automation'
-        || key === 'action_request_ratify_enabled') {
+        || key === 'action_request_ratify_enabled' || key === 'waiting_state_surfacer_enabled') {
         // 計畫E: ratify master switch — same string-safe boolean coercion (a bare
         // `!!raw` would turn the string 'false' true, fail-OPEN for an auto-merge gate).
+        // waiting_state_surfacer_enabled is dark-launch DEFAULT FALSE: the string
+        // 'false' must stay false so an accidental serialized flag never flips the
+        // inbox-flood risk open.
         return raw === true || raw === 'true';
     }
     if (typeof def === 'boolean') return !!raw;

--- a/backend/index.js
+++ b/backend/index.js
@@ -1889,6 +1889,14 @@ try {
                 ? agentActionRequestsModule.dismissActionRequestsForCard(...args)
                 : Promise.resolve([])
         ),
+        // Waiting-state surfacer (phases 2-3 of card_76b073959c279d6204d9fd42):
+        // NARROWER dismiss the surfacer uses so it only touches its own rows
+        // (decision_context.surfacer === true). Late-bound thunk, same reason.
+        dismissSurfacerActionRequestsForCard: (...args) => (
+            agentActionRequestsModule && typeof agentActionRequestsModule.dismissSurfacerActionRequestsForCard === 'function'
+                ? agentActionRequestsModule.dismissSurfacerActionRequestsForCard(...args)
+                : Promise.resolve([])
+        ),
     });
     app.use('/api/mission', kanbanModule.router);
     console.log('[Kanban] Module loaded successfully');

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -469,7 +469,7 @@ async function initKanbanDatabase() {
 /**
  * Factory: receives in-memory devices object from index.js
  */
-function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, pushToChannelCallback, saveChatMessage, getMissionApiHints, pushToBot, orgChart, notifyDevice, emitDevicePreferences, createActionRequest, dismissActionRequestsForCard } = {}) {
+function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, pushToChannelCallback, saveChatMessage, getMissionApiHints, pushToBot, orgChart, notifyDevice, emitDevicePreferences, createActionRequest, dismissActionRequestsForCard, dismissSurfacerActionRequestsForCard } = {}) {
     const router = express.Router();
 
     // Health check
@@ -3686,10 +3686,179 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
 
             for (const [deviceId, cards] of byDevice) {
                 await processDeviceStaleCards(deviceId, cards);
+                // Waiting-state surfacer (phases 2-3 of card_76b073959c279d6204d9fd42).
+                // Rides the SAME worker tick (no new cron). Fully gated behind the
+                // default-FALSE waiting_state_surfacer_enabled pref inside the
+                // function → a complete no-op until Hank explicitly enables it.
+                // Failure-isolated: a surfacer error NEVER breaks the stale scan.
+                try {
+                    await surfaceOwnerWaitingStates(deviceId);
+                } catch (e) {
+                    console.error('[Kanban] waiting-state surfacer error (non-blocking):', e.message);
+                }
             }
         } catch (err) {
             console.error('[Kanban] Stale check error:', err.message);
         }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // WAITING-STATE SURFACER (phases 2-3 of card_76b073959c279d6204d9fd42)
+    // ──────────────────────────────────────────────────────────────────────
+    // Hank ONLY monitors the 需要你 (action-request) inbox — he never opens task
+    // cards. This routine generalizes the review/blocked owner-decision move-hook
+    // into a periodic pass that catches EVERY card genuinely WAITING ON THE OWNER
+    // (including in_progress cards blocked on an owner decision) and auto-surfaces
+    // exactly ONE inbox item per card, then auto-dismisses it when the wait clears.
+    //
+    // SAFETY (the #1 risk is flooding the inbox):
+    //   * DARK-LAUNCH: gated behind waiting_state_surfacer_enabled (DEFAULT FALSE).
+    //     When false, this function early-returns BEFORE touching the DB — a
+    //     complete no-op. Nothing changes for anyone until Hank enables it.
+    //   * DEDUP: at most ONE open surfacer item per card. Surfacer items carry
+    //     decision_context.surfacer === true so we find/dedup/dismiss ONLY our own
+    //     rows and never touch ordinary owner-decision or agent action-requests.
+    //   * AUTO-DISMISS: when a card is no longer 'owner'-waiting (wait cleared, or
+    //     it left the waiting statuses entirely), its surfacer item is dismissed
+    //     via dismissSurfacerActionRequestsForCard (surfacer-only guard).
+    async function surfaceOwnerWaitingStates(deviceId) {
+        if (!deviceId) return;
+        if (typeof createActionRequest !== 'function') return;
+
+        // Gate: dark-launch, DEFAULT FALSE. Unset pref → false → complete no-op.
+        const prefs = await devicePrefs.getPrefs(deviceId).catch(() => ({}));
+        if (prefs.waiting_state_surfacer_enabled !== true) return;
+
+        const { classifyCardWaitingState } = require('./waiting-state');
+
+        // Candidate cards: any active card in a status that CAN be owner-waiting
+        // (blocked / review / in_progress). todo/done/backlog/archived excluded.
+        const cardsRes = await pool.query(
+            `SELECT * FROM kanban_cards
+              WHERE device_id = $1
+                AND archived = false
+                AND status IN ('blocked', 'review', 'in_progress')`,
+            [deviceId]
+        );
+        const cards = cardsRes.rows || [];
+
+        // All pending SURFACER items for this device, keyed by related_card_id, so
+        // we can dedup (skip create when one exists) and dismiss (wait cleared /
+        // card gone). We match ONLY our own rows via decision_context.surfacer.
+        const openRes = await pool.query(
+            `SELECT related_card_id AS "cardId"
+               FROM agent_action_requests
+              WHERE device_id = $1
+                AND status = 'pending'
+                AND (decision_context #>> '{surfacer}') = 'true'`,
+            [deviceId]
+        );
+        const openSurfacerCards = new Set(
+            (openRes.rows || []).map(r => r.cardId).filter(id => id != null)
+        );
+
+        const dismiss = (typeof dismissSurfacerActionRequestsForCard === 'function')
+            ? dismissSurfacerActionRequestsForCard
+            : async () => [];
+
+        for (const card of cards) {
+            const cardId = card.id;
+            // Latest non-system comment (the narrow in_progress await-owner marker
+            // lives here) — best-effort; a query error must not abort the pass.
+            let latestComment = '';
+            try {
+                const cmt = await pool.query(
+                    `SELECT text FROM kanban_comments
+                      WHERE card_id = $1 AND device_id = $2 AND is_system = false
+                      ORDER BY created_at DESC LIMIT 1`,
+                    [cardId, deviceId]
+                );
+                latestComment = (cmt.rows[0] && typeof cmt.rows[0].text === 'string') ? cmt.rows[0].text : '';
+            } catch (_) { latestComment = ''; }
+
+            let verdict = null;
+            try {
+                verdict = classifyCardWaitingState(card, {
+                    latestComment,
+                    decisionContext: card.decision_context || null,
+                });
+            } catch (_) { verdict = null; }
+
+            const hasItem = openSurfacerCards.has(cardId);
+
+            if (verdict === 'owner') {
+                // DEDUP: one surfacer item per card. If one exists, leave it.
+                if (hasItem) continue;
+                try {
+                    const reason = describeOwnerWaitReason(card, latestComment);
+                    const headline = `需要你決策：「${card.title || cardId}」(${reason})`.slice(0, 2000);
+                    const from = (Array.isArray(card.assigned_bots) && card.assigned_bots.length
+                        && Number.isInteger(Number(card.assigned_bots[0])))
+                        ? Number(card.assigned_bots[0])
+                        : 0;
+                    await createActionRequest({
+                        deviceId,
+                        fromEntityId: from,
+                        type: 'decision',
+                        prompt: headline,
+                        options: ['核可', '退回', '延後'], // RECORD-ONLY — no auto-execute
+                        relatedCardId: cardId,
+                        decisionContext: {
+                            surfacer: true,          // ← our distinguishing marker
+                            waitingOn: 'owner',
+                            ownerOnly: true,
+                            reason,
+                            whatWasDone: latestComment.slice(0, 1000),
+                            recommendation: latestComment.slice(0, 1000),
+                            evidence: [],
+                            recommendedOptionIndex: 0,
+                            relatedCardId: cardId,
+                        },
+                    });
+                    openSurfacerCards.add(cardId);
+                    console.log(`[Kanban] waiting-state surfaced (owner) card=${cardId} reason=${reason}`);
+                } catch (e) {
+                    console.error(`[Kanban] waiting-state surface create error card=${cardId} (non-blocking):`, e.message);
+                }
+            } else if (hasItem) {
+                // Wait cleared (card no longer owner-waiting) but a surfacer item is
+                // still open → dismiss it (surfacer-only guard in the helper).
+                try {
+                    await dismiss(deviceId, cardId);
+                    openSurfacerCards.delete(cardId);
+                    console.log(`[Kanban] waiting-state auto-dismissed (wait cleared) card=${cardId}`);
+                } catch (e) {
+                    console.error(`[Kanban] waiting-state dismiss error card=${cardId} (non-blocking):`, e.message);
+                }
+            }
+        }
+
+        // Sweep surfacer items whose card is GONE from the candidate set entirely
+        // (moved to done/archived/todo/backlog, or deleted) — those cards never
+        // appear in the loop above, so dismiss their stale surfacer items here.
+        const candidateIds = new Set(cards.map(c => c.id));
+        for (const cardId of openSurfacerCards) {
+            if (candidateIds.has(cardId)) continue;
+            try {
+                await dismiss(deviceId, cardId);
+                console.log(`[Kanban] waiting-state auto-dismissed (card left waiting statuses) card=${cardId}`);
+            } catch (e) {
+                console.error(`[Kanban] waiting-state dismiss(stale) error card=${cardId} (non-blocking):`, e.message);
+            }
+        }
+    }
+
+    // Compact human reason for the surfacer headline / decision_context.
+    function describeOwnerWaitReason(card, latestComment) {  // eslint-disable-line no-unused-vars
+        const status = String(card.status || '').toLowerCase();
+        const config = (card.config && typeof card.config === 'object') ? card.config : {};
+        if (String(config.waitingOn || '').toLowerCase() === 'owner' || config.awaitOwner === true) {
+            return 'config waitingOn=owner';
+        }
+        if (status === 'review') return 'review + ownerOnly';
+        if (status === 'blocked') return `blocked (${card.gate_reason || 'owner-only reason'})`.slice(0, 120);
+        if (status === 'in_progress') return 'in_progress + [await-owner] marker';
+        return 'owner-only';
     }
 
     async function processDeviceStaleCards(deviceId, cards) {

--- a/backend/tests/jest/waiting-state-surfacer.test.js
+++ b/backend/tests/jest/waiting-state-surfacer.test.js
@@ -1,0 +1,290 @@
+'use strict';
+
+/**
+ * Waiting-state surfacer — phases 2-3 of card_76b073959c279d6204d9fd42.
+ *
+ * Two layers under test:
+ *   A. The pure classifier backend/waiting-state.js:classifyCardWaitingState
+ *      (required directly).
+ *   B. The surfacer routine backend/kanban.js:surfaceOwnerWaitingStates
+ *      (extracted from source + reconstructed with mock pool/devicePrefs/
+ *      createActionRequest/dismiss deps — same extract-and-run pattern as
+ *      kanban-stall-severity-gate.test.js).
+ *
+ * Safety invariants pinned here:
+ *   - flag FALSE (default) → complete no-op (no createActionRequest, no dismiss).
+ *   - flag TRUE + owner card + no existing item → EXACTLY one createActionRequest
+ *     with decisionContext.surfacer === true.
+ *   - flag TRUE + existing surfacer item → no duplicate create.
+ *   - wait cleared + existing surfacer item → dismiss called (surfacer-only guard).
+ *   - classifier never throws on a malformed card (returns null).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { classifyCardWaitingState } = require('../../waiting-state');
+
+const kanbanSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'kanban.js'),
+    'utf8'
+);
+
+function extractFunctionBody(src, signature) {
+    const start = src.indexOf(signature);
+    if (start === -1) throw new Error(`function not found: ${signature}`);
+    const open = src.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) return src.slice(open, i + 1);
+        }
+    }
+    throw new Error(`unterminated function: ${signature}`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// A. Classifier
+// ─────────────────────────────────────────────────────────────────────────
+describe('classifyCardWaitingState — waiting-party classifier', () => {
+    test("blocked + owner-only reason → 'owner'", () => {
+        expect(classifyCardWaitingState(
+            { status: 'blocked', title: 'drop table users', gate_reason: 'irreversible data op' }, {}
+        )).toBe('owner');
+    });
+
+    test("review + decision_context.ownerOnly → 'owner'", () => {
+        expect(classifyCardWaitingState(
+            { status: 'review', title: 'ship it' }, { decisionContext: { ownerOnly: true } }
+        )).toBe('owner');
+    });
+
+    test("in_progress + narrow [await-owner] marker in latest comment → 'owner'", () => {
+        expect(classifyCardWaitingState(
+            { status: 'in_progress', title: 'the feature' },
+            { latestComment: 'coded + tested. [await-owner] on the pricing call.' }
+        )).toBe('owner');
+        // 繁中 marker variant.
+        expect(classifyCardWaitingState(
+            { status: 'in_progress', title: 'x' }, { latestComment: '做完了 [等Hank] 拍板' }
+        )).toBe('owner');
+    });
+
+    test("explicit config flags → 'owner'", () => {
+        expect(classifyCardWaitingState({ status: 'in_progress', config: { waitingOn: 'owner' } }, {})).toBe('owner');
+        expect(classifyCardWaitingState({ status: 'todo', config: { awaitOwner: true } }, {})).toBe('owner');
+    });
+
+    test("plain todo / in_progress (no marker) → null (no false-surface)", () => {
+        expect(classifyCardWaitingState({ status: 'todo', title: 'do a thing' }, {})).toBeNull();
+        // 'billing' would trip the owner-decision keyword classifier, but we do NOT
+        // run it for in_progress → must stay null (flood guard).
+        expect(classifyCardWaitingState(
+            { status: 'in_progress', title: 'billing integration' }, { latestComment: 'still coding' }
+        )).toBeNull();
+    });
+
+    test("review WITHOUT ownerOnly → 'commander' (NOT owner, not surfaced)", () => {
+        expect(classifyCardWaitingState({ status: 'review', title: 'x' }, {})).toBe('commander');
+    });
+
+    test("blocked WITHOUT owner reason → 'entity' (NOT owner, not surfaced)", () => {
+        expect(classifyCardWaitingState({ status: 'blocked', title: 'waiting on peer bot #4' }, {})).toBe('entity');
+    });
+
+    test('fail-safe: never throws on a malformed card → null', () => {
+        expect(classifyCardWaitingState(null, {})).toBeNull();
+        expect(classifyCardWaitingState(undefined, undefined)).toBeNull();
+        expect(classifyCardWaitingState({ status: 123, config: 'oops' }, { latestComment: {} })).toBeNull();
+        expect(classifyCardWaitingState('not-an-object', {})).toBeNull();
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// B. Surfacer routine
+// ─────────────────────────────────────────────────────────────────────────
+describe('surfaceOwnerWaitingStates — gated dark-launch surfacer', () => {
+    const surfacerBody = extractFunctionBody(
+        kanbanSrc, 'async function surfaceOwnerWaitingStates(deviceId)'
+    );
+    const reasonBody = extractFunctionBody(
+        kanbanSrc, 'function describeOwnerWaitReason(card, latestComment)'
+    );
+
+    // Reconstruct surfaceOwnerWaitingStates + its describeOwnerWaitReason helper in
+    // isolation, injecting mock pool / devicePrefs / createActionRequest /
+    // dismissSurfacerActionRequestsForCard. `require` is stubbed to return the REAL
+    // waiting-state classifier module. Both function bodies are re-declared with
+    // their real signatures so the surfacer can call the helper by name.
+    function makeSurfacer(deps) {
+        const realRequire = require;
+        const stubRequire = (mod) => {
+            if (mod === './waiting-state') return realRequire('../../waiting-state');
+            return realRequire(mod);
+        };
+        // eslint-disable-next-line no-new-func
+        return new Function(
+            'pool', 'devicePrefs', 'createActionRequest', 'dismissSurfacerActionRequestsForCard', 'require', 'console',
+            `function describeOwnerWaitReason(card, latestComment) ${reasonBody}\n` +
+            `return async function surfaceOwnerWaitingStates(deviceId) ${surfacerBody}`
+        )(
+            deps.pool, deps.devicePrefs, deps.createActionRequest,
+            deps.dismissSurfacerActionRequestsForCard, stubRequire,
+            { log: () => {}, error: () => {} }
+        );
+    }
+
+    // Mock pool.query dispatches by SQL shape:
+    //   - SELECT * FROM kanban_cards ...           → candidate cards
+    //   - SELECT related_card_id ... surfacer      → existing surfacer items
+    //   - SELECT text FROM kanban_comments ...     → latest comment
+    function makeDeps({ prefs, cards = [], openSurfacerCardIds = [], comments = {} }) {
+        const creates = [];
+        const dismisses = [];
+        const pool = {
+            query: async (sql, params) => {
+                if (/FROM kanban_cards/.test(sql)) {
+                    return { rows: cards };
+                }
+                if (/decision_context #>> '\{surfacer\}'/.test(sql) && /SELECT related_card_id/.test(sql)) {
+                    return { rows: openSurfacerCardIds.map(id => ({ cardId: id })) };
+                }
+                if (/FROM kanban_comments/.test(sql)) {
+                    const cardId = params[0];
+                    const text = comments[cardId];
+                    return { rows: text != null ? [{ text }] : [] };
+                }
+                return { rows: [] };
+            },
+        };
+        return {
+            creates, dismisses,
+            pool,
+            devicePrefs: { getPrefs: async () => prefs },
+            createActionRequest: async (arg) => { creates.push(arg); return { id: `req_${creates.length}` }; },
+            dismissSurfacerActionRequestsForCard: async (deviceId, cardId) => { dismisses.push({ deviceId, cardId }); return []; },
+        };
+    }
+
+    const ownerBlockedCard = {
+        id: 'card_owner_1', device_id: 'dev1', status: 'blocked',
+        title: 'delete account flow', gate_reason: 'irreversible', assigned_bots: [4],
+    };
+
+    test('flag FALSE (default) → complete no-op (no create, no dismiss, no card query)', async () => {
+        const deps = makeDeps({ prefs: { waiting_state_surfacer_enabled: false }, cards: [ownerBlockedCard] });
+        let cardQueried = false;
+        const origQuery = deps.pool.query;
+        deps.pool.query = async (sql, params) => {
+            if (/FROM kanban_cards/.test(sql)) cardQueried = true;
+            return origQuery(sql, params);
+        };
+        const fn = makeSurfacer(deps);
+        await fn('dev1');
+        expect(deps.creates.length).toBe(0);
+        expect(deps.dismisses.length).toBe(0);
+        expect(cardQueried).toBe(false); // early-return before any DB work
+    });
+
+    test('flag UNSET → treated as false → no-op', async () => {
+        const deps = makeDeps({ prefs: {}, cards: [ownerBlockedCard] });
+        const fn = makeSurfacer(deps);
+        await fn('dev1');
+        expect(deps.creates.length).toBe(0);
+        expect(deps.dismisses.length).toBe(0);
+    });
+
+    test('flag TRUE + owner card + no existing item → EXACTLY one create w/ decisionContext.surfacer===true', async () => {
+        const deps = makeDeps({
+            prefs: { waiting_state_surfacer_enabled: true },
+            cards: [ownerBlockedCard],
+            openSurfacerCardIds: [],
+        });
+        const fn = makeSurfacer(deps);
+        await fn('dev1');
+        expect(deps.creates.length).toBe(1);
+        const arg = deps.creates[0];
+        expect(arg.deviceId).toBe('dev1');
+        expect(arg.relatedCardId).toBe('card_owner_1');
+        expect(arg.type).toBe('decision');
+        expect(arg.decisionContext.surfacer).toBe(true);
+        expect(arg.decisionContext.waitingOn).toBe('owner');
+        expect(arg.decisionContext.ownerOnly).toBe(true);
+        expect(arg.fromEntityId).toBe(4); // first assigned bot
+        expect(deps.dismisses.length).toBe(0);
+    });
+
+    test('flag TRUE + existing surfacer item for that card → NO duplicate create', async () => {
+        const deps = makeDeps({
+            prefs: { waiting_state_surfacer_enabled: true },
+            cards: [ownerBlockedCard],
+            openSurfacerCardIds: ['card_owner_1'], // already surfaced
+        });
+        const fn = makeSurfacer(deps);
+        await fn('dev1');
+        expect(deps.creates.length).toBe(0);
+        expect(deps.dismisses.length).toBe(0); // still owner-waiting → keep, don't dismiss
+    });
+
+    test('wait cleared (card now non-owner) + existing surfacer item → dismiss called', async () => {
+        // Card is now a plain review card (no ownerOnly) → classifier returns
+        // 'commander', not 'owner' → its stale surfacer item must be dismissed.
+        const clearedCard = { id: 'card_owner_1', device_id: 'dev1', status: 'review', title: 'x', assigned_bots: [4] };
+        const deps = makeDeps({
+            prefs: { waiting_state_surfacer_enabled: true },
+            cards: [clearedCard],
+            openSurfacerCardIds: ['card_owner_1'],
+        });
+        const fn = makeSurfacer(deps);
+        await fn('dev1');
+        expect(deps.creates.length).toBe(0);
+        expect(deps.dismisses.length).toBe(1);
+        expect(deps.dismisses[0]).toEqual({ deviceId: 'dev1', cardId: 'card_owner_1' });
+    });
+
+    test('card LEFT the waiting statuses entirely (gone from candidates) → stale surfacer item swept', async () => {
+        // No candidate cards at all, but a surfacer item still open → dismiss sweep.
+        const deps = makeDeps({
+            prefs: { waiting_state_surfacer_enabled: true },
+            cards: [],
+            openSurfacerCardIds: ['card_gone_9'],
+        });
+        const fn = makeSurfacer(deps);
+        await fn('dev1');
+        expect(deps.creates.length).toBe(0);
+        expect(deps.dismisses.length).toBe(1);
+        expect(deps.dismisses[0].cardId).toBe('card_gone_9');
+    });
+
+    test('in_progress card with [await-owner] marker in latest comment → surfaced', async () => {
+        const ipCard = { id: 'card_ip_2', device_id: 'dev1', status: 'in_progress', title: 'feature', assigned_bots: [] };
+        const deps = makeDeps({
+            prefs: { waiting_state_surfacer_enabled: true },
+            cards: [ipCard],
+            comments: { card_ip_2: 'done + tested. [await-owner] on the go/no-go.' },
+        });
+        const fn = makeSurfacer(deps);
+        await fn('dev1');
+        expect(deps.creates.length).toBe(1);
+        expect(deps.creates[0].relatedCardId).toBe('card_ip_2');
+        expect(deps.creates[0].fromEntityId).toBe(0); // no assigned bots → 0
+    });
+
+    test('non-owner cards (plain in_progress / review-no-ownerOnly) with NO item → nothing happens', async () => {
+        const deps = makeDeps({
+            prefs: { waiting_state_surfacer_enabled: true },
+            cards: [
+                { id: 'a', status: 'in_progress', title: 'coding', assigned_bots: [1] },
+                { id: 'b', status: 'review', title: 'reviewing', assigned_bots: [1] },
+            ],
+            comments: { a: 'still working' },
+        });
+        const fn = makeSurfacer(deps);
+        await fn('dev1');
+        expect(deps.creates.length).toBe(0);
+        expect(deps.dismisses.length).toBe(0);
+    });
+});

--- a/backend/waiting-state.js
+++ b/backend/waiting-state.js
@@ -1,0 +1,123 @@
+// Waiting-state classifier (phases 2-3 of card_76b073959c279d6204d9fd42).
+//
+// Generalizes the owner-decision classifier into a "who is this card waiting
+// on?" verdict so the 需要你 (action-request) inbox can auto-surface EVERY
+// situation that is genuinely waiting on the OWNER (Hank), who only monitors
+// that inbox and never opens task cards.
+//
+// classifyCardWaitingState(card, ctx) → 'owner' | 'entity' | 'commander' | null
+//
+// Design rules (conservative / VETO-style — mirrors owner-decision-classifier):
+//   * DEFAULT is null (unknown → NOT surfaced). This is fail-safe: the #1 risk
+//     is flooding the inbox, so we only ever return 'owner' when there is a
+//     REAL owner-gate signal.
+//   * 'owner' is the only verdict the surfacer acts on. 'entity'/'commander'
+//     are classified (they feed the phase-1 census) but never create inbox
+//     items in this MVP.
+//   * Pure function, no DB/network, never throws on a malformed card.
+//
+// Reuses the existing owner-decision keyword classifier (irreversible data /
+// spend / product direction / legal-PII / security / strategic tradeoff /
+// explicit owner flag) so the "owner-only reason" test is consistent with the
+// move-hook that already ships.
+
+'use strict';
+
+const { classifyCardOwnerDecision } = require('./agent-improvement/owner-decision-classifier');
+
+// Narrow, DELIBERATE await-owner markers for the in_progress case. We do NOT
+// infer "waiting on owner" loosely from an in_progress card (that would flood
+// the inbox). Only an explicit marker in the latest comment OR an explicit
+// config flag counts. Case-insensitive; EN + 繁中.
+const AWAIT_OWNER_MARKER_RE = /\[\s*(?:等\s*hank|await[-\s]?owner|等老闆|待老闆|owner[-\s]?decision)\s*\]/i;
+
+/**
+ * Safely read a string field, returning '' for anything non-string.
+ * @param {*} v
+ * @returns {string}
+ */
+function str(v) {
+    return typeof v === 'string' ? v : '';
+}
+
+/**
+ * Classify which party a kanban card is waiting on.
+ *
+ * @param {object} card  A kanban card row (snake_case DB shape tolerated).
+ *   Recognized fields: status, title, description, gate_reason/gateReason,
+ *   requires_screenshot_review/requiresScreenshotReview, painTags,
+ *   config (JSONB object; may carry { waitingOn, awaitOwner }),
+ *   parent_card_id/parentCardId.
+ * @param {object} [ctx]  Optional context.
+ *   ctx.latestComment {string}  — text of the latest (non-system) comment.
+ *   ctx.decisionContext {object}— decision_context blob (e.g. { ownerOnly }).
+ *   ctx.painTags {string[]}     — pre-computed pain taxonomy tags.
+ * @returns {'owner'|'entity'|'commander'|null}
+ */
+function classifyCardWaitingState(card, ctx = {}) {
+    try {
+        if (!card || typeof card !== 'object') return null;
+
+        const context = (ctx && typeof ctx === 'object') ? ctx : {};
+        const status = str(card.status).toLowerCase();
+        const config = (card.config && typeof card.config === 'object') ? card.config : {};
+        const decisionContext = (context.decisionContext && typeof context.decisionContext === 'object')
+            ? context.decisionContext
+            : ((card.decision_context && typeof card.decision_context === 'object') ? card.decision_context : {});
+        const latestComment = str(context.latestComment);
+        const gateReason = str(card.gate_reason || card.gateReason);
+
+        // ── OWNER signals (VETO-style; any one is sufficient) ──
+
+        // (1) Explicit config flag: card.config.waitingOn === 'owner'.
+        if (str(config.waitingOn).toLowerCase() === 'owner') return 'owner';
+
+        // (2) Explicit config flag: card.config.awaitOwner === true.
+        if (config.awaitOwner === true) return 'owner';
+
+        // (3) review + decision_context.ownerOnly (the move-hook's own marker).
+        if (status === 'review' && decisionContext.ownerOnly === true) return 'owner';
+
+        // (4) blocked with an owner-only reason (keyword classifier on the
+        //     card text + gate reason). A plain "blocked, waiting on a peer"
+        //     card without an owner-only keyword returns null here → not owner.
+        if (status === 'blocked') {
+            const verdict = classifyCardOwnerDecision({
+                title: str(card.title),
+                description: str(card.description),
+                latestComment,
+                gateReason,
+                requiresScreenshotReview: (card.requires_screenshot_review === true || card.requiresScreenshotReview === true),
+                painTags: Array.isArray(context.painTags) ? context.painTags
+                    : (Array.isArray(card.painTags) ? card.painTags : []),
+            });
+            if (verdict.ownerOnly === true) return 'owner';
+        }
+
+        // (5) in_progress with a NARROW, explicit await-owner marker in the
+        //     latest comment. Deliberately does NOT run the loose keyword
+        //     classifier on in_progress cards — that would flood the inbox with
+        //     every card whose description happens to mention e.g. "billing".
+        if (status === 'in_progress' && AWAIT_OWNER_MARKER_RE.test(latestComment)) return 'owner';
+
+        // ── Non-owner classification (census only; NOT surfaced in this MVP) ──
+        // blocked (no owner reason) / review (no ownerOnly) → waiting on an
+        // entity or the commander to unblock/review. We keep this coarse: a
+        // review card is waiting on the commander/reviewer; a blocked card is
+        // waiting on an entity. Neither creates an inbox item.
+        if (status === 'review') return 'commander';
+        if (status === 'blocked') return 'entity';
+
+        // Everything else (todo / in_progress without a marker / done / etc.)
+        // is not in a waiting state we track → null (fail-safe: not surfaced).
+        return null;
+    } catch (_) {
+        // Never throw on a malformed card — fail-safe to "not surfaced".
+        return null;
+    }
+}
+
+module.exports = {
+    AWAIT_OWNER_MARKER_RE,
+    classifyCardWaitingState,
+};


### PR DESCRIPTION
Phases 2-3 of design card **card_76b073959c279d6204d9fd42**.

## What it does
Hank ONLY monitors the 需要你 (action-request) inbox — he never opens task cards. Today an owner-decision move-hook surfaces SOME cards (review/blocked child cards moving INTO those statuses). This generalizes that into a **waiting-state surfacer** that periodically catches EVERY card genuinely **waiting on the owner** — including `in_progress` cards blocked on an owner decision — and auto-surfaces exactly one inbox item per card, auto-dismissing it when the wait clears.

New pure classifier `backend/waiting-state.js` → `classifyCardWaitingState(card, ctx)` returns `'owner' | 'entity' | 'commander' | null`. Only `'owner'` creates inbox items; `'entity'`/`'commander'` feed the phase-1 census and are NOT surfaced. `'owner'` signals (VETO-style, default null / fail-safe):
- `blocked` with an owner-only reason (reuses the existing owner-decision keyword classifier)
- `review` + `decision_context.ownerOnly`
- explicit `config.waitingOn === 'owner'` or `config.awaitOwner === true`
- `in_progress` with a **narrow, explicit** `[await-owner]` / `[等Hank]` marker in the latest comment (deliberately NOT the loose keyword classifier, to avoid flooding)

## Default-off safety (the #1 risk is flooding the inbox)
- Behind device pref **`waiting_state_surfacer_enabled`, DEFAULT FALSE** (dark-launch). String-safe boolean coercion so a serialized `'false'` stays false. When false/unset the routine **early-returns before any DB work** — a complete no-op. Nothing changes for anyone until Hank explicitly enables it.
- Runs inside the EXISTING kanban stale-scan worker tick (`checkStaleCards` per-device loop) — **no new cron**.
- Failure-isolated: a surfacer error never breaks the stale scan.

## Dedup + dismiss guarantees
- Surfacer items carry `decision_context.surfacer === true` — a distinguishing marker so we find/dedup/dismiss ONLY our own rows and **never touch** ordinary action-requests or the move-hook's owner-decision rows.
- At most **ONE** open surfacer item per card (existing item → skip create).
- Auto-dismiss when the wait clears (card no longer `'owner'`) OR the card leaves the waiting statuses entirely, via a new NARROWER `dismissSurfacerActionRequestsForCard` (surfacer-only `WHERE decision_context #>> '{surfacer}' = 'true'`), distinct from the broader `dismissActionRequestsForCard`.

## Tests
`backend/tests/jest/waiting-state-surfacer.test.js` (16 tests, all green): classifier truth table incl. no-false-surface for plain review/in_progress + fail-safe on malformed cards; surfacer flag-false no-op, single-create with `surfacer===true`, no-duplicate, dismiss-on-clear (surfacer-only guard), stale-sweep, in_progress-marker path.
- Full kanban suite `npx jest tests/jest/kanban`: **39 suites / 427 tests pass**.
- device-preferences + agent-action-requests suites: 55 tests pass.
- `npx eslint` on all changed .js: **0 errors**.

Do NOT merge / do NOT enable the pref — dark-launch only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN