### PR TITLE
fix(a11y): darken .btn-danger fill to meet WCAG 2.1 AA contrast (card_a2234cc7)

### DIFF
--- a/backend/public/portal/shared/style.css
+++ b/backend/public/portal/shared/style.css
@@ -1075,14 +1075,24 @@ a:hover { text-decoration: underline; }
     flex-shrink: 0;
 }
 
-/* Danger button (destructive actions) */
+/* Danger button (destructive actions)
+   WCAG 2.1 AA: white-on-danger must reach >= 4.5:1 for this most
+   safety-critical control. Old #e53e3e was 4.13:1 (fail). The shades
+   below are scoped to the BUTTON fill only — the --danger accent token
+   (borders/icons/text elsewhere) is intentionally left untouched.
+     base   #c53030  -> 5.47:1 (AA pass)
+     hover  #b52b2b  -> 6.28:1
+     active #a52020  -> 7.43:1 */
 .btn-danger {
-    background: #e53e3e;
+    background: #c53030;
     color: #fff;
     border: none;
 }
 .btn-danger:hover {
-    background: #c53030;
+    background: #b52b2b;
+}
+.btn-danger:active {
+    background: #a52020;
 }
 
 /* ==========================================

--- a/backend/tests/jest/btn-danger-contrast.test.js
+++ b/backend/tests/jest/btn-danger-contrast.test.js
@@ -1,0 +1,107 @@
+/**
+ * WCAG 2.1 AA contrast invariant for the shared destructive-confirm button.
+ *
+ * Card: card_a2234cc7
+ *
+ * `.btn-danger` is the fill behind every irreversible delete/unbind in the
+ * portal — the single most safety-critical control. Its white label must
+ * keep a contrast ratio of >= 4.5:1 against the button background (WCAG 2.1
+ * AA, normal text). The old fill #e53e3e was 4.13:1 and failed.
+ *
+ * This test reads the *actual* background hex out of style.css and computes
+ * the WCAG relative-luminance contrast ratio itself (no hardcoded pass), so
+ * it FAILS at #e53e3e (4.13) and PASSES at the darkened #c53030 (5.47).
+ *
+ * jest.config.js uses testEnvironment: 'node', so we parse the source rather
+ * than render it — same static-invariant style as showConfirm-a11y-attrs.test.js.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const cssPath = path.join(
+    __dirname, '..', '..', 'public', 'portal', 'shared', 'style.css'
+);
+const css = fs.readFileSync(cssPath, 'utf8');
+
+// --- WCAG relative luminance + contrast ratio (self-checking, not hardcoded) ---
+// https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+// https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio
+function channelToLinear(c8) {
+    const c = c8 / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance(hex) {
+    const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+    if (!m) throw new Error(`not a 6-digit hex color: ${hex}`);
+    const n = m[1];
+    const r = parseInt(n.slice(0, 2), 16);
+    const g = parseInt(n.slice(2, 4), 16);
+    const b = parseInt(n.slice(4, 6), 16);
+    return 0.2126 * channelToLinear(r)
+         + 0.7152 * channelToLinear(g)
+         + 0.0722 * channelToLinear(b);
+}
+
+function contrastRatio(hexA, hexB) {
+    const la = relativeLuminance(hexA);
+    const lb = relativeLuminance(hexB);
+    const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+    return (hi + 0.05) / (lo + 0.05);
+}
+
+// Pull the `.btn-danger { ... background: #rrggbb ... }` fill out of the CSS.
+// We target the scoped destructive-button block (the effective, last-wins rule
+// with an explicit `color: #fff` label), not the --danger accent token.
+function extractBtnDangerBackground(source) {
+    // Match every `.btn-danger { ... }` block (no pseudo-class), take the last
+    // one — that is the rule that wins the cascade and is actually rendered.
+    const blockRe = /\.btn-danger\s*\{([^}]*)\}/g;
+    let match;
+    let lastHex = null;
+    while ((match = blockRe.exec(source)) !== null) {
+        const body = match[1];
+        const bg = /background(?:-color)?\s*:\s*(#[0-9a-fA-F]{6})/.exec(body);
+        if (bg) lastHex = bg[1];
+    }
+    return lastHex;
+}
+
+describe('.btn-danger — WCAG 2.1 AA contrast', () => {
+    test('the WCAG math is correct (sanity anchors: known ratios)', () => {
+        // Black on white is the canonical 21:1; white on white is 1:1.
+        expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 1);
+        expect(contrastRatio('#ffffff', '#ffffff')).toBeCloseTo(1, 5);
+        // The OLD failing color must compute to ~4.13 — proves the math would
+        // have caught the regression rather than just passing the new color.
+        expect(contrastRatio('#ffffff', '#e53e3e')).toBeCloseTo(4.13, 1);
+        expect(contrastRatio('#ffffff', '#e53e3e')).toBeLessThan(4.5);
+    });
+
+    test('button background is defined in style.css', () => {
+        const bg = extractBtnDangerBackground(css);
+        expect(bg).toMatch(/^#[0-9a-fA-F]{6}$/);
+    });
+
+    test('white label on the button background reaches >= 4.5:1', () => {
+        const bg = extractBtnDangerBackground(css);
+        const ratio = contrastRatio('#ffffff', bg);
+        // Fails at #e53e3e (4.13), passes at #c53030 (5.47).
+        expect(ratio).toBeGreaterThanOrEqual(4.5);
+    });
+
+    test('hover state also stays >= 4.5:1', () => {
+        const hover = /\.btn-danger:hover\s*\{[^}]*background(?:-color)?\s*:\s*(#[0-9a-fA-F]{6})/.exec(css);
+        expect(hover).not.toBeNull();
+        expect(contrastRatio('#ffffff', hover[1])).toBeGreaterThanOrEqual(4.5);
+    });
+
+    test('active state (if present) also stays >= 4.5:1', () => {
+        const active = /\.btn-danger:active\s*\{[^}]*background(?:-color)?\s*:\s*(#[0-9a-fA-F]{6})/.exec(css);
+        if (active) {
+            expect(contrastRatio('#ffffff', active[1])).toBeGreaterThanOrEqual(4.5);
+        }
+    });
+});


### PR DESCRIPTION
## Problem
`.btn-danger` — the shared fill behind **every irreversible delete/unbind** in the portal (mission/kanban/settings + every danger confirm) — is the single most safety-critical control, yet its white label failed WCAG 2.1 AA contrast.

Measured (WCAG relative-luminance, white `#ffffff` on the fill):
- Old background `#e53e3e` (rgb 229,62,62) = **4.13:1** — below the **4.5:1** AA threshold for normal text.

## Fix
Darken the **button fill only** — scoped to `.btn-danger`, leaving the shared `--danger` accent token (`#F44336`, used for borders/icons/badge/text elsewhere) **untouched** so no unrelated accent changes:

| state | old | new | white-on-fill ratio |
|-------|-----|-----|---------------------|
| base   | `#e53e3e` (4.13, fail) | `#c53030` | **5.47:1** ✅ |
| hover  | `#c53030`              | `#b52b2b` | **6.28:1** ✅ |
| active | — (added)              | `#a52020` | **7.43:1** ✅ |

Shades darken proportionally through the states. The focus ring is unchanged — `.btn:focus-visible` draws a `--primary` (#6C63FF) outline offset *outside* the fill, so it stays visible regardless of the darker background. No modal-behavior changes (role=alertdialog / focus-trap / Cancel-first / i18n left as-is per the existing E2E). The Cancel button (9.04:1) and all other controls are untouched.

## Test (fails on old, passes on new)
`backend/tests/jest/btn-danger-contrast.test.js` — reads the **actual** `.btn-danger` background hex out of `style.css` and computes the WCAG relative-luminance contrast ratio itself (per spec, self-checking — not a hardcoded pass), asserting `>= 4.5:1`. Includes sanity anchors (black-on-white ≈ 21:1) and an explicit check that the old `#e53e3e` computes to ~4.13 and is `< 4.5`, so the math would have caught the regression. Also covers hover/active.

- FAILS at `#e53e3e` (proven: 4.1256:1 < 4.5)
- PASSES at `#c53030` (5.47:1)
- Related suites still green: `css-class-coverage`, `showConfirm-a11y-attrs`.

## Diff
Tiny: the color change + hover/active shades + the one contrast test. 2 files, +120/-3.

Card: card_a2234cc7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN