### PR TITLE
fix(portal): task-completed notification now opens the card (mission.html deep-link self-loop) — card_92c17b66

### DIFF
--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -1080,7 +1080,16 @@
                 if (intent.target === 'card' && intent.cardId) {
                     const id = String(intent.cardId).trim();
                     if (!id) return false;
-                    if (window.SmartRouter && window.SmartRouter.navigate('card', { cardId: id })) return true;
+                    // eclawHandleNativeNavigateIntent is invoked ONLY by the native
+                    // replay (Android/iOS bridge) while this page is hosted in the
+                    // mission tab's WebView. SmartRouter.navigate('card') maps the
+                    // 'card' target to the 'mission' tab (APP_TARGET_TAB) — i.e. the
+                    // tab we are already on — so in app mode it re-enters the native
+                    // bridge, which re-launches this same Activity (SINGLE_TOP →
+                    // onNewIntent → replay → this handler) in an INFINITE LOOP and the
+                    // card never opens (card_92c17b66 notification deep-link bug).
+                    // Card detail lives in kanban.html, so navigate this WebView there
+                    // directly with the canonical ?card=<id>#<id> deep-link.
                     window.location.href = '/portal/kanban.html?card=' + encodeURIComponent(id) + '#' + encodeURIComponent(id);
                     return true;
                 }

--- a/backend/tests/jest/mission-card-deeplink-noloop.test.js
+++ b/backend/tests/jest/mission-card-deeplink-noloop.test.js
@@ -1,0 +1,119 @@
+/**
+ * Regression guard for the task-completed notification deep-link (card_92c17b66).
+ *
+ * MissionControlActivity hosts mission.html and, on an inbound card push, replays
+ * `eclawHandleNativeNavigateIntent({ targetTab:'mission', target:'card', cardId })`
+ * into the WebView. mission.html is a dashboard; card detail lives in kanban.html.
+ *
+ * The bug: the handler used to call `SmartRouter.navigate('card', {cardId})`. In
+ * app mode SmartRouter maps the 'card' target to the 'mission' tab (APP_TARGET_TAB)
+ * — the tab we are already on — so it re-enters the native bridge, which re-launches
+ * MissionControlActivity (SINGLE_TOP → onNewIntent → replay → this handler) in an
+ * INFINITE LOOP and the card never opens (the notification appears to only reach
+ * the home/mission screen). Fix: navigate the WebView straight to the canonical
+ * kanban.html deep-link instead of round-tripping through the tab router.
+ *
+ * This test drives the REAL router (app mode) + the REAL mission.html handler and
+ * asserts the handler never re-enters the native bridge and lands on kanban.html.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO = path.resolve(__dirname, '../..');
+const ROUTER_PATH = path.join(REPO, 'public/portal/shared/smart-router.js');
+const REGISTRY_PATH = path.join(REPO, 'shared/route-registry.js');
+const MISSION_HTML = path.join(REPO, 'public/portal/mission.html');
+
+// Extract the exact `window.eclawHandleNativeNavigateIntent = async function ... };`
+// block from mission.html so the test exercises the shipped source, not a copy.
+function extractMissionHandlerSource(html) {
+    const start = html.indexOf('window.eclawHandleNativeNavigateIntent = async function');
+    if (start === -1) throw new Error('mission.html: handler not found');
+    // Close on the first 8-space-indented `};` (the assignment terminator).
+    const end = html.indexOf('\n        };', start);
+    if (end === -1) throw new Error('mission.html: handler terminator not found');
+    return html.slice(start, end + '\n        };'.length);
+}
+
+// Load the real registry + router bound to a given window (mirrors smart-router.test.js).
+function loadRouter(win) {
+    jest.resetModules();
+    const reg = require(REGISTRY_PATH);
+    win.EClawRouteRegistry = reg;
+    global.window = win;
+    global.module = { exports: {} };
+    delete require.cache[require.resolve(ROUTER_PATH)];
+    return require(ROUTER_PATH);
+}
+
+function makeAppWindow(bridgeSpy) {
+    const win = {
+        location: { origin: 'https://eclawbot.com', search: '', assign: jest.fn(), href: '' },
+        navigator: { userAgent: 'Mozilla/5.0 (Linux; Android 14) EClawAndroid' },
+        document: { body: { dataset: {}, classList: { contains: () => false } } },
+        parent: null,
+        self: null,
+        addEventListener: () => {},
+        setTimeout: (fn, ms) => setTimeout(fn, ms),
+        clearTimeout: (id) => clearTimeout(id),
+        Math,
+        // Native bridge — in app mode SmartRouter routes tab navigations here.
+        EClawNativeNav: { navigate: bridgeSpy },
+    };
+    win.self = win;
+    return win;
+}
+
+afterEach(() => { delete global.window; delete global.module; });
+
+describe('mission.html card deep-link (card_92c17b66 no-loop guard)', () => {
+    test('app-mode SmartRouter maps card→mission tab (proves the self-loop trap)', () => {
+        // Positive control: this is WHY the handler must not use SmartRouter here.
+        const bridgeSpy = jest.fn(() => true);
+        const win = makeAppWindow(bridgeSpy);
+        const SmartRouter = loadRouter(win);
+        expect(SmartRouter.mode).toBe('app');
+        expect(SmartRouter.APP_TARGET_TAB.card).toBe('mission');
+
+        const ok = SmartRouter.navigate('card', { cardId: 'card_abc123def456' });
+        expect(ok).toBe(true);
+        // In app mode navigate('card') re-enters the native bridge aimed at the
+        // 'mission' tab — the same Activity → the loop the handler must avoid.
+        expect(bridgeSpy).toHaveBeenCalledTimes(1);
+        expect(bridgeSpy.mock.calls[0][0]).toMatchObject({ targetTab: 'mission', target: 'card' });
+    });
+
+    test('handler navigates straight to kanban.html and never re-enters the bridge', async () => {
+        const bridgeSpy = jest.fn(() => true);
+        const win = makeAppWindow(bridgeSpy);
+        win.SmartRouter = loadRouter(win); // real, app-mode router available to the handler
+
+        const src = extractMissionHandlerSource(fs.readFileSync(MISSION_HTML, 'utf8'));
+        const factory = new Function('window', 'console', src + '\nreturn window.eclawHandleNativeNavigateIntent;');
+        const handler = factory(win, { warn() {} });
+
+        const handled = await handler({ targetTab: 'mission', target: 'card', cardId: 'card_abc123def456' });
+
+        expect(handled).toBe(true);
+        // The card opens in kanban.html within the same WebView…
+        expect(win.location.href).toBe('/portal/kanban.html?card=card_abc123def456#card_abc123def456');
+        // …WITHOUT any native-bridge round-trip (which would re-launch this Activity → loop).
+        expect(bridgeSpy).not.toHaveBeenCalled();
+    });
+
+    test('handler ignores non-card / foreign-tab intents', async () => {
+        const bridgeSpy = jest.fn(() => true);
+        const win = makeAppWindow(bridgeSpy);
+        win.SmartRouter = loadRouter(win);
+        const src = extractMissionHandlerSource(fs.readFileSync(MISSION_HTML, 'utf8'));
+        const handler = new Function('window', 'console', src + '\nreturn window.eclawHandleNativeNavigateIntent;')(win, { warn() {} });
+
+        expect(await handler({ targetTab: 'chat', target: 'card', cardId: 'card_abc123def456' })).toBe(false);
+        expect(await handler({ targetTab: 'mission', target: 'card', cardId: '   ' })).toBe(false);
+        expect(await handler(null)).toBe(false);
+        expect(win.location.href).toBe('');
+        expect(bridgeSpy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Problem
Hank: tapping an Android **task-completed** notification only opens to home (首頁), never the specific card.

#3896 fixed the FCM **sender** (builds `{targetTab:mission, target:card, cardId}`) — correct. But the **receiver** in `mission.html` had a latent defect that #3896 first made reachable:

- The push routes to the **mission tab** → MissionControlActivity's WebView replays `eclawHandleNativeNavigateIntent(intent)` into `mission.html`.
- The handler called `SmartRouter.navigate('card', {cardId})`. In **app mode** `APP_TARGET_TAB` maps `'card' → 'mission'` — **the tab we're already on** — so it re-enters the native bridge, which re-launches `MissionControlActivity` (`SINGLE_TOP → onNewIntent → replay → this handler`) in an **infinite loop**. The card never opens; the app spins on the mission/home screen. Exactly the reported bug.

## Evidence (empirical, deployed router)
Headless harness (real `smart-router.js` + `route-registry.js`, forced app-mode via `EClawAndroid` UA), driving the exact handler:
- **Old handler:** `bridgeCalls: [{targetTab:'mission', target:'card', cardId}]`, `locChanges: []` → re-enters bridge, never reaches kanban.html → **loop**.
- **Fixed handler:** `bridgeCalls: []`, `locChanges: ['/portal/kanban.html?card=…#…']` → card opens, no bridge round-trip.

## Fix
`mission.html`'s card handler runs **only** inside the native WebView (bridge replay), where `card → mission` is a self-target. Card detail lives in `kanban.html`, so navigate the WebView **directly** to the canonical `/portal/kanban.html?card=<id>#<id>` deep-link instead of round-tripping through the tab router. (Matches how `kanban.html`'s own handler opens cards in-page.)

## Test
`backend/tests/jest/mission-card-deeplink-noloop.test.js` — jsdom, drives the **real** app-mode `SmartRouter` + the **real** `mission.html` handler:
1. Positive control: proves `navigate('card')` in app mode re-enters the bridge aimed at the `mission` tab (the loop trap).
2. Asserts the handler navigates to `kanban.html` and **never** re-enters the bridge.
3. Ignores non-card / foreign-tab intents.

Verified **fails on the old looping handler** (`Received: ""`), **passes on the fix** (3/3). Sibling nav/router/deep-link suites: 135 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)