### PR TITLE
fix(kanban): PUT /card/:id tolerates snake_case aliases + warns on unknown fields (footgun #1)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -2109,6 +2109,74 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
     router.put('/card/:id', async (req, res) => {
         if (!authenticate(req, res)) return;
         const _p = { ...req.query, ...req.body }; console.log('[Kanban] PUT /card/:id called', { deviceId: _p.deviceId, entityId: _p.entityId, cardId: req.params?.id });
+
+        // ── footgun #1 (card_c17d3c7bb6e789389edf58f4): snake_case tolerance +
+        // unknown-field warning. This handler destructures a FIXED set of
+        // camelCase config keys below; a caller sending the snake_case spelling
+        // (e.g. `requires_screenshot_review`) — the exact form used in the DB and
+        // in serializeCard output — used to be SILENTLY dropped (no error, no-op,
+        // caller believes it worked). We now:
+        //   1. Alias each known snake_case spelling onto its camelCase key,
+        //      applied ONLY when the camelCase key is absent so an explicit
+        //      camelCase value still wins.
+        //   2. Collect any leftover keys that are neither a known field, a known
+        //      alias, nor an auth passthrough, and surface them as a non-fatal
+        //      `warnings[]` in the response (NEVER 400 — stays backward-compatible;
+        //      it only ADDS a warnings array so a typo is visible not swallowed).
+        // The alias map + KNOWN_FIELDS set below are derived from the fields this
+        // handler ACTUALLY destructures/updates — keep them in sync if the
+        // destructure list changes.
+        const KNOWN_CONFIG_FIELDS = [
+            'title', 'description', 'priority', 'assignedBots', 'reviewerEntityId',
+            'requiresScreenshotReview', 'requiresInteractionReview', 'requiresPreflightReview',
+            'dispatchMode', 'requiresPrRework', 'reworkPrNumber',
+            'linkedPrevCardId', 'linkedNextCardId',
+        ];
+        // snake_case → camelCase for every config field this handler processes.
+        const SNAKE_ALIASES = {
+            requires_screenshot_review: 'requiresScreenshotReview',
+            requires_interaction_review: 'requiresInteractionReview',
+            requires_preflight_review: 'requiresPreflightReview',
+            requires_pr_rework: 'requiresPrRework',
+            rework_pr_number: 'reworkPrNumber',
+            dispatch_mode: 'dispatchMode',
+            reviewer_entity_id: 'reviewerEntityId',
+            assigned_bots: 'assignedBots',
+            linked_prev_card_id: 'linkedPrevCardId',
+            linked_next_card_id: 'linkedNextCardId',
+            // title/description/priority have no snake variant.
+        };
+        // Auth / routing keys that are legitimately present in the body but are
+        // not card-config fields — never warn on these.
+        const AUTH_PASSTHROUGH = new Set(['deviceId', 'deviceSecret', 'botSecret', 'entityId']);
+
+        const warnings = [];
+        if (req.body && typeof req.body === 'object') {
+            // 1. Fold snake_case aliases in (camelCase wins if both present).
+            for (const [snake, camel] of Object.entries(SNAKE_ALIASES)) {
+                if (Object.prototype.hasOwnProperty.call(req.body, snake) &&
+                    req.body[camel] === undefined) {
+                    req.body[camel] = req.body[snake];
+                }
+            }
+            // 2. Warn on truly-unknown keys (not a known field, alias, or auth key).
+            const known = new Set(KNOWN_CONFIG_FIELDS);
+            for (const key of Object.keys(req.body)) {
+                if (known.has(key) || AUTH_PASSTHROUGH.has(key) ||
+                    Object.prototype.hasOwnProperty.call(SNAKE_ALIASES, key)) {
+                    continue;
+                }
+                // Suggest the closest camelCase config field if the typo looks
+                // like a snake_case attempt at one of ours.
+                const guess = KNOWN_CONFIG_FIELDS.find(
+                    f => f.toLowerCase() === String(key).replace(/_/g, '').toLowerCase()
+                );
+                warnings.push(
+                    `Unknown field '${key}' ignored${guess ? ` — did you mean '${guess}'?` : ''}`
+                );
+            }
+        }
+
         const { deviceId, title, description, priority, assignedBots, reviewerEntityId, requiresScreenshotReview, requiresInteractionReview, requiresPreflightReview, dispatchMode, requiresPrRework, reworkPrNumber, linkedPrevCardId, linkedNextCardId } = req.body;
         const cardId = req.params.id;
 
@@ -2232,7 +2300,12 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             }
 
             if (updates.length === 0) {
-                return res.status(400).json({ success: false, error: 'Nothing to update' });
+                // Surface any unknown-field warnings here too, so a caller whose
+                // ONLY body key was a typo (nothing valid to update) still sees
+                // WHY nothing happened instead of a bare "Nothing to update".
+                const nothing = { success: false, error: 'Nothing to update' };
+                if (warnings.length > 0) nothing.warnings = warnings;
+                return res.status(400).json(nothing);
             }
 
             updates.push(`updated_at = NOW()`);
@@ -2356,7 +2429,9 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 }
             }
 
-            res.json({ success: true, card: serializeCard(result.rows[0]) });
+            const okResponse = { success: true, card: serializeCard(result.rows[0]) };
+            if (warnings.length > 0) okResponse.warnings = warnings;
+            res.json(okResponse);
         } catch (err) {
             console.error('[Kanban] Update card error:', err);
             res.status(err.status || 500).json({ success: false, error: err.message });

--- a/backend/tests/jest/kanban-put-snake-alias-warn.test.js
+++ b/backend/tests/jest/kanban-put-snake-alias-warn.test.js
@@ -1,0 +1,240 @@
+'use strict';
+
+/**
+ * footgun #1 — card_c17d3c7bb6e789389edf58f4
+ *
+ * PUT /api/mission/card/:id destructures a FIXED set of camelCase config keys.
+ * A caller sending the snake_case spelling (e.g. `requires_screenshot_review`,
+ * the exact form used in the DB column and in serializeCard output) used to be
+ * SILENTLY dropped — no error, a no-op UPDATE, and the caller believed it
+ * worked. This actually bit us: a `requires_screenshot_review` PUT silently
+ * failed and the flag never got set.
+ *
+ * The fix (backend/kanban.js, top of the PUT handler):
+ *   1. Alias each known snake_case key onto its camelCase key, applied ONLY when
+ *      the camelCase key is absent (explicit camelCase always wins).
+ *   2. Collect leftover keys that are neither a known config field, a known
+ *      alias, nor an auth passthrough, and return them as a non-fatal
+ *      `warnings[]` in the JSON response. Never 400 — backward-compatible.
+ *
+ * This suite drives the REAL router (supertest) over a mocked pg pool and
+ * asserts on the SQL/params the handler builds for the UPDATE (proving the flag
+ * is actually set), plus the response `warnings` contract. Harness mirrors
+ * kanban-notify-on-assign-comment.test.js.
+ */
+
+const mockQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockQuery,
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../safe-equal', () => (a, b) => a === b);
+
+const express = require('express');
+const request = require('supertest');
+
+let app;
+
+const mockDevices = {
+    'test-dev': {
+        deviceSecret: 'test-secret',
+        entities: {
+            0: { isBound: true, bindingType: 'channel', channelAccountId: 'acct0', botSecret: 'sec0', publicCode: 'aaaaaa', name: 'Bot0', character: 'Bot0' },
+            1: { isBound: true, bindingType: 'channel', channelAccountId: 'acct1', botSecret: 'sec1', publicCode: 'bbbbbb', name: 'Bot1', character: 'Bot1' },
+        },
+    },
+};
+
+beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    const kanbanModule = require('../../kanban')(mockDevices, {
+        pushToChannelCallback: jest.fn().mockResolvedValue({ pushed: true }),
+    });
+    app.use('/api/mission', kanbanModule.router);
+});
+
+beforeEach(() => {
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+const put = (p) => request(app).put(p);
+const AUTH = { deviceId: 'test-dev', deviceSecret: 'test-secret' };
+
+function cardRow(overrides = {}) {
+    return {
+        id: 'card_x', device_id: 'test-dev', title: 'My task',
+        description: 'do the thing', priority: 'P2', status: 'todo',
+        assigned_bots: [0], created_by: 0,
+        created_at: new Date(), updated_at: new Date(),
+        status_changed_at: new Date(), archived: false,
+        requires_screenshot_review: false,
+        ...overrides,
+    };
+}
+
+// Standard mock sequence for a PUT that reaches the UPDATE:
+//   existing SELECT * → UPDATE ... RETURNING * → bumpVersion → (getDeviceLanguage etc.)
+function primeUpdate(returned = cardRow()) {
+    mockQuery
+        .mockResolvedValueOnce({ rows: [cardRow()] })      // existing SELECT *
+        .mockResolvedValueOnce({ rows: [returned] })       // UPDATE RETURNING *
+        .mockResolvedValueOnce({ rows: [] });              // bumpVersion
+}
+
+// Find the UPDATE kanban_cards ... RETURNING call and return { sql, params }.
+function capturedUpdate() {
+    const call = mockQuery.mock.calls.find(
+        ([sql]) => typeof sql === 'string' && /UPDATE kanban_cards SET[\s\S]*RETURNING/.test(sql)
+    );
+    return call ? { sql: call[0], params: call[1] } : null;
+}
+
+// ════════════════════════════════════════════════════════════════
+// (a) snake_case field now ACTUALLY sets the flag (was silently ignored)
+// ════════════════════════════════════════════════════════════════
+describe('(a) snake_case alias sets the flag', () => {
+    it('requires_screenshot_review:true builds the requires_screenshot_review = TRUE update', async () => {
+        primeUpdate();
+
+        const res = await put('/api/mission/card/card_x')
+            .send({ ...AUTH, requires_screenshot_review: true });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        // No warnings — a known snake alias is not "unknown".
+        expect(res.body.warnings).toBeUndefined();
+
+        const upd = capturedUpdate();
+        expect(upd).toBeTruthy();
+        // The column is in the SET clause (previously this PUT was a no-op:
+        // updates would have been empty → "Nothing to update" 400).
+        expect(upd.sql).toMatch(/requires_screenshot_review = \$\d+/);
+        // and the coerced boolean value is present in params.
+        expect(upd.params).toContain(true);
+    });
+
+    it('other snake aliases (dispatch_mode / requires_preflight_review) also map through', async () => {
+        primeUpdate();
+
+        const res = await put('/api/mission/card/card_x')
+            .send({ ...AUTH, dispatch_mode: 'idle_only', requires_preflight_review: true });
+
+        expect(res.status).toBe(200);
+        expect(res.body.warnings).toBeUndefined();
+        const upd = capturedUpdate();
+        expect(upd.sql).toMatch(/dispatch_mode = \$\d+/);
+        expect(upd.sql).toMatch(/requires_preflight_review = \$\d+/);
+        expect(upd.params).toContain('idle_only');
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// (b) camelCase still works and WINS over a conflicting snake alias
+// ════════════════════════════════════════════════════════════════
+describe('(b) camelCase wins over conflicting snake alias', () => {
+    it('camelCase-only still updates', async () => {
+        primeUpdate();
+        const res = await put('/api/mission/card/card_x')
+            .send({ ...AUTH, requiresScreenshotReview: true });
+
+        expect(res.status).toBe(200);
+        expect(res.body.warnings).toBeUndefined();
+        const upd = capturedUpdate();
+        expect(upd.sql).toMatch(/requires_screenshot_review = \$\d+/);
+        expect(upd.params).toContain(true);
+    });
+
+    it('when BOTH are sent, the explicit camelCase value wins', async () => {
+        primeUpdate();
+        // camelCase=false must beat snake=true.
+        const res = await put('/api/mission/card/card_x')
+            .send({ ...AUTH, requiresScreenshotReview: false, requires_screenshot_review: true });
+
+        expect(res.status).toBe(200);
+        // requires_screenshot_review is a KNOWN alias key → no "unknown" warning.
+        expect(res.body.warnings).toBeUndefined();
+        const upd = capturedUpdate();
+        expect(upd.sql).toMatch(/requires_screenshot_review = \$\d+/);
+        // The coerced value pushed must be false (camelCase), not true (snake).
+        expect(upd.params).toContain(false);
+        expect(upd.params).not.toContain(true);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// (c) unknown field → warnings entry, does NOT error
+// ════════════════════════════════════════════════════════════════
+describe('(c) unknown field yields a warning, not an error', () => {
+    it('totally_bogus alongside a valid field → 200 + warnings, update still applies', async () => {
+        primeUpdate();
+        const res = await put('/api/mission/card/card_x')
+            .send({ ...AUTH, title: 'Renamed', totally_bogus: 1 });
+
+        expect(res.status).toBe(200);          // NOT a 400
+        expect(res.body.success).toBe(true);
+        expect(Array.isArray(res.body.warnings)).toBe(true);
+        expect(res.body.warnings.some(w => /totally_bogus/.test(w))).toBe(true);
+        expect(res.body.warnings[0]).toMatch(/Unknown field 'totally_bogus' ignored/);
+        // The valid field still went through.
+        const upd = capturedUpdate();
+        expect(upd.sql).toMatch(/title = \$\d+/);
+    });
+
+    it('a near-miss snake typo of a real field gets a "did you mean" suggestion', async () => {
+        primeUpdate();
+        // requires_screenshotreview (missing underscore) is NOT a registered
+        // alias but normalizes to requiresscreenshotreview → suggests the field.
+        const res = await put('/api/mission/card/card_x')
+            .send({ ...AUTH, title: 'x', requires_screenshotreview: true });
+
+        expect(res.status).toBe(200);
+        expect(res.body.warnings.some(w => /requiresScreenshotReview/.test(w))).toBe(true);
+    });
+
+    it('unknown field with NOTHING valid to update → 400 but warning is surfaced (not swallowed)', async () => {
+        // existing SELECT * only; never reaches UPDATE.
+        mockQuery.mockResolvedValueOnce({ rows: [cardRow()] });
+        const res = await put('/api/mission/card/card_x')
+            .send({ ...AUTH, totally_bogus: 1 });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('Nothing to update');
+        expect(res.body.warnings.some(w => /totally_bogus/.test(w))).toBe(true);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// (d) a normal valid PUT still succeeds with NO warnings
+// ════════════════════════════════════════════════════════════════
+describe('(d) normal valid PUT — no warnings', () => {
+    it('title update succeeds with no warnings array', async () => {
+        primeUpdate();
+        const res = await put('/api/mission/card/card_x')
+            .send({ ...AUTH, title: 'Just a rename' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.warnings).toBeUndefined();
+        const upd = capturedUpdate();
+        expect(upd.sql).toMatch(/title = \$\d+/);
+    });
+
+    it('auth passthrough keys (entityId/botSecret) never trigger warnings', async () => {
+        primeUpdate();
+        const res = await put('/api/mission/card/card_x')
+            .send({ deviceId: 'test-dev', deviceSecret: 'test-secret', entityId: 0, botSecret: 'sec0', title: 'ok' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.warnings).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Footgun #1 — card_c17d3c7bb6e789389edf58f4

### The bug
`PUT /api/mission/card/:id` (`backend/kanban.js`, the card-config PUT handler) destructures a **fixed set of camelCase** config keys. If a caller sends the **snake_case** spelling — e.g. `requires_screenshot_review`, which is the exact form used in the DB column and in `serializeCard()` output — it was **silently dropped**: no error, the UPDATE was a no-op, and the caller believed it worked. This bit us today: a `requires_screenshot_review` PUT silently failed and a flag never got set.

### The fix (backend/kanban.js, top of the PUT handler)
Both derived from the fields the handler **actually** destructures/updates:

1. **snake_case aliases** — each known snake key is folded onto its camelCase key, applied **only when the camelCase key is absent** so an explicit camelCase value still wins:

   | snake_case | → camelCase |
   |---|---|
   | `requires_screenshot_review` | `requiresScreenshotReview` |
   | `requires_interaction_review` | `requiresInteractionReview` |
   | `requires_preflight_review` | `requiresPreflightReview` |
   | `requires_pr_rework` | `requiresPrRework` |
   | `rework_pr_number` | `reworkPrNumber` |
   | `dispatch_mode` | `dispatchMode` |
   | `reviewer_entity_id` | `reviewerEntityId` |
   | `assigned_bots` | `assignedBots` |
   | `linked_prev_card_id` | `linkedPrevCardId` |
   | `linked_next_card_id` | `linkedNextCardId` |

   (`title`/`description`/`priority` have no snake variant. There is no real `requires_pr_link`/`requiresPrLink` *update* field in this handler — `requirePrLink` is read-only in `serializeCard`, so it's intentionally not in the map.)

2. **Unknown-field warnings** — any body key that is neither a known config field, a known alias, nor an auth passthrough (`deviceId`/`deviceSecret`/`botSecret`/`entityId`) is surfaced as a **non-fatal** `warnings: ["Unknown field 'X' ignored — did you mean 'Y'?"]` array in the JSON response (with a "did you mean" suggestion for near-miss typos). **Never 400** — fully backward-compatible; it only ADDS the array so a typo is visible instead of swallowed. Also surfaced on the existing `Nothing to update` 400 path so a caller whose only key was a typo learns why nothing happened.

No change to the update logic itself beyond alias normalization + the warnings array.

### Test
`backend/tests/jest/kanban-put-snake-alias-warn.test.js` (9 cases, green) drives the **real router** via supertest over a mocked pg pool (mirrors `kanban-notify-on-assign-comment.test.js`), asserting on the SQL/params the handler builds:
- (a) `requires_screenshot_review:true` now actually builds the `requires_screenshot_review = $n` column update (previously a no-op → `Nothing to update`);
- (b) camelCase still works **and wins** over a conflicting snake alias;
- (c) `totally_bogus:1` yields a `warnings` entry and does **not** error (200), plus a "did you mean" case and the nothing-to-update-with-warning case;
- (d) a clean valid PUT succeeds with **no** `warnings`, and auth passthrough keys never warn.

Related existing kanban suites (`kanban-notify-on-assign-comment`, `kanban-card`, `kanban-dispatch-mode-ux`) still green — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)