### PR TITLE
feat(routing): commander-forward fallback (dark-launch, default off)

### DIFF
--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -111,6 +111,19 @@ const DEFAULTS = {
     //   before it is treated as stale and ignored (the evaluator then falls back
     //   to lastSend / kanban-floor heuristics). Default 45; clamped [5, 600].
     entity_runtime_state_stale_seconds: 45,
+    // Commander-forward fallback (card_3ce0080a, Leg-2 Option-1). orgChartForward
+    // in index.js is DORMANT on devices with no org chart: with the default
+    // taskForward:false + an empty hierarchy it forwards NOTHING, so a
+    // subordinate's substantive output never reaches a commander (#2). When this
+    // pref is TRUE, a subordinate's substantive (non-low-signal) OWN output is
+    // forwarded up to a bound commander-class entity (#2, else #1) even without an
+    // org chart configured — reusing the same low-signal filter so handoff/
+    // heartbeat noise is still dropped.
+    // ⚠️ DEFAULT FALSE (dark-launch). This touches message routing, so it is
+    // gated OFF until explicitly enabled per-device via PUT /api/device-preferences.
+    // Same string-safe boolean coercion as the auto-escalate toggles (a bare
+    // `!!raw` would turn the string 'false' true → fail-OPEN, wrong for a routing gate).
+    commander_forward_fallback_enabled: false,
 };
 
 const ENTITY_IDLE_AFTER_SECONDS_MIN = 15;
