### PR TITLE
fix(portal): Key Reference GET-only — stop resurrecting deleted vault keys (card_f6038f0f, P1)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -10151,8 +10151,8 @@
             // chip — and worse, pushed the stale key back onto the server vault
             // (card_f6038f0f, P1). A read surface must not write.
             try {
-                const serverData = await apiCall('GET', `/api/device-vars?deviceId=${deviceId}&deviceSecret=${deviceSecret}`);
-                if (serverData && serverData.vars && typeof serverData.vars === 'object') {
+                const serverData = await apiCall('GET', `/api/device-vars?deviceId=${encodeURIComponent(deviceId)}&deviceSecret=${encodeURIComponent(deviceSecret)}`);
+                if (serverData && serverData.vars && typeof serverData.vars === 'object' && !Array.isArray(serverData.vars)) {
                     vars = serverData.vars;
                 } else {
                     // Reachable but no vars object → treat as an empty vault.

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -10137,30 +10137,34 @@
         // ── Env Var Reference ──
         async function initEnvVarBtn(deviceId, deviceSecret) {
             const storageKey = `eclawLocalVars_${deviceId}`;
-            let vars;
-            try { vars = JSON.parse(localStorage.getItem(storageKey) || '{}'); } catch { vars = {}; }
+            let vars = {};
 
-            // Sync from server so WebView / new sessions pick up vars set elsewhere.
-            // GET first to obtain updatedAt, then POST WITH expectedUpdatedAt so this
-            // background merge can't clobber concurrent edits (optimistic lock) and
-            // doesn't trip the server's "POST without expectedUpdatedAt" warn.
+            // The Key Reference popup is a READ surface — it only lists the vault's
+            // key names so you can insert {{KEY}}. Vars are authored on the mission
+            // page, so the SERVER is the single source of truth. GET-only, then
+            // reconcile the local cache to match the server (keys deleted on the
+            // mission page get dropped from the cache too).
+            //
+            // We must NEVER POST localStorage back here (the old code did): that
+            // "merge" resurrected keys deleted elsewhere and returned them as the
+            // display source, so a var deleted on the mission page reappeared as a
+            // chip — and worse, pushed the stale key back onto the server vault
+            // (card_f6038f0f, P1). A read surface must not write.
             try {
                 const serverData = await apiCall('GET', `/api/device-vars?deviceId=${deviceId}&deviceSecret=${deviceSecret}`);
-                const serverUpdatedAt = serverData && serverData.updatedAt;
-                if (Object.keys(vars).length > 0) {
-                    const body = { deviceId, deviceSecret, vars, source: 'web' };
-                    if (serverUpdatedAt) body.expectedUpdatedAt = serverUpdatedAt;
-                    const data = await apiCall('POST', '/api/device-vars', body);
-                    if (data && data.mergedVars) {
-                        vars = data.mergedVars;
-                        localStorage.setItem(storageKey, JSON.stringify(vars));
-                    }
-                } else if (serverData && serverData.vars) {
-                    // Fresh session — adopt server-side vars (no POST of an empty set)
+                if (serverData && serverData.vars && typeof serverData.vars === 'object') {
                     vars = serverData.vars;
-                    localStorage.setItem(storageKey, JSON.stringify(vars));
+                } else {
+                    // Reachable but no vars object → treat as an empty vault.
+                    vars = {};
                 }
-            } catch { /* non-critical — fall back to local; 409 on concurrent edit is fine */ }
+                // Cache := server truth, so deletions propagate on the next open.
+                localStorage.setItem(storageKey, JSON.stringify(vars));
+            } catch {
+                // Offline / locked / request error — display the last cached list for
+                // reference only. Read-only, no POST, so nothing can be resurrected.
+                try { vars = JSON.parse(localStorage.getItem(storageKey) || '{}'); } catch { vars = {}; }
+            }
 
             const keys = Object.keys(vars);
             if (!keys.length) return;

--- a/backend/tests/jest/chat-keyref-getonly-noresurrect.test.js
+++ b/backend/tests/jest/chat-keyref-getonly-noresurrect.test.js
@@ -1,0 +1,113 @@
+/**
+ * Regression guard for the Key Reference vault-sync bug (card_f6038f0f, P1).
+ *
+ * chat.html's initEnvVarBtn used to POST the localStorage cache back to
+ * /api/device-vars on open ("merge"), which resurrected keys deleted on the
+ * mission page: a var Hank deleted reappeared as a {{KEY}} chip AND got pushed
+ * back onto the server vault. Fix: the popup is a READ surface — GET-only, server
+ * is the single source of truth, and the local cache is reconciled to match the
+ * server (deletions propagate). It must NEVER POST.
+ *
+ * This test drives the REAL initEnvVarBtn extracted from chat.html against a
+ * mocked apiCall/localStorage/document and asserts: no POST ever, deletions
+ * propagate, fresh sessions adopt server vars, and offline falls back to cache
+ * read-only.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const CHAT_HTML = path.resolve(__dirname, '../../public/portal/chat.html');
+
+function extractInitEnvVarBtn(html) {
+    const start = html.indexOf('async function initEnvVarBtn(deviceId, deviceSecret)');
+    if (start === -1) throw new Error('chat.html: initEnvVarBtn not found');
+    // Close on the first 8-space-indented `}` (the function terminator; inner
+    // braces are indented deeper).
+    const end = html.indexOf('\n        }', start);
+    if (end === -1) throw new Error('chat.html: initEnvVarBtn terminator not found');
+    return html.slice(start, end + '\n        }'.length);
+}
+
+function harness(serverBehavior, initialCache) {
+    const store = new Map();
+    if (initialCache !== undefined) {
+        store.set('eclawLocalVars_dev1', JSON.stringify(initialCache));
+    }
+    const localStorage = {
+        getItem: (k) => (store.has(k) ? store.get(k) : null),
+        setItem: (k, v) => store.set(k, String(v)),
+    };
+    const calls = [];
+    const apiCall = async (method, url) => {
+        calls.push({ method, url });
+        return serverBehavior(method, url);
+    };
+    const chipsEl = { innerHTML: '' };
+    const envBtn = { style: { display: 'none' } };
+    const document = {
+        getElementById: (id) => (id === 'envVarChips' ? chipsEl : envBtn),
+    };
+    const src = extractInitEnvVarBtn(fs.readFileSync(CHAT_HTML, 'utf8'));
+    const initEnvVarBtn = new Function('apiCall', 'localStorage', 'document', src + '\nreturn initEnvVarBtn;')(apiCall, localStorage, document);
+    return { initEnvVarBtn, calls, store, chipsEl, envBtn };
+}
+
+const cachedKeys = (store) => Object.keys(JSON.parse(store.get('eclawLocalVars_dev1') || '{}'));
+
+describe('chat.html Key Reference — GET-only, no resurrect (card_f6038f0f)', () => {
+    test('deletion propagates: a cached key the server no longer has is dropped, and NO POST fires', async () => {
+        // Cache still has A + STALE (deleted on mission page); server has only A.
+        const { initEnvVarBtn, calls, store, chipsEl } = harness(
+            (method) => (method === 'GET' ? { vars: { API_KEY: 'a' }, updatedAt: 111 } : { mergedVars: {} }),
+            { API_KEY: 'a', STALE_DELETED: 'x' },
+        );
+        await initEnvVarBtn('dev1', 'sec1');
+
+        // THE FIX: never POST the localStorage cache back (that resurrected keys).
+        expect(calls.some((c) => c.method === 'POST')).toBe(false);
+        expect(calls.filter((c) => c.method === 'GET')).toHaveLength(1);
+        // Cache reconciled to server truth — STALE_DELETED is gone.
+        expect(cachedKeys(store).sort()).toEqual(['API_KEY']);
+        // Chip UI shows only the live key, not the resurrected one.
+        expect(chipsEl.innerHTML).toContain('{{API_KEY}}');
+        expect(chipsEl.innerHTML).not.toContain('STALE_DELETED');
+    });
+
+    test('fresh session adopts server vars (no POST of an empty set)', async () => {
+        const { initEnvVarBtn, calls, store, chipsEl, envBtn } = harness(
+            (method) => (method === 'GET' ? { vars: { A: '1', B: '2' }, updatedAt: 5 } : null),
+            undefined, // no cache
+        );
+        await initEnvVarBtn('dev1', 'sec1');
+        expect(calls.some((c) => c.method === 'POST')).toBe(false);
+        expect(cachedKeys(store).sort()).toEqual(['A', 'B']);
+        expect(chipsEl.innerHTML).toContain('{{A}}');
+        expect(chipsEl.innerHTML).toContain('{{B}}');
+        expect(envBtn.style.display).toBe('');
+    });
+
+    test('empty vault clears the cache and hides chips (no POST)', async () => {
+        const { initEnvVarBtn, calls, store, chipsEl } = harness(
+            (method) => (method === 'GET' ? { vars: {}, updatedAt: 9 } : null),
+            { OLD: 'v' },
+        );
+        await initEnvVarBtn('dev1', 'sec1');
+        expect(calls.some((c) => c.method === 'POST')).toBe(false);
+        expect(cachedKeys(store)).toEqual([]);
+        expect(chipsEl.innerHTML).toBe(''); // early return, chips untouched/empty
+    });
+
+    test('offline (GET throws): falls back to cache read-only, still NO POST', async () => {
+        const { initEnvVarBtn, calls, store, chipsEl } = harness(
+            () => { throw new Error('network down'); },
+            { API_KEY: 'a' },
+        );
+        await initEnvVarBtn('dev1', 'sec1');
+        expect(calls.some((c) => c.method === 'POST')).toBe(false);
+        // Cache untouched; display falls back to it (read-only, no resurrection risk).
+        expect(cachedKeys(store).sort()).toEqual(['API_KEY']);
+        expect(chipsEl.innerHTML).toContain('{{API_KEY}}');
+    });
+});

--- a/backend/tests/jest/portal-vault-post-sends-etag.test.js
+++ b/backend/tests/jest/portal-vault-post-sends-etag.test.js
@@ -12,9 +12,11 @@
 //   - backend/public/portal/publisher-setup.html  (deliberate 4-key X save)
 //   - backend/public/portal/mission.html          (background syncVarsToServer)
 //
-// chat.html and env-vars.html already did GET-then-POST-with-etag. This test
-// pins ALL web POST paths to that pattern so a future edit can't silently
-// regress one back to a no-etag POST and re-open this recurring card.
+// env-vars.html does GET-then-POST-with-etag. chat.html's Key Reference popup
+// used to as well, but is now GET-only (card_f6038f0f — the POST "merge"
+// resurrected deleted keys), so it must NOT POST the vault at all. This test
+// pins the remaining web POST paths to the etag pattern, and pins chat.html
+// read-only, so a future edit can't silently regress either.
 
 const fs = require('fs');
 const path = require('path');
@@ -42,9 +44,16 @@ describe('portal vault-save paths send expectedUpdatedAt (card_9bd4b4c0)', () =>
         expect(src).toMatch(/apiCall\(\s*['"]POST['"]\s*,\s*['"]\/api\/device-vars['"]\s*,\s*body\s*\)/);
     });
 
-    test('chat.html / env-vars.html keep their existing etag handling (regression guard)', () => {
-        expect(read('chat.html')).toMatch(/expectedUpdatedAt/);
+    test('env-vars.html keeps etag handling; chat.html no longer POSTs the vault (card_f6038f0f)', () => {
+        // env-vars.html still authors vars → must keep the optimistic-lock etag.
         expect(read('env-vars.html')).toMatch(/expectedUpdatedAt/);
+        // chat.html's Key Reference popup is now GET-only (card_f6038f0f): it must
+        // NOT POST localStorage back to /api/device-vars (that "merge" resurrected
+        // keys deleted on the mission page), so it correctly no longer references
+        // expectedUpdatedAt. Pin it read-only so a future edit can't re-introduce
+        // the resurrecting POST.
+        const chat = read('chat.html');
+        expect(/apiCall\(\s*['"]POST['"]\s*,\s*['"]\/api\/device-vars['"]/.test(chat)).toBe(false);
     });
 
     // Comprehensive guard: ANY portal file that POSTs to /api/device-vars MUST


### PR DESCRIPTION
## Problem (P1, card_f6038f0f)
chat.html `initEnvVarBtn` read the localStorage cache and, when non-empty, **POSTed it back** to `/api/device-vars` on every popup open ("merge"), using the returned `mergedVars` as the display source. So a key **deleted on the mission page** but still in the chat device's localStorage was (a) re-shown as a `{{KEY}}` chip and (b) **pushed back onto the server vault** — the var Hank deleted came back. A read surface must not write.

## Fix
The Key Reference popup only lists vault key *names* to insert `{{KEY}}`; vars are authored on the mission page, so the **server is the single source of truth**. GET-only, then reconcile the local cache to match the server (deletions propagate). On GET failure (offline / locked vault) fall back to the cached list for **read-only display** — never POST, so nothing can be resurrected. URL-encodes the query params and rejects a JSON-array response.

## Test
`backend/tests/jest/chat-keyref-getonly-noresurrect.test.js` (jsdom, drives the real extracted `initEnvVarBtn`): deletion propagates + **NO POST**, fresh session adopts server vars, empty vault clears cache, offline falls back read-only. **Fails on the old POST-merge code (2 cases), passes on the fix (4/4).**

## Relationship to #3900
Entity #1 opened #3900 in parallel for the same bug. #3900's Jest went **red** and it displays server truth but doesn't rewrite the localStorage cache on a partial delete (stale key lingers inert). This PR is green, fully reconciles the cache (acceptance #2), and **adopts #1's two good ideas** (`encodeURIComponent`, `Array.isArray` guard). Closing #3900 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)