### PR TITLE
fix(android): drive wallpaper walk actions from config

### DIFF
--- a/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
@@ -24,6 +24,7 @@ import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.local.LayoutPreferences
 import com.hank.clawlive.data.remote.NetworkModule
 import com.hank.clawlive.data.repository.CompanionRepository
+import com.hank.clawlive.data.repository.WalkConfigRepository
 import com.hank.clawlive.service.ClawWallpaperService
 import com.hank.clawlive.ui.RecordingIndicatorHelper
 import com.hank.clawlive.ui.WallpaperPreviewView
@@ -71,7 +72,9 @@ class WallpaperPreviewActivity : AppCompatActivity() {
     private val deviceManager by lazy { DeviceManager.getInstance(this) }
     private val layoutPrefs by lazy { LayoutPreferences.getInstance(this) }
     private val companionRepository by lazy { CompanionRepository(api, this) }
+    private val walkConfigRepository by lazy { WalkConfigRepository(this) }
     private val companionJobs = mutableMapOf<Int, Job>()
+    private val walkConfigJobs = mutableMapOf<Int, Job>()
 
     // Photo picker launcher
     private val photoPickerLauncher = registerForActivityResult(
@@ -131,7 +134,10 @@ class WallpaperPreviewActivity : AppCompatActivity() {
     override fun onDestroy() {
         companionJobs.values.forEach { it.cancel() }
         companionJobs.clear()
+        walkConfigJobs.values.forEach { it.cancel() }
+        walkConfigJobs.clear()
         companionRepository.release()
+        walkConfigRepository.release()
         previewView.onCustomLayoutEnabled = null
         super.onDestroy()
     }
@@ -426,6 +432,7 @@ class WallpaperPreviewActivity : AppCompatActivity() {
 
                 previewView.setEntities(boundEntities)
                 loadCompanions(boundEntities)
+                loadWalkConfigs(boundEntities)
 
             } catch (e: Exception) {
                 Timber.e(e, "Failed to load entities")
@@ -470,6 +477,30 @@ class WallpaperPreviewActivity : AppCompatActivity() {
             companionJobs[entityId] = lifecycleScope.launch {
                 companionRepository.getCompanionFlow(entityId, secret).collect {
                     previewView.invalidate()
+                }
+            }
+        }
+    }
+
+    private fun loadWalkConfigs(entities: List<com.hank.clawlive.data.model.EntityStatus>) {
+        val active = entities.mapNotNull { entity ->
+            entity.botSecret?.let { secret -> entity.entityId to secret }
+        }
+        val activeIds = active.map { it.first }.toSet()
+        walkConfigRepository.pruneTo(activeIds)
+        previewView.setWalkActionConfigs(walkConfigRepository.cachedMap())
+
+        walkConfigJobs.keys.toList().forEach { entityId ->
+            if (entityId !in activeIds) {
+                walkConfigJobs.remove(entityId)?.cancel()
+            }
+        }
+
+        for ((entityId, secret) in active) {
+            if (walkConfigJobs[entityId]?.isActive == true) continue
+            walkConfigJobs[entityId] = lifecycleScope.launch {
+                walkConfigRepository.getWalkConfigFlow(entityId, secret).collect {
+                    previewView.setWalkActionConfigs(walkConfigRepository.cachedMap())
                 }
             }
         }

--- a/app/src/main/java/com/hank/clawlive/data/model/WalkActionConfig.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/WalkActionConfig.kt
@@ -1,0 +1,94 @@
+package com.hank.clawlive.data.model
+
+import java.util.Locale
+
+data class WalkActionConfigResponse(
+    val success: Boolean = false,
+    val entityId: Int? = null,
+    val weights: Map<String, Float> = emptyMap(),
+    val allowNegative: Boolean = false,
+    val negativeActions: List<String> = emptyList(),
+    val error: String? = null
+) {
+    fun toConfig(): WalkActionConfig = WalkActionConfig(
+        weights = weights,
+        allowNegative = allowNegative,
+        negativeActions = negativeActions
+    )
+}
+
+data class WalkActionConfig(
+    val weights: Map<String, Float> = emptyMap(),
+    val allowNegative: Boolean = false,
+    val negativeActions: List<String> = emptyList()
+) {
+    fun weightedActionKeys(): List<Pair<String, Float>> {
+        val source = if (weights.isEmpty()) {
+            DEFAULT_NEUTRAL_ACTIONS.associateWith { 1f }
+        } else {
+            weights
+        }
+        val negativeSet = effectiveNegativeActions().map { canonicalNegativeAction(it) }.toSet()
+        val aggregate = linkedMapOf<String, Float>()
+
+        source.forEach { (rawAction, rawWeight) ->
+            val weight = rawWeight
+                .takeIf { !it.isNaN() && !it.isInfinite() && it > 0f }
+                ?.coerceAtMost(MAX_WEIGHT)
+                ?: return@forEach
+            if (!allowNegative && canonicalNegativeAction(rawAction) in negativeSet) {
+                return@forEach
+            }
+            val actionKey = wallpaperActionKey(rawAction) ?: return@forEach
+            aggregate[actionKey] = (aggregate[actionKey] ?: 0f) + weight
+        }
+
+        return aggregate.map { it.key to it.value }.ifEmpty {
+            DEFAULT_NEUTRAL_ACTIONS.mapNotNull { action ->
+                wallpaperActionKey(action)?.let { it to 1f }
+            }
+        }
+    }
+
+    private fun effectiveNegativeActions(): List<String> {
+        return negativeActions.ifEmpty { DEFAULT_NEGATIVE_ACTIONS }
+    }
+
+    companion object {
+        val DEFAULT_NEUTRAL_ACTIONS = listOf("idle", "walk", "sit", "look", "sleep", "eat")
+        val DEFAULT_NEGATIVE_ACTIONS = listOf("fail", "sad", "sick", "angry")
+        private const val MAX_WEIGHT = 1000f
+
+        fun wallpaperActionKey(raw: String?): String? {
+            val key = canonicalAction(raw) ?: return null
+            return when (key) {
+                "walk", "walking" -> "running"
+                "run" -> "running"
+                "run-right" -> "running-right"
+                "run-left" -> "running-left"
+                "wave" -> "waving"
+                "jump" -> "jumping"
+                "fail", "failure" -> "failed"
+                "sleep" -> "waiting"
+                else -> key
+            }
+        }
+
+        private fun canonicalNegativeAction(raw: String?): String? {
+            return when (wallpaperActionKey(raw)) {
+                "failed" -> "fail"
+                else -> canonicalAction(raw)
+            }
+        }
+
+        private fun canonicalAction(raw: String?): String? {
+            val key = raw
+                ?.trim()
+                ?.lowercase(Locale.US)
+                ?.replace('_', '-')
+                ?.takeIf { it.isNotBlank() }
+                ?: return null
+            return key
+        }
+    }
+}

--- a/app/src/main/java/com/hank/clawlive/data/repository/WalkConfigRepository.kt
+++ b/app/src/main/java/com/hank/clawlive/data/repository/WalkConfigRepository.kt
@@ -1,0 +1,101 @@
+package com.hank.clawlive.data.repository
+
+import android.content.Context
+import com.google.gson.GsonBuilder
+import com.hank.clawlive.data.local.DeviceManager
+import com.hank.clawlive.data.model.WalkActionConfig
+import com.hank.clawlive.data.model.WalkActionConfigResponse
+import com.hank.clawlive.data.remote.NetworkModule
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
+import timber.log.Timber
+
+class WalkConfigRepository(
+    context: Context
+) {
+    private val deviceManager = DeviceManager.getInstance(context)
+    private val configCache = ConcurrentHashMap<Int, WalkActionConfig>()
+    private val gson = GsonBuilder().create()
+
+    fun cachedMap(): Map<Int, WalkActionConfig> = configCache.toMap()
+
+    fun pruneTo(activeEntityIds: Set<Int>) {
+        configCache.keys.toList().forEach { entityId ->
+            if (entityId !in activeEntityIds) configCache.remove(entityId)
+        }
+    }
+
+    fun getWalkConfigFlow(
+        entityId: Int,
+        botSecret: String,
+        intervalMs: Long = 30_000
+    ): Flow<WalkActionConfig?> = flow {
+        delay((3_000L..9_000L).random())
+        var backoffMs = intervalMs
+        while (true) {
+            try {
+                val response = fetchWalkConfig(entityId, botSecret)
+                backoffMs = intervalMs
+                if (response.success) {
+                    val config = response.toConfig()
+                    configCache[entityId] = config
+                    emit(config)
+                } else {
+                    Timber.w("Walk config fetch failed for entity $entityId: ${response.error}")
+                    emit(null)
+                }
+            } catch (e: WalkConfigHttpException) {
+                if (e.code == 429) {
+                    backoffMs = minOf(backoffMs * 2, 300_000L).coerceAtLeast(60_000L)
+                    Timber.w("Walk config flow entity $entityId 429 rate-limited - backing off ${backoffMs}ms")
+                } else {
+                    backoffMs = intervalMs
+                    Timber.w(e, "Walk config fetch failed for entity $entityId")
+                }
+            } catch (e: Exception) {
+                backoffMs = intervalMs
+                Timber.w(e, "Walk config fetch failed for entity $entityId")
+            }
+            delay(backoffMs)
+        }
+    }
+
+    fun release() {
+        configCache.clear()
+    }
+
+    private suspend fun fetchWalkConfig(
+        entityId: Int,
+        botSecret: String
+    ): WalkActionConfigResponse = withContext(Dispatchers.IO) {
+        val url = WALK_CONFIG_URL.toHttpUrl().newBuilder()
+            .addQueryParameter("deviceId", deviceManager.deviceId)
+            .addQueryParameter("botSecret", botSecret)
+            .addQueryParameter("entityId", entityId.toString())
+            .build()
+        val request = Request.Builder().url(url).get().build()
+        NetworkModule.okHttpClient.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                throw WalkConfigHttpException(response.code, body)
+            }
+            gson.fromJson(body, WalkActionConfigResponse::class.java)
+                ?: WalkActionConfigResponse(success = false, error = "Empty walk-config response")
+        }
+    }
+
+    private class WalkConfigHttpException(
+        val code: Int,
+        body: String
+    ) : Exception("Walk config HTTP $code: ${body.take(160)}")
+
+    private companion object {
+        const val WALK_CONFIG_URL = "https://eclawbot.com/api/entity/walk-config"
+    }
+}

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -17,6 +17,7 @@ import com.hank.clawlive.data.model.CharacterState
 import com.hank.clawlive.data.model.CompanionDetail
 import com.hank.clawlive.data.model.EntityStatus
 import com.hank.clawlive.data.model.UsageSnapshotLatest
+import com.hank.clawlive.data.model.WalkActionConfig
 import com.hank.clawlive.data.model.WallpaperKanbanCard
 import com.hank.clawlive.data.repository.CompanionRepository
 import timber.log.Timber
@@ -54,6 +55,7 @@ class ClawRenderer(
     // Engine persists the drop point as the entity's pinned custom position.
     private var draggingEntityId: Int? = null
     private var dragPosPx: Pair<Float, Float>? = null
+    private var walkActionConfigsByEntity: Map<Int, WalkActionConfig> = emptyMap()
 
     /** Pixel centers each entity was last drawn at (entityId -> x,y). */
     fun lastRenderedPositions(): Map<Int, Pair<Float, Float>> = lastRenderedPositionsByEntity.toMap()
@@ -61,6 +63,10 @@ class ClawRenderer(
     /** Canvas width/height of the most recent frame (for hit-radius math). */
     fun lastDrawWidth(): Float = lastDrawWidthPx
     fun lastDrawHeight(): Float = lastDrawHeightPx
+
+    fun setWalkActionConfigs(configs: Map<Int, WalkActionConfig>) {
+        walkActionConfigsByEntity = configs
+    }
 
     /** Begin dragging [entityId]: stop its wander and draw it at the finger. */
     fun beginDrag(entityId: Int, xPx: Float, yPx: Float) {
@@ -702,7 +708,8 @@ class ClawRenderer(
             nowMs = nowMs,
             conversationEntityIds = conversationEntityIds,
             entityUnitPx = 300f * baseScale * maxEntityScale,
-            pinnedEntityIds = pinnedIds
+            pinnedEntityIds = pinnedIds,
+            walkActionConfigsByEntity = walkActionConfigsByEntity
         )
         val interactionState = interactionController.apply(
             positions = positions,
@@ -758,15 +765,21 @@ class ClawRenderer(
                     ?: wanderController.facingDirection(entity.entityId)
                 val actionState = kanbanActionStates[entity.entityId]
                     ?: interactionState.actionStatesByEntity[entity.entityId]
-                val effectiveState = actionState ?: entity.state
-                val spritesheetState = if (
-                    wanderController.isWalking(entity.entityId) &&
-                    effectiveState.canUseAmbientWalkingAnimation
-                ) {
-                    walkingSpritesheetStateFor(facingDirection)
+                val ambientActionKey = if (actionState == null) {
+                    wanderController.actionStateKey(entity.entityId)
                 } else {
-                    effectiveState.wallpaperActionKey
+                    null
                 }
+                val spritesheetState = actionState?.wallpaperActionKey
+                    ?: ambientActionKey
+                    ?: if (
+                        wanderController.isWalking(entity.entityId) &&
+                        entity.state.canUseAmbientWalkingAnimation
+                    ) {
+                        walkingSpritesheetStateFor(facingDirection)
+                    } else {
+                        entity.state.wallpaperActionKey
+                    }
                 try {
                     drawSingleEntityAt(
                         canvas,

--- a/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
@@ -2,6 +2,7 @@ package com.hank.clawlive.engine
 
 import android.graphics.PointF
 import com.hank.clawlive.data.model.EntityStatus
+import com.hank.clawlive.data.model.WalkActionConfig
 import kotlin.math.abs
 import kotlin.math.hypot
 import kotlin.math.min
@@ -65,6 +66,7 @@ class WallpaperWanderController(
         var ambientGoal: AmbientWanderGoal,
         var ambientStep: Int,
         var facingDirection: WalkFacingDirection,
+        var actionStateKey: String? = null,
         var manualTarget: Boolean = false,
         var onArrive: (() -> Unit)? = null
     )
@@ -97,6 +99,11 @@ class WallpaperWanderController(
         return states[entityId]?.ambientGoal ?: AmbientWanderGoal.RANDOM
     }
 
+    fun actionStateKey(entityId: Int): String? {
+        val state = states[entityId] ?: return null
+        return if (state.lastUpdateMs < state.actionUntilMs) state.actionStateKey else null
+    }
+
     fun facingDirection(entityId: Int): WalkFacingDirection {
         return states[entityId]?.facingDirection ?: WalkFacingDirection.RIGHT
     }
@@ -124,6 +131,8 @@ class WallpaperWanderController(
         val state = commandState(entityId)
         state.motionState = MotionState.STOPPED
         state.moving = false
+        state.actionUntilMs = 0L
+        state.actionStateKey = null
         state.manualTarget = false
         state.onArrive = null
     }
@@ -133,6 +142,7 @@ class WallpaperWanderController(
         if (state.motionState == MotionState.STOPPED) {
             state.motionState = MotionState.WANDERING
             state.actionUntilMs = 0L
+            state.actionStateKey = null
         }
     }
 
@@ -141,6 +151,7 @@ class WallpaperWanderController(
         state.motionState = MotionState.WANDERING
         state.moving = false
         state.actionUntilMs = 0L
+        state.actionStateKey = null
         state.manualTarget = false
         state.onArrive = null
     }
@@ -155,7 +166,8 @@ class WallpaperWanderController(
         nowMs: Long = System.currentTimeMillis(),
         conversationEntityIds: Set<Int> = emptySet(),
         entityUnitPx: Float = min(width, height) * DEFAULT_GATHER_SPACING_PCT,
-        pinnedEntityIds: Set<Int> = emptySet()
+        pinnedEntityIds: Set<Int> = emptySet(),
+        walkActionConfigsByEntity: Map<Int, WalkActionConfig> = emptyMap()
     ): List<Pair<Float, Float>> {
         if (!enabled || width <= 0f || height <= 0f) {
             states.clear()
@@ -204,7 +216,16 @@ class WallpaperWanderController(
                 advanceHome(entity, base, width, height, nowMs)
             } else {
                 // 行走功能 (free walking / ambient): roam continuously with goal-based actions.
-                advance(entity, base, width, height, nowMs, purposeful = true, ambientPeers = ambientPeers)
+                advance(
+                    entity,
+                    base,
+                    width,
+                    height,
+                    nowMs,
+                    purposeful = true,
+                    ambientPeers = ambientPeers,
+                    walkActionConfig = walkActionConfigsByEntity[entity.entityId]
+                )
             }
         }
     }
@@ -348,7 +369,8 @@ class WallpaperWanderController(
         height: Float,
         nowMs: Long,
         purposeful: Boolean,
-        ambientPeers: List<AmbientPeer>
+        ambientPeers: List<AmbientPeer>,
+        walkActionConfig: WalkActionConfig?
     ): Pair<Float, Float> {
         val entityId = entity.entityId
         val state = stateFor(entityId, base, width, height, nowMs)
@@ -361,7 +383,8 @@ class WallpaperWanderController(
         if (state.motionState == MotionState.SLEEPING || state.motionState == MotionState.STOPPED) {
             state.motionState = MotionState.WANDERING
             state.actionUntilMs = 0L
-            state.nextActionAtMs = nowMs + ACTION_INTERVAL_MS
+            state.actionStateKey = null
+            state.nextActionAtMs = nowMs + randomActionIntervalMs()
         }
 
         val dtSeconds = ((nowMs - state.lastUpdateMs).coerceIn(0L, 1000L)) / 1000f
@@ -386,15 +409,16 @@ class WallpaperWanderController(
             MotionState.WANDERING -> Unit
         }
 
-        // Every ~10s the entity performs a ~3s stationary random action. The cadence is
-        // independent of arrival so it reliably fires (the old arrival-only idle almost never
+        // Every 10-30s the entity performs a ~3s stationary random action. The per-entity
+        // randomized cadence is independent of arrival so it reliably fires (the old arrival-only idle almost never
         // triggered: retarget every 3-8s reassigned the target before the slow 0.04/s wander
         // could arrive, so the entity roamed nonstop and never paused).
         if (nowMs >= state.nextActionAtMs) {
             state.actionUntilMs = nowMs + ACTION_DURATION_MS
-            state.nextActionAtMs = nowMs + ACTION_INTERVAL_MS
+            state.nextActionAtMs = nowMs + randomActionIntervalMs()
             // Pick a fresh random ambient goal as the "action" flourish for this pause.
             state.ambientGoal = randomActionGoal()
+            state.actionStateKey = randomActionStateKey(walkActionConfig)
             state.ambientStep++
         }
 
@@ -425,6 +449,18 @@ class WallpaperWanderController(
         return goals[random.nextInt(goals.size)]
     }
 
+    private fun randomActionStateKey(config: WalkActionConfig?): String {
+        val actions = (config ?: WalkActionConfig()).weightedActionKeys()
+        val total = actions.sumOf { it.second.toDouble() }.toFloat()
+        if (total <= 0f) return "idle"
+        var cursor = random.nextFloat() * total
+        actions.forEach { (action, weight) ->
+            cursor -= weight
+            if (cursor <= 0f) return action
+        }
+        return actions.lastOrNull()?.first ?: "idle"
+    }
+
     /**
      * Pin [entityId] to [base]: force the in-memory state to the base position and
      * fully stop it so no motion path can move it. Idempotent per frame.
@@ -450,6 +486,7 @@ class WallpaperWanderController(
         state.manualTarget = false
         state.onArrive = null
         state.actionUntilMs = 0L
+        state.actionStateKey = null
         state.lastUpdateMs = nowMs
     }
 
@@ -473,13 +510,14 @@ class WallpaperWanderController(
                 targetYPct = target.second,
                 lastUpdateMs = nowMs,
                 actionUntilMs = 0L,
-                nextActionAtMs = nowMs + ACTION_INTERVAL_MS,
+                nextActionAtMs = nowMs + randomActionIntervalMs(),
                 retargetAtMs = nowMs + randomLong(MIN_RETARGET_MS, MAX_RETARGET_MS),
                 moving = false,
                 motionState = MotionState.WANDERING,
                 ambientGoal = AmbientWanderGoal.RANDOM,
                 ambientStep = 0,
-                facingDirection = WalkFacingDirection.RIGHT
+                facingDirection = WalkFacingDirection.RIGHT,
+                actionStateKey = null
             )
         }
         coerceToSafeBounds(state)
@@ -503,7 +541,8 @@ class WallpaperWanderController(
                 motionState = MotionState.STOPPED,
                 ambientGoal = AmbientWanderGoal.RANDOM,
                 ambientStep = 0,
-                facingDirection = WalkFacingDirection.RIGHT
+                facingDirection = WalkFacingDirection.RIGHT,
+                actionStateKey = null
             )
         }
     }
@@ -632,6 +671,10 @@ class WallpaperWanderController(
         return min + random.nextLong(max - min + 1)
     }
 
+    private fun randomActionIntervalMs(): Long {
+        return randomLong(MIN_ACTION_INTERVAL_MS, MAX_ACTION_INTERVAL_MS)
+    }
+
     private fun coerceToSafeBounds(state: WanderState) {
         state.xPct = state.xPct.coerceIn(MIN_X_PCT, MAX_X_PCT)
         state.yPct = state.yPct.coerceIn(MIN_Y_PCT, MAX_Y_PCT)
@@ -643,8 +686,9 @@ class WallpaperWanderController(
         const val DEFAULT_GATHER_SPACING_PCT = 0.18f
         private const val ARRIVAL_EPSILON_PX = 1f
         private const val FACING_EPSILON_PX = 0.5f
-        // Free-walking action cadence: every ~10s the entity performs a ~3s stationary action.
-        private const val ACTION_INTERVAL_MS = 10000L
+        // Free-walking action cadence: each entity independently pauses every 10-30s.
+        private const val MIN_ACTION_INTERVAL_MS = 10000L
+        private const val MAX_ACTION_INTERVAL_MS = 30000L
         private const val ACTION_DURATION_MS = 3000L
         private const val MIN_RETARGET_MS = 3000L
         private const val MAX_RETARGET_MS = 8000L

--- a/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
+++ b/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
@@ -44,6 +44,9 @@ class ClawWallpaperService : WallpaperService() {
             com.hank.clawlive.data.remote.NetworkModule.api,
             this@ClawWallpaperService
         )
+        private val walkConfigRepository = com.hank.clawlive.data.repository.WalkConfigRepository(
+            this@ClawWallpaperService
+        )
         private val renderer = ClawRenderer(this@ClawWallpaperService, companionRepository)
         private val repository = com.hank.clawlive.data.repository.StateRepository(
             com.hank.clawlive.data.remote.NetworkModule.api,
@@ -203,6 +206,7 @@ class ClawWallpaperService : WallpaperService() {
                 engineScope.cancel()
                 renderer.release()
                 companionRepository.release()
+                walkConfigRepository.release()
             }
         })
 
@@ -221,6 +225,7 @@ class ClawWallpaperService : WallpaperService() {
         // Tracks which entityIds already have a companion-poller flow running so
         // we don't spawn duplicate jobs each time getMultiEntityStatusFlow emits.
         private val companionJobs = mutableMapOf<Int, kotlinx.coroutines.Job>()
+        private val walkConfigJobs = mutableMapOf<Int, kotlinx.coroutines.Job>()
 
         // Held references so visibility transitions can cancel/restart pollers
         // rather than letting them burn API quota while the wallpaper is
@@ -246,6 +251,7 @@ class ClawWallpaperService : WallpaperService() {
                             currentEntities = response.entities
                             hasFirstResponse = true
                             ensureCompanionPollers(response.entities)
+                            ensureWalkConfigPollers(response.entities)
                             if (visible) draw()
                         }
                 } else {
@@ -291,6 +297,8 @@ class ClawWallpaperService : WallpaperService() {
             kanbanJob = null
             companionJobs.values.forEach { it.cancel() }
             companionJobs.clear()
+            walkConfigJobs.values.forEach { it.cancel() }
+            walkConfigJobs.clear()
         }
 
         private fun ensureCompanionPollers(entities: List<EntityStatus>) {
@@ -309,6 +317,30 @@ class ClawWallpaperService : WallpaperService() {
                 if (companionJobs[id]?.isActive == true) continue
                 companionJobs[id] = engineScope.launch {
                     companionRepository.getCompanionFlow(id, secret).collect {
+                        if (visible) draw()
+                    }
+                }
+            }
+        }
+
+        private fun ensureWalkConfigPollers(entities: List<EntityStatus>) {
+            val active = entities.mapNotNull { e ->
+                e.botSecret?.let { secret -> e.entityId to secret }
+            }
+            val activeIds = active.map { it.first }.toSet()
+            walkConfigRepository.pruneTo(activeIds)
+            renderer.setWalkActionConfigs(walkConfigRepository.cachedMap())
+
+            walkConfigJobs.keys.toList().forEach { id ->
+                if (id !in activeIds) {
+                    walkConfigJobs.remove(id)?.cancel()
+                }
+            }
+            for ((id, secret) in active) {
+                if (walkConfigJobs[id]?.isActive == true) continue
+                walkConfigJobs[id] = engineScope.launch {
+                    walkConfigRepository.getWalkConfigFlow(id, secret).collect {
+                        renderer.setWalkActionConfigs(walkConfigRepository.cachedMap())
                         if (visible) draw()
                     }
                 }

--- a/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
@@ -19,6 +19,7 @@ import com.hank.clawlive.data.model.CharacterState
 import com.hank.clawlive.data.model.CompanionDetail
 import com.hank.clawlive.data.model.EntityStatus
 import com.hank.clawlive.data.model.UsageSnapshotLatest
+import com.hank.clawlive.data.model.WalkActionConfig
 import com.hank.clawlive.engine.ProceduralCreatureDrawer
 import com.hank.clawlive.engine.SpritesheetCompanionDrawer
 import com.hank.clawlive.engine.UsageOverlayRenderer
@@ -66,6 +67,7 @@ class WallpaperPreviewView @JvmOverloads constructor(
     // Per-entity selected companion descriptor — drives renderer dispatch
     // (cat/dog/fish via ProceduralCreatureDrawer; null falls back to legacy lobster).
     private var companionsByEntity: Map<Int, CompanionDetail?> = emptyMap()
+    private var walkActionConfigsByEntity: Map<Int, WalkActionConfig> = emptyMap()
 
     private var usageSnapshot: UsageSnapshotLatest? = null
     private var usageOverlayTopInsetPx: Float = 0f
@@ -207,6 +209,11 @@ class WallpaperPreviewView @JvmOverloads constructor(
         invalidate()
     }
 
+    fun setWalkActionConfigs(configs: Map<Int, WalkActionConfig>) {
+        walkActionConfigsByEntity = configs
+        invalidate()
+    }
+
     fun setUsageSnapshot(snapshot: UsageSnapshotLatest?) {
         usageSnapshot = snapshot
         invalidate()
@@ -282,7 +289,8 @@ class WallpaperPreviewView @JvmOverloads constructor(
             width = width.toFloat(),
             height = height.toFloat(),
             enabled = layoutPrefs.wallpaperWalkingEnabled,
-            purposeful = layoutPrefs.wallpaperPurposefulWalkingEnabled
+            purposeful = layoutPrefs.wallpaperPurposefulWalkingEnabled,
+            walkActionConfigsByEntity = walkActionConfigsByEntity
         )
         val interactionState = interactionController.apply(
             positions = renderPositions,
@@ -337,7 +345,9 @@ class WallpaperPreviewView @JvmOverloads constructor(
                 entityScale,
                 walking = wanderController.isWalking(entity.entityId),
                 facingDirection = interactionPose?.facingDirection
-                    ?: wanderController.facingDirection(entity.entityId)
+                    ?: wanderController.facingDirection(entity.entityId),
+                actionState = interactionState.actionStatesByEntity[entity.entityId],
+                ambientActionKey = wanderController.actionStateKey(entity.entityId)
             )
 
             // Draw entity name label
@@ -532,18 +542,22 @@ class WallpaperPreviewView @JvmOverloads constructor(
         cy: Float,
         scale: Float,
         walking: Boolean = false,
-        facingDirection: WalkFacingDirection = WalkFacingDirection.RIGHT
+        facingDirection: WalkFacingDirection = WalkFacingDirection.RIGHT,
+        actionState: CharacterState? = null,
+        ambientActionKey: String? = null
     ) {
         val companion = companionRepository?.cached(entity.entityId) ?: companionsByEntity[entity.entityId]
         if (companion?.assetType == "spritesheet") {
-            val spritesheetState = if (walking && entity.state.canUseAmbientWalkingAnimation) {
-                when (facingDirection) {
-                    WalkFacingDirection.LEFT -> CharacterState.RUNNING_LEFT.wallpaperActionKey
-                    WalkFacingDirection.RIGHT -> CharacterState.RUNNING_RIGHT.wallpaperActionKey
+            val spritesheetState = actionState?.wallpaperActionKey
+                ?: ambientActionKey
+                ?: if (walking && entity.state.canUseAmbientWalkingAnimation) {
+                    when (facingDirection) {
+                        WalkFacingDirection.LEFT -> CharacterState.RUNNING_LEFT.wallpaperActionKey
+                        WalkFacingDirection.RIGHT -> CharacterState.RUNNING_RIGHT.wallpaperActionKey
+                    }
+                } else {
+                    entity.state.wallpaperActionKey
                 }
-            } else {
-                entity.state.wallpaperActionKey
-            }
             val result = spritesheetDrawer?.draw(
                 canvas,
                 companion,

--- a/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
@@ -2,6 +2,7 @@ package com.hank.clawlive
 
 import com.hank.clawlive.data.model.CharacterState
 import com.hank.clawlive.data.model.EntityStatus
+import com.hank.clawlive.data.model.WalkActionConfig
 import com.hank.clawlive.engine.MotionState
 import com.hank.clawlive.engine.WalkFacingDirection
 import com.hank.clawlive.engine.WallpaperWanderController
@@ -9,6 +10,7 @@ import kotlin.math.abs
 import kotlin.random.Random
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -203,7 +205,7 @@ class WallpaperWanderControllerTest {
 
     @Test
     fun freeWalkingHoldsPositionDuringRandomActionAndRoamsBetween() {
-        // 行走功能 (free walking): every ~10s the entity performs a ~3s stationary random
+        // 行走功能 (free walking): every 10-30s the entity performs a ~3s stationary random
         // action — during that window its position MUST NOT change (it freezes while the
         // gesture plays), and it MUST roam (advance) between actions.
         // Pre-fix bug: the pause was armed only on arrival, which the 0.04/s wander almost
@@ -217,7 +219,7 @@ class WallpaperWanderControllerTest {
         var prev: Pair<Float, Float>? = null
         var sawActionHold = false
         var sawRoamMove = false
-        repeat(400) { // 40s at 100ms ticks -> several 10s action cadences
+        repeat(400) { // 40s at 100ms ticks -> at least one 10-30s action cadence
             t += 100L
             val pos = controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = false, nowMs = t)[0]
             val acting = controller.isPerformingAction(1)
@@ -236,6 +238,115 @@ class WallpaperWanderControllerTest {
 
         assertTrue("expected at least one stationary action window within 40s", sawActionHold)
         assertTrue("entity must roam (advance) between actions", sawRoamMove)
+    }
+
+    @Test
+    fun freeWalkingRandomActionCadenceIsIndependentPerEntityAndWithinRange() {
+        val controller = WallpaperWanderController(random = Random(19))
+        val entities = listOf(
+            EntityStatus(entityId = 1, state = CharacterState.IDLE),
+            EntityStatus(entityId = 2, state = CharacterState.IDLE)
+        )
+        val base = listOf(250f to 500f, 750f to 500f)
+        val actionStarts = mutableMapOf<Int, MutableList<Long>>(
+            1 to mutableListOf(),
+            2 to mutableListOf()
+        )
+        val wasActing = mutableMapOf(1 to false, 2 to false)
+
+        controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = false, nowMs = 0L)
+        var t = 0L
+        repeat(700) {
+            t += 100L
+            controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = false, nowMs = t)
+            entities.forEach { entity ->
+                val acting = controller.isPerformingAction(entity.entityId)
+                if (acting && wasActing[entity.entityId] == false) {
+                    actionStarts.getValue(entity.entityId).add(t)
+                }
+                wasActing[entity.entityId] = acting
+            }
+        }
+
+        val first = actionStarts.getValue(1)
+        val second = actionStarts.getValue(2)
+        assertTrue("entity 1 should perform at least two actions", first.size >= 2)
+        assertTrue("entity 2 should perform at least two actions", second.size >= 2)
+        assertNotEquals("entities should not share the same first action time", first.first(), second.first())
+        (first.zipWithNext() + second.zipWithNext()).forEach { (prev, next) ->
+            val delta = next - prev
+            assertTrue("action interval should be >= 9.9s with tick rounding, got $delta", delta >= 9_900L)
+            assertTrue("action interval should be <= 30.1s with tick rounding, got $delta", delta <= 30_100L)
+        }
+    }
+
+    @Test
+    fun walkConfigFiltersNegativeActionsBeforeRandomSelection() {
+        val controller = WallpaperWanderController(random = Random(23))
+        val entities = listOf(EntityStatus(entityId = 1, state = CharacterState.IDLE))
+        val base = listOf(250f to 500f)
+        val config = WalkActionConfig(
+            weights = mapOf("fail" to 100f),
+            allowNegative = false,
+            negativeActions = listOf("fail", "sad", "sick", "angry")
+        )
+
+        controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = false, nowMs = 0L)
+        var actionKey: String? = null
+        var t = 0L
+        repeat(310) {
+            t += 100L
+            controller.positionsFor(
+                base,
+                entities,
+                1000f,
+                1000f,
+                enabled = true,
+                purposeful = false,
+                nowMs = t,
+                walkActionConfigsByEntity = mapOf(1 to config)
+            )
+            if (controller.isPerformingAction(1) && actionKey == null) {
+                actionKey = controller.actionStateKey(1)
+            }
+        }
+
+        assertTrue("expected an action inside the 30s max interval", actionKey != null)
+        assertNotEquals("failed", actionKey)
+    }
+
+    @Test
+    fun walkConfigAllowsNegativeActionsWhenEntityOptsIn() {
+        val controller = WallpaperWanderController(random = Random(29))
+        val entities = listOf(EntityStatus(entityId = 1, state = CharacterState.IDLE))
+        val base = listOf(250f to 500f)
+        val config = WalkActionConfig(
+            weights = mapOf("fail" to 1f),
+            allowNegative = true,
+            negativeActions = listOf("fail", "sad", "sick", "angry")
+        )
+
+        controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = false, nowMs = 0L)
+        var actionKey: String? = null
+        var t = 0L
+        repeat(310) {
+            t += 100L
+            controller.positionsFor(
+                base,
+                entities,
+                1000f,
+                1000f,
+                enabled = true,
+                purposeful = false,
+                nowMs = t,
+                walkActionConfigsByEntity = mapOf(1 to config)
+            )
+            if (controller.isPerformingAction(1) && actionKey == null) {
+                actionKey = controller.actionStateKey(1)
+            }
+        }
+
+        assertEquals("failed", actionKey)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- change wallpaper free-walking stop cadence from fixed 10s to independent per-entity 10-30s random intervals
- add Android walk-config polling per bound entity using that entity's botSecret, with cached fail-safe defaults and 429 backoff
- drive live wallpaper and preview stop-action spritesheet rows from walk-config weights while filtering negative actions unless allowNegative is true
- cover cadence bounds and negative-action filtering in WallpaperWanderControllerTest

## Validation
- PASS: `git diff --cached --check`
- BLOCKED: `./gradlew :app:testDebugUnitTest --tests com.hank.clawlive.WallpaperWanderControllerTest` cannot start in this workspace because Android SDK is missing (`ANDROID_HOME`/`ANDROID_SDK_ROOT` empty and no `sdk.dir` in local.properties).

Card: card_31f828967b38f61b2043c808