### PR TITLE
fix(portal): make chat key refs server-authoritative

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -10137,37 +10137,37 @@
         // ── Env Var Reference ──
         async function initEnvVarBtn(deviceId, deviceSecret) {
             const storageKey = `eclawLocalVars_${deviceId}`;
-            let vars;
-            try { vars = JSON.parse(localStorage.getItem(storageKey) || '{}'); } catch { vars = {}; }
+            const envBtn = document.getElementById('attachMenuEnvBtn');
+            const chipsEl = document.getElementById('envVarChips');
+            let vars = {};
 
-            // Sync from server so WebView / new sessions pick up vars set elsewhere.
-            // GET first to obtain updatedAt, then POST WITH expectedUpdatedAt so this
-            // background merge can't clobber concurrent edits (optimistic lock) and
-            // doesn't trip the server's "POST without expectedUpdatedAt" warn.
+            if (envBtn) envBtn.style.display = 'none';
+            if (chipsEl) chipsEl.innerHTML = '';
+
+            // Key Reference is read-only. Treat the server vault as authoritative
+            // so keys deleted from mission/env-vars pages cannot be resurrected from
+            // stale chat localStorage.
             try {
-                const serverData = await apiCall('GET', `/api/device-vars?deviceId=${deviceId}&deviceSecret=${deviceSecret}`);
-                const serverUpdatedAt = serverData && serverData.updatedAt;
+                const data = await apiCall(
+                    'GET',
+                    `/api/device-vars?deviceId=${encodeURIComponent(deviceId)}&deviceSecret=${encodeURIComponent(deviceSecret)}`
+                );
+                const serverVars = data && data.vars && typeof data.vars === 'object' && !Array.isArray(data.vars)
+                    ? data.vars
+                    : {};
+                vars = serverVars;
                 if (Object.keys(vars).length > 0) {
-                    const body = { deviceId, deviceSecret, vars, source: 'web' };
-                    if (serverUpdatedAt) body.expectedUpdatedAt = serverUpdatedAt;
-                    const data = await apiCall('POST', '/api/device-vars', body);
-                    if (data && data.mergedVars) {
-                        vars = data.mergedVars;
-                        localStorage.setItem(storageKey, JSON.stringify(vars));
-                    }
-                } else if (serverData && serverData.vars) {
-                    // Fresh session — adopt server-side vars (no POST of an empty set)
-                    vars = serverData.vars;
                     localStorage.setItem(storageKey, JSON.stringify(vars));
+                } else {
+                    localStorage.removeItem(storageKey);
                 }
-            } catch { /* non-critical — fall back to local; 409 on concurrent edit is fine */ }
+            } catch { return; }
 
             const keys = Object.keys(vars);
             if (!keys.length) return;
 
-            document.getElementById('attachMenuEnvBtn').style.display = '';
-            const chipsEl = document.getElementById('envVarChips');
-            chipsEl.innerHTML = keys.map(k =>
+            if (envBtn) envBtn.style.display = '';
+            if (chipsEl) chipsEl.innerHTML = keys.map(k =>
                 `<button class="env-var-chip" onclick="insertEnvVarRef('${k.replace(/'/g, "\\'")}')">{{${k}}}</button>`
             ).join('');
         }

--- a/backend/tests/jest/chat-env-var-reference.test.js
+++ b/backend/tests/jest/chat-env-var-reference.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.join(__dirname, '..', '..');
+const chatHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'chat.html'), 'utf8');
+
+function extractInitEnvVarBtn() {
+    const start = chatHtml.indexOf('async function initEnvVarBtn(deviceId, deviceSecret)');
+    expect(start).toBeGreaterThan(0);
+    const end = chatHtml.indexOf('function openEnvVarFromMenu()', start);
+    expect(end).toBeGreaterThan(start);
+    return chatHtml.slice(start, end);
+}
+
+function buildContext(serverVars, initialLocalVars = {}) {
+    const calls = [];
+    const storage = new Map();
+    storage.set('eclawLocalVars_device-1', JSON.stringify(initialLocalVars));
+    const elements = {
+        attachMenuEnvBtn: { style: { display: 'inline-flex' } },
+        envVarChips: { innerHTML: 'stale chip' },
+    };
+
+    return {
+        calls,
+        elements,
+        context: {
+            apiCall: async (method, url, body) => {
+                calls.push({ method, url, body });
+                return { vars: serverVars };
+            },
+            document: {
+                getElementById: id => elements[id] || null,
+            },
+            localStorage: {
+                getItem: key => storage.has(key) ? storage.get(key) : null,
+                setItem: (key, value) => storage.set(key, value),
+                removeItem: key => storage.delete(key),
+            },
+            encodeURIComponent,
+            JSON,
+            Array,
+            Object,
+        },
+        storage,
+    };
+}
+
+describe('chat Key Reference server authority', () => {
+    test('loads key chips from GET /api/device-vars without POST-merging local cache', async () => {
+        const fnSource = extractInitEnvVarBtn();
+        const { context, calls, storage, elements } = buildContext(
+            { KEEP_ME: 'server-value' },
+            { KEEP_ME: 'old-value', DELETED_ON_TASK_PAGE: 'stale-value' },
+        );
+        vm.createContext(context);
+        const initEnvVarBtn = vm.runInContext(`${fnSource}; initEnvVarBtn;`, context);
+
+        await initEnvVarBtn('device-1', 'secret-1');
+
+        expect(calls).toEqual([
+            {
+                method: 'GET',
+                url: '/api/device-vars?deviceId=device-1&deviceSecret=secret-1',
+                body: undefined,
+            },
+        ]);
+        expect(calls.some(call => call.method === 'POST')).toBe(false);
+        expect(JSON.parse(storage.get('eclawLocalVars_device-1'))).toEqual({ KEEP_ME: 'server-value' });
+        expect(elements.attachMenuEnvBtn.style.display).toBe('');
+        expect(elements.envVarChips.innerHTML).toContain('{{KEEP_ME}}');
+        expect(elements.envVarChips.innerHTML).not.toContain('DELETED_ON_TASK_PAGE');
+    });
+
+    test('clears stale local cache and hides chips when server vault is empty', async () => {
+        const fnSource = extractInitEnvVarBtn();
+        const { context, calls, storage, elements } = buildContext(
+            {},
+            { DELETED_ON_TASK_PAGE: 'stale-value' },
+        );
+        vm.createContext(context);
+        const initEnvVarBtn = vm.runInContext(`${fnSource}; initEnvVarBtn;`, context);
+
+        await initEnvVarBtn('device-1', 'secret-1');
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].method).toBe('GET');
+        expect(calls.some(call => call.method === 'POST')).toBe(false);
+        expect(storage.has('eclawLocalVars_device-1')).toBe(false);
+        expect(elements.attachMenuEnvBtn.style.display).toBe('none');
+        expect(elements.envVarChips.innerHTML).toBe('');
+    });
+});


### PR DESCRIPTION
## Summary
- Make chat Key Reference read /api/device-vars with GET only; remove the background POST merge that could resurrect stale localStorage keys.
- Reconcile chat localStorage from the server response, removing stale cached keys when the server vault no longer has them.
- Hide/clear Key Reference chips when the server vault is empty or unavailable instead of showing stale cache.

## Validation
- npx jest tests/jest/chat-env-var-reference.test.js --runInBand
- npm run smoke:portal

Card: card_f6038f0fe7ef8f07d2741c3e