@@ -159,9 +172,13 @@ function coerceValue(key, raw) {
     // (a bare `!!raw` would coerce the string 'false' to true — wrong for an API
     // that may serialize the flag as a query/JSON string).
     if (key === 'kanban_auto_escalate_enabled' || key === 'kanban_auto_escalate_skip_automation'
-        || key === 'action_request_ratify_enabled') {
+        || key === 'action_request_ratify_enabled'
+        || key === 'commander_forward_fallback_enabled') {
         // 計畫E: ratify master switch — same string-safe boolean coercion (a bare
         // `!!raw` would turn the string 'false' true, fail-OPEN for an auto-merge gate).
+        // commander_forward_fallback_enabled (card_3ce0080a) shares the coercion for
+        // the same fail-OPEN reason: it is a message-routing gate that MUST stay off
+        // unless the value is a real true / the string 'true'.
         return raw === true || raw === 'true';
     }
     if (typeof def === 'boolean') return !!raw;

--- a/backend/index.js
+++ b/backend/index.js
@@ -19746,6 +19746,82 @@ async function pushToBot(entity, deviceId, eventType, payload, opts = {}) {
 const ORG_FWD_PREFIX = '[📢 FWD';
 const ORG_TASK_FWD_PREFIX = '[📋 TASK FWD';
 
+// Commander-class entities, ordered by preference (#2 commander, then #1 deputy).
+// Mirrors kanban.js ESCALATION_SUPERVISOR_ENTITY_IDS — the platform already treats
+// #1/#2 as supervisors. Used as the commander-forward fallback target (below) when
+// no org chart is configured. (card_3ce0080a, Leg-2 Option-1.)
+const COMMANDER_FORWARD_ENTITY_IDS = [2, 1];
+
+/**
+ * Commander-forward fallback (card_3ce0080a, Leg-2 Option-1).
+ *
+ * orgChartForward() below is DORMANT on devices with no org chart: with the
+ * default taskForward:false + an empty hierarchy it returns without forwarding,
+ * so a subordinate's substantive OWN output never reaches a commander (#2). This
+ * fallback — gated behind the DEFAULT-OFF pref commander_forward_fallback_enabled
+ * — forwards that output up to a bound commander-class entity (#2, else #1) even
+ * without a hierarchy. It reuses the SAME low-signal filter and delivery path as
+ * the normal superior-forward so handoff/heartbeat noise is still dropped and no
+ * chat bubble is created.
+ *
+ * Called ONLY from orgChartForward's dormant return points (taskForward off OR no
+ * org-chart superior for this entity). `message` is already known non-low-signal
+ * (classifyLowSignalFwd ran + returned null at the top of orgChartForward) and
+ * `opts.inbound` is already falsy (the inbound branch returns earlier), but both
+ * are re-checked here so the helper is safe in isolation and unit-testable.
+ *
+ * Failure-isolated: any error is swallowed (logged) — a fallback error must never
+ * break the caller. Returns nothing.
+ *
+ * Commander resolution: the first entity id in COMMANDER_FORWARD_ENTITY_IDS ([2,1])
+ * that is bound AND is not the forwarding entity itself AND is not opts.fromEntityId
+ * (the original sender already has the message). Never self-forwards.
+ */
+async function commanderForwardFallback(entity, deviceId, message, opts = {}) {
+    try {
+        // Re-assert the guards (caller already checked, but keep the helper safe
+        // in isolation): only the entity's OWN substantive output, never inbound.
+        if (opts.inbound) return;
+        if (!message || isLowSignalFwd(message)) return;
+
+        const prefs = await devicePrefs.getPrefs(deviceId);
+        if (!prefs || prefs.commander_forward_fallback_enabled !== true) return; // DEFAULT-OFF gate
+
+        const device = devices[deviceId];
+        if (!device || !device.entities) return;
+
+        // Resolve a bound commander that is neither this entity nor the original
+        // sender. Ordered #2-then-#1, mirroring the escalation supervisor fallback.
+        const fromEntityId = opts.fromEntityId != null ? Number(opts.fromEntityId) : null;
+        let commanderId = null;
+        for (const cid of COMMANDER_FORWARD_ENTITY_IDS) {
+            if (cid === entity.entityId) continue;      // never self-forward
+            if (fromEntityId != null && cid === fromEntityId) continue; // sender already has it
+            const cand = device.entities[cid];
+            if (cand && cand.isBound) { commanderId = cid; break; }
+        }
+        if (commanderId == null) return; // no bound commander → no-op
+
+        const commanderEntity = device.entities[commanderId];
+        const prefix = `${ORG_FWD_PREFIX} from #${entity.entityId}] `;
+        const fwdMsg = prefix + message;
+        console.log(`[OrgChart] Commander-forward fallback #${entity.entityId} -> #${commanderId} (no org chart)`);
+        serverLog('info', 'org_forward_fallback', `#${entity.entityId} -> #${commanderId} (commander fallback): "${fwdMsg.slice(0, 80)}"`, { deviceId, entityId: entity.entityId });
+
+        // Silent push — same delivery as the normal superior-forward (no
+        // saveChatMessage → no duplicate chat bubble).
+        unifiedPush(commanderEntity, deviceId, 'org_forward', { message: fwdMsg }, {
+            skipMiddleware: true,
+            from: `entity:${entity.entityId}`,
+        }).catch(err => {
+            console.error(`[OrgChart] Commander-forward fallback to #${commanderId} failed:`, err.message);
+        });
+    } catch (err) {
+        // Failure-isolated: never let the fallback break orgChartForward.
+        console.error('[OrgChart] commanderForwardFallback error:', err.message);
+    }
+}
+
 async function orgChartForward(entity, deviceId, message, opts = {}) {
     if (!message || message.startsWith(ORG_TASK_FWD_PREFIX) || message.startsWith(ORG_FWD_PREFIX)) return;
     // card_59f41e5b: "drop-but-surface" — classify WHY it's low-signal, drop the
@@ -19802,11 +19878,25 @@ async function orgChartForward(entity, deviceId, message, opts = {}) {
 
     try {
         const orgData = await orgChartModule.getOrgChart(deviceId);
-        if (!orgData.options.taskForward && !orgData.options.allForward) return;
-        if (!orgData.hierarchy || !orgData.hierarchy.USER) return;
+        // Dormant-when-no-org-chart path (card_3ce0080a): with the default
+        // taskForward:false + no configured hierarchy, the org-chart forward does
+        // nothing, so a subordinate's substantive output never reaches a commander.
+        // The DEFAULT-OFF commander_forward_fallback_enabled pref (checked inside the
+        // helper) routes it to a bound commander (#2, else #1) instead. Behavior is
+        // byte-for-byte unchanged while the pref is false (helper no-ops).
+        if (!orgData.options.taskForward && !orgData.options.allForward) {
+            return commanderForwardFallback(entity, deviceId, message, opts);
+        }
+        if (!orgData.hierarchy || !orgData.hierarchy.USER) {
+            return commanderForwardFallback(entity, deviceId, message, opts);
+        }
 
         const superiorId = orgChartModule.getSuperior(orgData.hierarchy, entity.entityId);
-        if (superiorId == null) return;
+        // No org-chart superior for this entity (orphan / not placed in the tree)
+        // → same dormant case; try the commander fallback before giving up.
+        if (superiorId == null) {
+            return commanderForwardFallback(entity, deviceId, message, opts);
+        }
         // USER is the top — not a pushable entity. If direct superior is USER, skip.
         if (superiorId === 'USER') return;
         // Skip if superior is the original sender — they already have the message (prevents speakTo echo)

--- a/backend/tests/jest/commander-forward-fallback.test.js
+++ b/backend/tests/jest/commander-forward-fallback.test.js
@@ -1,0 +1,219 @@
+'use strict';
+
+/**
+ * Dark-launched commander-forward fallback (card_3ce0080a, Leg-2 Option-1).
+ *
+ * Root cause it addresses: orgChartForward() in index.js is DORMANT on devices
+ * with no org chart. After the low-signal filter it hits
+ *     if (!orgData.options.taskForward && !orgData.options.allForward) return;
+ *     if (!orgData.hierarchy || !orgData.hierarchy.USER) return;
+ * so with the default taskForward:false + an empty hierarchy, NOTHING is
+ * forwarded — a subordinate's substantive report never reaches the commander (#2).
+ *
+ * Fix (behind the DEFAULT-OFF pref commander_forward_fallback_enabled):
+ * commanderForwardFallback() forwards a subordinate's substantive (non-low-signal)
+ * OWN output up to a bound commander-class entity (#2, else #1) even without an
+ * org chart. It reuses the same low-signal filter (drops handoff/heartbeat noise),
+ * only fires for the entity's own output (not inbound-to-it), never self-forwards,
+ * and is failure-isolated.
+ *
+ * Style mirrors kanban-escalate-to-supervisor.test.js: extractFunctionBody +
+ * new Function, with the module-scope deps injected. Plus source-grep invariants
+ * proving the wiring at the dormant return points and the default-off pref.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const indexSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'index.js'), 'utf8');
+const prefsMod = require('../../device-preferences.js');
+const { isLowSignalFwd } = require('../../org-fwd-filter.js');
+
+function extractFunctionBody(src, signature) {
+    const start = src.indexOf(signature);
+    if (start === -1) throw new Error(`function not found: ${signature}`);
+    // Start scanning for the body's opening brace AFTER the signature text so a
+    // `= {}` default in the parameter list isn't mistaken for the function body.
+    const open = src.indexOf('{', start + signature.length);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) return src.slice(open, i + 1);
+        }
+    }
+    throw new Error(`unterminated function: ${signature}`);
+}
+
+const fallbackSrc = extractFunctionBody(
+    indexSrc,
+    'async function commanderForwardFallback(entity, deviceId, message, opts = {})'
+);
+
+// Rebuild commanderForwardFallback in isolation with its module-scope deps
+// injected. unifiedPush is a spy so we can assert delivery target + payload.
+function makeFallback(deps) {
+    // eslint-disable-next-line no-new-func
+    return new Function(
+        'devicePrefs', 'devices', 'unifiedPush', 'serverLog', 'isLowSignalFwd',
+        'ORG_FWD_PREFIX', 'COMMANDER_FORWARD_ENTITY_IDS', 'console',
+        `return async function commanderForwardFallback(entity, deviceId, message, opts = {}) ${fallbackSrc}`
+    )(
+        deps.devicePrefs, deps.devices, deps.unifiedPush,
+        deps.serverLog || (() => {}),
+        deps.isLowSignalFwd || isLowSignalFwd,
+        '[📢 FWD', [2, 1],
+        deps.console || { log() {}, error() {} }
+    );
+}
+
+function boundDevice(boundIds) {
+    const entities = {};
+    for (const id of boundIds) entities[id] = { entityId: id, isBound: true };
+    return { entities };
+}
+
+function makeDeps({ prefEnabled, boundIds }) {
+    const pushCalls = [];
+    return {
+        pushCalls,
+        deps: {
+            devicePrefs: { getPrefs: async () => ({ commander_forward_fallback_enabled: prefEnabled }) },
+            devices: { dev1: boundDevice(boundIds) },
+            unifiedPush: async (targetEntity, deviceId, kind, payload, opts) => {
+                pushCalls.push({ targetEntity, deviceId, kind, payload, opts });
+            },
+        },
+    };
+}
+
+const SUBSTANTIVE = '完成 card_ab12cd 的修復，PR #123 已開，待 review — ETA 30 分鐘。';
+const LOW_SIGNAL = '收到🦞';
+
+describe('commanderForwardFallback — behavioural', () => {
+    test('pref FALSE (default) → no fallback forward (no-op)', async () => {
+        const { pushCalls, deps } = makeDeps({ prefEnabled: false, boundIds: [1, 2, 6] });
+        const fallback = makeFallback(deps);
+        await fallback({ entityId: 6 }, 'dev1', SUBSTANTIVE, { fromEntityId: 99 });
+        expect(pushCalls).toHaveLength(0);
+    });
+
+    test('pref TRUE + substantive + no hierarchy + #2 bound + sender=#6 → forwards to #2', async () => {
+        const { pushCalls, deps } = makeDeps({ prefEnabled: true, boundIds: [1, 2, 6] });
+        const fallback = makeFallback(deps);
+        await fallback({ entityId: 6 }, 'dev1', SUBSTANTIVE, { fromEntityId: 99 });
+        expect(pushCalls).toHaveLength(1);
+        expect(pushCalls[0].targetEntity.entityId).toBe(2); // commander #2 preferred
+        expect(pushCalls[0].payload.message).toContain(SUBSTANTIVE);
+        expect(pushCalls[0].payload.message.startsWith('[📢 FWD from #6]')).toBe(true);
+        expect(pushCalls[0].opts.skipMiddleware).toBe(true);
+        expect(pushCalls[0].opts.from).toBe('entity:6');
+    });
+
+    test('pref TRUE but message is LOW-SIGNAL → NOT forwarded (filter still applies)', async () => {
+        const { pushCalls, deps } = makeDeps({ prefEnabled: true, boundIds: [1, 2, 6] });
+        const fallback = makeFallback(deps);
+        await fallback({ entityId: 6 }, 'dev1', LOW_SIGNAL, { fromEntityId: 99 });
+        expect(pushCalls).toHaveLength(0);
+    });
+
+    test('pref TRUE + sender IS #2 itself → does not self-forward, falls to #1', async () => {
+        const { pushCalls, deps } = makeDeps({ prefEnabled: true, boundIds: [1, 2] });
+        const fallback = makeFallback(deps);
+        // #2 is the FORWARDING entity → #2 skipped (never self-forward) → #1 chosen.
+        await fallback({ entityId: 2 }, 'dev1', SUBSTANTIVE, { fromEntityId: 99 });
+        expect(pushCalls).toHaveLength(1);
+        expect(pushCalls[0].targetEntity.entityId).toBe(1);
+    });
+
+    test('pref TRUE + original sender is #2 → #2 skipped (already has it), falls to #1', async () => {
+        const { pushCalls, deps } = makeDeps({ prefEnabled: true, boundIds: [1, 2, 6] });
+        const fallback = makeFallback(deps);
+        await fallback({ entityId: 6 }, 'dev1', SUBSTANTIVE, { fromEntityId: 2 });
+        expect(pushCalls).toHaveLength(1);
+        expect(pushCalls[0].targetEntity.entityId).toBe(1);
+    });
+
+    test('pref TRUE + no bound commander (#1/#2 unbound) → no-op', async () => {
+        const { pushCalls, deps } = makeDeps({ prefEnabled: true, boundIds: [6] });
+        const fallback = makeFallback(deps);
+        await fallback({ entityId: 6 }, 'dev1', SUBSTANTIVE, { fromEntityId: 99 });
+        expect(pushCalls).toHaveLength(0);
+    });
+
+    test('inbound message → NOT force-forwarded (escalation is the other path)', async () => {
+        const { pushCalls, deps } = makeDeps({ prefEnabled: true, boundIds: [1, 2, 6] });
+        const fallback = makeFallback(deps);
+        await fallback({ entityId: 6 }, 'dev1', SUBSTANTIVE, { fromEntityId: 99, inbound: true });
+        expect(pushCalls).toHaveLength(0);
+    });
+
+    test('failure-isolated: getPrefs throws → swallowed, no push, no throw', async () => {
+        const pushCalls = [];
+        const deps = {
+            devicePrefs: { getPrefs: async () => { throw new Error('db down'); } },
+            devices: { dev1: boundDevice([1, 2, 6]) },
+            unifiedPush: async (...a) => { pushCalls.push(a); },
+        };
+        const fallback = makeFallback(deps);
+        await expect(fallback({ entityId: 6 }, 'dev1', SUBSTANTIVE, {})).resolves.toBeUndefined();
+        expect(pushCalls).toHaveLength(0);
+    });
+
+    test('device not present → no-op (no throw)', async () => {
+        const pushCalls = [];
+        const deps = {
+            devicePrefs: { getPrefs: async () => ({ commander_forward_fallback_enabled: true }) },
+            devices: {},
+            unifiedPush: async (...a) => { pushCalls.push(a); },
+        };
+        const fallback = makeFallback(deps);
+        await fallback({ entityId: 6 }, 'dev1', SUBSTANTIVE, {});
+        expect(pushCalls).toHaveLength(0);
+    });
+});
+
+describe('device-preferences — pref default + coercion', () => {
+    test('commander_forward_fallback_enabled DEFAULTS to false (dark-launch)', () => {
+        expect(prefsMod.DEFAULTS.commander_forward_fallback_enabled).toBe(false);
+    });
+
+    test('string-safe boolean coercion: "false" stays false, only real true / "true" enable', () => {
+        // Re-run coerceValue via updatePrefs path indirectly is heavy; assert the
+        // documented contract through DEFAULTS + the code invariant grep below.
+        // Here we prove the coercion is wired the same as the other routing gates.
+        const src = fs.readFileSync(path.join(__dirname, '..', '..', 'device-preferences.js'), 'utf8');
+        // The pref is in the string-safe boolean branch (raw === true || raw === 'true'),
+        // NOT the bare `!!raw` branch (which would coerce 'false' → true).
+        const branch = src.slice(
+            src.indexOf("if (key === 'kanban_auto_escalate_enabled'"),
+            src.indexOf("return raw === true || raw === 'true';")
+        );
+        expect(branch).toContain("key === 'commander_forward_fallback_enabled'");
+    });
+});
+
+describe('source invariants — orgChartForward wiring', () => {
+    test('the two dormant return points call commanderForwardFallback', () => {
+        const fwdSrc = extractFunctionBody(
+            indexSrc,
+            'async function orgChartForward(entity, deviceId, message, opts = {})'
+        );
+        // taskForward/allForward-off return → fallback
+        expect(fwdSrc).toMatch(/!orgData\.options\.taskForward && !orgData\.options\.allForward\)\s*\{\s*return commanderForwardFallback/);
+        // no superior for this entity → fallback
+        expect(fwdSrc).toMatch(/superiorId == null\)\s*\{\s*return commanderForwardFallback/);
+    });
+
+    test('commander fallback uses the #2-before-#1 ordering constant', () => {
+        expect(indexSrc).toMatch(/COMMANDER_FORWARD_ENTITY_IDS\s*=\s*\[2,\s*1\]/);
+    });
+
+    test('fallback is default-off gated on the pref and re-applies the low-signal filter', () => {
+        expect(fallbackSrc).toMatch(/commander_forward_fallback_enabled !== true/);
+        expect(fallbackSrc).toMatch(/isLowSignalFwd\(message\)/);
+        expect(fallbackSrc).toMatch(/if \(opts\.inbound\) return/);
+    });
+});


### PR DESCRIPTION
## Problem — `orgChartForward` is dormant without an org chart

`orgChartForward(entity, deviceId, message, opts)` (backend/index.js) forwards a subordinate entity's own output UP to its org-chart superior. On devices with **no org chart configured** it is DORMANT: after the low-signal filter it hits

```js
if (!orgData.options.taskForward && !orgData.options.allForward) return; // default taskForward:false
if (!orgData.hierarchy || !orgData.hierarchy.USER) return;               // empty hierarchy
```

so with the default `taskForward:false` + an empty hierarchy, **nothing is forwarded** — a subordinate's substantive reports never reach the commander (#2). This is the root cause behind the supervisor-visibility incident (`card_3ce0080a`). The escalation-on-stuck half was already shipped in **#3864** (`resolveEscalationSupervisor` in kanban.js); this PR is **Leg-2, Option-1 (code fallback)**.

## Change — a DEFAULT-OFF commander-forward fallback

New `commanderForwardFallback(entity, deviceId, message, opts)` runs at `orgChartForward`'s two dormant return points (taskForward/allForward both off; and no org-chart superior for this entity). When enabled, it forwards the subordinate's substantive OWN output to a bound commander-class entity, reusing the exact same delivery path (`unifiedPush` silent push, `[📢 FWD from #N]` prefix, no chat bubble).

### Default-off safety (dark-launch)
- New pref `commander_forward_fallback_enabled` in `device-preferences.js` DEFAULTS, **default `false`**.
- It uses the same **string-safe boolean coercion** branch as the other routing gates (`raw === true || raw === 'true'`) — a bare `!!raw` would coerce the string `'false'` to `true` (fail-OPEN), wrong for a message-routing gate.
- When the pref is false (default) behavior is **byte-for-byte unchanged** — the helper no-ops before any push (unit-tested).

### Guards (all must hold to forward)
- **Low-signal filter still applies** — reuses `classifyLowSignalFwd`/`isLowSignalFwd` from `./org-fwd-filter`, so handoff/heartbeat/ack noise is still dropped.
- **Own output only** — `opts.inbound` falsy (the inbound branch already returns earlier; re-asserted in the helper).
- **Never self-forward** — the resolved commander is never the forwarding entity, and never `opts.fromEntityId` (the original sender already has the message).
- **Failure-isolated** — the whole helper is wrapped in try/catch; any error is logged and swallowed, never breaking `orgChartForward`.

### Commander resolution
First id in `COMMANDER_FORWARD_ENTITY_IDS = [2, 1]` (mirrors kanban's `ESCALATION_SUPERVISOR_ENTITY_IDS`) that is **bound** AND not the forwarding entity AND not the original sender. Prefers #2 (commander), falls back to #1 (deputy). No bound commander → no-op.

## Tests

`backend/tests/jest/commander-forward-fallback.test.js` (extract-and-run + source invariants, mirroring `kanban-escalate-to-supervisor.test.js`). **14 tests, all pass**:
- pref false (default) → no forward (no-op)
- pref true + substantive + no hierarchy + #2 bound + sender=#6 → forwards to #2
- pref true + LOW-SIGNAL msg → not forwarded (filter still applies)
- pref true + sender IS #2 → does not self-forward, falls to #1
- pref true + original sender is #2 → #2 skipped, falls to #1
- pref true + no bound commander → no-op
- inbound message → not force-forwarded
- getPrefs throws → failure-isolated (no push, no throw); device absent → no-op
- pref DEFAULTS to false; string-safe coercion branch wiring
- source invariants: both dormant return points call the fallback, `[2,1]` ordering, pref gate + low-signal + inbound guards present

Regression suites green: `org-fwd-filter`, `org-fwd-escalation`, `org-chart`, `kanban-escalate-to-supervisor`, `kanban-auto-escalate-toggle`, `device-preferences*` — **136 + 30 pass**. `eslint` on changed source files: **0 errors**.

## Rollout
Dark-launched, default OFF. Enable per-device via `PUT /api/device-preferences {commander_forward_fallback_enabled:true}`. **Not enabled here.** Leg-2 Option-1 of `card_3ce0080a`; escalation half already shipped in #3864.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN
