### PR TITLE
feat(action-requests): GET /pending-count for home-screen widget / icon badge

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -9,10 +9,11 @@
  * is pushed back to the emitting agent so it can unblock and continue.
  *
  * Endpoints:
- *   POST   /            — emit a request        (agent action → botSecret+entityId, or deviceSecret+fromEntityId)
- *   GET    /            — list requests          (deviceSecret OR botSecret; default status=pending)
- *   POST   /:id/resolve — answer a request       (user action → deviceSecret, or botSecret)
- *   POST   /:id/dismiss — drop a request         (user action → deviceSecret, or botSecret)
+ *   POST   /              — emit a request        (agent action → botSecret+entityId, or deviceSecret+fromEntityId)
+ *   GET    /              — list requests          (deviceSecret OR botSecret; default status=pending)
+ *   GET    /pending-count — cheap unresolved COUNT (deviceSecret OR botSecret; for the home-screen widget / icon badge)
+ *   POST   /:id/resolve   — answer a request       (user action → deviceSecret, or botSecret)
+ *   POST   /:id/dismiss   — drop a request         (user action → deviceSecret, or botSecret)
  *
  * `anchorMessageId` pins the originating chat message (a chat_messages UUID,
  * surfaced in chat as his_<uuid>) so the inbox item routes back to that
@@ -1308,6 +1309,41 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
             return res.json({ success: true, requests: result.rows.map(rowToApi) });
         } catch (err) {
             console.error('[AgentActionRequests] GET failed:', err.message);
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    // ════════════════════════════════════════
+    // GET /pending-count — cheap unresolved-count for the home-screen widget / icon badge
+    // ──────────────────────────────────────────────────────────────────────
+    // The App's home-screen widget / launcher icon polls this to know whether to
+    // light the 需要你 badge (only when count > 0). "Unresolved" == status =
+    // 'pending' (the same predicate GET / uses for its default list, and the same
+    // rows the guarded resolve/dismiss UPDATEs move off pending) — a resolved or
+    // dismissed request has status != 'pending' and is NOT counted. Kept to a
+    // single COUNT(*) so a widget can poll it frequently without cost.
+    //
+    // Auth is IDENTICAL to GET / (authenticate): deviceSecret (owner) OR
+    // botSecret + entityId (bound bot). Device-scoped — counts the whole device
+    // inbox regardless of which entity emitted the requests (the badge is a
+    // device-level "you have owner decisions waiting" signal).
+    //   → { success: true, count: <int>, deviceId }
+    // ════════════════════════════════════════
+    router.get('/pending-count', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        try {
+            const result = await pool.query(
+                `SELECT COUNT(*)::int AS count
+                   FROM agent_action_requests
+                  WHERE device_id = $1 AND status = 'pending'`,
+                [deviceId]
+            );
+            const count = (result.rows[0] && result.rows[0].count) || 0;
+            return res.json({ success: true, count, deviceId });
+        } catch (err) {
+            console.error('[AgentActionRequests] pending-count failed:', err.message);
             return res.status(500).json({ success: false, error: 'Internal error' });
         }
     });

--- a/backend/tests/jest/action-request-pending-count.test.js
+++ b/backend/tests/jest/action-request-pending-count.test.js
@@ -1,0 +1,231 @@
+/**
+ * 需要你 inbox — GET /api/action-requests/pending-count.
+ *
+ * The App's home-screen widget / launcher icon polls this endpoint to know how
+ * many 需要你 (owner action-request inbox) items are currently UNRESOLVED for a
+ * device, so the badge/widget lights up only when count > 0. It is a single
+ * COUNT(*) over agent_action_requests WHERE device_id = $1 AND status = 'pending'
+ * — the SAME "unresolved" predicate the default list (GET /) uses and the same
+ * rows the guarded resolve/dismiss UPDATEs move off pending.
+ *
+ * These tests drive the REAL router (mounted via supertest) against a small
+ * STATEFUL in-memory pg mock that models the count query + the guarded
+ * pending-only resolve/dismiss UPDATEs, so the transitions are real: a resolved
+ * or dismissed request actually stops being counted. Auth is exercised too — it
+ * is identical to GET / (deviceSecret owner OR botSecret+entityId bound bot).
+ *
+ * FAIL-ON-OLD: the /pending-count route does not exist on origin/main, so every
+ * count assertion below returns 404 on old code and the expected integer on new.
+ */
+'use strict';
+
+// ── Stateful in-memory pg mock ──
+// Rows keyed by id. The count query and the guarded pending-only UPDATEs are the
+// only shapes these tests exercise; parse just enough of each to mutate/return.
+const store = new Map();
+
+const mockQuery = jest.fn(async (sql, params = []) => {
+    const text = String(sql);
+
+    // COUNT(*) of pending rows for a device — the endpoint under test.
+    if (/SELECT COUNT\(\*\)/i.test(text) && /FROM agent_action_requests/i.test(text)) {
+        const deviceId = params[0];
+        const count = [...store.values()].filter(
+            (r) => r.device_id === deviceId && r.status === 'pending'
+        ).length;
+        return { rows: [{ count }], rowCount: 1 };
+    }
+
+    // Guarded pending-only resolve (params: [answerJson, requestId, deviceId]).
+    if (/UPDATE agent_action_requests/i.test(text) && /status = 'resolved'/i.test(text)) {
+        const requestId = params[1];
+        const deviceId = params[2];
+        const row = store.get(requestId);
+        if (row && row.device_id === deviceId && row.status === 'pending') {
+            row.status = 'resolved';
+            row.resolved_at = new Date();
+            row.answer = JSON.parse(params[0]);
+            return { rows: [{ ...row }], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 0 };
+    }
+
+    // Guarded pending-only dismiss (params: [requestId, deviceId, ...]).
+    if (/UPDATE agent_action_requests/i.test(text) && /status = 'dismissed'/i.test(text)) {
+        const requestId = params[0];
+        const deviceId = params[1];
+        const row = store.get(requestId);
+        if (row && row.device_id === deviceId && row.status === 'pending') {
+            row.status = 'dismissed';
+            row.resolved_at = new Date();
+            return { rows: [{ ...row }], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 0 };
+    }
+
+    return { rows: [], rowCount: 0 };
+});
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockQuery,
+        connect: jest.fn().mockResolvedValue({ query: mockQuery, release: jest.fn() }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const express = require('express');
+const request = require('supertest');
+
+const deviceId = 'pending-count-dev';
+const otherDeviceId = 'other-dev';
+const deviceSecret = 'dev-secret';
+const botSecret = 'bot-2-secret';
+const entityId = 2;
+
+const device = {
+    deviceSecret,
+    entities: { [entityId]: { isBound: true, botSecret } },
+};
+
+let app;
+
+function uuid(n) {
+    const h = String(n).padStart(12, '0');
+    return `00000000-0000-4000-8000-${h}`;
+}
+
+// Seed a row directly into the store (bypassing the emit route — we only test
+// the count + resolve/dismiss transitions here).
+function seed(id, over = {}) {
+    store.set(id, {
+        id,
+        device_id: deviceId,
+        from_entity_id: entityId,
+        anchor_message_id: null,
+        type: 'decision',
+        prompt: 'decide X',
+        options: null,
+        status: 'pending',
+        answer: null,
+        related_card_id: null,
+        decision_context: null,
+        created_at: new Date(),
+        resolved_at: null,
+        consensus_triggered_at: null,
+        ...over,
+    });
+}
+
+beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    const mod = require('../../agent-action-requests')(
+        { [deviceId]: device, [otherDeviceId]: { deviceSecret: 'x', entities: {} } },
+        { serverLog: () => {} }
+    );
+    app.use('/api/action-requests', mod.router);
+});
+
+beforeEach(() => {
+    store.clear();
+    mockQuery.mockClear();
+});
+
+const get = (p) => request(app).get(p);
+
+describe('GET /api/action-requests/pending-count', () => {
+    it('counts pending items for the device (owner deviceSecret auth)', async () => {
+        seed(uuid(1));
+        seed(uuid(2));
+        seed(uuid(3));
+        const res = await get('/api/action-requests/pending-count')
+            .query({ deviceId, deviceSecret });
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ success: true, count: 3, deviceId });
+    });
+
+    it('EXCLUDES resolved and dismissed items from the count', async () => {
+        seed(uuid(1)); // pending
+        seed(uuid(2), { status: 'resolved', resolved_at: new Date() });
+        seed(uuid(3), { status: 'dismissed', resolved_at: new Date() });
+        seed(uuid(4)); // pending
+        const res = await get('/api/action-requests/pending-count')
+            .query({ deviceId, deviceSecret });
+        expect(res.status).toBe(200);
+        expect(res.body.count).toBe(2); // only the two pending rows
+    });
+
+    it('returns 0 when there are no pending items', async () => {
+        // no rows seeded at all
+        const res0 = await get('/api/action-requests/pending-count')
+            .query({ deviceId, deviceSecret });
+        expect(res0.status).toBe(200);
+        expect(res0.body).toEqual({ success: true, count: 0, deviceId });
+
+        // and 0 again when every row is already resolved/dismissed
+        seed(uuid(1), { status: 'resolved', resolved_at: new Date() });
+        seed(uuid(2), { status: 'dismissed', resolved_at: new Date() });
+        const res = await get('/api/action-requests/pending-count')
+            .query({ deviceId, deviceSecret });
+        expect(res.status).toBe(200);
+        expect(res.body.count).toBe(0);
+    });
+
+    it('the count drops as items are resolved / dismissed (real transitions)', async () => {
+        seed(uuid(1));
+        seed(uuid(2));
+        seed(uuid(3));
+
+        // start: 3 pending
+        let res = await get('/api/action-requests/pending-count').query({ deviceId, deviceSecret });
+        expect(res.body.count).toBe(3);
+
+        // resolve one → 2
+        const r1 = await request(app)
+            .post(`/api/action-requests/${uuid(1)}/resolve`)
+            .send({ deviceId, deviceSecret, answer: 'ok' });
+        expect(r1.status).toBe(200);
+        res = await get('/api/action-requests/pending-count').query({ deviceId, deviceSecret });
+        expect(res.body.count).toBe(2);
+
+        // dismiss one → 1
+        const r2 = await request(app)
+            .post(`/api/action-requests/${uuid(2)}/dismiss`)
+            .send({ deviceId, deviceSecret });
+        expect(r2.status).toBe(200);
+        res = await get('/api/action-requests/pending-count').query({ deviceId, deviceSecret });
+        expect(res.body.count).toBe(1);
+    });
+
+    it('is device-scoped — never counts another device\'s pending items', async () => {
+        seed(uuid(1)); // belongs to `deviceId`
+        seed(uuid(2), { device_id: otherDeviceId }); // another device's pending item
+        const res = await get('/api/action-requests/pending-count')
+            .query({ deviceId, deviceSecret });
+        expect(res.body.count).toBe(1);
+    });
+
+    it('works with botSecret + entityId auth (same as GET /)', async () => {
+        seed(uuid(1));
+        seed(uuid(2));
+        const res = await get('/api/action-requests/pending-count')
+            .query({ deviceId, botSecret, entityId });
+        expect(res.status).toBe(200);
+        expect(res.body.count).toBe(2);
+    });
+
+    it('rejects bad credentials (401) and missing creds (400) — no count leaked', async () => {
+        seed(uuid(1));
+        const bad = await get('/api/action-requests/pending-count')
+            .query({ deviceId, deviceSecret: 'wrong' });
+        expect(bad.status).toBe(401);
+        expect(bad.body.success).toBe(false);
+        expect(bad.body.count).toBeUndefined();
+
+        const missing = await get('/api/action-requests/pending-count')
+            .query({ deviceId });
+        expect(missing.status).toBe(400);
+        expect(missing.body.success).toBe(false);
+    });
+});


