### PR TITLE
[codex] Keep AI chat responsive size until saved

### DIFF
--- a/backend/public/portal/shared/ai-chat.js
+++ b/backend/public/portal/shared/ai-chat.js
@@ -105,7 +105,12 @@
 
     function applyPanelSize(panel) {
         if (!panel) return;
-        const size = clampPanelSize(windowState.width || DEFAULT_PANEL_SIZE.width, windowState.height || DEFAULT_PANEL_SIZE.height);
+        if (!Number.isFinite(Number(windowState.width)) || !Number.isFinite(Number(windowState.height))) {
+            panel.style.width = '';
+            panel.style.height = '';
+            return;
+        }
+        const size = clampPanelSize(windowState.width, windowState.height);
         panel.style.width = size.width + 'px';
         panel.style.height = size.height + 'px';
     }

--- a/backend/tests/jest/ai-chat-widget-guard.test.js
+++ b/backend/tests/jest/ai-chat-widget-guard.test.js
@@ -95,6 +95,14 @@ describe('AI Chat Widget WebView Guard (#419)', () => {
         expect(code).toMatch(/resizeEnabled/);
     });
 
+    test('ai-chat.js keeps CSS responsive sizing until a window size is saved', () => {
+        const code = fs.readFileSync(AI_CHAT_JS, 'utf-8');
+        expect(code).toMatch(/function applyPanelSize/);
+        expect(code).toMatch(/panel\.style\.width\s*=\s*''/);
+        expect(code).toMatch(/panel\.style\.height\s*=\s*''/);
+        expect(code).toMatch(/const size = clampPanelSize\(windowState\.width, windowState\.height\)/);
+    });
+
     test('ai-chat resize CSS includes desktop grip and disable/mobile fallback', () => {
         const css = fs.readFileSync(STYLE_CSS, 'utf-8');
         expect(css).toMatch(/\.ai-chat-resize-grip\s*\{/);


### PR DESCRIPTION
## What changed
- Updated the floating AI chat resize logic so fresh panels do not write inline `width`/`height` before a saved window size exists.
- Added a Jest static guard that locks the responsive-CSS fallback behavior.

## Why
PR #3873 was merged as `36a67124`, but it only included `ef1715fe`. That version applies default inline panel dimensions on first load, which can override the mobile responsive CSS and make the panel slightly exceed the viewport.

## Validation
- `node --check backend/public/portal/shared/ai-chat.js`
- `git diff --check -- backend/public/portal/shared/ai-chat.js backend/tests/jest/ai-chat-widget-guard.test.js`
- `PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin:$PATH NODE_PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules node /Users/hank/Desktop/Project/EClaw/backend/node_modules/jest/bin/jest.js tests/jest/ai-chat-widget-guard.test.js --runInBand`

## Coordination
This is the follow-up inline-size fix split from the post-merge work, based on latest `origin/main@36a67124`.