### PR TITLE
feat(wishlist-matchmaking): reachability = opt-in ONLY (drop heartbeat-liveness gate)

### DIFF
--- a/backend/tests/jest/wishlist-matchmaking-p3.test.js
+++ b/backend/tests/jest/wishlist-matchmaking-p3.test.js
@@ -298,23 +298,30 @@ describe('seller-initiated matchmaking (real governed invite)', () => {
         expect(sent[0].toPublicCode).toBe(BUYER.publicCode);      // invite goes TO the buyer
     });
 
-    // REGRESSION 2: target buyer OFFLINE/unreachable ⇒ NOTHING sent. Before the fix,
-    // the buyer was P2's caller so only the seller's reachability was checked and an
-    // invite fired to an offline buyer.
-    it('sends NOTHING when the target buyer is offline/unreachable', async () => {
+    // NEW CONTRACT (owner directive 「不建議使用心跳新鮮度來阻擋撮合，opt-in 阻擋合理」):
+    // reachability is OPT-IN ONLY. A target buyer that is opted-in but OFFLINE (stale
+    // roster) is STILL reachable — the seller-scan invite MUST fire through P2's
+    // governed sink (invites are async/durable). This was formerly REGRESSION 2
+    // (offline ⇒ nothing sent); the liveness gate has been removed. Note the seller-
+    // scan still binds `from` to the SELLER (caller) — see the impersonation test
+    // above — so this inversion does NOT relax the P3 principal-binding fix.
+    it('opted-in buyer that is OFFLINE (stale roster) ⇒ invite STILL sent (liveness no longer gates)', async () => {
         const { app, sent } = buildApp({
             ...matchWish(BUYER),
             roster: {
                 [SELLER.publicCode]: { publicCode: SELLER.publicCode, entityId: SELLER.entityId, state: 'IDLE', lastUpdated: Date.now(), isBound: true },
-                // buyer is stale/offline: lastUpdated far in the past
+                // buyer is stale/offline: lastUpdated far in the past — no longer a block.
                 [BUYER.publicCode]: { publicCode: BUYER.publicCode, entityId: BUYER.entityId, state: 'IDLE', lastUpdated: Date.now() - 60 * 60 * 1000, isBound: true },
             },
         });
         const res = await post(app, '/seller-listing-scan').send({ ...SELLER, itemId: 42, itemName: 'x' });
         expect(res.status).toBe(200);
-        expect(res.body.invitedCount).toBe(0);
-        expect(res.body.skipped.some((s) => s.reason === 'unreachable')).toBe(true);
-        expect(sent).toHaveLength(0);
+        expect(res.body.invitedCount).toBe(1);
+        expect((res.body.skipped || []).some((s) => s.reason === 'unreachable')).toBe(false);
+        expect(sent).toHaveLength(1);
+        // principal-binding preserved: the send is FROM the seller (caller), TO the buyer.
+        expect(sent[0].fromPublicCode).toBe(SELLER.publicCode);
+        expect(sent[0].toPublicCode).toBe(BUYER.publicCode);
     });
 
     // REGRESSION 4: target buyer NOT opted-in ⇒ NOTHING sent (recipient consent gate,

--- a/backend/tests/jest/wishlist-matchmaking.test.js
+++ b/backend/tests/jest/wishlist-matchmaking.test.js
@@ -129,7 +129,7 @@ describe('governance: owner opt-in (default OFF)', () => {
         const { app, sent } = buildApp({
             prefs: {
                 [BUYER.deviceId]: { wishlist_matchmaking_enabled: true },
-                [SELLER.deviceId]: {}, // seller not opted in
+                [SELLER.deviceId]: {}, // seller not opted in ⇒ the ONLY thing that blocks
             },
         });
         const res = await post(app, '/invite').send({
@@ -140,7 +140,11 @@ describe('governance: owner opt-in (default OFF)', () => {
         expect(sent).toHaveLength(0);
     });
 
-    it('target OFFLINE (stale lastUpdated) ⇒ unreachable ⇒ 409, no send', async () => {
+    // NEW CONTRACT (owner directive 「不建議使用心跳新鮮度來阻擋撮合，opt-in 阻擋合理」):
+    // reachability is OPT-IN ONLY. An opted-in target whose roster liveness is stale
+    // / offline / SLEEPING is STILL reachable — the invite MUST fire (durable/async).
+    // Only opt-in OFF (or kill-switch / quota) blocks the send.
+    it('opted-in target with STALE (offline) roster ⇒ invite STILL sent (liveness no longer gates)', async () => {
         const { app, sent } = buildApp({
             roster: {
                 [SELLER.publicCode]: {
@@ -152,9 +156,51 @@ describe('governance: owner opt-in (default OFF)', () => {
         const res = await post(app, '/invite').send({
             ...BUYER, sellerPublicCode: SELLER.publicCode, itemId: 1, itemName: 'x',
         });
-        expect(res.status).toBe(409);
-        expect(res.body.reason).toBe('unreachable');
-        expect(sent).toHaveLength(0);
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe('invited');
+        expect(sent).toHaveLength(1);
+    });
+
+    it('opted-in target in SLEEPING state ⇒ invite STILL sent (SLEEPING ≠ opted-out)', async () => {
+        const { app, sent } = buildApp({
+            roster: {
+                [SELLER.publicCode]: {
+                    publicCode: SELLER.publicCode, entityId: SELLER.entityId,
+                    state: 'SLEEPING', lastUpdated: Date.now(), isBound: true,
+                },
+            },
+        });
+        const res = await post(app, '/invite').send({
+            ...BUYER, sellerPublicCode: SELLER.publicCode, itemId: 1, itemName: 'x',
+        });
+        expect(res.status).toBe(200);
+        expect(sent).toHaveLength(1);
+    });
+
+    it('opted-in target with NO roster entry at all ⇒ invite STILL sent (roster absent ≠ opted-out)', async () => {
+        const { app, sent } = buildApp({
+            roster: {}, // getRosterEntry returns null for the seller
+        });
+        const res = await post(app, '/invite').send({
+            ...BUYER, sellerPublicCode: SELLER.publicCode, itemId: 1, itemName: 'x',
+        });
+        expect(res.status).toBe(200);
+        expect(sent).toHaveLength(1);
+    });
+
+    it('isReachableTarget is opt-in ONLY — ignores roster liveness/state entirely', () => {
+        // opted-in ⇒ reachable regardless of roster staleness/state/absence.
+        expect(mm.isReachableTarget({ prefs: { wishlist_matchmaking_enabled: true } })).toBe(true);
+        expect(mm.isReachableTarget({
+            rosterEntry: { state: 'FAILED', lastUpdated: 0, isBound: true, publicCode: 'sellrx' },
+            prefs: { wishlist_matchmaking_enabled: true },
+        })).toBe(true);
+        expect(mm.isReachableTarget({ rosterEntry: null, prefs: { wishlist_matchmaking_enabled: true } })).toBe(true);
+        // opt-in OFF ⇒ NOT reachable, even with a perfectly fresh/online roster.
+        expect(mm.isReachableTarget({
+            rosterEntry: { state: 'ACTIVE', lastUpdated: Date.now(), isBound: true, publicCode: 'sellrx' },
+            prefs: {},
+        })).toBe(false);
     });
 });
 

--- a/backend/wishlist-matchmaking.js
+++ b/backend/wishlist-matchmaking.js
@@ -24,8 +24,11 @@
  *      (`wishlist_matchmaking_enabled`, default OFF), a global kill-switch
  *      (`wishlist_matchmaking_killswitch`) disables ALL sends, and a per-entity
  *      quota (separate counter from CROSS_SPEAK_MAX_MESSAGES) caps invites.
- *   3. Reachability — an invite is only sent to a target that is BOTH online (per
- *      the /api/entities roster) AND opted-in.
+ *   3. Reachability — an invite is only sent to a target whose owner OPTED IN.
+ *      Reachability is opt-in ONLY: it does NOT depend on the roster's current
+ *      liveness (invites are async/durable, so an opted-in but momentarily idle or
+ *      SLEEPING party still receives them). The kill-switch is the "stop reaching
+ *      me" control; heartbeat freshness is not.
  *   4. Dual lightweight consent (D5) — the agent name-card (publicCode/displayName/
  *      caps) may auto-exchange, but ANY real contact info (email/phone/…) is
  *      released ONLY after BOTH owners approve it in their 需要你 inbox. A contact
@@ -249,30 +252,25 @@ function sanitizeContactInfo(contactInfo) {
     return out;
 }
 
-// ── Reachability (online AND opted-in) ──────────────────────────────────────
+// ── Reachability (opt-in ONLY — NOT liveness) ───────────────────────────────
 
 /**
- * True iff the target public code is BOTH online (per the roster) AND its owner
- * device has opted into matchmaking. rosterEntry is one /api/entities record;
- * prefs is that owner device's preferences.
+ * True iff the target's owner device has opted into matchmaking. Reachability is
+ * OPT-IN ONLY — it does NOT depend on the roster's current liveness (owner spec,
+ * 2026-07: 「不建議使用心跳新鮮度來阻擋撮合，opt-in 阻擋合理」).
+ *
+ * Matchmaking invites are asynchronous, durable action-requests: an opted-in
+ * seller/buyer that is momentarily idle (heartbeat stale) or SLEEPING (idle-20min-
+ * no-work) is STILL reachable — it receives the invite and responds whenever next
+ * active. Blocking on current liveness only produced false-negatives (a real
+ * opted-in party idle for a few minutes got silently skipped). SLEEPING/FAILED/
+ * stale-heartbeat none mean "opted out", so none may gate matchmaking.
+ *
+ * The kill-switch (checked separately by the caller) is the intentional per-owner
+ * "stop reaching me" control — liveness is not.
  */
-function isReachableTarget({ rosterEntry, prefs, now, onlineWindowMs = 5 * 60 * 1000 }) {
-    if (!rosterEntry || !rosterEntry.isBound || !rosterEntry.publicCode) return false;
-    if (!isOnline(rosterEntry, now, onlineWindowMs)) return false;
-    if (!isOptedIn(prefs)) return false;
-    return true;
-}
-
-function isOnline(rosterEntry, now, onlineWindowMs) {
-    if (!rosterEntry) return false;
-    const state = rosterEntry.state;
-    // SLEEPING/FAILED are not reachable for an unsolicited invite.
-    const reachableState = state === 'BUSY' || state === 'ACTIVE' || state === 'IDLE' || state === 'REVIEW';
-    if (!reachableState) return false;
-    const last = Number(rosterEntry.lastUpdated);
-    if (!Number.isFinite(last)) return false;
-    const t = typeof now === 'function' ? now() : Date.now();
-    return t - last <= onlineWindowMs;
+function isReachableTarget({ rosterEntry, prefs }) {
+    return isOptedIn(prefs);
 }
 
 function isOptedIn(prefs) {
@@ -499,7 +497,10 @@ function createRouter(opts = {}) {
         }
 
         // (b) Resolve the seller + its owner device, then enforce reachability:
-        // the seller must be BOTH online AND opted-in.
+        // the seller must be opted-in. Reachability is OPT-IN ONLY — NOT current
+        // liveness. Invites are durable/async, so an opted-in seller that is idle
+        // or SLEEPING still receives the invite (blocking on liveness only caused
+        // false-negatives).
         const sellerResolved = typeof resolvePublicCode === 'function' ? resolvePublicCode(sellerCode) : null;
         if (!sellerResolved || !sellerResolved.deviceId) {
             return res.status(404).json({ error: 'seller public code not found' });
@@ -509,9 +510,9 @@ function createRouter(opts = {}) {
         if (isKillSwitchOn(sellerPrefs)) {
             return res.status(403).json({ error: 'target has matchmaking disabled', reason: 'target_killswitch' });
         }
-        if (!isReachableTarget({ rosterEntry: sellerRoster, prefs: sellerPrefs, now: clock })) {
+        if (!isReachableTarget({ rosterEntry: sellerRoster, prefs: sellerPrefs })) {
             return res.status(409).json({
-                error: 'seller is not reachable (must be online and opted-in)',
+                error: 'seller has not opted into matchmaking',
                 reason: 'unreachable',
             });
         }
@@ -864,7 +865,6 @@ module.exports = {
     buildDeclineEnvelope,
     buildContactEnvelope,
     isReachableTarget,
-    isOnline,
     isOptedIn,
     isKillSwitchOn,
     createQuotaTracker,


### PR DESCRIPTION
## What & why

Owner directive: 「不建議使用心跳新鮮度來阻擋撮合，opt-in 阻擋合理」.

Matchmaking invites are **asynchronous, durable action-requests** — a target who is opted-in should receive the invite and respond whenever next active. Gating on **current liveness** only produced false-negatives: a real opted-in seller/buyer idle for a few minutes (stale heartbeat) or in `SLEEPING` (idle-20min-no-work) got silently skipped. None of those states means "opted out".

So **reachability is now opt-in ONLY.**

## Change (`backend/wishlist-matchmaking.js`)

- `isReachableTarget({ prefs })` now returns just the opt-in check (`prefs.wishlist_matchmaking_enabled === true`).
- Removed `isOnline` (the 5-min heartbeat-freshness window **and** the reachable-state SLEEPING/FAILED check) and its export. It was used **only** by `isReachableTarget` — grep confirmed no other caller (index.js P3 glue wires `getRosterEntry` but never called `isOnline`; the `getRosterEntry` injectable is left intact/harmless).
- Updated the `/invite` 409 message + HARD RULE #3 doc to reflect opt-in-only reachability.

**Untouched (verified no regression):** opt-in gate, kill-switch (buyer + target), separate invite quota, dual-consent/contact release (server-side `getPartyContact`, cross-owner-PII human-only gate), matchId dedup, and the **P3 #3910 seller-scan/rescan caller-principal binding** (invite still binds `from` to the verified caller — the impersonation fix is preserved and re-asserted in a test).

## Tests (inverted to the new contract)

- `wishlist-matchmaking.test.js`: **inverted** "target OFFLINE (stale) ⇒ 409" → now asserts the invite **IS sent** (200, one send). Added: opted-in + `SLEEPING` ⇒ sent; opted-in + no roster entry ⇒ sent; a direct `isReachableTarget` unit test (opt-in only; ignores state/staleness/absence; opt-in OFF ⇒ false even with a fresh/online roster). Kept opt-in-OFF ⇒ 409.
- `wishlist-matchmaking-p3.test.js`: **inverted** REGRESSION 2 (offline buyer ⇒ nothing sent) → opted-in offline buyer ⇒ invite **still sent**, and re-asserts `from=seller,to=buyer` so the inversion does NOT relax the P3 principal-binding fix.

**Full matchmaking suite green: 62/62** (`wishlist-matchmaking`, `-p3`, `-p3-inprocess`, `-consent-integration`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN