### PR TITLE
fix(done-gate): exempt automation/ops cards from the PR-link requirement (keep 6-item checklist)

### DIFF
--- a/backend/agent-improvement/done-gate.js
+++ b/backend/agent-improvement/done-gate.js
@@ -60,6 +60,11 @@ const UI_PAIN_TAGS = Object.freeze(['ux_feedback', 'redirect_deeplink', 'deliver
  * @property {boolean} [isUiCard]            explicit override; if undefined, painTags is inspected
  * @property {string[]} [painTags]           used to infer isUiCard when not passed
  * @property {boolean} [strictArtifacts]     default true when severity/files provided; false otherwise
+ * @property {boolean} [isAutomation]        automation / ops card (scheduled cron母卡 is_automation OR
+ *                                           cron-spawned [Auto] child is_auto_generated). Pure operations
+ *                                           (health checks, audits, scheduled automations) have no PR, so
+ *                                           the PR-link sub-requirement is SKIPPED for these cards. The
+ *                                           6-item evidence checklist is still enforced.
  */
 
 /**
@@ -176,8 +181,15 @@ function evaluateDoneGate(input) {
     // v1 path: text-only, allow now.
     if (!useV2) return { allowed: true };
 
-    // 3. v2 — PR link in evidence (severity-tier independent: always required)
-    if (!PR_LINK_PATTERN.test(evidenceComment.text)) {
+    // 3. v2 — PR link in evidence (severity-tier independent: always required),
+    // EXCEPT for automation / ops cards. Scheduled automations, health-check
+    // sweeps and audit crons (is_automation母卡 OR is_auto_generated [Auto] child)
+    // are pure operations with NO code change → no PR to cite. Requiring a PR link
+    // blocked every ops card and forced a manual requiresPreflightReview:false. The
+    // 6-item evidence checklist above (Scope/Acceptance/Test plan/Evidence plan/
+    // Out-of-scope/User POV) is STILL enforced for them — only this PR-link
+    // sub-check is skipped. Non-automation cards are unchanged.
+    if (!input.isAutomation && !PR_LINK_PATTERN.test(evidenceComment.text)) {
         return {
             allowed: false,
             code: 'PREFLIGHT_GATE_FAILED',

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -2532,6 +2532,10 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     files: filesRes.rows,
                     severity: (card.priority || 'P2'),
                     painTags,
+                    // Automation / ops cards (scheduled automation母卡 or a
+                    // cron-spawned [Auto] child) have no PR to cite — exempt them
+                    // from the PR-link sub-check (6-item checklist still enforced).
+                    isAutomation: card.is_automation === true || card.is_auto_generated === true,
                 });
                 if (!verdict.allowed) {
                     return res.status(400).json({

--- a/backend/tests/jest/donegate-ops-prlink-exempt.test.js
+++ b/backend/tests/jest/donegate-ops-prlink-exempt.test.js
@@ -1,0 +1,127 @@
+/**
+ * done-gate: automation / ops cards are exempt from the PR-link sub-requirement,
+ * but STILL must cite the 6-item evidence checklist.
+ *
+ * Ops/cron cards (health checks, audits, scheduled automations) have NO code
+ * change → no PR to cite, so the PR-link check blocked every one of them and
+ * forced a manual requiresPreflightReview:false. This exemption keys off the
+ * isAutomation flag (is_automation母卡 OR is_auto_generated [Auto] child) that
+ * kanban.js passes from the card row.
+ */
+'use strict';
+
+const {
+    evaluateDoneGate,
+    PREFLIGHT_MARKER,
+} = require('../../agent-improvement/done-gate');
+
+const preflightText = `${PREFLIGHT_MARKER} — auto-composed]\n## 本任務如何避免過往同類錯誤\n...`;
+
+// Build a 6-item evidence comment. Toggle the PR link / a single checklist item.
+function evidence(opts = {}) {
+    const includePR = opts.pr !== false;
+    const dropItem = opts.drop || null; // e.g. 'Test plan' to omit that heading
+    const items = [
+        'Scope', 'Acceptance', 'Test plan',
+        'Evidence plan', 'Out-of-scope', 'User POV',
+    ].filter(h => h !== dropItem);
+    const lines = items.map(h => `## ${h} — written content here`);
+    if (includePR) {
+        lines.push('see https://github.com/HankHuang0516/EClaw/pull/9999 for the change');
+    }
+    return lines.join('\n');
+}
+
+function mkComment(text, opts = {}) {
+    return {
+        text,
+        isSystem: opts.isSystem ?? false,
+        createdAt: opts.t ?? '2026-06-07T02:00:00Z',
+    };
+}
+
+function mkFile(filename, mimeType, t = '2026-06-07T03:00:00Z') {
+    return { filename, mime_type: mimeType, created_at: t };
+}
+
+// Common: preflight marker + a jest-log artifact so the ONLY variable under
+// test is the PR link / checklist completeness, not the artifact requirement.
+function baseComments(evidenceOpts) {
+    return [
+        mkComment(preflightText, { isSystem: true, t: '2026-06-07T01:00:00Z' }),
+        mkComment(evidence(evidenceOpts), { isSystem: false, t: '2026-06-07T02:00:00Z' }),
+    ];
+}
+const jestLog = [mkFile('jest_out.txt', 'text/plain')];
+
+describe('done-gate — automation/ops PR-link exemption', () => {
+    test('(a) automation card with 6 items but NO PR link → ALLOWED', () => {
+        const v = evaluateDoneGate({
+            oldStatus: 'in_progress', newStatus: 'done',
+            requiresPreflightReview: true,
+            severity: 'P2',
+            painTags: ['task_context'],
+            comments: baseComments({ pr: false }),
+            files: jestLog,
+            isAutomation: true,
+        });
+        expect(v.allowed).toBe(true);
+    });
+
+    test('(b) NON-automation card with 6 items but no PR link → BLOCKED on PR link', () => {
+        const v = evaluateDoneGate({
+            oldStatus: 'in_progress', newStatus: 'done',
+            requiresPreflightReview: true,
+            severity: 'P2',
+            painTags: ['task_context'],
+            comments: baseComments({ pr: false }),
+            files: jestLog,
+            isAutomation: false,
+        });
+        expect(v.allowed).toBe(false);
+        expect(v.code).toBe('PREFLIGHT_GATE_FAILED');
+        expect(v.missingItems).toEqual(['PR link']);
+    });
+
+    test('(b2) omitting isAutomation entirely is treated as non-automation → still needs PR link', () => {
+        const v = evaluateDoneGate({
+            oldStatus: 'in_progress', newStatus: 'done',
+            requiresPreflightReview: true,
+            severity: 'P2',
+            painTags: ['task_context'],
+            comments: baseComments({ pr: false }),
+            files: jestLog,
+            // isAutomation not passed
+        });
+        expect(v.allowed).toBe(false);
+        expect(v.missingItems).toEqual(['PR link']);
+    });
+
+    test('(c) automation card STILL needs all 6 checklist items — missing one → BLOCKED', () => {
+        const v = evaluateDoneGate({
+            oldStatus: 'in_progress', newStatus: 'done',
+            requiresPreflightReview: true,
+            severity: 'P2',
+            painTags: ['task_context'],
+            comments: baseComments({ pr: false, drop: 'Test plan' }),
+            files: jestLog,
+            isAutomation: true,
+        });
+        expect(v.allowed).toBe(false);
+        expect(v.code).toBe('PREFLIGHT_GATE_FAILED');
+        expect(v.missingItems).toContain('Test plan');
+    });
+
+    test('automation card WITH a PR link is still fine (exemption only skips the check, never rejects a present link)', () => {
+        const v = evaluateDoneGate({
+            oldStatus: 'in_progress', newStatus: 'done',
+            requiresPreflightReview: true,
+            severity: 'P2',
+            painTags: ['task_context'],
+            comments: baseComments({ pr: true }),
+            files: jestLog,
+            isAutomation: true,
+        });
+        expect(v.allowed).toBe(true);
+    });
+});


### PR DESCRIPTION
## Problem
The OODA-R done-gate (`backend/agent-improvement/done-gate.js`) requires **every** card moving to `done` to cite a GitHub PR link. But ops/cron cards — health checks, audits, scheduled automations — have **no code change and no PR**. They got blocked on the `missingItems: ['PR link']` sub-check every time, forcing #2 to manually set `requiresPreflightReview:false` (which drops ALL gate protection, not just the PR-link bit).

## Fix
Add an `isAutomation` gate input. When the card is automation/ops:
- **SKIP** the PR-link sub-requirement only.
- **KEEP** the preflight marker + the full 6-item evidence checklist (Scope / Acceptance / Test plan / Evidence plan / Out-of-scope / User POV) and the artifact checks.

Non-automation cards are **unchanged** — still require the PR link.

## Detection signal (reliable at the call site)
`backend/kanban.js` `/card/:id/move` loads the card via `SELECT * FROM kanban_cards`, so the raw DB columns are present on `card`. The flag is derived as:

```js
isAutomation: card.is_automation === true || card.is_auto_generated === true,
```

- `is_automation` — scheduled automation母卡 (cron parent) flag
- `is_auto_generated` — cron-spawned `[Auto] … (date)` child rows (the actual recurring health-check/audit cards that move to done)

Both are real persisted columns (not derived), so the signal is reliable and doesn't depend on a fragile title convention.

## Tests
New `backend/tests/jest/donegate-ops-prlink-exempt.test.js` (5 cases):
- (a) automation card, 6 items, **no PR link** → **ALLOWED**
- (b) non-automation card, 6 items, no PR link → **BLOCKED** on `['PR link']`
- (b2) `isAutomation` omitted → treated as non-automation → still needs PR link
- (c) automation card missing a checklist item (Test plan) → **BLOCKED** (checklist still enforced)
- automation card WITH a PR link → still fine

New test: 5/5 pass. Existing done-gate suites (`kanban-ooda-r-done-gate.test.js`, `kanban-ooda-r-done-gate-v2.test.js`): green. Combined run: **52/52 pass**. `eslint` on changed files: **0 errors**.

## Consensus
4/4 entity consensus + owner approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN