### PR TITLE
fix(petdx): proxy community sprites same-origin to defeat Chrome ORB 🦞 fallback (resurrect #3817)

### DIFF
--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -18,7 +18,10 @@ const express = require('express');
 const fs = require('fs');
 const path = require('path');
 const { Pool } = require('pg');
-const { syncPetdexCatalog, R2_KEY_PREFIX, PROXY_PATH_PREFIX } = require('./petdex-bridge');
+const {
+    syncPetdexCatalog, R2_KEY_PREFIX, PROXY_PATH_PREFIX,
+    rewriteCommunitySpriteUrl, rewriteDescriptorSpriteUrl,
+} = require('./petdex-bridge');
 const { extractFrameZero } = require('./companion-avatar-util');
 const extractCreds = require('./extract-creds');
 
@@ -162,7 +165,9 @@ function rowToCompanionCard(row) {
         id: row.id,
         name: row.name,
         version: row.version,
-        avatarUrl: row.avatar_url,
+        // Rewrite external community-CDN URLs to the same-origin proxy so the
+        // browser doesn't ORB-block them (no-op for R2/proxy/null URLs).
+        avatarUrl: rewriteCommunitySpriteUrl(row.avatar_url),
         thumbnailUrl: row.thumbnail_url,
         author: row.author_entity_id != null
             ? { entityId: row.author_entity_id }
@@ -186,10 +191,18 @@ function rowToCompanionCard(row) {
     // so cards can animate without a follow-up /:id fetch per tile. Procedural
     // cards already work off the renderer-key heuristic in petdx-browser.html.
     if (row.asset_type === 'spritesheet') {
-        card.assetUrl = row.asset_url;
+        card.assetUrl = rewriteCommunitySpriteUrl(row.asset_url);
         const d = row.descriptor || {};
-        if (d.asset) card.asset = d.asset;
+        // descriptor.asset.url is the URL the renderer actually loads — rewrite
+        // it too (clone, never mutate the row) so the grid fetches same-origin.
+        if (d.asset) {
+            const rewritten = rewriteDescriptorSpriteUrl(d);
+            card.asset = rewritten.asset;
+        }
         if (d.stateAssets) card.stateAssets = d.stateAssets;
+        // Surface `kind` so the grid's synthetic descriptor can pick the right
+        // emoji fallback (🐾/🧑/🎯) instead of always defaulting to 🦞.
+        if (d.kind) card.kind = d.kind;
     }
     return card;
 }
@@ -197,8 +210,11 @@ function rowToCompanionCard(row) {
 function rowToCompanionDetail(row) {
     return {
         ...rowToCompanionCard(row),
-        descriptor: row.descriptor,
-        assetUrl: row.asset_url,
+        // The modal renders straight off detail.descriptor — rewrite its
+        // asset.url (and assetUrl) to the same-origin proxy too, or the
+        // bigger preview ORB-blocks even though the grid card is fixed.
+        descriptor: rewriteDescriptorSpriteUrl(row.descriptor),
+        assetUrl: rewriteCommunitySpriteUrl(row.asset_url),
         license: row.license,
         i18nData: row.i18n_data,
         publishedAt: row.published_at,

--- a/backend/petdex-bridge.js
+++ b/backend/petdex-bridge.js
@@ -28,6 +28,49 @@ const MANIFEST_URL = 'https://petdex.crafter.run/api/manifest';
 const R2_KEY_PREFIX = 'petdx-sprites';
 const PROXY_PATH_PREFIX = '/api/petdx';
 
+// ── Community sprite same-origin proxy (ORB fix) ─────────────────────
+// Community/partner pets whose sprite bytes failed to self-host in R2
+// (needs_recovery) keep the EXTERNAL CDN URL `https://assets.petdex.dev/
+// pets/<slug>/sprite.webp`. The browser ORB-blocks that cross-origin webp
+// (Chrome Opaque Response Blocking — curl 200, browser net::ERR_BLOCKED_BY_ORB),
+// so the companion browser renders the 🦞 fallback for every partner. We
+// rewrite those URLs to a same-origin proxy path served by petdex-route.js;
+// a same-origin response is outside ORB's scope. SSRF-safe: the proxy host
+// + path shape are hard literals and only a charset-validated slug varies.
+const COMMUNITY_SPRITE_HOST = 'assets.petdex.dev';
+const COMMUNITY_PROXY_PATH_PREFIX = `${PROXY_PATH_PREFIX}/community`;
+const COMMUNITY_SLUG_PATTERN = /^[a-z0-9_-]+$/i;
+const COMMUNITY_SPRITE_URL_RE =
+    /^https?:\/\/assets\.petdex\.dev\/pets\/([a-z0-9_-]+)\/sprite\.webp(?:[?#].*)?$/i;
+
+// Extract the slug from an external community sprite URL, or null if the URL
+// is not an exact assets.petdex.dev/pets/<slug>/sprite.webp shape.
+function communitySpriteSlugFromUrl(url) {
+    if (typeof url !== 'string') return null;
+    const m = url.match(COMMUNITY_SPRITE_URL_RE);
+    return m ? m[1] : null;
+}
+
+// Rewrite an external community sprite URL to the same-origin proxy path.
+// Non-matching URLs (already proxied, R2-hosted, avatar.webp, null) pass
+// through unchanged — the rewrite is a no-op for everything but the ORB case.
+function rewriteCommunitySpriteUrl(url) {
+    const slug = communitySpriteSlugFromUrl(url);
+    return slug ? `${COMMUNITY_PROXY_PATH_PREFIX}/${slug}/sprite.webp` : url;
+}
+
+// Apply the rewrite to descriptor.asset.url (the URL the renderer actually
+// loads), returning a shallow clone so callers never mutate the DB row's
+// descriptor. Returns the input untouched when nothing needs rewriting.
+function rewriteDescriptorSpriteUrl(descriptor) {
+    if (!descriptor || typeof descriptor !== 'object') return descriptor;
+    const asset = descriptor.asset;
+    if (!asset || typeof asset.url !== 'string') return descriptor;
+    const rewritten = rewriteCommunitySpriteUrl(asset.url);
+    if (rewritten === asset.url) return descriptor;
+    return { ...descriptor, asset: { ...asset, url: rewritten } };
+}
+
 // Animation table — rows + per-frame durations in milliseconds. The idle row
 // uses variable durations per frame (matches petdex desktop); all other rows
 // use a single `dur` plus an optional `last` for the trailing frame.
@@ -339,4 +382,11 @@ module.exports = {
     MANIFEST_URL,
     R2_KEY_PREFIX,
     PROXY_PATH_PREFIX,
+    COMMUNITY_SPRITE_HOST,
+    COMMUNITY_PROXY_PATH_PREFIX,
+    COMMUNITY_SLUG_PATTERN,
+    COMMUNITY_SPRITE_URL_RE,
+    communitySpriteSlugFromUrl,
+    rewriteCommunitySpriteUrl,
+    rewriteDescriptorSpriteUrl,
 };

--- a/backend/petdex-route.js
+++ b/backend/petdex-route.js
@@ -17,10 +17,14 @@
 
 const express = require('express');
 const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
+const {
+    COMMUNITY_SPRITE_HOST,
+    COMMUNITY_SLUG_PATTERN,
+} = require('./petdex-bridge');
 
 const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,128}$/;
 
-function createRouter({ r2, bucket, log } = {}) {
+function createRouter({ r2, bucket, log, fetch: fetchImpl } = {}) {
     const router = express.Router();
     const client = r2 || new S3Client({
         region: 'auto',
@@ -32,6 +36,7 @@ function createRouter({ r2, bucket, log } = {}) {
     });
     const bucketName = bucket || process.env.R2_BUCKET_NAME || 'eclaw-files';
     const logger = typeof log === 'function' ? log : () => {};
+    const doFetch = fetchImpl || globalThis.fetch;
 
     // Shared streamer for the immutable public webp assets under
     // petdx-sprites/{slug}/. `filename` is the object basename (sprite.webp /
@@ -65,9 +70,64 @@ function createRouter({ r2, bucket, log } = {}) {
         }
     }
 
+    // Community sprite proxy — fixes the 🦞 fallback caused by Chrome ORB
+    // (Opaque Response Blocking) on the cross-origin `assets.petdex.dev` CDN.
+    // Streaming the bytes back same-origin removes the cross-origin condition
+    // ORB blocks on. SECURITY: this is NOT an open proxy — the upstream host
+    // and `/pets/<slug>/sprite.webp` path shape are hard-coded literals, and
+    // only a charset-validated slug is interpolated (no host/scheme/path is
+    // taken from the request), so it cannot be coerced into SSRF.
+    async function streamCommunitySprite(req, res) {
+        const { slug } = req.params;
+        if (!slug || !COMMUNITY_SLUG_PATTERN.test(slug)) {
+            return res.status(404).type('text/plain').send('not found');
+        }
+        if (typeof doFetch !== 'function') {
+            logger('error', 'petdex-route', '[petdx] community proxy: no fetch available');
+            return res.status(502).type('text/plain').send('upstream error');
+        }
+        const upstreamUrl = `https://${COMMUNITY_SPRITE_HOST}/pets/${slug}/sprite.webp`;
+        let upstream;
+        try {
+            upstream = await doFetch(upstreamUrl, {
+                headers: {
+                    // Custom UA — a default urllib/empty UA can trip the CDN's
+                    // edge UA filter (CF 1010). curl/named agents return 200.
+                    'User-Agent': 'EClaw-petdex-proxy/1.0',
+                    'Accept': 'image/webp,image/*;q=0.8,*/*;q=0.5',
+                },
+            });
+        } catch (err) {
+            logger('warn', 'petdex-route', `[petdx] community fetch ${slug} failed: ${err.message}`);
+            return res.status(502).type('text/plain').send('upstream error');
+        }
+        if (!upstream.ok) {
+            if (upstream.status === 404) {
+                return res.status(404).type('text/plain').send('not found');
+            }
+            logger('warn', 'petdex-route', `[petdx] community ${slug} upstream HTTP ${upstream.status}`);
+            return res.status(502).type('text/plain').send('upstream error');
+        }
+        let buf;
+        try {
+            buf = Buffer.from(await upstream.arrayBuffer());
+        } catch (err) {
+            logger('warn', 'petdex-route', `[petdx] community ${slug} body read failed: ${err.message}`);
+            return res.status(502).type('text/plain').send('upstream error');
+        }
+        res.setHeader('Content-Type', 'image/webp');
+        // Not immutable: community sprites can recover/update upstream, so cache
+        // for a day rather than the year-long immutable TTL the R2 assets use.
+        res.setHeader('Cache-Control', 'public, max-age=86400');
+        res.setHeader('Content-Length', String(buf.length));
+        return res.end(buf);
+    }
+
     router.get('/:slug/sprite.webp', (req, res) => streamPetdxWebp(req, res, 'sprite.webp'));
     // Plaza Plan-3 Phase 4: single-frame avatar (derived frame 0, ≤512×512).
     router.get('/:slug/avatar.webp', (req, res) => streamPetdxWebp(req, res, 'avatar.webp'));
+    // Community partner sprites still on the external CDN (ORB same-origin fix).
+    router.get('/community/:slug/sprite.webp', (req, res) => streamCommunitySprite(req, res));
 
     return router;
 }

--- a/backend/public/portal/petdx-browser.html
+++ b/backend/public/portal/petdx-browser.html
@@ -346,6 +346,40 @@
         }
     }
 
+    // ── Load-failure sort demotion ────────────────────────────────
+    // Under 熱門/最新, a spritesheet whose sprite fails to load (404 or an
+    // ORB-blocked community CDN URL) is stably demoted below cards that
+    // render, so the first rows aren't all broken avatars. We probe with a
+    // throwaway Image (the browser dedupes the request against the renderer's
+    // own load) and re-sort the grid on the first failure. Only applied to the
+    // popular/recent paths; rating/favorites keep their exact server order.
+    function setupLoadDemotion(node, card, grid) {
+        const url = card && card.asset && card.asset.url;
+        if (!card || card.assetType !== 'spritesheet' || !url) return;
+        const probe = new Image();
+        probe.onerror = () => {
+            if (node.dataset.loadFailed === '1') return;
+            node.dataset.loadFailed = '1';
+            demoteFailedCards(grid);
+        };
+        probe.src = url;
+    }
+
+    function demoteFailedCards(grid) {
+        // Stable secondary sort: load-ok/pending cards keep the server's
+        // primary order (original index); failed cards sink to the end, also
+        // in their original relative order. appendChild on an existing child
+        // MOVES it — no re-render, the live renderer canvases are preserved.
+        const nodes = Array.from(grid.children);
+        nodes.sort((a, b) => {
+            const fa = a.dataset.loadFailed === '1' ? 1 : 0;
+            const fb = b.dataset.loadFailed === '1' ? 1 : 0;
+            if (fa !== fb) return fa - fb;
+            return (Number(a.dataset.idx) || 0) - (Number(b.dataset.idx) || 0);
+        });
+        nodes.forEach(n => grid.appendChild(n));
+    }
+
     // ── Filter UI ─────────────────────────────────────────────────
     function renderFilters() {
         const root = document.getElementById('filters');
@@ -467,9 +501,13 @@
             return;
         }
 
-        items.forEach(card => {
+        // 熱門/最新 demote sprites that fail to load below ones that render.
+        const demoteOnLoadFail = filterState.sort === 'popular' || filterState.sort === 'recent';
+        items.forEach((card, idx) => {
             const node = renderCardNode(card);
+            node.dataset.idx = String(idx);
             grid.appendChild(node);
+            if (demoteOnLoadFail) setupLoadDemotion(node, card, grid);
         });
         renderPagination();
         syncUrlPage();
@@ -572,6 +610,11 @@
                 name: card.name,
                 assetType: 'spritesheet',
                 asset: card.asset,
+                // Carry kind + category so a sprite that fails to load (e.g. an
+                // ORB-blocked community CDN URL) draws the matching emoji
+                // fallback (🐾/🧑/🎯) instead of always defaulting to 🦞.
+                kind: card.kind,
+                category: card.category,
                 supportedStates: card.supportedStates && card.supportedStates.length
                     ? card.supportedStates
                     : ['IDLE'],

--- a/backend/public/shared/petdx-renderer.js
+++ b/backend/public/shared/petdx-renderer.js
@@ -39,6 +39,38 @@
     const DEFAULT_FPS = 4;
     const DEFAULT_FALLBACK_POLICY = 'silent_to_idle';
 
+    // ── Per-kind emoji fallback (sprite missing / ORB-blocked) ──────────
+    // Spec §3.4: when a sprite fails to load we draw a per-kind emoji + the
+    // name initial. The grid's synthetic descriptor used to omit `kind`, so
+    // EVERY card fell through to the 🦞 default. resolveCompanionKind also
+    // infers `kind` from the companion `category` so a card that only carries
+    // category (animal/human/…) still gets the right emoji.
+    const FALLBACK_EMOJI_BY_KIND = { creature: '🐾', character: '🧑', object: '🎯' };
+    const DEFAULT_FALLBACK_EMOJI = '🦞';
+    const CATEGORY_TO_KIND = {
+        animal: 'creature',
+        human: 'character',
+        robot: 'object',
+        mascot: 'object',
+        custom: 'object',
+    };
+
+    function resolveCompanionKind(descriptor) {
+        if (!descriptor || typeof descriptor !== 'object') return null;
+        const direct = descriptor.kind
+            || (descriptor.sourceAttribution && descriptor.sourceAttribution.kind);
+        if (direct) return direct;
+        if (descriptor.category && CATEGORY_TO_KIND[descriptor.category]) {
+            return CATEGORY_TO_KIND[descriptor.category];
+        }
+        return null;
+    }
+
+    function fallbackEmojiForKind(descriptor) {
+        const kind = resolveCompanionKind(descriptor);
+        return FALLBACK_EMOJI_BY_KIND[kind] || DEFAULT_FALLBACK_EMOJI;
+    }
+
     // ── Spritesheet image cache ─────────────────────────────────
     // Multiple renderer instances on the same page (the grid is 1 canvas
     // per card) hit the same R2 URLs; cache by URL so the browser only
@@ -277,9 +309,7 @@
         function drawSpritesheetFallback(ctx, w, h, descriptor) {
             // Per-kind emoji + name-initial badge, used when sprite asset is missing
             // or failed to load. See docs/specs/petdx-uiux-spec-amendment-2026-06-05-self-host-sprite.md §3.4.
-            const kind = descriptor && (descriptor.kind || (descriptor.sourceAttribution && descriptor.sourceAttribution.kind));
-            const emojiByKind = { creature: '🐾', character: '🧑', object: '🎯' };
-            const emoji = emojiByKind[kind] || '🦞';
+            const emoji = fallbackEmojiForKind(descriptor);
             const name = (descriptor && descriptor.name) || '';
             const initial = name.trim().charAt(0).toUpperCase();
 
@@ -627,6 +657,9 @@
         // spritesheet cache during the descriptor fetch instead of waiting
         // for the first rAF tick to start the WEBP download.
         prefetchSpritesheet: loadSpritesheet,
+        // Per-kind emoji fallback (exposed for unit tests + grid reuse).
+        resolveCompanionKind,
+        fallbackEmojiForKind,
         DEFAULT_STATE,
     };
 }));

--- a/backend/tests/jest/petdx-community-sprite-proxy.test.js
+++ b/backend/tests/jest/petdx-community-sprite-proxy.test.js
@@ -1,0 +1,226 @@
+'use strict';
+
+/**
+ * Petdex community sprite same-origin proxy — ORB (Opaque Response Blocking) fix.
+ *
+ * Root cause: community/partner pets whose sprite bytes failed to self-host in
+ * R2 keep the EXTERNAL CDN URL `https://assets.petdex.dev/pets/<slug>/sprite.webp`.
+ * Chrome ORB-blocks that cross-origin webp in the browser (curl 200, browser
+ * net::ERR_BLOCKED_BY_ORB), so the companion browser renders the 🦞 fallback for
+ * every partner. Approach ②: proxy the sprite same-origin so ORB no longer applies.
+ *
+ * This suite proves:
+ *   (a) the proxy route accepts the valid assets.petdex.dev/pets/<slug>/sprite.webp
+ *       shape and REJECTS other hosts/paths/slug charsets (SSRF guard);
+ *   (b) the serializer rewrites the external URL to the same-origin proxy path
+ *       (asset_url, avatar_url, AND descriptor.asset.url) — and is a no-op for
+ *       already-proxied / R2 / null URLs;
+ *   (c) the per-kind emoji fallback returns a non-lobster emoji for
+ *       character/object/creature (and infers kind from category).
+ */
+
+// companion-api pulls in `pg` at require time — mock it so no real connection.
+jest.mock('pg', () => {
+    const mockQuery = jest.fn();
+    const Pool = jest.fn().mockImplementation(() => ({
+        query: mockQuery,
+        connect: jest.fn().mockResolvedValue({ query: mockQuery, release: jest.fn() }),
+        end: jest.fn(),
+    }));
+    return { Pool, __mockQuery: mockQuery };
+});
+
+const express = require('express');
+const request = require('supertest');
+
+const bridge = require('../../petdex-bridge');
+const { createRouter } = require('../../petdex-route');
+const companionFactory = require('../../companion-api');
+const renderer = require('../../public/shared/petdx-renderer');
+
+const EXT = (slug) => `https://assets.petdex.dev/pets/${slug}/sprite.webp`;
+const PROXY = (slug) => `/api/petdx/community/${slug}/sprite.webp`;
+
+// ── (b-helpers) bridge rewrite primitives ───────────────────────────
+describe('petdex-bridge: community sprite URL rewrite (SSRF-safe)', () => {
+    const { rewriteCommunitySpriteUrl, communitySpriteSlugFromUrl, rewriteDescriptorSpriteUrl } = bridge;
+
+    test('rewrites the exact external sprite URL to the same-origin proxy path', () => {
+        expect(rewriteCommunitySpriteUrl(EXT('zoro-9889c11ded54')))
+            .toBe(PROXY('zoro-9889c11ded54'));
+        expect(communitySpriteSlugFromUrl(EXT('boba'))).toBe('boba');
+    });
+
+    test('http:// variant also rewrites', () => {
+        expect(rewriteCommunitySpriteUrl('http://assets.petdex.dev/pets/boba/sprite.webp'))
+            .toBe(PROXY('boba'));
+    });
+
+    test('passes through (no-op) for non-matching hosts/paths/files (SSRF guard)', () => {
+        const untouched = [
+            'https://evil.com/pets/boba/sprite.webp',                  // wrong host
+            'https://assets.petdex.dev.evil.com/pets/boba/sprite.webp', // host suffix attack
+            'https://assets.petdex.dev/secret/boba/sprite.webp',       // wrong path root
+            'https://assets.petdex.dev/pets/boba/avatar.webp',         // wrong file
+            'https://assets.petdex.dev/pets/../../etc/sprite.webp',    // traversal in slug
+            '/api/petdx/community/boba/sprite.webp',                   // already proxied
+            'https://pub-abc.r2.dev/pets/boba/sprite.webp',            // already R2-hosted
+            null, undefined, 42, {},
+        ];
+        for (const u of untouched) {
+            expect(rewriteCommunitySpriteUrl(u)).toBe(u);
+            expect(communitySpriteSlugFromUrl(u)).toBeNull();
+        }
+    });
+
+    test('rewriteDescriptorSpriteUrl clones (never mutates the row descriptor)', () => {
+        const row = { kind: 'character', asset: { url: EXT('zoro'), cols: 8 } };
+        const out = rewriteDescriptorSpriteUrl(row);
+        expect(out).not.toBe(row);
+        expect(out.asset).not.toBe(row.asset);
+        expect(out.asset.url).toBe(PROXY('zoro'));
+        expect(out.asset.cols).toBe(8);
+        expect(row.asset.url).toBe(EXT('zoro')); // original untouched
+    });
+
+    test('rewriteDescriptorSpriteUrl is a no-op for non-community asset urls', () => {
+        const row = { asset: { url: '/api/petdx/boba/sprite.webp' } };
+        expect(rewriteDescriptorSpriteUrl(row)).toBe(row);
+        expect(rewriteDescriptorSpriteUrl(null)).toBeNull();
+        expect(rewriteDescriptorSpriteUrl({ name: 'x' })).toEqual({ name: 'x' });
+    });
+});
+
+// ── (a) proxy route — SSRF guard + streaming ────────────────────────
+describe('GET /api/petdx/community/:slug/sprite.webp', () => {
+    function appWith(fetchImpl) {
+        const app = express();
+        app.use('/api/petdx', createRouter({
+            r2: { send: () => Promise.reject(new Error('r2 unused')) },
+            bucket: 'test-bucket',
+            fetch: fetchImpl,
+        }));
+        return app;
+    }
+
+    function okFetch(bytes = Buffer.from('RIFF....WEBPfake')) {
+        return jest.fn().mockResolvedValue({
+            ok: true, status: 200, arrayBuffer: async () => bytes,
+        });
+    }
+
+    test('200 + image/webp for a valid slug, fetching the locked-down upstream URL', async () => {
+        const fetchImpl = okFetch();
+        const app = appWith(fetchImpl);
+        const res = await request(app).get(PROXY('zoro-9889c11ded54'));
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toBe('image/webp');
+        expect(res.headers['cache-control']).toBe('public, max-age=86400');
+        expect(res.body.length).toBeGreaterThan(0);
+        // SSRF proof: host + path are hard literals; only the slug varies.
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+        const calledUrl = fetchImpl.mock.calls[0][0];
+        expect(calledUrl).toBe('https://assets.petdex.dev/pets/zoro-9889c11ded54/sprite.webp');
+        expect(new URL(calledUrl).host).toBe('assets.petdex.dev');
+    });
+
+    test('rejects bad slug charsets BEFORE any fetch (no SSRF, no open proxy)', async () => {
+        const fetchImpl = okFetch();
+        const app = appWith(fetchImpl);
+        // dot, encoded slash/traversal, and a smuggled host all 404 (or never match
+        // the route) and must never reach the upstream fetch.
+        for (const bad of ['a.b', '..%2F..%2Fetc', 'zoro%2Fevil', 'zoro.evil']) {
+            const res = await request(app).get(`/api/petdx/community/${bad}/sprite.webp`);
+            expect(res.status).toBe(404);
+        }
+        // a different filename does not match the route at all
+        expect((await request(app).get('/api/petdx/community/zoro/avatar.webp')).status).toBe(404);
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    test('404 when upstream is 404, 502 when upstream errors', async () => {
+        const notFound = jest.fn().mockResolvedValue({ ok: false, status: 404 });
+        expect((await request(appWith(notFound)).get(PROXY('ghost'))).status).toBe(404);
+
+        const fiveHundred = jest.fn().mockResolvedValue({ ok: false, status: 500 });
+        expect((await request(appWith(fiveHundred)).get(PROXY('ghost'))).status).toBe(502);
+
+        const threw = jest.fn().mockRejectedValue(new Error('ECONNRESET'));
+        expect((await request(appWith(threw)).get(PROXY('ghost'))).status).toBe(502);
+    });
+});
+
+// ── (b) serializer rewrite + kind passthrough ───────────────────────
+describe('companion-api serializer: rewrites external sprite URLs to the proxy', () => {
+    const { rowToCompanionCard, rowToCompanionDetail } = companionFactory._test;
+
+    function spriteRow(over = {}) {
+        return {
+            id: 'petdex-zoro', name: 'Zoro', version: '1.0.0', author_entity_id: null,
+            asset_url: EXT('zoro'), avatar_url: EXT('zoro'), thumbnail_url: null, tags: ['petdex'],
+            mood: null, color: null, category: 'human', asset_type: 'spritesheet',
+            supported_states: ['IDLE'], download_count: 0, favorite_count: 0,
+            rating_avg: null, rating_count: 0, comment_count: 0, scope: 'community',
+            descriptor: { kind: 'character', asset: { url: EXT('zoro'), cols: 8, rows: 9 } },
+            ...over,
+        };
+    }
+
+    test('rowToCompanionCard rewrites asset_url, avatar_url and descriptor.asset.url', () => {
+        const card = rowToCompanionCard(spriteRow());
+        expect(card.assetUrl).toBe(PROXY('zoro'));
+        expect(card.avatarUrl).toBe(PROXY('zoro'));
+        expect(card.asset.url).toBe(PROXY('zoro'));
+        expect(card.asset.cols).toBe(8); // other asset fields preserved
+        expect(card.kind).toBe('character'); // kind surfaced for the emoji fallback
+    });
+
+    test('rowToCompanionCard does not mutate the source descriptor', () => {
+        const row = spriteRow();
+        rowToCompanionCard(row);
+        expect(row.descriptor.asset.url).toBe(EXT('zoro'));
+    });
+
+    test('rowToCompanionCard is a no-op for already-proxied / R2 URLs', () => {
+        const card = rowToCompanionCard(spriteRow({
+            avatar_url: '/api/petdx/zoro/avatar.webp',
+            descriptor: { kind: 'creature', asset: { url: '/api/petdx/boba/sprite.webp' } },
+        }));
+        expect(card.avatarUrl).toBe('/api/petdx/zoro/avatar.webp');
+        expect(card.asset.url).toBe('/api/petdx/boba/sprite.webp');
+    });
+
+    test('rowToCompanionDetail rewrites descriptor.asset.url + assetUrl (modal path)', () => {
+        const det = rowToCompanionDetail(spriteRow());
+        expect(det.assetUrl).toBe(PROXY('zoro'));
+        expect(det.descriptor.asset.url).toBe(PROXY('zoro'));
+    });
+});
+
+// ── (c) per-kind emoji fallback (non-lobster) ───────────────────────
+describe('petdx-renderer: fallbackEmojiForKind', () => {
+    const { fallbackEmojiForKind, resolveCompanionKind } = renderer;
+
+    test('returns the matching non-lobster emoji per kind', () => {
+        expect(fallbackEmojiForKind({ kind: 'character' })).toBe('🧑');
+        expect(fallbackEmojiForKind({ kind: 'object' })).toBe('🎯');
+        expect(fallbackEmojiForKind({ kind: 'creature' })).toBe('🐾');
+    });
+
+    test('infers kind from category when kind is absent', () => {
+        expect(fallbackEmojiForKind({ category: 'human' })).toBe('🧑');
+        expect(fallbackEmojiForKind({ category: 'animal' })).toBe('🐾');
+        expect(fallbackEmojiForKind({ category: 'mascot' })).toBe('🎯');
+        expect(resolveCompanionKind({ category: 'human' })).toBe('character');
+    });
+
+    test('reads kind off sourceAttribution as a last resort', () => {
+        expect(fallbackEmojiForKind({ sourceAttribution: { kind: 'object' } })).toBe('🎯');
+    });
+
+    test('only falls back to 🦞 when kind is genuinely unknown', () => {
+        expect(fallbackEmojiForKind({})).toBe('🦞');
+        expect(fallbackEmojiForKind(null)).toBe('🦞');
+        expect(fallbackEmojiForKind({ kind: 'martian' })).toBe('🦞');
+    });
+});


### PR DESCRIPTION
## Problem (owner complaint)

The 夥伴瀏覽器 / companion browser (`petdx-browser.html`) still shows the 🦞 lobster **default appearance on page 1** even after a "done" card was supposed to demote fallback-default avatars to the back.

## Root cause (confirmed with live headless-browser verification)

The demote-to-back fix **already existed** in PR #3817 — but it was **never merged**, and has since gone 39 commits stale. So prod never got it.

The deeper reason page 1 is *all* fallback: **all 3321 catalog companions** carry an external CDN sprite URL `https://assets.petdex.dev/pets/<slug>/sprite.webp`. Chrome **ORB (Opaque Response Blocking)** blocks that cross-origin `.webp` in the browser, so every card fails to load its sprite and draws the emoji fallback (🦞). A server-side health check (curl) can't see this — curl gets `200 image/webp`; only a real browser hits it.

A sort keyed on "server has avatar_url" would never help here, because the URL *is* non-null — it just can't render client-side. This PR fixes the actual client-renderability problem.

### Live verification (headless chromium, this session)
- External `assets.petdex.dev/.../sprite.webp` in-browser: **`net::ERR_BLOCKED_BY_ORB`**, `naturalWidth = 0` (curl of the same URL: `200 image/webp`).
- Same-origin proxy of the *very same* sprite (`/api/petdx/community/<slug>/sprite.webp`, served by this PR's route, run locally): **loads, `naturalWidth = 1536`**, zero request failures.
- Manifest census: **3321 / 3321** companions on the ORB-blocked external CDN.

## Fix (Approach ② — external CDN, so proxy same-origin)

- **`petdex-route.js`** — `GET /api/petdx/community/:slug/sprite.webp` streams the upstream bytes back same-origin (`image/webp`, 1-day cache). SSRF-guarded: host + `/pets/<slug>/sprite.webp` are hard-coded literals; only a charset-validated slug is interpolated. Verified: valid slug → `200 image/webp`; bad slug → `404`.
- **`petdex-bridge.js`** — `rewriteCommunitySpriteUrl` / `rewriteDescriptorSpriteUrl` rewrite the external sprite URL to the proxy path; no-op for already-proxied / R2 / null / other hosts.
- **`companion-api.js`** — `rowToCompanionCard` / `rowToCompanionDetail` route `asset_url` / `avatar_url` / `descriptor.asset.url` through the proxy and surface `descriptor.kind`.
- **`petdx-renderer.js`** — `fallbackEmojiForKind` / `resolveCompanionKind` so a genuine load failure draws 🐾/🧑/🎯 by kind instead of always 🦞.
- **`petdx-browser.html`** — carries `kind`+`category` into the synthetic descriptor, and under 熱門/最新 **stably demotes cards whose sprite fails to load** below ones that render (real `Image` probe + stable secondary sort; primary order preserved; rating/favorites untouched).

## Tests
`petdx-community-sprite-proxy.test.js` (16) + `community-plaza-avatar-petdx.test.js` pass; **all 244 petdx/companion tests green**.

## Owner note
This supersedes the stale **PR #3817** (same change, rebased onto current `main`). If #3817 is preferred, close this one — but #3817 needs a 39-commit rebase either way. Approach ② (proxy, don't reconfigure the CDN) was the owner-decided direction recorded in the original card; no new infra decision is required to merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
