### PR TITLE
fix(chat): 需要你 inbox prompt fully readable, not line-clamped (card_2e969ff3)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -435,9 +435,21 @@
             border: 1px solid rgba(45,212,191,0.65); color: #2dd4bf; background: rgba(20,184,166,0.12);
             max-width: 100%; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
         }
+        /* The prompt is the owner's DECISION QUESTION — it must always be fully
+           readable. It was previously clamped with `-webkit-line-clamp:5;
+           overflow:hidden`, which cut long prompts off with an invisible ellipsis
+           ("…可合併。我不…") that no normal scroll could reveal — the ONLY way to see
+           the rest was to drag a text selection (the browser auto-scrolls the
+           selection). The sections below (做了什麼/選項/回覆) rendered fully because
+           they are separate elements outside the clamped box (card_2e969ff3). Fix:
+           no clamp — show the whole prompt. A generous max-height + native scroll
+           caps a pathologically long prompt so it can't push the options off-screen,
+           but it scrolls with an ordinary drag (overscroll-behavior:contain keeps
+           the mobile fixed-overlay body from also scrolling). */
         .action-request-prompt {
-            color: var(--text, #ffffff); overflow-wrap: anywhere;
-            display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden;
+            color: var(--text, #ffffff); overflow-wrap: anywhere; white-space: pre-wrap;
+            max-height: 46vh; overflow-y: auto;
+            overscroll-behavior: contain; -webkit-overflow-scrolling: touch;
         }
         .action-request-type-hint { color: var(--text-secondary, #AAAAAA); font-size: 12px; line-height: 1.45; }
         .action-request-options, .action-request-actions { display: flex; flex-wrap: wrap; gap: 6px; }

--- a/backend/tests/jest/chat-action-request-inbox.test.js
+++ b/backend/tests/jest/chat-action-request-inbox.test.js
@@ -282,3 +282,43 @@ describe('需要你 inbox ratify badge (計畫E, buildRatifyBadge)', () => {
         expect(i18nJs).toContain('"action_request_ratify_default_agree_badge"');
     });
 });
+
+describe('需要你 inbox prompt is fully readable, not clamped (card_2e969ff3)', () => {
+    // Regression guard: the decision PROMPT was clamped with `-webkit-line-clamp:5;
+    // overflow:hidden`, cutting long prompts off with an invisible ellipsis that no
+    // ordinary scroll could reveal — the owner could only see the rest by dragging a
+    // text selection (Android, screenshot-confirmed). The sections below it rendered
+    // fully. The prompt must show the whole text and, if capped, scroll with a normal
+    // drag — never re-introduce a line-clamp on the prompt.
+    function promptRule() {
+        const m = chatHtml.match(/\.action-request-prompt\s*\{([^}]*)\}/);
+        expect(m).toBeTruthy();
+        return m[1];
+    }
+
+    test('the prompt is NOT line-clamped (no -webkit-line-clamp / -webkit-box clip)', () => {
+        const rule = promptRule();
+        expect(rule).not.toMatch(/-webkit-line-clamp/);
+        expect(rule).not.toMatch(/-webkit-box-orient/);
+        expect(rule).not.toMatch(/display:\s*-webkit-box/);
+    });
+
+    test('a long prompt scrolls with a normal drag (max-height + overflow-y:auto, not overflow:hidden)', () => {
+        const rule = promptRule();
+        expect(rule).toMatch(/max-height:\s*\d/);
+        expect(rule).toMatch(/overflow-y:\s*auto/);
+        // must not silently clip: no bare `overflow: hidden` on the prompt.
+        expect(rule).not.toMatch(/overflow:\s*hidden/);
+    });
+
+    test('the prompt scroll is touch-friendly and does not chain to the overlay body', () => {
+        const rule = promptRule();
+        expect(rule).toMatch(/overscroll-behavior:\s*contain/);
+        expect(rule).toMatch(/-webkit-overflow-scrolling:\s*touch/);
+    });
+
+    test('the mobile fixed-overlay inbox body still scrolls (PR #3869 not regressed)', () => {
+        expect(chatHtml).toMatch(/\.action-request-inbox\.is-open\s*\{[^}]*position:\s*fixed/);
+        expect(chatHtml).toMatch(/\.action-request-inbox\.is-open\s+\.action-request-inbox-body\s*\{[^}]*overflow-y:\s*auto/);
+    });
+});


### PR DESCRIPTION
## Bug (Android, screenshot-confirmed)
In the 需要你 (owner-decision) inbox, a decision item's main **PROMPT** text was truncated with an ellipsis (e.g. `…可合併。我不…`) while the sections below it (做了什麼 / 選項 a/b/c / 回覆·任務卡·略過) rendered fully. Scrolling didn't reveal the rest — the **only** way to see the clipped prompt was to drag a text selection (the browser auto-scrolls the selection). So the prompt had a clamped height with `overflow:hidden` and no usable scroll.

## Root cause
`.action-request-prompt` in `backend/public/portal/chat.html`:
```css
.action-request-prompt {
    color: var(--text, #ffffff); overflow-wrap: anywhere;
    display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden;
}
```
`-webkit-line-clamp:5` + `overflow:hidden` truncated the prompt to 5 lines with an invisible ellipsis and no scroll. The sections below render fully because they are separate elements outside the clamped box.

## Fix
Remove the clamp so the whole prompt shows. Cap a pathologically long prompt with `max-height:46vh` + `overflow-y:auto` (`overscroll-behavior:contain` + `-webkit-overflow-scrolling:touch`) so it scrolls with a **normal drag** — not a text selection — inside the `position:fixed` mobile overlay (PR #3869, not regressed) without chaining to the inbox body. `white-space:pre-wrap` also preserves the owner's intended line breaks.

## Guard
`chat-action-request-inbox.test.js` (+4 static tests): asserts `.action-request-prompt` is NOT line-clamped (no `-webkit-line-clamp` / `-webkit-box`), has `max-height` + `overflow-y:auto` (no bare `overflow:hidden`), has `overscroll-behavior:contain` + touch scrolling, and that the mobile fixed-overlay body still scrolls (PR #3869 guard).

## Tests
- `chat-action-request-inbox.test.js`: 30/30 pass (4 new)
- All `tests/jest/chat*`: 368/368 pass
- eslint: clean (HTML + test file are in the eslint ignore set; no errors)

## Deploy caveat (post-merge, not in this PR)
`chat.html`'s shared CSS is inline in the page; `chat.html` itself is served fresh, but note the general portal edge-cache caveat — allow Cloudflare edge (`max-age ~4h`) to refresh, then verify the real rendered drag on a phone after propagation.

Card: card_2e969ff3ce93a383c06a34d3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN