### PR TITLE
fix(routing): drop low-signal heartbeats on the direct-b2b deliver path (card_39226e06)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -9262,6 +9262,51 @@ async function deliverToEntity(opts) {
         viaChannel = null
     } = opts;
 
+    // ── Direct-b2b deliver-time low-signal guard (card_39226e06) ──
+    // deliverToEntity is the SINGLE deliver point for direct bot-to-bot messages
+    // (/api/transform speakTo + broadcast): the sender (fromEntity/fromId) and the
+    // recipient (toEntity/toId) are BOTH bound bot entities — a real end user goes
+    // through /api/client/speak, which never calls this function, so user delivery
+    // is untouched by construction.
+    //
+    // The org-fwd low-signal filter (classifyLowSignalFwd) previously ran ONLY
+    // inside orgChartForward(), so #6's routine "Codex #N status heartbeat" noise —
+    // delivered DIRECTLY to #2 via speakTo/transform after Hank set #6→#2 in the
+    // org chart — bypassed it entirely and flooded the commander. Run the SAME
+    // classifier here, before we persist/push to the recipient bot, and DROP only
+    // when it flags the message low-signal. Conservative by design:
+    //   • only affects bot recipients (this fn is entity→entity only),
+    //   • only drops when classifyLowSignalFwd returns non-null (heartbeat / ack /
+    //     kanban-echo / machine-noise) — a substantive report ("已完成任務，PR #1234
+    //     merged…") classifies as null and is delivered normally,
+    //   • fail-safe: if classification throws, we DELIVER (never let the filter eat
+    //     a message on error).
+    // Recorded via the shared drop-but-surface suppression log (card_59f41e5b) so
+    // the dashboard shows what was filtered and why.
+    try {
+        const lowSignalReason = classifyLowSignalFwd(text);
+        if (lowSignalReason) {
+            recordSuppressedForward(targetDeviceId, {
+                fromEntityId: fromId,
+                reason: lowSignalReason,
+                snippet: typeof text === 'string' ? text.slice(0, 80) : '',
+            });
+            console.log(`[b2b-suppress] dropped low-signal direct-b2b deliver Entity ${fromId} -> ${toId} on ${targetDeviceId} (reason=${lowSignalReason}): "${(typeof text === 'string' ? text : '').slice(0, 60)}"`);
+            return {
+                entityId: toId,
+                character: toEntity && toEntity.character,
+                pushed: false,
+                mode: 'suppressed',
+                reason: `low_signal:${lowSignalReason}`,
+                suppressed: true,
+                ...(isCrossDevice ? { publicCode: toEntity && toEntity.publicCode, targetDeviceId } : {})
+            };
+        }
+    } catch (err) {
+        // Fail-safe: classification error → deliver normally (never drop on error).
+        console.error(`[b2b-suppress] classify error, delivering normally: ${err.message}`);
+    }
+
     const sourceLabel = isCrossDevice
         ? `xdevice:${fromEntity.publicCode}:${fromEntity.character}`
         : `entity:${fromId}:${fromEntity.character}`;
@@ -24915,6 +24960,10 @@ module.exports._BOT2BOT_REGEN_INTERVAL_MS = BOT2BOT_REGEN_INTERVAL_MS;
 module.exports._recordSuppressedForward = recordSuppressedForward;
 module.exports._suppressionLog = suppressionLog;
 module.exports._SUPPRESSION_LOG_CAP = SUPPRESSION_LOG_CAP;
+// Direct-b2b deliver point — exported for the deliver-time low-signal guard test
+// (card_39226e06). This is the single entity→entity delivery fn for
+// /api/transform speakTo + broadcast.
+module.exports._deliverToEntity = deliverToEntity;
 // Server-authoritative entity ACTIVITY state machine (lib/entity-activity.js)
 module.exports._entityActivity = entityActivity;
 module.exports._evaluateEntityActivity = evaluateEntityActivity;

--- a/backend/tests/jest/b2b-deliver-lowsignal.test.js
+++ b/backend/tests/jest/b2b-deliver-lowsignal.test.js
@@ -1,0 +1,181 @@
+/**
+ * Direct-b2b deliver-time low-signal guard (card_39226e06).
+ *
+ * Problem: entity #6 (Codex) emits routine "Codex #N status heartbeat" messages
+ * every ~3 min. After #6→#2 was set in the org chart, #6's watchdog started
+ * sending these heartbeats DIRECTLY to #2 via speakTo/transform (the
+ * bot-to-bot delivery path — deliverToEntity), NOT via orgChartForward(). The
+ * existing low-signal filter (classifyLowSignalFwd) only ran inside
+ * orgChartForward, so it never fired on the direct-b2b path → heartbeat noise
+ * flooded the commander.
+ *
+ * Fix: deliverToEntity() now runs classifyLowSignalFwd at the top and DROPS the
+ * delivery (before persist/push) when the message is low-signal, recording it in
+ * the drop-but-surface suppression log. This test asserts:
+ *   (a) a "Codex #6 status heartbeat…" b2b message is SUPPRESSED (dropped),
+ *   (b) a substantive #6 report ("已完成任務，PR #1234 merged…") is DELIVERED,
+ *   (c) a real-user-style message is DELIVERED (never eat content),
+ *   (d) a classification error → DELIVERED (fail-safe; the filter must never
+ *       drop a message on error).
+ *
+ * Guard is exercised through the exported deliver point (index._deliverToEntity)
+ * — the SINGLE entity→entity delivery fn shared by /api/transform speakTo +
+ * broadcast. A real end user goes through /api/client/speak, which never calls
+ * deliverToEntity, so user delivery is untouched by construction; (c) here is the
+ * belt-and-suspenders "substantive prose is never suppressed" case.
+ *
+ * On PRE-CHANGE code (guard absent) case (a) DELIVERS the heartbeat (enqueued,
+ * no suppression record) → the (a) assertions FAIL. After the fix they PASS.
+ */
+
+require('./helpers/mock-setup');
+
+// Wrap the real org-fwd-filter so the classifier keeps its true behaviour for
+// cases (a)-(c), but case (d) can flip `throwNext` to force a classification
+// error and assert the deliver-time guard's fail-safe (deliver-on-error). We
+// must mock at the module boundary because index.js captures
+// classifyLowSignalFwd as a destructured local at load time — spying on the
+// module object afterwards would not affect index's binding.
+const orgFwdControl = { throwNext: false };
+jest.mock('../../org-fwd-filter', () => {
+    const actual = jest.requireActual('../../org-fwd-filter');
+    return {
+        ...actual,
+        classifyLowSignalFwd: (message) => {
+            if (orgFwdControl.throwNext) throw new Error('boom: classifier poisoned');
+            return actual.classifyLowSignalFwd(message);
+        },
+    };
+});
+
+let indexModule;
+
+const DEVICE_ID = 'b2b-deliver-lowsignal-dev';
+
+// Build a minimal-but-valid bound entity object (enough for deliverToEntity:
+// messageQueue for enqueue, character/name for labels, isBound, no webhook and
+// non-channel binding so NO real push fires — delivery is observable purely via
+// the messageQueue + return shape).
+function makeEntity(entityId, character) {
+    return {
+        entityId,
+        character,
+        name: character,
+        isBound: true,
+        webhook: null,           // no webhook  → webhook push path skipped
+        bindingType: 'personal', // not 'channel' → channel push path skipped
+        botSecret: `botsecret-${entityId}`,
+        identity: { name: character },
+        level: 1,
+        state: 'IDLE',
+        messageQueue: [],
+        deadLetterQueue: [],
+    };
+}
+
+async function deliver(fromEntity, toEntity, text) {
+    return indexModule._deliverToEntity({
+        senderDeviceId: DEVICE_ID,
+        fromId: fromEntity.entityId,
+        fromEntity,
+        targetDeviceId: DEVICE_ID,
+        toId: toEntity.entityId,
+        toEntity,
+        text,
+        expectsReply: true,
+        isBroadcast: false,
+        isCrossDevice: false,
+    });
+}
+
+function suppressionCount() {
+    const log = indexModule._suppressionLog[DEVICE_ID] || [];
+    return log.length;
+}
+
+beforeAll(() => {
+    indexModule = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+beforeEach(() => {
+    // Fresh suppression buffer per test so counts are unambiguous.
+    delete indexModule._suppressionLog[DEVICE_ID];
+    orgFwdControl.throwNext = false;
+});
+
+describe('deliverToEntity() direct-b2b low-signal guard (card_39226e06)', () => {
+    it('(a) SUPPRESSES a "Codex #6 status heartbeat" b2b message to a bot recipient', async () => {
+        const from = makeEntity(6, 'LOBSTER'); // #6 Codex
+        const to = makeEntity(2, 'COMMANDER'); // #2 commander
+        const result = await deliver(from, to, 'Codex #6 status heartbeat — bridge alive, 3m idle');
+
+        // Dropped before persist/push: recognisable "suppressed" result.
+        expect(result.suppressed).toBe(true);
+        expect(result.mode).toBe('suppressed');
+        expect(result.pushed).toBe(false);
+        expect(result.reason).toMatch(/^low_signal:heartbeat$/);
+
+        // Nothing enqueued to the recipient bot.
+        expect(to.messageQueue).toHaveLength(0);
+
+        // Recorded in the drop-but-surface suppression log with the right reason.
+        expect(suppressionCount()).toBe(1);
+        const rec = indexModule._suppressionLog[DEVICE_ID][0];
+        expect(rec).toMatchObject({ fromEntityId: 6, reason: 'heartbeat' });
+    });
+
+    it('(b) DELIVERS a substantive #6 completion report to a bot recipient', async () => {
+        const from = makeEntity(6, 'LOBSTER');
+        const to = makeEntity(2, 'COMMANDER');
+        const text = '已完成任務，PR #1234 merged，card_39226e06 已關閉，詳見 https://github.com/x/y/pull/1234';
+        const result = await deliver(from, to, text);
+
+        // Not suppressed — normal fire-and-forget delivery result.
+        expect(result.suppressed).toBeUndefined();
+        expect(result.mode).not.toBe('suppressed');
+
+        // Enqueued to the recipient bot's messageQueue.
+        expect(to.messageQueue).toHaveLength(1);
+        expect(to.messageQueue[0].text).toBe(text);
+
+        // No suppression record.
+        expect(suppressionCount()).toBe(0);
+    });
+
+    it('(c) DELIVERS a real-user-style prose message (never eats content)', async () => {
+        const from = makeEntity(6, 'LOBSTER');
+        const to = makeEntity(2, 'COMMANDER');
+        const text = 'Hello, can you please help me check the order status for my account?';
+        const result = await deliver(from, to, text);
+
+        expect(result.suppressed).toBeUndefined();
+        expect(to.messageQueue).toHaveLength(1);
+        expect(to.messageQueue[0].text).toBe(text);
+        expect(suppressionCount()).toBe(0);
+    });
+
+    it('(d) FAIL-SAFE: a classification error still DELIVERS the message', async () => {
+        const from = makeEntity(6, 'LOBSTER');
+        const to = makeEntity(2, 'COMMANDER');
+
+        // Force classifyLowSignalFwd to throw (via the module wrapper). The guard's
+        // try/catch must fall through to normal delivery — even a heartbeat-looking
+        // body must be DELIVERED when classification cannot run (annoying noise is
+        // acceptable; an eaten message on error is not).
+        orgFwdControl.throwNext = true;
+        const result = await deliver(from, to, 'Codex #6 status heartbeat — should still be delivered on error');
+
+        // Delivered despite the throw — guard fell through to normal path.
+        expect(result.suppressed).toBeUndefined();
+        expect(result.mode).not.toBe('suppressed');
+        expect(to.messageQueue).toHaveLength(1);
+        // No suppression record because nothing was dropped.
+        expect(suppressionCount()).toBe(0);
+    });
+});


### PR DESCRIPTION
## Scope
Entity #6 (Codex) emits routine `Codex #N status heartbeat` messages every ~3 min. After Hank set **#6→#2** in the org chart, #6's watchdog started sending these heartbeats **directly** to #2 via `speakTo`/`transform` (the direct **bot-to-bot** delivery path — `deliverToEntity`), **not** via `orgChartForward()`.

The existing low-signal filter `classifyLowSignalFwd` (in `backend/org-fwd-filter.js`) was **only** applied inside `orgChartForward` (`backend/index.js` ~line 19919), so it never ran on the direct-b2b path → heartbeat noise flooded the commander (#2).

This adds a **deliver-time low-signal guard** at the single entity→entity deliver point so routine heartbeats are dropped **before** reaching a recipient bot, without touching substantive bot-to-bot reports or any real user message.

## What changed
- **`backend/index.js`** — guard at the **top of `deliverToEntity()`** (`~line 9265`), the SINGLE deliver point shared by `/api/transform` `speakTo` **and** `broadcast`. It runs `classifyLowSignalFwd(text)`; on a non-null (low-signal) result it **drops** the delivery (returns before any persist/enqueue/push) and records it in the shared **drop-but-surface suppression log** (`recordSuppressedForward` → `GET /api/suppression-log` + socket `suppression:logged`, card_59f41e5b). Exported `_deliverToEntity` for the test.
- **`backend/org-fwd-filter.js`** — **no change needed**: the existing `heartbeat` pattern already matches `Codex #N status heartbeat` reliably, and substantive reports/escalations classify as `null`.

## Safety / why it can't over-suppress
- **User messages untouched by construction**: real users go through `/api/client/speak`, which never calls `deliverToEntity`. This guard only sees entity→entity (bot→bot) traffic.
- **Only drops on a positive classification**: a substantive report (`已完成任務，PR #1234 merged…`), a genuine escalation (`請 owner … rollback🦞`), or any prose classifies as `null` → delivered normally.
- **Fail-safe**: if classification throws, the guard falls through to normal delivery — it never eats a message on error.

## Acceptance / Test plan
New: `backend/tests/jest/b2b-deliver-lowsignal.test.js`
- (a) `Codex #6 status heartbeat…` b2b → **SUPPRESSED** (no enqueue, suppression record `reason=heartbeat`)
- (b) substantive #6 completion report → **DELIVERED** (enqueued, no record)
- (c) real-user-style prose → **DELIVERED**
- (d) classification error → **DELIVERED** (fail-safe)

Verified **FAIL on pre-guard code** (case (a) delivers the heartbeat), **PASS after**. Full backend jest suite green: **442 suites / 6092 passed**. ESLint clean on `index.js` + `org-fwd-filter.js`.

## User POV
The commander (#2) stops getting flooded by #6's ~3-min heartbeat pings; genuine work/completion reports and escalations still arrive. Suppressed heartbeats remain visible in the drop-but-surface suppression drawer, so nothing disappears silently.

## Out of scope / residual risk
- The **deprecated** `POST /api/entity/speak-to` endpoint (`index.js` ~12725) has its OWN inline delivery (does not call `deliverToEntity`), so heartbeats sent via that legacy path would still slip through. #6's watchdog uses the modern `/api/transform` path, and the endpoint is already flagged deprecated (migration hint → `/api/transform`). Folding it (or its inline path) onto `deliverToEntity` is a follow-up, not needed to fix this flood.
- Broadcasts are also covered (same deliver point) — a heartbeat broadcast is noise too; substantive broadcasts are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN