### PR TITLE
[codex] Add AI chat resize grip

### DIFF
--- a/backend/public/portal/shared/ai-chat.js
+++ b/backend/public/portal/shared/ai-chat.js
@@ -14,18 +14,23 @@
 
     const STORAGE_KEY = 'eclaw_ai_chat_history';
     const PENDING_KEY = 'eclaw_ai_chat_pending';
+    const WINDOW_STATE_KEY = 'eclaw_ai_chat_window_state_v1';
     const MAX_HISTORY = 20;
     const MAX_IMAGES = 3;
     const MAX_IMAGE_SIZE = 2 * 1024 * 1024; // 2MB after compression
     const MAX_IMAGE_DIM = 1024; // max width/height for compression
     const POLL_INTERVAL = 3000; // 3 seconds
     const POLL_MAX_DURATION = 150000; // 2.5 minutes
+    const DEFAULT_PANEL_SIZE = { width: 380, height: 520 };
+    const MIN_PANEL_SIZE = { width: 300, height: 360 };
+    const PANEL_VIEWPORT_MARGIN = 16;
 
     let chatHistory = [];
     let isOpen = false;
     let isLoading = false;
     let pendingImages = []; // { data: base64, mimeType: string }
     let pollTimer = null;
+    let windowState = { resizeEnabled: true };
 
     // ── localStorage ──────────────────────────
     function loadHistory() {
@@ -48,6 +53,158 @@
     function getCurrentPage() {
         const m = window.location.pathname.match(/\/([^/]+)\.html/);
         return m ? m[1] : 'unknown';
+    }
+
+    function getWindowStateId() {
+        return window.location.pathname || getCurrentPage();
+    }
+
+    function readWindowStates() {
+        try {
+            const parsed = JSON.parse(localStorage.getItem(WINDOW_STATE_KEY) || '{}');
+            return parsed && typeof parsed === 'object' ? parsed : {};
+        } catch (_) {
+            return {};
+        }
+    }
+
+    function loadWindowState() {
+        const state = readWindowStates()[getWindowStateId()] || {};
+        return {
+            resizeEnabled: state.resizeEnabled !== false,
+            width: Number.isFinite(Number(state.width)) ? Number(state.width) : undefined,
+            height: Number.isFinite(Number(state.height)) ? Number(state.height) : undefined,
+        };
+    }
+
+    function saveWindowState(patch) {
+        windowState = Object.assign({}, windowState, patch || {});
+        try {
+            const all = readWindowStates();
+            all[getWindowStateId()] = {
+                resizeEnabled: windowState.resizeEnabled !== false,
+                width: Number.isFinite(Number(windowState.width)) ? Math.round(Number(windowState.width)) : undefined,
+                height: Number.isFinite(Number(windowState.height)) ? Math.round(Number(windowState.height)) : undefined,
+            };
+            localStorage.setItem(WINDOW_STATE_KEY, JSON.stringify(all));
+        } catch (_) {}
+    }
+
+    function clampPanelSize(width, height) {
+        const viewportWidth = Math.max(0, window.innerWidth || DEFAULT_PANEL_SIZE.width);
+        const viewportHeight = Math.max(0, window.innerHeight || DEFAULT_PANEL_SIZE.height);
+        const maxWidth = Math.max(260, viewportWidth - PANEL_VIEWPORT_MARGIN);
+        const maxHeight = Math.max(300, viewportHeight - PANEL_VIEWPORT_MARGIN);
+        const minWidth = Math.min(MIN_PANEL_SIZE.width, maxWidth);
+        const minHeight = Math.min(MIN_PANEL_SIZE.height, maxHeight);
+        return {
+            width: Math.round(Math.min(Math.max(Number(width) || DEFAULT_PANEL_SIZE.width, minWidth), maxWidth)),
+            height: Math.round(Math.min(Math.max(Number(height) || DEFAULT_PANEL_SIZE.height, minHeight), maxHeight)),
+        };
+    }
+
+    function applyPanelSize(panel) {
+        if (!panel) return;
+        const size = clampPanelSize(windowState.width || DEFAULT_PANEL_SIZE.width, windowState.height || DEFAULT_PANEL_SIZE.height);
+        panel.style.width = size.width + 'px';
+        panel.style.height = size.height + 'px';
+    }
+
+    function syncResizeControls(panel) {
+        if (!panel) return;
+        const enabled = windowState.resizeEnabled !== false;
+        const btn = panel.querySelector('.ai-chat-resize-toggle-btn');
+        panel.classList.toggle('ai-chat-resize-disabled', !enabled);
+        if (btn) {
+            btn.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+            btn.setAttribute('aria-label', enabled ? 'Disable window resizing' : 'Enable window resizing');
+            btn.title = enabled ? 'Disable window resizing' : 'Enable window resizing';
+        }
+    }
+
+    function startPanelResize(event) {
+        if (windowState.resizeEnabled === false) return;
+        if (event.button !== undefined && event.button !== 0) return;
+        const panel = event.currentTarget && event.currentTarget.closest
+            ? event.currentTarget.closest('.ai-chat-panel')
+            : document.getElementById('aiChatPanel');
+        if (!panel) return;
+        event.preventDefault();
+
+        const rect = panel.getBoundingClientRect();
+        const startX = event.clientX;
+        const startY = event.clientY;
+        const startWidth = rect.width;
+        const startHeight = rect.height;
+        panel.classList.add('ai-chat-resizing');
+
+        const onPointerMove = (moveEvent) => {
+            const size = clampPanelSize(
+                startWidth + (startX - moveEvent.clientX),
+                startHeight + (startY - moveEvent.clientY)
+            );
+            panel.style.width = size.width + 'px';
+            panel.style.height = size.height + 'px';
+        };
+
+        const onPointerUp = () => {
+            panel.classList.remove('ai-chat-resizing');
+            const finalRect = panel.getBoundingClientRect();
+            saveWindowState(clampPanelSize(finalRect.width, finalRect.height));
+            document.removeEventListener('pointermove', onPointerMove);
+            document.removeEventListener('pointerup', onPointerUp);
+            document.removeEventListener('pointercancel', onPointerUp);
+        };
+
+        document.addEventListener('pointermove', onPointerMove);
+        document.addEventListener('pointerup', onPointerUp);
+        document.addEventListener('pointercancel', onPointerUp);
+    }
+
+    function adjustPanelSizeByKeyboard(event) {
+        if (windowState.resizeEnabled === false) return;
+        const delta = event.shiftKey ? 40 : 20;
+        let widthDelta = 0;
+        let heightDelta = 0;
+        if (event.key === 'ArrowLeft') widthDelta = delta;
+        else if (event.key === 'ArrowRight') widthDelta = -delta;
+        else if (event.key === 'ArrowUp') heightDelta = delta;
+        else if (event.key === 'ArrowDown') heightDelta = -delta;
+        else return;
+
+        event.preventDefault();
+        const panel = event.currentTarget && event.currentTarget.closest
+            ? event.currentTarget.closest('.ai-chat-panel')
+            : document.getElementById('aiChatPanel');
+        const rect = panel ? panel.getBoundingClientRect() : DEFAULT_PANEL_SIZE;
+        const size = clampPanelSize(rect.width + widthDelta, rect.height + heightDelta);
+        if (panel) {
+            panel.style.width = size.width + 'px';
+            panel.style.height = size.height + 'px';
+        }
+        saveWindowState(size);
+    }
+
+    function setupPanelWindowControls(panel) {
+        windowState = loadWindowState();
+        applyPanelSize(panel);
+        syncResizeControls(panel);
+
+        const toggle = panel.querySelector('.ai-chat-resize-toggle-btn');
+        if (toggle) {
+            toggle.addEventListener('click', () => {
+                saveWindowState({ resizeEnabled: windowState.resizeEnabled === false });
+                syncResizeControls(panel);
+            });
+        }
+
+        const grip = panel.querySelector('.ai-chat-resize-grip');
+        if (grip) {
+            grip.addEventListener('pointerdown', startPanelResize);
+            grip.addEventListener('keydown', adjustPanelSizeByKeyboard);
+        }
+
+        window.addEventListener('resize', () => applyPanelSize(panel));
     }
 
     // ── Image Utilities ──────────────────────
@@ -161,6 +318,14 @@
                     <span class="ai-chat-header-title">E-Claw AI</span>
                 </div>
                 <div class="ai-chat-header-right">
+                    <button class="ai-chat-resize-toggle-btn" type="button" aria-pressed="true" title="Disable window resizing" aria-label="Disable window resizing">
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M15 3h6v6"></path>
+                            <path d="M21 3l-7 7"></path>
+                            <path d="M9 21H3v-6"></path>
+                            <path d="M3 21l7-7"></path>
+                        </svg>
+                    </button>
                     <button class="ai-chat-clear-btn" title="Clear history">\u{1F5D1}\uFE0F</button>
                     <button class="ai-chat-close-btn" title="Close">&times;</button>
                 </div>
@@ -183,7 +348,8 @@
                         <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
                     </svg>
                 </button>
-            </div>`;
+            </div>
+            <div class="ai-chat-resize-grip" role="separator" aria-orientation="vertical" aria-label="Resize chat window" title="Drag to resize" tabindex="0"></div>`;
 
         // Inject CSS for image features
         const style = document.createElement('style');
@@ -268,6 +434,10 @@
                 color: var(--text-secondary, #888);
                 animation: ai-chat-pulse 1.5s ease-in-out infinite;
             }
+            .ai-chat-resizing,
+            .ai-chat-resizing * {
+                user-select: none;
+            }
             @keyframes ai-chat-pulse {
                 0%, 100% { opacity: 0.6; }
                 50% { opacity: 1; }
@@ -277,6 +447,7 @@
 
         document.body.appendChild(fab);
         document.body.appendChild(panel);
+        setupPanelWindowControls(panel);
 
         // Events
         panel.querySelector('.ai-chat-close-btn').addEventListener('click', toggleChat);

--- a/backend/public/portal/shared/style.css
+++ b/backend/public/portal/shared/style.css
@@ -1406,6 +1406,7 @@ a:hover { text-decoration: underline; }
 .ai-chat-header-icon { font-size: 20px; }
 .ai-chat-header-title { font-size: 15px; font-weight: 700; }
 .ai-chat-header-right { display: flex; gap: 4px; }
+.ai-chat-resize-toggle-btn,
 .ai-chat-clear-btn,
 .ai-chat-close-btn {
     background: none;
@@ -1417,8 +1418,41 @@ a:hover { text-decoration: underline; }
     border-radius: 4px;
     transition: background 0.15s;
 }
+.ai-chat-resize-toggle-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.ai-chat-resize-toggle-btn[aria-pressed="true"] { color: var(--primary); }
 .ai-chat-clear-btn:hover,
-.ai-chat-close-btn:hover { background: var(--card-border); color: var(--text); }
+.ai-chat-close-btn:hover,
+.ai-chat-resize-toggle-btn:hover { background: var(--card-border); color: var(--text); }
+
+.ai-chat-resize-grip {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 22px;
+    height: 22px;
+    cursor: nwse-resize;
+    touch-action: none;
+    z-index: 1;
+}
+.ai-chat-resize-grip::before {
+    content: "";
+    position: absolute;
+    top: 5px;
+    left: 5px;
+    width: 10px;
+    height: 10px;
+    border-top: 2px solid var(--text-muted);
+    border-left: 2px solid var(--text-muted);
+    opacity: 0.7;
+}
+.ai-chat-resize-grip:hover::before,
+.ai-chat-resize-grip:focus-visible::before { border-color: var(--primary); opacity: 1; }
+.ai-chat-resize-grip:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
+.ai-chat-resize-disabled .ai-chat-resize-grip { display: none; }
 
 .ai-chat-messages {
     flex: 1;
@@ -1544,6 +1578,8 @@ a:hover { text-decoration: underline; }
 @media (max-width: 640px) {
     .ai-chat-panel { width: calc(100vw - 16px); height: calc(100vh - 80px); bottom: 8px; right: 8px; }
     .ai-chat-fab { bottom: 16px; right: 16px; width: 50px; height: 50px; }
+    .ai-chat-resize-grip,
+    .ai-chat-resize-toggle-btn { display: none; }
 }
 
 /* ── Help Popover ───────────────────────────────────────────────────────────── */

--- a/backend/tests/jest/ai-chat-widget-guard.test.js
+++ b/backend/tests/jest/ai-chat-widget-guard.test.js
@@ -11,6 +11,7 @@ const path = require('path');
 
 const PORTAL_DIR = path.resolve(__dirname, '../../public/portal');
 const AI_CHAT_JS = path.resolve(__dirname, '../../public/portal/shared/ai-chat.js');
+const STYLE_CSS = path.resolve(__dirname, '../../public/portal/shared/style.css');
 
 const PAGES_WITH_AI_CHAT = [
     'admin.html',
@@ -81,5 +82,24 @@ describe('AI Chat Widget WebView Guard (#419)', () => {
         expect(code).not.toMatch(/flushDebugToServer/);
         expect(code).not.toMatch(/background:\s*red/);
         expect(code).not.toMatch(/_debugLogs/);
+    });
+
+    test('ai-chat.js exposes per-window resize state and controls', () => {
+        const code = fs.readFileSync(AI_CHAT_JS, 'utf-8');
+        expect(code).toMatch(/WINDOW_STATE_KEY\s*=\s*'eclaw_ai_chat_window_state_v1'/);
+        expect(code).toMatch(/function getWindowStateId/);
+        expect(code).toMatch(/function setupPanelWindowControls/);
+        expect(code).toMatch(/ai-chat-resize-toggle-btn/);
+        expect(code).toMatch(/ai-chat-resize-grip/);
+        expect(code).toMatch(/pointerdown/);
+        expect(code).toMatch(/resizeEnabled/);
+    });
+
+    test('ai-chat resize CSS includes desktop grip and disable/mobile fallback', () => {
+        const css = fs.readFileSync(STYLE_CSS, 'utf-8');
+        expect(css).toMatch(/\.ai-chat-resize-grip\s*\{/);
+        expect(css).toMatch(/cursor:\s*nwse-resize/);
+        expect(css).toMatch(/\.ai-chat-resize-disabled\s+\.ai-chat-resize-grip\s*\{\s*display:\s*none/);
+        expect(css).toMatch(/@media\s*\(max-width:\s*640px\)[\s\S]*\.ai-chat-resize-grip[\s\S]*display:\s*none/);
     });
 });


### PR DESCRIPTION
## What changed
- Added a resize grip to the floating portal AI chat panel.
- Persisted panel size and resize enabled/disabled state per portal path in localStorage.
- Added a header toggle to enable/disable resizing, keyboard arrow-key resizing, desktop grip CSS, mobile hidden fallback, and static guard coverage.

## Context
Kanban card: `card_c44c318865d2aa77376e9746`

#2 requested a PR so the local #6 implementation can be reviewed and merged. This PR intentionally includes only:
- `backend/public/portal/shared/ai-chat.js`
- `backend/public/portal/shared/style.css`
- `backend/tests/jest/ai-chat-widget-guard.test.js`

## Validation
- `node --check backend/public/portal/shared/ai-chat.js`
- `git diff --check -- backend/public/portal/shared/ai-chat.js backend/public/portal/shared/style.css backend/tests/jest/ai-chat-widget-guard.test.js`
- `PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin:$PATH NODE_PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules node /Users/hank/Desktop/Project/EClaw/backend/node_modules/jest/bin/jest.js tests/jest/ai-chat-widget-guard.test.js --runInBand`

## Notes
The current task remains `in_progress` because #2 still owns the broader `需要你回覆輸入區` resize follow-up. This PR covers the AI chat window resize implementation for review.