### PR TITLE
feat(entity): self-sovereign wallpaper walk-config API (weights + negative-action opt-in)

### DIFF
--- a/backend/entity-walk-config.js
+++ b/backend/entity-walk-config.js
@@ -1,0 +1,134 @@
+// ============================================
+// Entity Walk Config Module (card_31f828967b38f61b2043c808)
+// Per-entity self-configured wallpaper "walking / idle stop-action" behavior.
+//
+// Each entity picks WEIGHTS for its neutral stop-actions and may opt IN to
+// NEGATIVE actions (fail/sad/sick/angry). The App reads every bound entity's
+// config to drive the live-wallpaper animation; when it picks a stop-action it
+// MUST exclude negative actions for entities that did not opt in.
+//
+// Storage mirrors entity-cross-device-settings.js exactly: one JSONB row keyed
+// by (device_id, entity_id). Auth for the WRITE path is self-sovereign — an
+// entity may only configure ITSELF, proven by botSecret ownership (the same
+// gate as GET /api/device-vars/value, card_keyref). See index.js endpoints.
+// ============================================
+
+// Canonical negative-action list. The App AND this backend agree on which
+// stop-actions count as "negative"; an entity that has not opted in never
+// performs any of these on the wallpaper. Keep in sync with the App renderer.
+const NEGATIVE_ACTIONS = ['fail', 'sad', 'sick', 'angry'];
+
+// Neutral stop-actions the App can pick from when no explicit weights are set.
+// Missing weights → these are treated as equal weight (fail-safe default).
+const NEUTRAL_ACTIONS = ['idle', 'walk', 'sit', 'look', 'sleep', 'eat'];
+
+// Fail-safe defaults: negative actions are NOT performed unless the entity
+// explicitly opts in (allowNegative:false), and neutral actions are all equal.
+const DEFAULTS = Object.freeze({
+    weights: {},          // {} → App treats neutral actions as equal weight
+    allowNegative: false, // opt-in required before any negative action fires
+});
+
+// Clamp weights so a single value can't be gamed into an integer overflow or a
+// negative pull. Any non-finite / <0 value is dropped; >MAX is capped.
+const MAX_WEIGHT = 1000;
+
+let pool = null;
+
+async function initTable(chatPool) {
+    pool = chatPool;
+    if (!pool) return;
+    await pool.query(`
+        CREATE TABLE IF NOT EXISTS entity_walk_config (
+            device_id TEXT NOT NULL,
+            entity_id INT NOT NULL,
+            config JSONB DEFAULT '{}',
+            updated_at BIGINT DEFAULT EXTRACT(EPOCH FROM NOW()) * 1000,
+            PRIMARY KEY (device_id, entity_id)
+        )
+    `);
+}
+
+// Coerce/validate a caller-supplied weights object. Only keeps finite numbers
+// >= 0, capped at MAX_WEIGHT; non-object input → {} (fail-safe: equal weight).
+function sanitizeWeights(weights) {
+    if (!weights || typeof weights !== 'object' || Array.isArray(weights)) return {};
+    const clean = {};
+    for (const [action, raw] of Object.entries(weights)) {
+        const key = String(action).trim();
+        if (!key) continue;
+        const n = Number(raw);
+        if (!Number.isFinite(n) || n < 0) continue; // drop invalid / negative
+        clean[key] = Math.min(n, MAX_WEIGHT);
+    }
+    return clean;
+}
+
+// Merge a stored row with defaults so a missing/partial row still yields a
+// complete, fail-safe config the App can consume directly.
+function mergeWithDefaults(stored) {
+    const s = (stored && typeof stored === 'object' && !Array.isArray(stored)) ? stored : {};
+    return {
+        weights: sanitizeWeights(s.weights),
+        allowNegative: s.allowNegative === true, // fail-safe: anything else → false
+    };
+}
+
+// Read ONE entity's config, always returning a complete fail-safe shape plus
+// the canonical negativeActions list (so the App/gate agree on "negative").
+async function getConfig(deviceId, entityId) {
+    let stored = null;
+    if (pool) {
+        try {
+            const result = await pool.query(
+                'SELECT config FROM entity_walk_config WHERE device_id = $1 AND entity_id = $2',
+                [deviceId, entityId]
+            );
+            if (result.rows.length > 0) {
+                stored = result.rows[0].config;
+                if (typeof stored === 'string') {
+                    try { stored = JSON.parse(stored); } catch { stored = {}; }
+                }
+            }
+        } catch (err) {
+            console.error('[WalkConfig] getConfig error:', err.message);
+        }
+    }
+    const merged = mergeWithDefaults(stored);
+    return {
+        weights: merged.weights,
+        allowNegative: merged.allowNegative,
+        negativeActions: [...NEGATIVE_ACTIONS],
+    };
+}
+
+// Write ONE entity's config. Only weights + allowNegative are persisted; both
+// are sanitized first. Replaces the row's config wholesale (a PUT sets the full
+// desired state for that entity, like cross-device-settings' updateSettings).
+async function setConfig(deviceId, entityId, { weights, allowNegative }) {
+    const cleaned = {
+        weights: sanitizeWeights(weights),
+        allowNegative: allowNegative === true,
+    };
+    if (!pool) return cleaned;
+    await pool.query(`
+        INSERT INTO entity_walk_config (device_id, entity_id, config, updated_at)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (device_id, entity_id) DO UPDATE
+        SET config = $3::jsonb,
+            updated_at = $4
+    `, [deviceId, entityId, JSON.stringify(cleaned), Date.now()]);
+    return cleaned;
+}
+
+module.exports = {
+    NEGATIVE_ACTIONS,
+    NEUTRAL_ACTIONS,
+    DEFAULTS,
+    MAX_WEIGHT,
+    initTable,
+    sanitizeWeights,
+    mergeWithDefaults,
+    getConfig,
+    setConfig,
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -30,6 +30,7 @@ const devicePrefs = require('./device-preferences');
 const entityActivity = require('./lib/entity-activity');
 const orgChartModule = require('./org-chart');
 const crossDeviceSettings = require('./entity-cross-device-settings');
+const walkConfig = require('./entity-walk-config');
 const feedbackEmail = require('./feedback-email');
 const chatEmbedding = require('./chat-embedding');
 const embeddingClient = require('./embedding-client');
@@ -13126,6 +13127,112 @@ app.delete('/api/entity/cross-device-settings', async (req, res) => {
     }
 });
 
+// ==========================================================================
+// Entity Walk Config — self-sovereign wallpaper "walking / idle stop-action"
+// weights + negative-action opt-in (card_31f828967b38f61b2043c808).
+//
+// Auth model (self-sovereign, mirrors GET /api/device-vars/value, card_keyref):
+// the WRITE path is proven by botSecret OWNERSHIP — a caller may only set the
+// config for the entity whose botSecret it presents. Cross-entity writes are
+// rejected: even a valid botSecret for entity A cannot write entity B's config.
+// The READ path uses the same botSecret-of-a-bound-entity-on-this-device gate
+// so an entity (or a peer bound on the same device) can read a config; the App
+// drives the wallpaper from these values and MUST exclude negativeActions for
+// entities whose allowNegative is false.
+//
+// Helper: resolve the entity that OWNS a botSecret on this device. Returns the
+// integer entityId, or -1 if the botSecret does not belong to any bound entity
+// (same scan as the device-vars/value handler, index.js ~23024).
+// ==========================================================================
+function resolveBotSecretEntity(device, botSecret, declaredEntityId) {
+    let eId = parseInt(declaredEntityId, 10);
+    let ent = !isNaN(eId) && device.entities && device.entities[eId];
+    if (ent && ent.isBound && safeEqual(ent.botSecret, botSecret)) {
+        return eId;
+    }
+    // Fall back to a scan so a caller that omits/mis-sends entityId is still
+    // authorized iff the botSecret genuinely belongs to a bound entity here.
+    for (const i of Object.keys(device.entities || {}).map(Number)) {
+        const e = device.entities[i];
+        if (e && e.isBound && safeEqual(e.botSecret, botSecret)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+/**
+ * GET /api/entity/walk-config?deviceId=&entityId=&botSecret=
+ * Read an entity's wallpaper walk config. Auth = botSecret of a bound entity on
+ * this device (self or a peer bound on the same device may read). Returns a
+ * complete fail-safe shape (allowNegative defaults false, weights {} = equal).
+ */
+app.get('/api/entity/walk-config', async (req, res) => {
+    const { deviceId, botSecret, entityId } = req.query;
+    if (!deviceId || !botSecret) {
+        return res.status(400).json({ success: false, error: 'deviceId and botSecret required' });
+    }
+    const device = devices[deviceId];
+    if (!device) {
+        return res.status(404).json({ success: false, error: 'Device not found' });
+    }
+    // Caller must present a botSecret that belongs to SOME bound entity here.
+    const callerEid = resolveBotSecretEntity(device, botSecret, entityId);
+    if (callerEid < 0) {
+        return res.status(403).json({ success: false, error: 'Invalid botSecret' });
+    }
+    // Which entity's config to read: the declared entityId if valid+bound,
+    // else the caller's own entity. (A peer read is allowed; only WRITES are
+    // locked to the caller's own entity.)
+    let targetEid = parseInt(entityId, 10);
+    if (isNaN(targetEid) || !device.entities || !device.entities[targetEid] || !device.entities[targetEid].isBound) {
+        targetEid = callerEid;
+    }
+    try {
+        const config = await walkConfig.getConfig(deviceId, targetEid);
+        return res.json({ success: true, entityId: targetEid, ...config });
+    } catch (err) {
+        console.error('[WalkConfig] GET error:', err.message);
+        return res.status(500).json({ success: false, error: 'Internal error' });
+    }
+});
+
+/**
+ * PUT /api/entity/walk-config { deviceId, entityId, botSecret, weights, allowNegative }
+ * An entity sets ITS OWN config. Self-sovereign auth: the presented botSecret
+ * MUST own the target entityId on this device — cross-entity writes rejected.
+ * Fail-safe: allowNegative defaults false; invalid/omitted weights → {} (equal).
+ */
+app.put('/api/entity/walk-config', async (req, res) => {
+    const { deviceId, botSecret, entityId, weights, allowNegative } = req.body || {};
+    if (!deviceId || !botSecret || entityId === undefined || entityId === null) {
+        return res.status(400).json({ success: false, error: 'deviceId, botSecret, entityId required' });
+    }
+    const device = devices[deviceId];
+    if (!device) {
+        return res.status(404).json({ success: false, error: 'Device not found' });
+    }
+    const targetEid = parseInt(entityId, 10);
+    if (isNaN(targetEid) || !device.entities || !device.entities[targetEid]) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+    // Self-sovereign gate: the botSecret must own EXACTLY this entity. Unlike
+    // the read path, no scan-fallback to another slot — an entity can only
+    // configure ITSELF (reject cross-entity writes explicitly).
+    const target = device.entities[targetEid];
+    if (!target.isBound || !safeEqual(target.botSecret, botSecret)) {
+        return res.status(403).json({ success: false, error: 'Invalid botSecret for this entity' });
+    }
+    try {
+        await walkConfig.setConfig(deviceId, targetEid, { weights, allowNegative });
+        const config = await walkConfig.getConfig(deviceId, targetEid);
+        return res.json({ success: true, entityId: targetEid, ...config });
+    } catch (err) {
+        console.error('[WalkConfig] PUT error:', err.message);
+        return res.status(500).json({ success: false, error: 'Internal error' });
+    }
+});
+
 /**
  * POST /api/entity/cross-speak
  * Cross-device entity-to-entity messaging via public code.
@@ -20960,6 +21067,7 @@ passiveHealth.startScheduler(3_600_000); // hourly tick; per-device intervalHour
 
 orgChartModule.initTable(chatPool);
 crossDeviceSettings.initTable(chatPool);
+walkConfig.initTable(chatPool);
 chatIntegrity.initIntegrityTable(chatPool);
 articlePublisher.initPublisherTable(chatPool);
 // Wire per-device vault resolver for BYO credentials (Phase 1: X/Twitter)

--- a/backend/tests/jest/entity-walk-config.test.js
+++ b/backend/tests/jest/entity-walk-config.test.js
@@ -1,0 +1,221 @@
+/**
+ * /api/entity/walk-config — self-sovereign wallpaper walk config (Jest + Supertest)
+ * card_31f828967b38f61b2043c808 (App wallpaper "entity walking", part 2).
+ *
+ * Each entity self-configures WEIGHTS for its neutral stop-actions and may opt
+ * IN to NEGATIVE actions (fail/sad/sick/angry). Auth = botSecret OWNERSHIP,
+ * mirroring GET /api/device-vars/value (card_keyref): an entity may only set
+ * ITS OWN config; a valid botSecret for entity A cannot write entity B's config.
+ *
+ * Persistence: entity-walk-config.js is pool-backed like
+ * entity-cross-device-settings.js. The shared jest pg mock returns empty rows
+ * (no state), so this suite injects a tiny in-memory pool into the module via
+ * initTable() AFTER loading index.js — the same module instance the endpoints
+ * use (require cache) — so weights/allowNegative genuinely persist round-trip.
+ */
+
+require('./helpers/mock-setup');
+const request = require('supertest');
+let app;
+const get = (path) => request(app).get(path).set('Host', 'localhost');
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+const put = (path) => request(app).put(path).set('Host', 'localhost');
+
+const walkConfig = require('../../entity-walk-config');
+
+// Minimal in-memory pool implementing only the two queries the module runs
+// (SELECT config … / INSERT … ON CONFLICT DO UPDATE). Keyed by device|entity.
+function makeMemoryPool() {
+    const store = new Map();
+    const key = (d, e) => `${d}|${e}`;
+    return {
+        _store: store,
+        async query(sql, params) {
+            const s = String(sql);
+            if (s.includes('CREATE TABLE')) return { rows: [], rowCount: 0 };
+            if (s.startsWith('SELECT')) {
+                const [deviceId, entityId] = params;
+                const row = store.get(key(deviceId, entityId));
+                return row ? { rows: [{ config: row }], rowCount: 1 } : { rows: [], rowCount: 0 };
+            }
+            if (s.includes('INSERT INTO entity_walk_config')) {
+                const [deviceId, entityId, config] = params;
+                store.set(key(deviceId, entityId), typeof config === 'string' ? JSON.parse(config) : config);
+                return { rows: [], rowCount: 1 };
+            }
+            return { rows: [], rowCount: 0 };
+        },
+    };
+}
+
+// Register + bind entity 0 on a fresh device; returns its creds.
+async function registerAndBind(deviceId) {
+    const deviceSecret = `secret-${deviceId}`;
+    const regRes = await post('/api/device/register').send({ deviceId, deviceSecret, entityId: 0 });
+    const bindRes = await post('/api/bind').send({ code: regRes.body.bindingCode });
+    return { deviceSecret, entityId: bindRes.body.entityId, botSecret: bindRes.body.botSecret };
+}
+
+// Add a SECOND entity slot to an existing device and bind it.
+async function addAndBindSecond(deviceId, deviceSecret) {
+    const addRes = await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+    const newEid = addRes.body.entityId;
+    const regRes = await post('/api/device/register').send({ deviceId, deviceSecret, entityId: newEid });
+    const bindRes = await post('/api/bind').send({ code: regRes.body.bindingCode });
+    return { entityId: bindRes.body.entityId, botSecret: bindRes.body.botSecret };
+}
+
+beforeAll(() => {
+    app = require('../../index');
+    // Inject a real (in-memory) pool so config actually persists round-trip.
+    walkConfig.initTable(makeMemoryPool());
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+});
+
+describe('PUT /api/entity/walk-config — validation', () => {
+    it('400 when deviceId/botSecret missing', async () => {
+        const res = await put('/api/entity/walk-config').send({ entityId: 0 });
+        expect(res.status).toBe(400);
+    });
+
+    it('404 for an unknown device', async () => {
+        const res = await put('/api/entity/walk-config').send({ deviceId: 'nope', botSecret: 'x', entityId: 0 });
+        expect(res.status).toBe(404);
+    });
+
+    it('400 for a non-numeric entityId', async () => {
+        const devId = `wc-badeid-${Date.now()}`;
+        const { botSecret } = await registerAndBind(devId);
+        const res = await put('/api/entity/walk-config').send({ deviceId: devId, botSecret, entityId: 'abc' });
+        expect(res.status).toBe(400);
+    });
+});
+
+describe('PUT /api/entity/walk-config — self-sovereign auth', () => {
+    it('sets config with the entity OWN botSecret', async () => {
+        const devId = `wc-self-${Date.now()}`;
+        const { botSecret, entityId } = await registerAndBind(devId);
+        const res = await put('/api/entity/walk-config').send({
+            deviceId: devId, botSecret, entityId,
+            weights: { idle: 3, walk: 1 }, allowNegative: true,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.entityId).toBe(entityId);
+        expect(res.body.weights).toEqual({ idle: 3, walk: 1 });
+        expect(res.body.allowNegative).toBe(true);
+    });
+
+    it('REJECTS a write for a DIFFERENT entity (cross-entity)', async () => {
+        const devId = `wc-cross-${Date.now()}`;
+        const first = await registerAndBind(devId);
+        const second = await addAndBindSecond(devId, first.deviceSecret);
+        // entity-1 tries to write entity-0's config using its OWN (valid) botSecret.
+        const res = await put('/api/entity/walk-config').send({
+            deviceId: devId, botSecret: second.botSecret, entityId: first.entityId,
+            weights: { walk: 9 }, allowNegative: true,
+        });
+        expect(res.status).toBe(403);
+        expect(res.body.success).toBe(false);
+        // And entity-0's config must be UNCHANGED (still fail-safe defaults).
+        const check = await get(`/api/entity/walk-config?deviceId=${devId}&botSecret=${first.botSecret}&entityId=${first.entityId}`);
+        expect(check.body.allowNegative).toBe(false);
+        expect(check.body.weights).toEqual({});
+    });
+
+    it('REJECTS a wrong/garbage botSecret', async () => {
+        const devId = `wc-wrongsecret-${Date.now()}`;
+        const { entityId } = await registerAndBind(devId);
+        const res = await put('/api/entity/walk-config').send({
+            deviceId: devId, botSecret: 'totally-wrong', entityId,
+            weights: {}, allowNegative: true,
+        });
+        expect(res.status).toBe(403);
+    });
+});
+
+describe('GET /api/entity/walk-config — defaults + persistence', () => {
+    it('returns fail-safe DEFAULTS (allowNegative=false, weights={}) when unset', async () => {
+        const devId = `wc-defaults-${Date.now()}`;
+        const { botSecret, entityId } = await registerAndBind(devId);
+        const res = await get(`/api/entity/walk-config?deviceId=${devId}&botSecret=${botSecret}&entityId=${entityId}`);
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.allowNegative).toBe(false);
+        expect(res.body.weights).toEqual({});
+        // Canonical negative-action list is echoed so the App/gate agree.
+        expect(res.body.negativeActions).toEqual(expect.arrayContaining(['fail', 'sad', 'sick', 'angry']));
+    });
+
+    it('403 without a valid botSecret', async () => {
+        const devId = `wc-get-auth-${Date.now()}`;
+        await registerAndBind(devId);
+        const res = await get(`/api/entity/walk-config?deviceId=${devId}&botSecret=nope&entityId=0`);
+        expect(res.status).toBe(403);
+    });
+
+    it('allowNegative + weights PERSIST across PUT → GET', async () => {
+        const devId = `wc-persist-${Date.now()}`;
+        const { botSecret, entityId } = await registerAndBind(devId);
+        await put('/api/entity/walk-config').send({
+            deviceId: devId, botSecret, entityId,
+            weights: { sit: 5, look: 2 }, allowNegative: true,
+        });
+        const res = await get(`/api/entity/walk-config?deviceId=${devId}&botSecret=${botSecret}&entityId=${entityId}`);
+        expect(res.status).toBe(200);
+        expect(res.body.allowNegative).toBe(true);
+        expect(res.body.weights).toEqual({ sit: 5, look: 2 });
+    });
+
+    it('a later PUT with allowNegative:false turns opt-in back OFF (fail-safe)', async () => {
+        const devId = `wc-toggle-${Date.now()}`;
+        const { botSecret, entityId } = await registerAndBind(devId);
+        await put('/api/entity/walk-config').send({ deviceId: devId, botSecret, entityId, weights: {}, allowNegative: true });
+        await put('/api/entity/walk-config').send({ deviceId: devId, botSecret, entityId, weights: {}, allowNegative: false });
+        const res = await get(`/api/entity/walk-config?deviceId=${devId}&botSecret=${botSecret}&entityId=${entityId}`);
+        expect(res.body.allowNegative).toBe(false);
+    });
+});
+
+describe('PUT /api/entity/walk-config — weight sanitization + fail-safe', () => {
+    it('drops negative / non-finite weights and caps huge ones', async () => {
+        const devId = `wc-sanitize-${Date.now()}`;
+        const { botSecret, entityId } = await registerAndBind(devId);
+        const res = await put('/api/entity/walk-config').send({
+            deviceId: devId, botSecret, entityId,
+            weights: { good: 2, neg: -5, nan: 'xyz', huge: 999999, zero: 0 },
+            allowNegative: true,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.weights.good).toBe(2);
+        expect(res.body.weights.zero).toBe(0);
+        expect(res.body.weights).not.toHaveProperty('neg');
+        expect(res.body.weights).not.toHaveProperty('nan');
+        expect(res.body.weights.huge).toBe(walkConfig.MAX_WEIGHT);
+    });
+
+    it('non-object weights → {} (equal-weight fail-safe), allowNegative missing → false', async () => {
+        const devId = `wc-noweights-${Date.now()}`;
+        const { botSecret, entityId } = await registerAndBind(devId);
+        const res = await put('/api/entity/walk-config').send({
+            deviceId: devId, botSecret, entityId, weights: 'not-an-object',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.weights).toEqual({});
+        expect(res.body.allowNegative).toBe(false);
+    });
+
+    it('allowNegative coerces truthy-but-not-true (e.g. "yes") to false (fail-safe)', async () => {
+        const devId = `wc-coerce-${Date.now()}`;
+        const { botSecret, entityId } = await registerAndBind(devId);
+        const res = await put('/api/entity/walk-config').send({
+            deviceId: devId, botSecret, entityId, weights: {}, allowNegative: 'yes',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.allowNegative).toBe(false);
+    });
+});


### PR DESCRIPTION
## What
Backend API so **each entity self-configures** how its wallpaper "walking / idle stop-action" behaves — part 2 of the App wallpaper "entity walking" feature (`card_31f828967b38f61b2043c808`).

An entity picks **weights** for its neutral stop-actions and may opt **in** to **negative** actions (fail/sad/sick/angry). The App reads every bound entity's config to drive the animation and, when picking a stop-action, **must exclude negative actions for entities that did not opt in**.

## Endpoints
| Method | Path | Auth | Returns |
|---|---|---|---|
| `GET` | `/api/entity/walk-config?deviceId=&entityId=&botSecret=` | botSecret of a bound entity on this device | `{success,entityId,weights,allowNegative,negativeActions}` |
| `PUT` | `/api/entity/walk-config {deviceId,entityId,botSecret,weights,allowNegative}` | botSecret **must own** `entityId` (self only) | the saved config |

## Self-sovereign auth
Mirrors `GET /api/device-vars/value` (`card_keyref`): the **write path is proven by botSecret OWNERSHIP** — an entity may only set **its own** config. A valid botSecret for entity A **cannot** write entity B's config → `403` (no scan-fallback on the write path; the read path uses the same bound-entity gate). Reuses `safeEqual` + `device.entities[eId].isBound && safeEqual(botSecret)`.

## Fail-safe defaults
- `allowNegative` defaults **false** — negative actions never fire unless explicitly opted in.
- Missing/invalid `weights` -> `{}` (App treats neutral actions as **equal weight**).
- Weights sanitized: drop `<0`/non-finite, cap at `MAX_WEIGHT` (1000).
- `negativeActions` is a **server constant** `[fail, sad, sick, angry]`, echoed in the GET so the App and the exclusion gate agree on which actions are "negative".

## Storage
Mirrors `entity-cross-device-settings.js`: one JSONB row per `(device_id, entity_id)` in a new `entity_walk_config` table, created idempotently at boot via `initTable` (`CREATE TABLE IF NOT EXISTS`). New module `backend/entity-walk-config.js`.

## Tests
`backend/tests/jest/entity-walk-config.test.js` — **13 green**: own-botSecret sets config; cross-entity write rejected + target left unchanged; GET returns defaults (`allowNegative=false`, `weights={}`) when unset; allowNegative + weights persist round-trip; opt-out toggles back off; weight sanitization (negative/NaN dropped, huge capped); non-object weights -> `{}`.

## Verify
`node --check` clean on both files. Live read-only probe confirmed the endpoint is not yet deployed (`404 Cannot GET`) and that the identical self-auth model already authorizes the standard mission creds on the live `/api/device-vars/value` (auth passed -> `not_found`, not `403`). No prod mutation performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)