### PR TITLE
fix(android): deep-link "task completed" push to the finished kanban card (card_92c17b66)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
+++ b/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
@@ -13,10 +13,13 @@ import com.google.firebase.messaging.RemoteMessage
 import com.hank.clawlive.ChatActivity
 import com.hank.clawlive.FeedbackHistoryActivity
 import com.hank.clawlive.MainActivity
+import com.hank.clawlive.MissionControlActivity
 import com.hank.clawlive.R
 import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.remote.NetworkModule
 import com.hank.clawlive.location.LocationHelper
+import com.hank.clawlive.ui.nav.EClawNativeNavBridge
+import org.json.JSONObject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -142,6 +145,24 @@ class ClawFcmService : FirebaseMessagingService() {
                 Intent(this, ChatActivity::class.java)
             "feedback_reply", "feedback_resolved" ->
                 Intent(this, FeedbackHistoryActivity::class.java)
+            // Task-completed pushes deep-link straight to the finished card
+            // instead of dumping the user on the home screen (card_92c17b66).
+            // The backend carries the card id in data.metadata.cardId (and,
+            // redundantly, in data.link=/portal/kanban.html?card=<id>). We hand
+            // it to MissionControlActivity as a native-nav intent extra; that
+            // Activity loads mission.html then replays the intent via
+            // window.eclawHandleNativeNavigateIntent once the WebView is ready,
+            // which opens the specific kanban card. Works on cold start
+            // (onCreate reads the extra) and warm resume (onNewIntent) because
+            // the intent also clears-top + single-top the running instance.
+            "kanban_done", "kanban_done_auto" -> {
+                val cardId = extractCardId(data)
+                Intent(this, MissionControlActivity::class.java).apply {
+                    if (cardId != null) {
+                        putExtra(EClawNativeNavBridge.EXTRA_NAV_INTENT, buildCardNavIntentJson(cardId))
+                    }
+                }
+            }
             "app_update" -> {
                 val storeUrl = data["link"]
                     ?: "https://play.google.com/store/apps/details?id=com.hank.clawlive"
@@ -149,7 +170,15 @@ class ClawFcmService : FirebaseMessagingService() {
             }
             else ->
                 Intent(this, MainActivity::class.java)
-        }.apply { flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK }
+        }.apply {
+            // CLEAR_TOP + SINGLE_TOP so a running MissionControl/Chat instance is
+            // reused and receives the deep-link extra via onNewIntent rather than
+            // being recreated (neither Activity declares a singleTop launchMode;
+            // the in-app nav bridge relies on the same per-intent flags).
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
 
         val pi = PendingIntent.getActivity(
             this, System.currentTimeMillis().toInt(), targetIntent,
@@ -168,4 +197,46 @@ class ClawFcmService : FirebaseMessagingService() {
 
         nm.notify(System.currentTimeMillis().toInt(), notif)
     }
+
+    /**
+     * Pull the kanban card id out of an FCM data payload. The backend puts it in
+     * `metadata.cardId` (JSON-encoded string) and, redundantly, in the deep-link
+     * `link=/portal/kanban.html?card=<id>`. Prefer metadata; fall back to parsing
+     * the link so a payload shape change on one side doesn't break the deep link.
+     * Returns null when neither is present (caller then just opens Mission
+     * Control without a card focus — still better than the home screen).
+     */
+    private fun extractCardId(data: Map<String, String>): String? {
+        // 1) metadata JSON → cardId
+        data["metadata"]?.let { raw ->
+            try {
+                val id = JSONObject(raw).optString("cardId", "").trim()
+                if (id.isNotEmpty()) return id
+            } catch (e: Exception) {
+                Timber.w(e, "[FCM] kanban_done metadata parse failed: $raw")
+            }
+        }
+        // 2) link → ?card=<id> (value may be url-encoded but card ids are safe chars)
+        data["link"]?.let { link ->
+            try {
+                val id = Uri.parse(link).getQueryParameter("card")?.trim()
+                if (!id.isNullOrEmpty()) return id
+            } catch (e: Exception) {
+                Timber.w(e, "[FCM] kanban_done link parse failed: $link")
+            }
+        }
+        return null
+    }
+
+    /**
+     * Build the native-nav intent JSON that the portal pages understand. mission.html
+     * (loaded by MissionControlActivity) requires BOTH `target=="card"` and `cardId`;
+     * kanban.html only needs `cardId`. Emitting both keeps either page working.
+     */
+    private fun buildCardNavIntentJson(cardId: String): String =
+        JSONObject()
+            .put("targetTab", "mission")
+            .put("target", "card")
+            .put("cardId", cardId)
+            .toString()
 }

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -1,6 +1,7 @@
 package com.hank.clawlive
 
 import com.hank.clawlive.fcm.FcmChannelCreationTest
+import com.hank.clawlive.fcm.KanbanDoneDeepLinkTest
 import com.hank.clawlive.settings.NotificationPreferenceCatalogTest
 import com.hank.clawlive.settings.SettingsManifestResolverTest
 import com.hank.clawlive.settings.SettingsManifestSyncTest
@@ -31,6 +32,7 @@ import org.junit.runners.Suite
     NotificationPreferenceCatalogTest::class,
     SettingsManifestResolverTest::class,
     SettingsManifestSyncTest::class,
-    FcmChannelCreationTest::class
+    FcmChannelCreationTest::class,
+    KanbanDoneDeepLinkTest::class
 )
 class UnitTestSuite

