### PR TITLE
feat(done-gate): PR-link enforcement is a per-card opt-in option (default off)

### DIFF
--- a/backend/agent-improvement/done-gate.js
+++ b/backend/agent-improvement/done-gate.js
@@ -60,11 +60,19 @@ const UI_PAIN_TAGS = Object.freeze(['ux_feedback', 'redirect_deeplink', 'deliver
  * @property {boolean} [isUiCard]            explicit override; if undefined, painTags is inspected
  * @property {string[]} [painTags]           used to infer isUiCard when not passed
  * @property {boolean} [strictArtifacts]     default true when severity/files provided; false otherwise
+ * @property {boolean} [requirePrLink]       per-card opt-in for the PR-link sub-check. DEFAULT false
+ *                                           (NOT blocking) — owner directive 2026-07-03: "PR link 是
+ *                                           option 且默認不阻擋". The PR-link requirement is enforced
+ *                                           ONLY when this is explicitly TRUE (set at card creation via
+ *                                           POST /card {requirePrLink} or later via PUT /card/:id/config).
+ *                                           This SUPERSEDES the isAutomation-only exemption: by default
+ *                                           NO card needs a PR link at done; opting in turns it on.
  * @property {boolean} [isAutomation]        automation / ops card (scheduled cron母卡 is_automation OR
- *                                           cron-spawned [Auto] child is_auto_generated). Pure operations
- *                                           (health checks, audits, scheduled automations) have no PR, so
- *                                           the PR-link sub-requirement is SKIPPED for these cards. The
- *                                           6-item evidence checklist is still enforced.
+ *                                           cron-spawned [Auto] child is_auto_generated). Kept as a
+ *                                           redundant safety exemption: even if a card opts in with
+ *                                           requirePrLink=true, automation/ops cards (which have no PR)
+ *                                           still skip the PR-link sub-check. The 6-item evidence
+ *                                           checklist is always enforced regardless of either flag.
  */
 
 /**
@@ -181,15 +189,20 @@ function evaluateDoneGate(input) {
     // v1 path: text-only, allow now.
     if (!useV2) return { allowed: true };
 
-    // 3. v2 — PR link in evidence (severity-tier independent: always required),
-    // EXCEPT for automation / ops cards. Scheduled automations, health-check
-    // sweeps and audit crons (is_automation母卡 OR is_auto_generated [Auto] child)
-    // are pure operations with NO code change → no PR to cite. Requiring a PR link
-    // blocked every ops card and forced a manual requiresPreflightReview:false. The
+    // 3. v2 — PR link in evidence. Owner directive 2026-07-03: this is now a
+    // PER-CARD OPT-IN that DEFAULTS OFF ("PR link 是 option 且默認不阻擋").
+    // The PR-link sub-check blocks ONLY when the card explicitly opted in with
+    // requirePrLink === true (set at create via POST /card {requirePrLink} or
+    // later via PUT /card/:id/config). By default (false/undefined) NO card
+    // needs a PR link at done. This generalises & supersedes the old
+    // automation-only exemption: everything is exempt by default, and opting in
+    // is what turns enforcement on. isAutomation is KEPT as a redundant safety —
+    // automation / ops cards (is_automation母卡 OR is_auto_generated [Auto] child)
+    // have no PR to cite, so they skip the check even if they opted in. The
     // 6-item evidence checklist above (Scope/Acceptance/Test plan/Evidence plan/
-    // Out-of-scope/User POV) is STILL enforced for them — only this PR-link
-    // sub-check is skipped. Non-automation cards are unchanged.
-    if (!input.isAutomation && !PR_LINK_PATTERN.test(evidenceComment.text)) {
+    // Out-of-scope/User POV) is STILL enforced regardless of requirePrLink.
+    const prLinkRequired = input.requirePrLink === true && !input.isAutomation;
+    if (prLinkRequired && !PR_LINK_PATTERN.test(evidenceComment.text)) {
         return {
             allowed: false,
             code: 'PREFLIGHT_GATE_FAILED',

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -1069,6 +1069,9 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             reviewerEntityId: row.reviewer_entity_id != null ? parseInt(row.reviewer_entity_id) : null,
             requiresScreenshotReview: row.requires_screenshot_review !== false,
             requiresPreflightReview: row.requires_preflight_review !== false,
+            // Per-card PR-link opt-in (owner directive 2026-07-03). Defaults FALSE
+            // (not blocking); only when TRUE does the done-gate require a PR link.
+            requirePrLink: row.requires_pr_link === true,
             gated: !!row.gated,
             gateReason: row.gate_reason || null,
             reopenedAt: row.reopened_at ? new Date(row.reopened_at).getTime() : null,
@@ -1165,7 +1168,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         // from req.body alone meant a query-cred caller (deviceId not in body) passed auth
         // then bound NULL device_id into the INSERT → "null value in column device_id ...
         // violates not-null constraint" 500 on card create.
-        const { deviceId, title, description, priority, status, assignedBots, entityId, reviewerEntityId, isAutomation, schedule, requiresScreenshotReview, chatAnchorMessageId, chatAnchorCoord, dispatchMode } = { ...req.query, ...req.body };
+        const { deviceId, title, description, priority, status, assignedBots, entityId, reviewerEntityId, isAutomation, schedule, requiresScreenshotReview, requirePrLink, chatAnchorMessageId, chatAnchorCoord, dispatchMode } = { ...req.query, ...req.body };
 
         if (!deviceId) {
             return res.status(400).json({ success: false, error: 'Missing deviceId' });
@@ -1287,6 +1290,11 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             ? false  // Default to disabled for all new cards
             : requiresScreenshotReview !== false;
 
+        // Per-card PR-link opt-in for the done-gate (owner directive 2026-07-03).
+        // DEFAULT false (not blocking) — only an explicit truthy requirePrLink at
+        // create time turns done-gate PR-link enforcement on for this card.
+        const finalRequirePrLink = requirePrLink === true || requirePrLink === 'true';
+
         // Validate dispatch mode
         const finalDispatchMode = (dispatchMode === 'idle_only') ? 'idle_only' : 'immediate';
 
@@ -1341,16 +1349,16 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 `INSERT INTO kanban_cards (id, device_id, title, description, priority, status, assigned_bots, created_by, reviewer_entity_id, status_changed_at,
                     is_automation, schedule_enabled, schedule_type, schedule_cron, schedule_run_at, schedule_timezone, schedule_next_run_at, requires_screenshot_review,
                     chat_anchor_message_id, chat_anchor_coord, dispatch_mode,
-                    schedule_skip_if_5h_pct_over, schedule_skip_if_7d_pct_over)
+                    schedule_skip_if_5h_pct_over, schedule_skip_if_7d_pct_over, requires_pr_link)
                  VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, NOW(),
                     $10, $11, $12, $13, $14, $15, $16, $17,
                     $18, $19::jsonb, $20,
-                    $21, $22)
+                    $21, $22, $23)
                  RETURNING *`,
                 [newCardId(), deviceId, title.trim(), finalDescription, cardPriority, cardStatus, JSON.stringify(bots), createdBy, reviewer,
                     finalAutomation, schedEnabled, schedType, schedCron, schedRunAt, schedTz, schedNextRunAt, finalRequiresScreenshot,
                     anchorMsgId, anchorCoord ? JSON.stringify(anchorCoord) : null, finalDispatchMode,
-                    schedSkip5h, schedSkip7d]
+                    schedSkip5h, schedSkip7d, finalRequirePrLink]
             );
 
             const card = serializeCard(result.rows[0]);
@@ -2532,9 +2540,15 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     files: filesRes.rows,
                     severity: (card.priority || 'P2'),
                     painTags,
-                    // Automation / ops cards (scheduled automation母卡 or a
-                    // cron-spawned [Auto] child) have no PR to cite — exempt them
-                    // from the PR-link sub-check (6-item checklist still enforced).
+                    // Per-card PR-link opt-in (owner directive 2026-07-03). The
+                    // PR-link sub-check enforces ONLY when this card explicitly
+                    // opted in (requires_pr_link=true, set at create or via
+                    // PUT /card/:id/config). DEFAULT false → PR link NOT required.
+                    requirePrLink: card.requires_pr_link === true,
+                    // Redundant safety exemption: automation / ops cards (scheduled
+                    // automation母卡 or a cron-spawned [Auto] child) have no PR to
+                    // cite, so they skip the PR-link sub-check even if opted in.
+                    // The 6-item evidence checklist is always enforced.
                     isAutomation: card.is_automation === true || card.is_auto_generated === true,
                 });
                 if (!verdict.allowed) {
@@ -3283,7 +3297,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
     router.put('/card/:id/config', async (req, res) => {
         if (!authenticate(req, res)) return;
         const _p = { ...req.query, ...req.body }; console.log('[Kanban] PUT /card/:id/config called', { deviceId: _p.deviceId, entityId: _p.entityId, cardId: req.params?.id });
-        const { deviceId, staleThresholdMs, doneRetentionMs, isAutomation } = req.body;
+        const { deviceId, staleThresholdMs, doneRetentionMs, isAutomation, requirePrLink } = req.body;
         const cardId = req.params.id;
 
         try {
@@ -3311,6 +3325,14 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 updates.push(`is_automation = $${paramIdx++}`);
                 params.push(!!isAutomation);
                 console.log(`[Kanban] Config: set is_automation=${!!isAutomation} for card ${cardId}`);
+            }
+            // Per-card PR-link opt-in for the done-gate (owner directive 2026-07-03).
+            // Settable/updatable here — including on automation母卡. Default (never
+            // set) is FALSE = not blocking; flip TRUE to make done require a PR link.
+            if (requirePrLink !== undefined) {
+                updates.push(`requires_pr_link = $${paramIdx++}`);
+                params.push(!!requirePrLink);
+                console.log(`[Kanban] Config: set requires_pr_link=${!!requirePrLink} for card ${cardId}`);
             }
 
             if (updates.length === 0) {

--- a/backend/kanban_schema.sql
+++ b/backend/kanban_schema.sql
@@ -68,6 +68,16 @@ ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS requires_screenshot_review BOO
 -- Bypass: flip to FALSE via PUT /card/:id for trivial dep-bumps / doc renames.
 ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS requires_preflight_review BOOLEAN DEFAULT TRUE;
 
+-- Per-card PR-link opt-in (2026-07-03, owner directive "PR link 是 option 且默認不阻擋"):
+-- when TRUE, the done-gate additionally requires the evidence comment to cite a
+-- https://github.com/<owner>/<repo>/pull/<N> link. DEFAULT FALSE = NOT blocking, so
+-- by default no card needs a PR link at done. Set at card creation via
+-- POST /card {requirePrLink} or later via PUT /card/:id/config {requirePrLink};
+-- also settable on automation母卡 (parent cron cards). Supersedes the old
+-- automation-only PR-link exemption — everything is exempt by default, opting in
+-- turns enforcement on. Automation/ops cards stay exempt even when opted in.
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS requires_pr_link BOOLEAN DEFAULT FALSE;
+
 -- Backlog launch-gate (2026-05-20): when gated=true, L1/L2/L3 staleness escalation
 -- skips this card so launch-pending drafts don't auto-bounce backlog→blocked.
 -- App layer auto-resets gated=false on any status change out of backlog.

--- a/backend/migrations/20260703_kanban_card_requires_pr_link.down.sql
+++ b/backend/migrations/20260703_kanban_card_requires_pr_link.down.sql
@@ -1,0 +1,4 @@
+-- Reverse of 20260703_kanban_card_requires_pr_link.up.sql
+
+ALTER TABLE kanban_cards
+    DROP COLUMN IF EXISTS requires_pr_link;

--- a/backend/migrations/20260703_kanban_card_requires_pr_link.up.sql
+++ b/backend/migrations/20260703_kanban_card_requires_pr_link.up.sql
@@ -1,0 +1,23 @@
+-- Migration: 20260703_kanban_card_requires_pr_link
+-- Owner directive 2026-07-03 (Hank): "PR link 是 option 且默認不阻擋。應該是創卡的
+-- 時候就要設定 PR link option 啟動阻擋 或關閉阻擋。自動化任務母卡也應該要能設定這個部分。"
+--
+-- PR-link enforcement in the OODA-R done-gate becomes a PER-CARD OPT-IN. When
+-- requires_pr_link = TRUE, moving a card to done additionally requires the
+-- evidence comment to cite a https://github.com/<owner>/<repo>/pull/<N> link.
+-- DEFAULT FALSE = NOT blocking, so by default no card needs a PR link at done.
+-- Settable at card creation (POST /card {requirePrLink}) and later
+-- (PUT /card/:id/config {requirePrLink}), including on automation母卡.
+--
+-- This supersedes / generalises the automation-only PR-link exemption (PR #3870):
+-- everything is exempt by default; opting in is what turns enforcement on. The
+-- 6-item evidence checklist is unaffected and always enforced.
+
+ALTER TABLE kanban_cards
+    ADD COLUMN IF NOT EXISTS requires_pr_link BOOLEAN DEFAULT FALSE;
+
+COMMENT ON COLUMN kanban_cards.requires_pr_link IS
+    'OODA-R done-gate per-card PR-link opt-in. When TRUE, moving to done requires '
+    'the evidence comment to include a github.com/<owner>/<repo>/pull/<N> link. '
+    'DEFAULT FALSE = not blocking. Set at create (POST /card) or via '
+    'PUT /card/:id/config. Automation/ops cards stay exempt even when opted in.';

--- a/backend/tests/jest/donegate-ops-prlink-exempt.test.js
+++ b/backend/tests/jest/donegate-ops-prlink-exempt.test.js
@@ -55,7 +55,14 @@ function baseComments(evidenceOpts) {
 const jestLog = [mkFile('jest_out.txt', 'text/plain')];
 
 describe('done-gate — automation/ops PR-link exemption', () => {
-    test('(a) automation card with 6 items but NO PR link → ALLOWED', () => {
+    // NOTE (2026-07-03 owner directive): PR-link enforcement is now a per-card
+    // opt-in (requirePrLink) that DEFAULTS OFF. These automation-exemption tests
+    // therefore pass requirePrLink:true to exercise the "opted-in but still exempt
+    // because automation" path — the load-bearing rule that keeps ops cards free of
+    // the PR-link requirement even when a board opts everything in. The
+    // isAutomation exemption is kept as a REDUNDANT safety layer on top of the
+    // default-off requirePrLink behavior (covered in the per-card test file).
+    test('(a) automation card OPTED-IN with 6 items but NO PR link → ALLOWED (automation still exempt)', () => {
         const v = evaluateDoneGate({
             oldStatus: 'in_progress', newStatus: 'done',
             requiresPreflightReview: true,
@@ -63,12 +70,13 @@ describe('done-gate — automation/ops PR-link exemption', () => {
             painTags: ['task_context'],
             comments: baseComments({ pr: false }),
             files: jestLog,
+            requirePrLink: true,
             isAutomation: true,
         });
         expect(v.allowed).toBe(true);
     });
 
-    test('(b) NON-automation card with 6 items but no PR link → BLOCKED on PR link', () => {
+    test('(b) NON-automation card OPTED-IN with 6 items but no PR link → BLOCKED on PR link', () => {
         const v = evaluateDoneGate({
             oldStatus: 'in_progress', newStatus: 'done',
             requiresPreflightReview: true,
@@ -76,6 +84,7 @@ describe('done-gate — automation/ops PR-link exemption', () => {
             painTags: ['task_context'],
             comments: baseComments({ pr: false }),
             files: jestLog,
+            requirePrLink: true,
             isAutomation: false,
         });
         expect(v.allowed).toBe(false);
@@ -83,7 +92,7 @@ describe('done-gate — automation/ops PR-link exemption', () => {
         expect(v.missingItems).toEqual(['PR link']);
     });
 
-    test('(b2) omitting isAutomation entirely is treated as non-automation → still needs PR link', () => {
+    test('(b2) opted-in, omitting isAutomation entirely is treated as non-automation → still needs PR link', () => {
         const v = evaluateDoneGate({
             oldStatus: 'in_progress', newStatus: 'done',
             requiresPreflightReview: true,
@@ -91,6 +100,7 @@ describe('done-gate — automation/ops PR-link exemption', () => {
             painTags: ['task_context'],
             comments: baseComments({ pr: false }),
             files: jestLog,
+            requirePrLink: true,
             // isAutomation not passed
         });
         expect(v.allowed).toBe(false);
@@ -105,6 +115,7 @@ describe('done-gate — automation/ops PR-link exemption', () => {
             painTags: ['task_context'],
             comments: baseComments({ pr: false, drop: 'Test plan' }),
             files: jestLog,
+            requirePrLink: true,
             isAutomation: true,
         });
         expect(v.allowed).toBe(false);
@@ -120,6 +131,7 @@ describe('done-gate — automation/ops PR-link exemption', () => {
             painTags: ['task_context'],
             comments: baseComments({ pr: true }),
             files: jestLog,
+            requirePrLink: true,
             isAutomation: true,
         });
         expect(v.allowed).toBe(true);

--- a/backend/tests/jest/donegate-percard-prlink-option.test.js
+++ b/backend/tests/jest/donegate-percard-prlink-option.test.js
@@ -1,0 +1,179 @@
+/**
+ * done-gate: PR-link enforcement is a PER-CARD OPT-IN option (requirePrLink),
+ * DEFAULT OFF (not blocking).
+ *
+ * Owner directive 2026-07-03 (Hank):
+ *   「PR link 是 option 且默認不阻擋。應該是創卡的時候就要設定 PR link option
+ *     啟動阻擋 或關閉阻擋。自動化任務母卡也應該要能設定這個部分。」
+ *
+ * Behavior under test (the load-bearing rule):
+ *   - requirePrLink absent / false  → PR link is NOT required at done (default no block).
+ *   - requirePrLink === true         → the evidence comment MUST cite a github PR link.
+ *   - The 6-item evidence checklist is ALWAYS enforced regardless of requirePrLink.
+ *   - Automation/ops cards stay exempt from the PR-link sub-check even when opted in
+ *     (redundant safety on top of the default-off behavior — see
+ *     donegate-ops-prlink-exempt.test.js).
+ *
+ * This supersedes / generalises PR #3870's automation-only PR-link exemption:
+ * everything is exempt by default; opting in (requirePrLink:true) turns it on.
+ */
+'use strict';
+
+const {
+    evaluateDoneGate,
+    PREFLIGHT_MARKER,
+} = require('../../agent-improvement/done-gate');
+
+const preflightText = `${PREFLIGHT_MARKER} — auto-composed]\n## 本任務如何避免過往同類錯誤\n...`;
+
+// Build a 6-item evidence comment. Toggle the PR link / drop one checklist item.
+function evidence(opts = {}) {
+    const includePR = opts.pr !== false;
+    const dropItem = opts.drop || null; // e.g. 'Test plan' to omit that heading
+    const items = [
+        'Scope', 'Acceptance', 'Test plan',
+        'Evidence plan', 'Out-of-scope', 'User POV',
+    ].filter(h => h !== dropItem);
+    const lines = items.map(h => `## ${h} — written content here`);
+    if (includePR) {
+        lines.push('see https://github.com/HankHuang0516/EClaw/pull/9999 for the change');
+    }
+    return lines.join('\n');
+}
+
+function mkComment(text, opts = {}) {
+    return {
+        text,
+        isSystem: opts.isSystem ?? false,
+        createdAt: opts.t ?? '2026-06-07T02:00:00Z',
+    };
+}
+
+function mkFile(filename, mimeType, t = '2026-06-07T03:00:00Z') {
+    return { filename, mime_type: mimeType, created_at: t };
+}
+
+// preflight marker (system) + one evidence comment. jest-log artifact so the ONLY
+// variable under test is the PR link / checklist completeness.
+function baseComments(evidenceOpts) {
+    return [
+        mkComment(preflightText, { isSystem: true, t: '2026-06-07T01:00:00Z' }),
+        mkComment(evidence(evidenceOpts), { isSystem: false, t: '2026-06-07T02:00:00Z' }),
+    ];
+}
+const jestLog = [mkFile('jest_out.txt', 'text/plain')];
+
+function baseInput(extra = {}) {
+    return {
+        oldStatus: 'in_progress', newStatus: 'done',
+        requiresPreflightReview: true,
+        severity: 'P2',
+        painTags: ['task_context'],
+        files: jestLog,
+        ...extra,
+    };
+}
+
+describe('done-gate — per-card requirePrLink option (default off)', () => {
+    // (a) opted IN + 6 items + NO PR link → BLOCKED on PR link
+    test('(a) requirePrLink:true + 6 items + NO PR link → BLOCKED with "PR link"', () => {
+        const v = evaluateDoneGate(baseInput({
+            comments: baseComments({ pr: false }),
+            requirePrLink: true,
+        }));
+        expect(v.allowed).toBe(false);
+        expect(v.code).toBe('PREFLIGHT_GATE_FAILED');
+        expect(v.missingItems).toEqual(['PR link']);
+        expect(v.error).toMatch(/PR link/i);
+    });
+
+    // (b) default off — requirePrLink:false + 6 items + no PR link → ALLOWED
+    test('(b) requirePrLink:false + 6 items + no PR link → ALLOWED (default no longer blocks)', () => {
+        const v = evaluateDoneGate(baseInput({
+            comments: baseComments({ pr: false }),
+            requirePrLink: false,
+        }));
+        expect(v.allowed).toBe(true);
+    });
+
+    // (b2) default off — requirePrLink absent entirely + no PR link → ALLOWED
+    test('(b2) requirePrLink ABSENT + 6 items + no PR link → ALLOWED (default off)', () => {
+        const v = evaluateDoneGate(baseInput({
+            comments: baseComments({ pr: false }),
+            // requirePrLink not passed
+        }));
+        expect(v.allowed).toBe(true);
+    });
+
+    // (b3) explicit non-true truthy-ish values do NOT enable enforcement — only === true does
+    test('(b3) requirePrLink truthy-but-not-true (e.g. "true" string / 1) does NOT enforce', () => {
+        for (const val of ['true', 1, {}, 'yes']) {
+            const v = evaluateDoneGate(baseInput({
+                comments: baseComments({ pr: false }),
+                requirePrLink: val,
+            }));
+            expect(v.allowed).toBe(true);
+        }
+    });
+
+    // (c) opted IN + PR link present → ALLOWED
+    test('(c) requirePrLink:true + PR link present → ALLOWED', () => {
+        const v = evaluateDoneGate(baseInput({
+            comments: baseComments({ pr: true }),
+            requirePrLink: true,
+        }));
+        expect(v.allowed).toBe(true);
+    });
+
+    // (d) 6-item checklist still enforced regardless of requirePrLink
+    describe('(d) 6-item checklist ALWAYS enforced regardless of requirePrLink', () => {
+        test('requirePrLink:false, missing a checklist item → BLOCKED on that item', () => {
+            const v = evaluateDoneGate(baseInput({
+                comments: baseComments({ pr: false, drop: 'Test plan' }),
+                requirePrLink: false,
+            }));
+            expect(v.allowed).toBe(false);
+            expect(v.code).toBe('PREFLIGHT_GATE_FAILED');
+            expect(v.missingItems).toContain('Test plan');
+        });
+
+        test('requirePrLink absent, missing a checklist item → BLOCKED on that item', () => {
+            const v = evaluateDoneGate(baseInput({
+                comments: baseComments({ pr: false, drop: 'Acceptance' }),
+            }));
+            expect(v.allowed).toBe(false);
+            expect(v.missingItems).toContain('Acceptance');
+        });
+
+        test('requirePrLink:true, missing a checklist item → BLOCKED on the item (not PR link first)', () => {
+            const v = evaluateDoneGate(baseInput({
+                comments: baseComments({ pr: false, drop: 'Out-of-scope' }),
+                requirePrLink: true,
+            }));
+            expect(v.allowed).toBe(false);
+            expect(v.missingItems).toContain('Out-of-scope');
+        });
+    });
+
+    // Automation exemption is a redundant safety on top of default-off: even when
+    // a card opts in, automation/ops cards skip the PR-link sub-check.
+    test('(e) requirePrLink:true + isAutomation:true + no PR link → ALLOWED (automation exempt even opted-in)', () => {
+        const v = evaluateDoneGate(baseInput({
+            comments: baseComments({ pr: false }),
+            requirePrLink: true,
+            isAutomation: true,
+        }));
+        expect(v.allowed).toBe(true);
+    });
+
+    // Artifact (jest log) requirement is orthogonal — still enforced when opted in.
+    test('(f) requirePrLink:true + 6 items + PR link but NO jest artifact → BLOCKED on jest artifact', () => {
+        const v = evaluateDoneGate(baseInput({
+            comments: baseComments({ pr: true }),
+            requirePrLink: true,
+            files: [], // no artifact after preflight
+        }));
+        expect(v.allowed).toBe(false);
+        expect(v.missingItems).toEqual(['jest_output_artifact']);
+    });
+});

--- a/backend/tests/jest/kanban-card.test.js
+++ b/backend/tests/jest/kanban-card.test.js
@@ -323,6 +323,96 @@ describe('POST /card — assignedBots validation', () => {
 });
 
 // ════════════════════════════════════════════════════════════════
+// POST /card + PUT /card/:id/config — per-card requirePrLink option
+// (owner directive 2026-07-03: PR link is opt-in, default off)
+// ════════════════════════════════════════════════════════════════
+describe('requirePrLink per-card option', () => {
+    const anchor = 'aaaaaaaa-1111-2222-3333-444444444444';
+
+    function insertCall() {
+        return mockQuery.mock.calls.find(c => /INSERT INTO kanban_cards/.test(c[0]));
+    }
+    function configUpdateCall() {
+        return mockQuery.mock.calls.find(c => /UPDATE kanban_cards SET/.test(c[0]) && /requires_pr_link/.test(c[0]));
+    }
+
+    it('POST /card persists requires_pr_link=true when requirePrLink:true', async () => {
+        const res = await post('/api/mission/card').send({
+            ...AUTH, title: 'Opt-in card', assignedBots: [0],
+            chatAnchorMessageId: anchor, requirePrLink: true,
+        });
+        expect(res.status).not.toBe(400);
+        const call = insertCall();
+        const idx = columnParamIndex(call[0], 'requires_pr_link');
+        expect(idx).toBeGreaterThanOrEqual(0);
+        expect(call[1][idx]).toBe(true);
+    });
+
+    it('POST /card defaults requires_pr_link=false when option absent', async () => {
+        const res = await post('/api/mission/card').send({
+            ...AUTH, title: 'Default card', assignedBots: [0],
+            chatAnchorMessageId: anchor,
+        });
+        expect(res.status).not.toBe(400);
+        const call = insertCall();
+        const idx = columnParamIndex(call[0], 'requires_pr_link');
+        expect(idx).toBeGreaterThanOrEqual(0);
+        expect(call[1][idx]).toBe(false);
+    });
+
+    it('POST /card treats non-true value as false (only === true / "true" opts in)', async () => {
+        const res = await post('/api/mission/card').send({
+            ...AUTH, title: 'Weird value', assignedBots: [0],
+            chatAnchorMessageId: anchor, requirePrLink: 0,
+        });
+        expect(res.status).not.toBe(400);
+        const call = insertCall();
+        const idx = columnParamIndex(call[0], 'requires_pr_link');
+        expect(call[1][idx]).toBe(false);
+    });
+
+    it('PUT /card/:id/config accepts requirePrLink:true and writes requires_pr_link', async () => {
+        mockQuery.mockResolvedValueOnce({
+            rows: [{
+                id: 'card-x', device_id: 'test-dev', title: 'C',
+                priority: 'P2', status: 'todo', assigned_bots: [0],
+                created_by: 0, requires_pr_link: true,
+                created_at: new Date(), updated_at: new Date(),
+                status_changed_at: new Date(), archived: false,
+            }],
+        });
+        const res = await put('/api/mission/card/card-x/config').send({
+            ...AUTH, requirePrLink: true,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.card.requirePrLink).toBe(true);
+        const call = configUpdateCall();
+        expect(call).toBeTruthy();
+        // the boolean param is coerced via !!requirePrLink
+        expect(call[1]).toContain(true);
+    });
+
+    it('PUT /card/:id/config accepts requirePrLink:false to turn enforcement off', async () => {
+        mockQuery.mockResolvedValueOnce({
+            rows: [{
+                id: 'card-y', device_id: 'test-dev', title: 'C',
+                priority: 'P2', status: 'todo', assigned_bots: [0],
+                created_by: 0, requires_pr_link: false,
+                created_at: new Date(), updated_at: new Date(),
+                status_changed_at: new Date(), archived: false,
+            }],
+        });
+        const res = await put('/api/mission/card/card-y/config').send({
+            ...AUTH, requirePrLink: false,
+        });
+        expect(res.status).toBe(200);
+        const call = configUpdateCall();
+        expect(call).toBeTruthy();
+        expect(call[0]).toMatch(/requires_pr_link\s*=\s*\$\d+/);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
 // PUT /card/:id — Update rejects empty assignedBots
 // ════════════════════════════════════════════════════════════════
 describe('PUT /card/:id — assignedBots validation', () => {

--- a/backend/tests/jest/kanban-ooda-r-done-gate-v2.test.js
+++ b/backend/tests/jest/kanban-ooda-r-done-gate-v2.test.js
@@ -159,7 +159,9 @@ describe('evaluateDoneGate v2 — artifact requirements', () => {
 describe('evaluateDoneGate v2 — PR link requirement', () => {
     const baseFiles = [{ filename: 'jest.txt', mime_type: 'text/plain', created_at: '2026-06-07T03:00:00Z' }];
 
-    test('rejected when no github.com pull/N link in evidence', () => {
+    // 2026-07-03: PR link is now a per-card opt-in that defaults OFF — pass
+    // requirePrLink:true to exercise the enforced-when-opted-in path.
+    test('rejected when opted-in (requirePrLink) but no github.com pull/N link in evidence', () => {
         const v = evaluateDoneGate({
             oldStatus: 'in_progress', newStatus: 'done',
             requiresPreflightReview: true,
@@ -170,6 +172,7 @@ describe('evaluateDoneGate v2 — PR link requirement', () => {
                 mkComment(evidence({ pr: false }), { isSystem: false, t: '2026-06-07T02:00:00Z' }),
             ],
             files: baseFiles,
+            requirePrLink: true,
         });
         expect(v.allowed).toBe(false);
         expect(v.missingItems).toEqual(['PR link']);
@@ -399,13 +402,14 @@ describe('evaluateDoneGate v2 — evidence comment selection (card_4c3a75bc)', (
         expect(v.allowed).toBe(true);
     });
 
-    test('still fails when NO complete comment carries a PR link', () => {
+    test('opted-in: still fails when NO complete comment carries a PR link', () => {
         const v = evaluateDoneGate({
             oldStatus: 'in_progress', newStatus: 'done',
             requiresPreflightReview: true,
             severity: 'P2', painTags: ['task_context'],
             comments: [preflight, completeNoPr],
             files: [jest],
+            requirePrLink: true,
         });
         expect(v.allowed).toBe(false);
         expect(v.missingItems).toEqual(['PR link']);


### PR DESCRIPTION
## Owner requirement (Hank, 2026-07-03)

> 「PR link 是 option 且默認不阻擋。應該是創卡的時候就要設定 PR link option 啟動阻擋 或關閉阻擋。自動化任務母卡也應該要能設定這個部分。」

PR-link enforcement in the OODA-R done-gate becomes a **per-card option** named `requirePrLink`, **default = false (NOT blocking)**.

## Behavior

- **Default off**: by default NO card needs a PR link at `done`. The gate enforces the PR-link sub-check **only when `requirePrLink === true`** on that card (and still no PR link present in the evidence comment).
- **Settable at card creation**: `POST /card { requirePrLink: true }`.
- **Updatable later**: `PUT /card/:id/config { requirePrLink: true|false }` — including on **automation母卡** (parent cron cards).
- **6-item evidence checklist + artifact checks are unchanged** and always enforced regardless of `requirePrLink`.

## Supersedes / generalises #3870

PR #3870 made *automation* cards exempt from the PR-link requirement via an `isAutomation` flag. This PR generalises that: **everything is exempt by default**, and opting in (`requirePrLink:true`) is what turns enforcement on. The `isAutomation`→exempt path is **kept as a redundant safety** — automation/ops cards (which have no PR to cite) skip the PR-link sub-check even if they opted in. The load-bearing rule is now `requirePrLink`.

## Storage & plumbing

- New column `kanban_cards.requires_pr_link BOOLEAN DEFAULT FALSE` (migration `20260703_kanban_card_requires_pr_link.{up,down}.sql` + `kanban_schema.sql` `ADD COLUMN IF NOT EXISTS`, mirroring `requires_preflight_review`; auto-applied at startup by `initKanbanDatabase()`).
- `POST /card`: reads optional `requirePrLink` (only `=== true` / `"true"` opts in), persists into the INSERT.
- `PUT /card/:id/config`: accepts `requirePrLink` (coerced `!!`), mirrors the existing `isAutomation`/threshold fields.
- Move-handler (`POST /card/:id/move`) loads the card via `SELECT *` and threads `card.requires_pr_link` into `GateInput.requirePrLink`.
- `done-gate.js`: PR-link check now `input.requirePrLink === true && !input.isAutomation` (AND still no PR link) → block; otherwise skipped. `GateInput` typedef documents the new field.
- `serializeCard` exposes `requirePrLink` in API responses.

## Tests

- **New** `backend/tests/jest/donegate-percard-prlink-option.test.js` (13 cases): (a) `requirePrLink:true` + 6 items + no PR link → BLOCKED on `PR link`; (b)/(b2) `false`/absent + no PR link → ALLOWED (default no longer blocks); (b3) non-`true` truthy values do not enforce; (c) `true` + PR link → allowed; (d) 6-item checklist still enforced regardless; (e) opted-in + automation → exempt; (f) jest-artifact requirement orthogonal.
- **Updated** `donegate-ops-prlink-exempt.test.js` + `kanban-ooda-r-done-gate-v2.test.js`: the block-on-missing-PR-link cases now pass `requirePrLink:true` (they were asserting the old default-on behavior).
- **Added** to `kanban-card.test.js` (supertest): POST /card persists `requires_pr_link` true/false/default; PUT /card/:id/config accepts `requirePrLink` true/false.
- Full backend jest suite: **440 suites, 6064 passed / 17 skipped, 0 failures**. Done-gate + kanban-card focused runs green. `eslint` on changed files: **0 errors** (one pre-existing unrelated `entityId` warning at kanban.js:5097, outside this diff).

Does NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN