### PR TITLE
fix(portal): normalize community capability maps

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -1424,6 +1424,26 @@
     /* ══════ Load ══════ */
     // Default: merge rental listings + community bots in one grid.
     // "出租" filter narrows to rental-only; other filters narrow to community-only.
+    function normalizeCommunityCapabilities(raw) {
+        const labelFor = (value, fallback) => {
+            if (value == null || value === false) return '';
+            if (typeof value === 'string' || typeof value === 'number') return String(value);
+            if (typeof value === 'object') return value.name || value.label || value.id || fallback || '';
+            return fallback || String(value);
+        };
+        if (Array.isArray(raw)) {
+            return raw.map(c => labelFor(c)).filter(Boolean);
+        }
+        if (raw && typeof raw === 'object') {
+            return Object.entries(raw)
+                .filter(([, value]) => !(value && typeof value === 'object' && value.supported === false))
+                .map(([key, value]) => labelFor(value, key))
+                .filter(Boolean);
+        }
+        const label = labelFor(raw);
+        return label ? [label] : [];
+    }
+
     async function loadBots() {
         const requestSeq = ++loadBotsRequestSeq;
         document.getElementById('loading').style.display = 'flex';
@@ -1442,7 +1462,7 @@
                     publicCode: r.publicCode, name: r.name || 'Unnamed',
                     avatar: resolveBotAvatar(r),
                     desc: r.description || '', tags: r.tags || [],
-                    caps: (r.capabilities || []).map(c => c.name || c.id || c),
+                    caps: normalizeCommunityCapabilities(r.capabilities),
                     stars: r.avgRating || 0, reviews: r.messageCount || 0,
                     level: r.level || 1, xp: r.xp || 0,
                     // Arena verified score (card_ad404375). Number fields only —

--- a/backend/tests/jest/qa-uiux-20260606-regressions.test.js
+++ b/backend/tests/jest/qa-uiux-20260606-regressions.test.js
@@ -2,12 +2,24 @@
 
 const fs = require('fs');
 const path = require('path');
+const vm = require('vm');
 
 const ROOT = path.join(__dirname, '..', '..');
 const kanbanHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'kanban.html'), 'utf8');
 const communityHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'community.html'), 'utf8');
 const portalStyle = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'shared', 'style.css'), 'utf8');
 const publisherHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'publisher.html'), 'utf8');
+
+function loadCommunityFunction(name, nextMarker) {
+    const start = communityHtml.indexOf(`function ${name}`);
+    const end = communityHtml.indexOf(nextMarker, start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const sandbox = { result: null };
+    vm.createContext(sandbox);
+    vm.runInContext(`${communityHtml.slice(start, end)}\nresult = ${name};`, sandbox);
+    return sandbox.result;
+}
 
 describe('QA/UIUX 2026-06-06 regression guards', () => {
     test('kanban automation status filter includes Backlog and migrates the legacy 5-status default', () => {
@@ -21,6 +33,24 @@ describe('QA/UIUX 2026-06-06 regression guards', () => {
         expect(communityHtml).toContain('const requestSeq = ++loadBotsRequestSeq;');
         expect(communityHtml).toContain('if (requestSeq !== loadBotsRequestSeq) return;');
         expect(communityHtml).toContain('if (requestSeq === loadBotsRequestSeq)');
+    });
+
+    test('Bot Plaza normalizes object-shaped community capability maps before rendering chips', () => {
+        expect(communityHtml).toContain('function normalizeCommunityCapabilities(raw)');
+        expect(communityHtml).toContain('Object.entries(raw)');
+        expect(communityHtml).toContain('value.supported === false');
+        expect(communityHtml).toContain('caps: normalizeCommunityCapabilities(r.capabilities)');
+        expect(communityHtml).not.toContain('caps: (r.capabilities || []).map');
+
+        const normalize = loadCommunityFunction('normalizeCommunityCapabilities', 'async function loadBots');
+        expect(normalize([{ id: 'vision' }, { name: 'Web Browse' }, 'coding'])).toEqual(['vision', 'Web Browse', 'coding']);
+        expect(normalize({
+            voice: { supported: true, probes: [] },
+            reasoning: { supported: false, probes: [] },
+            custom: { supported: true, name: 'Custom Tool' },
+        })).toEqual(['voice', 'Custom Tool']);
+        expect(normalize('search')).toEqual(['search']);
+        expect(normalize(null)).toEqual([]);
     });
 
     test('authenticated portal nav compresses at laptop desktop widths before account controls overflow', () => {


### PR DESCRIPTION
## Summary
- Fix Bot Plaza / card-holder embedded community page crash when `/api/community/search` returns `capabilities` as an arena capability map object instead of an array.
- Normalize array/object/string capability shapes before rendering chips and skip `supported:false` capabilities.
- Add a focused QA/UIUX regression guard that executes the normalizer against array, object, string, and null inputs.

## Verification
- `npx jest tests/jest/qa-uiux-20260606-regressions.test.js --runInBand`
- `npm run smoke:portal`

## QA Source
Found during card `card_dee33aa5c20408f5cddf13a0` daily prod QA/UIUX regression: card-holder -> Bot 廣場 iframe showed `無法載入 Bot 廣場` and console threw `(r.capabilities || []).map is not a function`.