--- a/app/src/test/java/com/hank/clawlive/fcm/KanbanDoneDeepLinkTest.kt
+++ b/app/src/test/java/com/hank/clawlive/fcm/KanbanDoneDeepLinkTest.kt
@@ -1,0 +1,120 @@
+package com.hank.clawlive.fcm
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Regression guard for card_92c17b66 — tapping a "task completed" (kanban_done /
+ * kanban_done_auto) push on Android opened the app to the HOME screen instead of
+ * the specific finished card.
+ *
+ * Root cause: ClawFcmService's onMessageReceived channel/intent switch had no
+ * case for the kanban_done categories, so they fell into `else ->
+ * Intent(MainActivity)` with no card extra — the WebView was never told which
+ * card to open. The backend was already correct (data.link=
+ * /portal/kanban.html?card=<id> and data.metadata.cardId), and the WebView deep
+ * link handler already existed (window.eclawHandleNativeNavigateIntent), so the
+ * fix lives entirely in the app's notification-tap routing.
+ *
+ * These are source-assertion tests (no emulator / Robolectric), consistent with
+ * FcmChannelCreationTest and the project's existing manifest/source unit tests.
+ * Full end-to-end (send push → tap → card opens) requires a device + FCM.
+ */
+class KanbanDoneDeepLinkTest {
+
+    private val fcmSrc: String by lazy { readSource("com/hank/clawlive/fcm/ClawFcmService.kt") }
+
+    @Test
+    fun kanbanDoneTapRoutesToMissionControlActivity() {
+        // The kanban_done branch must build an Intent for MissionControlActivity
+        // (which hosts the mission/kanban WebView) — not fall through to the
+        // MainActivity home screen.
+        assertTrue(
+            "onMessageReceived must route kanban_done/kanban_done_auto to " +
+                "MissionControlActivity so the tap can deep-link to the card.",
+            fcmSrc.contains("\"kanban_done\", \"kanban_done_auto\" ->") &&
+                fcmSrc.contains("Intent(this, MissionControlActivity::class.java)")
+        )
+    }
+
+    @Test
+    fun kanbanDoneCarriesNativeNavIntentExtra() {
+        // The tap PendingIntent must carry the native-nav intent extra so the
+        // receiving Activity can replay it into the WebView.
+        assertTrue(
+            "kanban_done tap intent must put EClawNativeNavBridge.EXTRA_NAV_INTENT " +
+                "carrying the card deep link.",
+            fcmSrc.contains("EClawNativeNavBridge.EXTRA_NAV_INTENT")
+        )
+    }
+
+    @Test
+    fun cardIdExtractedFromMetadataAndLink() {
+        // Resilience: the card id must be pulled from metadata.cardId AND fall
+        // back to the ?card= query param on the deep link.
+        assertTrue(
+            "extractCardId must read metadata.cardId.",
+            fcmSrc.contains("optString(\"cardId\"")
+        )
+        assertTrue(
+            "extractCardId must fall back to the ?card= param on data.link.",
+            fcmSrc.contains("getQueryParameter(\"card\")")
+        )
+    }
+
+    @Test
+    fun navIntentTargetsMissionCardForBothPortalHandlers() {
+        // mission.html requires target=="card" && cardId; kanban.html needs cardId.
+        // The built JSON must include all three so either page routes correctly.
+        assertTrue(
+            "nav intent JSON must set targetTab=mission, target=card, and cardId.",
+            fcmSrc.contains("\"targetTab\", \"mission\"") &&
+                fcmSrc.contains("\"target\", \"card\"") &&
+                fcmSrc.contains("\"cardId\", cardId")
+        )
+    }
+
+    @Test
+    fun deepLinkIntentReusesRunningInstanceViaSingleTop() {
+        // Warm-resume correctness: without SINGLE_TOP the running MissionControl
+        // instance (no singleTop launchMode in the manifest) is destroyed+
+        // recreated instead of receiving the extra via onNewIntent.
+        assertTrue(
+            "tap intent flags must include FLAG_ACTIVITY_SINGLE_TOP so a running " +
+                "instance receives the deep-link extra via onNewIntent.",
+            fcmSrc.contains("FLAG_ACTIVITY_SINGLE_TOP")
+        )
+    }
+
+    @Test
+    fun missionControlReplaysNavIntentIntoWebView() {
+        // The receiving side must exist and be wired: MissionControlActivity reads
+        // the extra on cold start (onCreate) and warm resume (onNewIntent), then
+        // replays it into the page once loaded.
+        val mc = readSource("com/hank/clawlive/MissionControlActivity.kt")
+        assertTrue(
+            "MissionControlActivity must read EXTRA_NAV_INTENT in onCreate (cold start).",
+            mc.contains("getStringExtra(EClawNativeNavBridge.EXTRA_NAV_INTENT)")
+        )
+        assertTrue(
+            "MissionControlActivity must handle onNewIntent (warm resume).",
+            mc.contains("override fun onNewIntent")
+        )
+        assertTrue(
+            "MissionControlActivity must replay the pending nav intent after the page loads.",
+            mc.contains("deliverPendingNavIntent()") &&
+                mc.contains("buildIntentReplayJs")
+        )
+    }
+
+    private fun readSource(relPath: String): String {
+        val candidates = listOf(
+            File("src/main/java/$relPath"),
+            File("app/src/main/java/$relPath")
+        )
+        val file = candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate $relPath from ${File(".").absolutePath}")
+        return file.readText()
+    }
+}


### PR DESCRIPTION
## Problem
On the latest Android app, tapping a **"任務完成" (task completed)** push notification opens the app only to the **HOME screen** instead of routing to the specific task card. Kanban card: `card_92c17b667d3e339ee651a489`.

## Root cause (app-side only — backend + web were already correct)
`ClawFcmService.onMessageReceived`'s intent `when(category)` switch had **no case** for the `kanban_done` / `kanban_done_auto` categories, so they fell into `else -> Intent(this, MainActivity::class.java)` with **no card extra**. The WebView was never told which card to open.

Already correct and untouched:
- Backend sets `link: /portal/kanban.html?card=<cardId>` **and** `metadata.cardId` (`backend/kanban.js` ~2956 / ~5205), and `buildFcmNotificationData` forwards `link` + `metadata` in the FCM `data` payload (`backend/notifications.js`).
- The WebView deep-link handler `window.eclawHandleNativeNavigateIntent({targetTab:'mission', target:'card', cardId})` already exists in `mission.html` / `kanban.html`.
- `MissionControlActivity` already reads `EClawNativeNavBridge.EXTRA_NAV_INTENT` on cold start (`onCreate`) and warm resume (`onNewIntent`) and replays it into the WebView after the page loads.

So the gap was **only** the notification-tap routing not wiring the card id into that existing pipeline.

## Fix
`app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt`:
- Route `kanban_done` / `kanban_done_auto` taps to **`MissionControlActivity`** (hosts the mission/kanban WebView) instead of `MainActivity`.
- Carry the card id via the **existing** native-nav extra `EClawNativeNavBridge.EXTRA_NAV_INTENT` = `{"targetTab":"mission","target":"card","cardId":"<id>"}` (satisfies mission.html's stricter `target=="card"` requirement and is backward-compatible with kanban.html).
- `extractCardId()` reads `metadata.cardId`, falling back to the `?card=` param on `data.link` (resilient to either side changing shape).
- Tap intent adds `FLAG_ACTIVITY_SINGLE_TOP` (on top of the existing `CLEAR_TOP | NEW_TASK`) so a **running** MissionControl instance receives the extra via `onNewIntent` rather than being destroyed+recreated (neither Activity declares a `singleTop` launchMode; the in-app nav bridge relies on the same per-intent flags).

### How the tap now routes
- **Cold start** (app not running): `MissionControlActivity.onCreate` reads the extra → stores `pendingNavIntent` → replayed into the WebView on `onPageFinished`.
- **Warm resume** (app already running): `CLEAR_TOP | SINGLE_TOP` reuses the instance → `onNewIntent` delivers the extra → replayed immediately if the page is ready.
- **No card id extractable** (defensive): opens Mission Control without a card focus — still the correct tab, never the home screen.

## Tests
Adds `KanbanDoneDeepLinkTest` (source-assertion style, matching the existing `FcmChannelCreationTest` convention; registered in `UnitTestSuite`) covering: routing to MissionControlActivity, carrying the nav extra, cardId extraction from metadata + link, the mission/card nav JSON shape, `SINGLE_TOP` flag, and the receiving-side wiring in `MissionControlActivity`.

## Verification
- `./gradlew :app:compileDebugKotlin` → **BUILD SUCCESSFUL** (no new warnings/errors).
- `./gradlew :app:compileDebugUnitTestKotlin` → **BUILD SUCCESSFUL**.
- `./gradlew :app:testDebugUnitTest --tests "*.KanbanDoneDeepLinkTest"` → **passes**.

### Manual real-device verification (still pending a build + device/FCM)
End-to-end (real push → tap → card opens) cannot be validated in this environment — it needs a Gradle build installed on a device/emulator with FCM. Precise steps for the owner:
1. Build + install this branch on a device/emulator logged into the account (`./gradlew :app:installDebug`).
2. Complete a real task so a `kanban_done` push fires (or move a card to Done), OR trigger an auto-done for `kanban_done_auto`.
3. **Background or kill the app**, then tap the "✅ 任務完成" notification in the system tray → app should open **Mission Control and the specific card detail**, not the home screen. Repeat with the app **foregrounded** (warm-resume path) and with it **fully killed** (cold-start path).
4. Confirm via `adb logcat | grep -E "Mission|NavBridge"` that the WebView loaded and the nav intent was replayed (`[Mission] WebView page loaded` then the card opens).

**Unverified / remaining:** the real on-device tap→card-open flow (build + device + live FCM). Code is compile-checked and self-consistent with the existing deep-link pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)