### PR TITLE
feat(kanban): capability-aware dispatch guard — warn when browser/screenshot cards are assigned to browser-incapable entities (card_f5023a5)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -466,6 +466,65 @@ async function initKanbanDatabase() {
     }
 }
 
+// ── Dispatch capability guard (card_f5023a5204ef729dfa98abda) ──
+// The platform keeps dispatching visual/screenshot tasks (destructive-modal
+// E2E, UI review, simulator review) to entity #6, but #6's environment has NO
+// usable browser tool (Copilot Computer Use is declined; the browser plugin
+// errors), so those cards dead-end and bounce back to #2. This is a conservative,
+// config-driven registry of entities KNOWN to lack a usable browser today.
+//
+// ⚠️ This is a documented constant map reflecting the CURRENT known reality from
+// card_f5023a5 — it is NOT a real per-entity capability model. When entities gain
+// a proper `capabilities` field (per-entity flag), replace this Set with a lookup
+// of that flag. Bias: a false "incapable" merely posts a non-blocking heads-up
+// (the safe direction); it NEVER rejects an assignment. #2 has Playwright.
+const BROWSER_INCAPABLE_ENTITIES = new Set([6]);
+function isBrowserCapableEntity(entityId) {
+    return !BROWSER_INCAPABLE_ENTITIES.has(Number(entityId));
+}
+
+// Reuse the SAME UI/UX detection the done-gate / review-reminder / move-handler
+// use (kanban.js `_uiTitleHit` / `_uxTitleHit`), so the dispatch guard fires on
+// exactly the cards the done-gate will later HARD-require vision/interaction
+// evidence for. Keep these regexes in ONE place so the two never diverge.
+const UI_TITLE_KEYWORDS_RE = /\bUI\b|\bUIUX\b|介面|畫面|外觀|縮圖|按鈕|版面|排版|配色|破圖|樣式|圖示|\bmodal\b|\bdialog\b|\bbutton\b|\bicon\b|\bthumbnail\b|\bcss\b/i;
+const UX_TITLE_KEYWORDS_RE = /\bUX\b|拖曳|拖移|手勢|滑動|長按|操作流程|互動|\bgesture\b|\bswipe\b|\bscroll\b|\bdrag\b|\bnavigation\b/i;
+
+// True when a card needs a browser/screenshot to verify: explicit
+// requires_screenshot_review / requires_interaction_review flags, OR the
+// title+description read as UI/UX. Accepts a serialized card (camelCase) or a
+// raw DB row (snake_case) so both the create path (`card`) and the PUT path
+// (`updated.*`) can call it.
+function cardNeedsVisualVerification(card) {
+    if (!card || typeof card !== 'object') return false;
+    const screenshot = card.requiresScreenshotReview === true || card.requires_screenshot_review === true;
+    const interaction = card.requiresInteractionReview === true || card.requires_interaction_review === true;
+    if (screenshot || interaction) return true;
+    const text = String(card.title || '') + ' ' + String(card.description || '');
+    return UI_TITLE_KEYWORDS_RE.test(text) || UX_TITLE_KEYWORDS_RE.test(text);
+}
+
+// Build the non-blocking capability-mismatch warning IFF the card needs visual
+// verification AND *every* assigned entity is browser-incapable. Returns the
+// warning string, or null when no warning is warranted (card is non-visual, no
+// assignees, or at least one assignee HAS a browser). Never throws.
+function buildDispatchCapabilityWarning(card, assignedBots) {
+    try {
+        if (!cardNeedsVisualVerification(card)) return null;
+        const ids = (Array.isArray(assignedBots) ? assignedBots : [])
+            .map(Number)
+            .filter(Number.isFinite);
+        if (ids.length === 0) return null;
+        // Only warn when NOBODY assigned can drive a browser — if a capable
+        // entity is on the card, the work can land, so stay quiet (anti-noise).
+        if (ids.some(isBrowserCapableEntity)) return null;
+        const who = ids.map(id => `#${id}`).join(', ');
+        return `⚠️ 派工能力提醒：此卡需要瀏覽器/截圖驗證，但指派的實體(${who})沒有可用的瀏覽器工具 → 建議改派 #2(有 Playwright) 或由 #2 協作。`;
+    } catch (_) {
+        return null;
+    }
+}
+
 /**
  * Factory: receives in-memory devices object from index.js
  */
@@ -1385,6 +1444,18 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     status: statusLabel(lang, cardStatus)
                 });
                 notifyEntities(deviceId, bots, msg, { description, cardId: card.id, dispatcherEntityId: createdBy });
+            }
+
+            // ── Dispatch capability guard (card_f5023a5) ──
+            // If this card needs browser/screenshot verification but EVERY assigned
+            // entity lacks a usable browser tool (e.g. #6), post a NON-BLOCKING system
+            // comment suggesting a browser-capable entity (#2/Playwright), so the card
+            // does not silently dead-end and bounce back. Never rejects the assignment.
+            try {
+                const capWarn = buildDispatchCapabilityWarning(card, bots);
+                if (capWarn) await addSystemComment(card.id, deviceId, capWarn);
+            } catch (capErr) {
+                console.error('[Kanban] dispatch-capability-guard (create) failed:', capErr.message);
             }
 
             if (awardEntityXP) {
@@ -2426,6 +2497,25 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     }
                 } catch (notifyErr) {
                     console.error('[Kanban] assign-notify failed:', notifyErr.message);
+                }
+            }
+
+            // ── Dispatch capability guard (card_f5023a5) ──
+            // A reassignment that puts a browser/screenshot card entirely onto
+            // browser-incapable entities (e.g. #6) would dead-end. When assigned_bots
+            // was touched, evaluate the RESULTING set: if the card needs visual
+            // verification and no assignee can drive a browser, post a NON-BLOCKING
+            // system comment + surface it in the API `warnings`. Never rejects.
+            if (assignedBots !== undefined && Array.isArray(assignedBots)) {
+                try {
+                    const updated = result.rows[0];
+                    const capWarn = buildDispatchCapabilityWarning(updated, updated.assigned_bots);
+                    if (capWarn) {
+                        await addSystemComment(cardId, deviceId, capWarn);
+                        warnings.push(capWarn);
+                    }
+                } catch (capErr) {
+                    console.error('[Kanban] dispatch-capability-guard (update) failed:', capErr.message);
                 }
             }
 
@@ -5459,4 +5549,9 @@ module.exports._private = {
     SCHEDULE_USAGE_THRESHOLD_MAX,
     DEFAULT_SKIP_5H_PCT,
     DEFAULT_SKIP_7D_PCT,
+    // card_f5023a5 dispatch capability guard
+    BROWSER_INCAPABLE_ENTITIES,
+    isBrowserCapableEntity,
+    cardNeedsVisualVerification,
+    buildDispatchCapabilityWarning,
 };

--- a/backend/tests/jest/kanban-dispatch-capability-guard.test.js
+++ b/backend/tests/jest/kanban-dispatch-capability-guard.test.js
@@ -1,0 +1,229 @@
+'use strict';
+
+/**
+ * card_f5023a5204ef729dfa98abda — Dispatch capability guard.
+ *
+ * Problem: the platform dispatches visual/screenshot tasks (destructive-modal
+ * E2E, UI review, simulator review) to entity #6, but #6's environment has NO
+ * usable browser tool (Copilot Computer Use declined; browser plugin errors),
+ * so those cards dead-end and bounce back to #2.
+ *
+ * Fix (NON-BLOCKING): when a card that needs browser/screenshot verification is
+ * assigned to a set of entities that ALL lack a usable browser, post a system
+ * comment suggesting a browser-capable entity (#2/Playwright). It is a warning —
+ * it never rejects the assignment.
+ *
+ * Two layers of proof:
+ *  A. Pure-unit tests of the exported detection + warning builders.
+ *  B. An integration test driving the REAL PUT /card router (supertest over a
+ *     mocked pg pool), asserting the warning system-comment is INSERTed and
+ *     surfaced in the API `warnings` array — mirrors the sibling harness
+ *     backend/tests/jest/kanban-notify-on-assign-comment.test.js.
+ */
+
+// ── B-layer plumbing: mock pg so the real router runs without a DB. ──
+const mockQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockQuery,
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../safe-equal', () => (a, b) => a === b);
+
+const express = require('express');
+const request = require('supertest');
+
+const kanbanFactory = require('../../kanban');
+const {
+    isBrowserCapableEntity,
+    cardNeedsVisualVerification,
+    buildDispatchCapabilityWarning,
+    BROWSER_INCAPABLE_ENTITIES,
+} = kanbanFactory._private;
+
+// The exact warning copy the card specifies (matched loosely on the anchor bits
+// so a future wording tweak of the tail doesn't break the assertion).
+const WARN_RE = /派工能力提醒[\s\S]*瀏覽器\/截圖驗證[\s\S]*沒有可用的瀏覽器工具[\s\S]*建議改派 #2/;
+
+// ════════════════════════════════════════════════════════════════
+// A. Pure detection + warning builder
+// ════════════════════════════════════════════════════════════════
+describe('A. capability registry + detection', () => {
+    it('#6 is browser-incapable; #2/#1/#5 are capable', () => {
+        expect(BROWSER_INCAPABLE_ENTITIES.has(6)).toBe(true);
+        expect(isBrowserCapableEntity(6)).toBe(false);
+        expect(isBrowserCapableEntity(2)).toBe(true);
+        expect(isBrowserCapableEntity(1)).toBe(true);
+        expect(isBrowserCapableEntity(5)).toBe(true);
+        // string id coerces
+        expect(isBrowserCapableEntity('6')).toBe(false);
+    });
+
+    it('cardNeedsVisualVerification: explicit flags', () => {
+        expect(cardNeedsVisualVerification({ requiresScreenshotReview: true })).toBe(true);
+        expect(cardNeedsVisualVerification({ requires_screenshot_review: true })).toBe(true);
+        expect(cardNeedsVisualVerification({ requiresInteractionReview: true })).toBe(true);
+        expect(cardNeedsVisualVerification({ requires_interaction_review: true })).toBe(true);
+    });
+
+    it('cardNeedsVisualVerification: UI/UX title keywords (EN + ZH)', () => {
+        expect(cardNeedsVisualVerification({ title: 'destructive modal dialog E2E' })).toBe(true); // modal/dialog
+        expect(cardNeedsVisualVerification({ title: 'Fix the UI review card' })).toBe(true);  // UI
+        expect(cardNeedsVisualVerification({ title: '按鈕外觀破圖' })).toBe(true);            // ZH UI
+        expect(cardNeedsVisualVerification({ description: 'verify the drag gesture' })).toBe(true); // UX
+        expect(cardNeedsVisualVerification({ title: '拖曳互動流程' })).toBe(true);            // ZH UX
+        // Real destructive-modals E2E cards carry requires_screenshot_review=true
+        // (an E2E screenshot task); the title alone ("modals" plural) does NOT hit
+        // the reused \bmodal\b regex, but the explicit flag catches it.
+        expect(cardNeedsVisualVerification({ title: 'destructive-modals E2E', requires_screenshot_review: true })).toBe(true);
+    });
+
+    it('cardNeedsVisualVerification: pure-backend card is NOT visual', () => {
+        expect(cardNeedsVisualVerification({ title: 'Refactor the SQL pool', description: 'batch the queries' })).toBe(false);
+        expect(cardNeedsVisualVerification({ title: 'Harden auth token rotation' })).toBe(false);
+        expect(cardNeedsVisualVerification(null)).toBe(false);
+        expect(cardNeedsVisualVerification({})).toBe(false);
+    });
+});
+
+describe('A. buildDispatchCapabilityWarning', () => {
+    it('UI card assigned ONLY to browser-incapable #6 → warns', () => {
+        const w = buildDispatchCapabilityWarning({ requiresScreenshotReview: true }, [6]);
+        expect(w).toMatch(WARN_RE);
+        expect(w).toContain('#6');
+    });
+
+    it('UI card assigned to a capable entity (#2) → does NOT warn', () => {
+        expect(buildDispatchCapabilityWarning({ requiresScreenshotReview: true }, [2])).toBeNull();
+    });
+
+    it('UI card assigned to a MIX (#6 + #2) → does NOT warn (a capable entity can land it)', () => {
+        expect(buildDispatchCapabilityWarning({ title: 'UI review' }, [6, 2])).toBeNull();
+    });
+
+    it('NON-UI card assigned to #6 → never warns', () => {
+        expect(buildDispatchCapabilityWarning({ title: 'Refactor pool' }, [6])).toBeNull();
+    });
+
+    it('no assignees → no warning', () => {
+        expect(buildDispatchCapabilityWarning({ requiresScreenshotReview: true }, [])).toBeNull();
+        expect(buildDispatchCapabilityWarning({ requiresScreenshotReview: true }, undefined)).toBeNull();
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// B. Integration — PUT /card/:id reassignment posts the warning
+// ════════════════════════════════════════════════════════════════
+describe('B. PUT /card/:id dispatch-capability guard', () => {
+    let app;
+
+    const mockDevices = {
+        'test-dev': {
+            deviceSecret: 'test-secret',
+            entities: {
+                0: { isBound: true, name: 'Boss', character: 'Boss' },
+                2: { isBound: true, name: 'Bot2', character: 'Bot2' },
+                6: { isBound: true, name: 'Bot6', character: 'Bot6' },
+            },
+        },
+    };
+
+    beforeAll(() => {
+        app = express();
+        app.use(express.json());
+        const mod = kanbanFactory(mockDevices, {});
+        app.use('/api/mission', mod.router);
+    });
+
+    beforeEach(() => {
+        mockQuery.mockReset();
+        mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    });
+
+    const put = (p) => request(app).put(p);
+    const AUTH = { deviceId: 'test-dev', deviceSecret: 'test-secret' };
+    const flushAsync = () => new Promise((r) => setImmediate(r));
+
+    function cardRow(overrides = {}) {
+        return {
+            id: 'card_x', device_id: 'test-dev', title: 'UI review card',
+            description: 'check the modal', priority: 'P2', status: 'todo',
+            assigned_bots: [0], created_by: 0, requires_screenshot_review: true,
+            created_at: new Date(), updated_at: new Date(),
+            status_changed_at: new Date(), archived: false,
+            ...overrides,
+        };
+    }
+
+    // Drive by SQL SHAPE (positional ordering is brittle because addSystemComment
+    // + assign-notify + latest-comment fetch all fire out of band). Capture every
+    // INSERT into kanban_comments so we can assert on the system-comment text.
+    function primeMock({ before, after }) {
+        const systemComments = [];
+        mockQuery.mockImplementation((sql, params) => {
+            if (/INSERT INTO kanban_comments/.test(sql)) {
+                // addSystemComment binds text as params[2] (card_id, device_id, text)
+                systemComments.push(params && params[2]);
+                return Promise.resolve({ rows: [{ id: 'cmt' }] });
+            }
+            if (/UPDATE kanban_cards SET[\s\S]*RETURNING/.test(sql)) {
+                return Promise.resolve({ rows: [after] });
+            }
+            if (/^\s*SELECT \* FROM kanban_cards/.test(sql)) {
+                return Promise.resolve({ rows: [before] });
+            }
+            return Promise.resolve({ rows: [], rowCount: 0 });
+        });
+        return systemComments;
+    }
+
+    it('reassigning a UI/screenshot card ONLY to #6 → warns (comment + API warnings), 200', async () => {
+        const systemComments = primeMock({
+            before: cardRow({ assigned_bots: [0] }),
+            after: cardRow({ assigned_bots: [6] }),
+        });
+
+        const res = await put('/api/mission/card/card_x').send({ ...AUTH, assignedBots: [6] });
+        expect(res.status).toBe(200);              // NON-BLOCKING — assignment succeeds
+        await flushAsync();
+
+        expect(systemComments.some((t) => WARN_RE.test(String(t)))).toBe(true);
+        expect((res.body.warnings || []).some((w) => WARN_RE.test(String(w)))).toBe(true);
+    });
+
+    it('reassigning the SAME UI card to a capable entity (#2) → NO warning', async () => {
+        const systemComments = primeMock({
+            before: cardRow({ assigned_bots: [0] }),
+            after: cardRow({ assigned_bots: [2] }),
+        });
+
+        const res = await put('/api/mission/card/card_x').send({ ...AUTH, assignedBots: [2] });
+        expect(res.status).toBe(200);
+        await flushAsync();
+
+        expect(systemComments.some((t) => WARN_RE.test(String(t)))).toBe(false);
+        expect((res.body.warnings || []).some((w) => WARN_RE.test(String(w)))).toBe(false);
+    });
+
+    it('reassigning a NON-UI backend card to #6 → never warns', async () => {
+        const backend = { title: 'Refactor SQL pool', description: 'batch queries', requires_screenshot_review: false };
+        const systemComments = primeMock({
+            before: cardRow({ assigned_bots: [0], ...backend }),
+            after: cardRow({ assigned_bots: [6], ...backend }),
+        });
+
+        const res = await put('/api/mission/card/card_x').send({ ...AUTH, assignedBots: [6] });
+        expect(res.status).toBe(200);
+        await flushAsync();
+
+        expect(systemComments.some((t) => WARN_RE.test(String(t)))).toBe(false);
+        expect((res.body.warnings || []).some((w) => WARN_RE.test(String(w)))).toBe(false);
+    });
+});


### PR DESCRIPTION
## Problem (card_f5023a5204ef729dfa98abda)

The platform keeps dispatching visual/screenshot tasks — destructive-modal E2E, UI review, simulator review — to entity **#6**, whose environment has **no usable browser tool** (Copilot Computer Use is declined; the browser plugin errors). Those cards silently dead-end and bounce back to **#2**.

## Fix (minimal, NON-BLOCKING)

When a card that needs browser/screenshot verification is assigned to a set of entities that **all** lack a usable browser, post a system comment suggesting a browser-capable entity. It is a **warning** — it never rejects the assignment.

> ⚠️ 派工能力提醒：此卡需要瀏覽器/截圖驗證，但指派的實體(#6)沒有可用的瀏覽器工具 → 建議改派 #2(有 Playwright) 或由 #2 協作。

### How capability is modeled
`BROWSER_INCAPABLE_ENTITIES = new Set([6])` — a conservative, config-driven registry reflecting the **current known reality** from card_f5023a5. Documented as a stopgap: entities have no per-entity capability flag today, so when one is added, replace this Set with a lookup of that flag. Bias is safe — a false "incapable" merely posts a heads-up; it never blocks.

### Where it fires
- **Create path** (`POST /card`) — after the create-notify.
- **Reassign path** (`PUT /card/:id`) — only when `assigned_bots` is touched; evaluates the *resulting* set. Surfaced as a system comment **and** in the API `warnings` array.
- Both are `try`-guarded/best-effort: a failure never breaks the response.

### UI/UX detection reused (not duplicated divergently)
`cardNeedsVisualVerification()` keys off `requires_screenshot_review` / `requires_interaction_review` **or** the same `UI_/UX_TITLE_KEYWORDS_RE` regexes the done-gate / review-reminder / move-handler already use (`_uiTitleHit` / `_uxTitleHit`). The regexes are hoisted to one module-level constant so the guard and the done-gate can never diverge.

## Tests
`backend/tests/jest/kanban-dispatch-capability-guard.test.js` — **12 cases green** (unit + real-router supertest over a mocked pg pool, mirroring `kanban-notify-on-assign-comment.test.js`):
- UI/screenshot card assigned only to **#6** → warns (system comment + `warnings`), still **200**.
- Same UI card assigned to a capable entity (**#2**) or a **mix** (#6+#2) → does **not** warn.
- Non-UI backend card assigned to #6 → **never** warns.

Sibling suites (`kanban-card`, `kanban-notify-on-assign-comment`, `kanban-ooda-r-done-gate` = 73 tests) still green. `node --check backend/kanban.js` passes.

## Verify (live, later)
`PUT /api/mission/card/<id>` with `assignedBots:[6]` on a card carrying `requiresScreenshotReview:true` → response includes a `warnings[]` entry and a `⚠️ 派工能力提醒…` system comment appears on the card. (Delete any test card afterward — no test cards left on prod.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)