### PR TITLE
fix(inbox): 需要你 inbox opens as full-screen scrollable overlay on mobile

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -362,7 +362,27 @@
             -webkit-overflow-scrolling: touch; min-width: 0; max-width: 100%;
         }
         .action-request-inbox.is-open .action-request-inbox-body { display: flex; }
-        @media (max-width: 640px) { .action-request-inbox-body { max-height: 38vh; } }
+        /* Mobile: the inbox lived inside .chat-messages-wrapper{overflow:hidden} as a
+           tiny 38vh nested-scroll box — on real phones that nested scroll region is
+           unusable and the owner could not scroll to see all items. When OPEN on a
+           phone, lift the inbox into a full-height fixed overlay that ESCAPES the
+           clipping wrapper, so the body gets a large, reliably-swipeable scroll area
+           and every action-request is reachable. Collapsed state + desktop unchanged. */
+        @media (max-width: 640px) {
+            .action-request-inbox.is-open {
+                position: fixed; left: 6px; right: 6px; top: 54px; bottom: 10px;
+                z-index: 6000; margin: 0; overflow: hidden;
+                display: flex; flex-direction: column;
+                background: var(--card-bg, #12121a);
+                border: 1px solid var(--card-border, #333355);
+                border-radius: 12px; box-shadow: 0 8px 40px rgba(0,0,0,0.5); padding: 10px;
+            }
+            .action-request-inbox.is-open .action-request-inbox-body {
+                max-height: none; flex: 1 1 auto; overflow-y: auto;
+                -webkit-overflow-scrolling: touch; overscroll-behavior: contain;
+            }
+            .action-request-inbox:not(.is-open) .action-request-inbox-body { max-height: 38vh; }
+        }
         @media (prefers-reduced-motion: reduce) { .ar-chevron { transition: none; } }
         .action-request-inbox-head { display: flex; align-items: center; justify-content: flex-end; flex-wrap: wrap; gap: 10px; }
         .action-request-inbox-title { font-weight: 700; color: var(--text, #ffffff); }

--- a/backend/tests/jest/chat-inbox-mobile-overlay.test.js
+++ b/backend/tests/jest/chat-inbox-mobile-overlay.test.js
@@ -1,0 +1,50 @@
+/**
+ * Static invariant — 需要你 inbox must be reliably scrollable on phones.
+ *
+ * Bug (owner-reported, repeated): on mobile the inbox lived inside
+ * .chat-messages-wrapper{overflow:hidden} as a tiny 38vh nested-scroll box; the
+ * owner physically could not scroll it to see all items. A real-touch swipe test
+ * (CDP Input.dispatchTouchEvent) confirmed the body itself CAN scroll, but the
+ * nested tiny window trapped in an overflow:hidden ancestor is unusable on real
+ * devices.
+ *
+ * Fix: when OPEN on a phone (max-width:640px), the inbox becomes a position:fixed
+ * full-height overlay (escapes the clipping wrapper) and its body flex-fills with
+ * overflow-y:auto → large, reliable scroll area; every item reachable. Collapsed
+ * state keeps the compact 38vh; desktop unchanged.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const chatHtml = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html'),
+    'utf8'
+);
+
+// Isolate the mobile (max-width:640px) media block that styles the open inbox.
+const mq = chatHtml.match(/@media \(max-width: 640px\) \{[\s\S]*?\.action-request-inbox\.is-open[\s\S]*?\n\s{8}\}/);
+
+describe('需要你 inbox — mobile open state is a scrollable fixed overlay', () => {
+    test('open inbox on phones is position:fixed (escapes the overflow:hidden wrapper)', () => {
+        expect(mq).not.toBeNull();
+        const css = mq[0];
+        expect(css).toMatch(/\.action-request-inbox\.is-open\s*\{[^}]*position:\s*fixed/);
+        // full-height overlay: pinned top and bottom
+        expect(css).toMatch(/\.action-request-inbox\.is-open\s*\{[^}]*top:\s*\d/);
+        expect(css).toMatch(/\.action-request-inbox\.is-open\s*\{[^}]*bottom:\s*\d/);
+    });
+
+    test('open inbox body flex-fills and scrolls (max-height:none + flex + overflow-y:auto)', () => {
+        const css = mq[0];
+        expect(css).toMatch(/\.action-request-inbox\.is-open\s*\.action-request-inbox-body\s*\{[^}]*max-height:\s*none/);
+        expect(css).toMatch(/\.action-request-inbox\.is-open\s*\.action-request-inbox-body\s*\{[^}]*overflow-y:\s*auto/);
+        expect(css).toMatch(/\.action-request-inbox\.is-open\s*\.action-request-inbox-body\s*\{[^}]*flex:\s*1/);
+    });
+
+    test('collapsed inbox keeps the compact height (does not blanket-apply the overlay)', () => {
+        // The 38vh cap must now be scoped to the NON-open state, not all bodies.
+        expect(chatHtml).toMatch(/\.action-request-inbox:not\(\.is-open\)\s*\.action-request-inbox-body\s*\{[^}]*max-height:\s*38vh/);
+    });
+});


### PR DESCRIPTION
## Problem (owner-blocking, repeated)
On mobile the 需要你 inbox lived inside `.chat-messages-wrapper{overflow:hidden}` as a tiny **38vh** nested-scroll box. On real phones that nested region is unusable — the owner physically **could not scroll** to see all action-request items. (The earlier flex-shrink:0 fix let items keep height, but the trapped 38vh window was the real problem.)

A CDP real-touch swipe test (`Input.dispatchTouchEvent`) confirmed the body CAN scroll in emulation — so the culprit is the tiny window jammed inside an `overflow:hidden` ancestor, which fails on real devices.

## Fix (CSS-only, mobile-scoped)
When OPEN on phones (`max-width:640px`), lift the inbox into a `position:fixed` full-height overlay that **escapes the clipping wrapper**; the body flex-fills with `overflow-y:auto` → a large, reliably-swipeable scroll area with every item reachable. Collapsed state keeps the compact 38vh; **desktop unchanged**.

**Verified live on prod (390×844)**: prototype injected → inbox 780px overlay, body scrollHeight 914 in a 714px window, both action-requests + their 回覆/略過 buttons visible and scrollable.

## Test
`chat-inbox-mobile-overlay.test.js` (3): open→position:fixed + top/bottom pinned; body max-height:none + flex + overflow-y:auto; collapsed keeps 38vh (overlay not blanket-applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)