### PR TITLE
[codex] Keep saved AI chat size off compact viewports

### DIFF
--- a/backend/public/portal/shared/ai-chat.js
+++ b/backend/public/portal/shared/ai-chat.js
@@ -24,6 +24,7 @@
     const DEFAULT_PANEL_SIZE = { width: 380, height: 520 };
     const MIN_PANEL_SIZE = { width: 300, height: 360 };
     const PANEL_VIEWPORT_MARGIN = 16;
+    const COMPACT_PANEL_BREAKPOINT = 640;
 
     let chatHistory = [];
     let isOpen = false;
@@ -103,9 +104,14 @@
         };
     }
 
+    function isCompactPanelViewport() {
+        if (window.matchMedia && window.matchMedia(`(max-width: ${COMPACT_PANEL_BREAKPOINT}px)`).matches) return true;
+        return (window.innerWidth || 0) <= COMPACT_PANEL_BREAKPOINT;
+    }
+
     function applyPanelSize(panel) {
         if (!panel) return;
-        if (!Number.isFinite(Number(windowState.width)) || !Number.isFinite(Number(windowState.height))) {
+        if (isCompactPanelViewport() || !Number.isFinite(Number(windowState.width)) || !Number.isFinite(Number(windowState.height))) {
             panel.style.width = '';
             panel.style.height = '';
             return;

--- a/backend/tests/jest/ai-chat-widget-guard.test.js
+++ b/backend/tests/jest/ai-chat-widget-guard.test.js
@@ -89,6 +89,7 @@ describe('AI Chat Widget WebView Guard (#419)', () => {
         expect(code).toMatch(/WINDOW_STATE_KEY\s*=\s*'eclaw_ai_chat_window_state_v1'/);
         expect(code).toMatch(/function getWindowStateId/);
         expect(code).toMatch(/function setupPanelWindowControls/);
+        expect(code).toMatch(/function isCompactPanelViewport/);
         expect(code).toMatch(/ai-chat-resize-toggle-btn/);
         expect(code).toMatch(/ai-chat-resize-grip/);
         expect(code).toMatch(/pointerdown/);
@@ -100,6 +101,7 @@ describe('AI Chat Widget WebView Guard (#419)', () => {
         expect(code).toMatch(/function applyPanelSize/);
         expect(code).toMatch(/panel\.style\.width\s*=\s*''/);
         expect(code).toMatch(/panel\.style\.height\s*=\s*''/);
+        expect(code).toMatch(/isCompactPanelViewport\(\)\s*\|\|/);
         expect(code).toMatch(/const size = clampPanelSize\(windowState\.width, windowState\.height\)/);
     });
 


### PR DESCRIPTION
## Summary
- Keep the AI chat panel on CSS-controlled responsive sizing for compact viewports, even when a desktop resize has already been saved in localStorage.
- Preserve saved desktop window sizing for non-compact viewports.
- Extend the existing AI chat widget guard test to cover the compact viewport guard.

## Root Cause
PR #3874 correctly avoided writing inline width/height before a size was saved, but a previously saved desktop size could still be applied on mobile. At 390x844 that left the panel at the saved desktop height instead of the mobile CSS fallback height.

## Validation
- `npm test -- --runTestsByPath tests/jest/ai-chat-widget-guard.test.js`
- `npm run smoke:portal`
- Playwright render/interaction check: desktop resize persisted from 380x520 to 471x601; then the same saved state on 390x844 kept mobile at 374x764 with no inline width/height and resize controls hidden.