### PR DESCRIPTION
## What

Adds a lightweight backend data source for the 需要你 (owner action-request inbox) **home-screen widget / icon badge** feature (kanban card `card_93ef80e21b1e6d63ea63f3da`). This is the **backend data source only** — the widget/app is separate work.

`GET /api/action-requests/pending-count` — the App's home-screen widget / launcher icon polls this to know how many 需要你 items are currently **UNRESOLVED** for a device, so the badge lights up only when `count > 0`.

## Endpoint

- **Route:** `GET /api/action-requests/pending-count` (mounted alongside the existing action-request routes, placed before the `/:id/*` routes so it is never shadowed).
- **Auth:** IDENTICAL to the existing list endpoint `GET /` — `authenticate(req, res)`: either `deviceSecret` (owner) **or** `botSecret` + `entityId` (bound bot). Device-scoped.
- **Query:** a single cheap `COUNT(*)` —
  ```sql
  SELECT COUNT(*)::int AS count
    FROM agent_action_requests
   WHERE device_id = $1 AND status = 'pending'
  ```
  `status = 'pending'` is the same "unresolved" predicate the default `GET /` list uses and the same rows the guarded resolve/dismiss `UPDATE`s move off pending. Resolved / dismissed rows have `status != 'pending'` and are excluded.
- **Response:** `{ success: true, count: <int>, deviceId }`

## Test

`backend/tests/jest/action-request-pending-count.test.js` (mirrors the `action-request-cross-target` harness: supertest + a stateful in-memory `pg` mock driving the **real** router):

- pending items are counted
- resolved / dismissed items are **excluded**
- `count` is `0` when there are none
- count **drops** as items are resolved/dismissed (real state transitions)
- device-scoped — never counts another device's items
- works with **both** auth modes (`deviceSecret` and `botSecret`+`entityId`)
- bad creds → 401, missing creds → 400 (no count leaked)

7/7 pass; the suite FAILS on `origin/main` (route absent) and PASSES here (fail-on-old verified). Sibling suites (`action-request-cross-target`, `action-request-e2e-flow`) stay green.

## Live verification

The new route is not deployed yet (only merged code runs on prod) — `GET /pending-count` returns 404 on prod as expected. Cross-checked auth + live data via the existing `GET /api/action-requests?...&status=pending` endpoint with the same creds: HTTP 200, `success:true`, **0 pending items** for the standard device right now — so once deployed `pending-count` returns `count: 0` for that device, matching the "0 when none" path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)