### PR TITLE
chore(app): bump to 1.1.15 (vc126) — ship notification card deep-link (#3896)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 125
-        versionName = "1.1.14"
+        versionCode = 126
+        versionName = "1.1.15"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Version bump to release the task-completed notification deep-link fix onto devices.

- **#3896** (app FCM handler): `kanban_done`/`kanban_done_auto` push tap now builds a card deep-link Intent → **needs this version to reach phones**.
- **#3898** (portal receiver): the mission.html self-loop that swallowed the deep-link — already merged + **live on prod**.

`:app:testDebugUnitTest --tests com.hank.clawlive.fcm.*` → 6/6 pass (KanbanDoneDeepLink + FcmChannelCreation).

After merge: `bundleRelease` → Play staged rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)