### PR TITLE
feat(wishlist-matchmaking): price-aware match predicate (card_e1b8af79)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3029,7 +3029,7 @@ const wishlistMatchmakingP3 = require('./wishlist-matchmaking-p3');
 // the invite target (P2's `sellerPublicCode` body field is just "the target").
 // The canonical (buyer,item,seller) dedup is owned by the P3 module on the shared
 // store; this function only performs the governed send.
-function runP2InviteInProcess({ callerCreds, toPublicCode, itemId, itemName, note, bypassFriendsOnly }) {
+function runP2InviteInProcess({ callerCreds, toPublicCode, itemId, itemName, note, bypassFriendsOnly, buyerMaxPrice, buyerCurrency, sellerAskPrice, sellerCurrency }) {
     return new Promise((resolve) => {
         if (!callerCreds || !callerCreds.deviceId || callerCreds.entityId === undefined || callerCreds.entityId === null || !callerCreds.botSecret) {
             return resolve({ status: 'blocked', reason: 'caller_creds_missing' });
@@ -3049,6 +3049,12 @@ function runP2InviteInProcess({ callerCreds, toPublicCode, itemId, itemName, not
                 itemId,
                 itemName,
                 note,
+                // Price basis (card_e1b8af79): P2 handleInvite re-runs price-compat on
+                // the REAL control path and carries the basis in the invite envelope.
+                buyerMaxPrice,
+                buyerCurrency,
+                sellerAskPrice,
+                sellerCurrency,
             },
             headers: {},
             get() { return undefined; },
@@ -3104,8 +3110,8 @@ app.use('/api/wishlist-matchmaking-p3', wishlistMmRateLimit, wishlistGaSendGateP
     // Reuse P2's ENTIRE governed invite path in-process. No re-implementation.
     // The invite is driven with the AUTHENTICATED CALLER as the P2 principal (its
     // own verified creds), inviting `toPublicCode`. NEVER another entity's secret.
-    governedInvite: async ({ callerCreds, toPublicCode, itemId, itemName, note, bypassFriendsOnly }) =>
-        runP2InviteInProcess({ callerCreds, toPublicCode, itemId, itemName, note, bypassFriendsOnly }),
+    governedInvite: async ({ callerCreds, toPublicCode, itemId, itemName, note, bypassFriendsOnly, buyerMaxPrice, buyerCurrency, sellerAskPrice, sellerCurrency }) =>
+        runP2InviteInProcess({ callerCreds, toPublicCode, itemId, itemName, note, bypassFriendsOnly, buyerMaxPrice, buyerCurrency, sellerAskPrice, sellerCurrency }),
     // SHARE the P2 match store so P3 dedup is symmetric with P2 (matchId identity).
     matchStore: wishlistMatchmakingRouter._store,
 }));

--- a/backend/tests/jest/wishlist-matchmaking-price.test.js
+++ b/backend/tests/jest/wishlist-matchmaking-price.test.js
@@ -1,0 +1,302 @@
+/**
+ * Price-aware matchmaking — EClaw side (card_e1b8af79).
+ *
+ * Hank's confirmed defaults:
+ *   - Price is OPTIONAL. Filter ONLY when BOTH sides have a price; either side
+ *     missing ⇒ name/tags-only fallback (do NOT exclude).
+ *   - Currency default TWD; DIFFERENT currencies ⇒ cannot compare (no FX) ⇒
+ *     name-only fallback.
+ *   - Compatible ⇔ buyer.maxPrice >= seller.askPrice (same currency).
+ *
+ * Tests drive the REAL control paths through supertest and assert the load-bearing
+ * invariant: an INCOMPATIBLE pair produces NO b2b send. Price is an ADDITIONAL
+ * filter — it can only BLOCK, never enable, a send.
+ */
+
+const express = require('express');
+const request = require('supertest');
+const mm = require('../../wishlist-matchmaking');
+const p3 = require('../../wishlist-matchmaking-p3');
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const BUYER = { deviceId: 'dev-buyer', entityId: 2, botSecret: 'BUYER_SECRET', publicCode: 'buyera' };
+const SELLER = { deviceId: 'dev-seller', entityId: 3, botSecret: 'SELLER_SECRET', publicCode: 'sellrx' };
+
+function fakeAuth() {
+    return async ({ deviceId, botSecret }) => {
+        if (deviceId === BUYER.deviceId && botSecret === BUYER.botSecret) return { ok: true, publicCode: BUYER.publicCode };
+        if (deviceId === SELLER.deviceId && botSecret === SELLER.botSecret) return { ok: true, publicCode: SELLER.publicCode };
+        return { ok: false };
+    };
+}
+
+// A P2 app with everyone opted in + reachable, capturing every b2b send.
+function buildP2(over = {}) {
+    const sent = [];
+    const prefs = over.prefs || {
+        [BUYER.deviceId]: { wishlist_matchmaking_enabled: true },
+        [SELLER.deviceId]: { wishlist_matchmaking_enabled: true },
+    };
+    const roster = {
+        [SELLER.publicCode]: { publicCode: SELLER.publicCode, entityId: SELLER.entityId, state: 'IDLE', lastUpdated: Date.now(), isBound: true },
+        [BUYER.publicCode]: { publicCode: BUYER.publicCode, entityId: BUYER.entityId, state: 'IDLE', lastUpdated: Date.now(), isBound: true },
+    };
+    const resolveMap = {
+        [SELLER.publicCode]: { deviceId: SELLER.deviceId, entityId: SELLER.entityId, entity: {} },
+        [BUYER.publicCode]: { deviceId: BUYER.deviceId, entityId: BUYER.entityId, entity: {} },
+    };
+    const store = mm.createMatchStore();
+    const router = mm.createRouter({
+        authenticateCaller: fakeAuth(),
+        searchItems: over.searchItems || (async () => ({ items: [] })),
+        resolvePublicCode: (code) => resolveMap[code] || null,
+        getRosterEntry: (code) => roster[code] || null,
+        getDevicePrefs: async (deviceId) => prefs[deviceId] || {},
+        sendB2bMessage: async (m) => { sent.push(m); return { success: true }; },
+        matchStore: store,
+    });
+    const app = express();
+    app.use(express.json());
+    app.use('/mm', router);
+    return { app, sent, store };
+}
+
+const p2invite = (app, body) => request(app).post('/mm/invite').send({ ...BUYER, ...body });
+
+// ── 1) priceCompat pure helper (every branch) ───────────────────────────────
+
+describe('priceCompat (pure)', () => {
+    it('both present, same currency, buyer >= seller ⇒ compatible', () => {
+        expect(mm.priceCompat({ buyerMaxPrice: 9000, buyerCurrency: 'TWD', sellerAskPrice: 8000, sellerCurrency: 'TWD' }))
+            .toEqual({ compatible: true, reason: 'price_compatible' });
+        // exact equality is compatible (>=).
+        expect(mm.priceCompat({ buyerMaxPrice: 8000, buyerCurrency: 'TWD', sellerAskPrice: 8000, sellerCurrency: 'TWD' }).compatible).toBe(true);
+    });
+    it('both present, same currency, buyer < seller ⇒ INCOMPATIBLE', () => {
+        expect(mm.priceCompat({ buyerMaxPrice: 5000, buyerCurrency: 'TWD', sellerAskPrice: 8000, sellerCurrency: 'TWD' }))
+            .toEqual({ compatible: false, reason: 'price_incompatible' });
+    });
+    it('either side missing price ⇒ name-only fallback (compatible)', () => {
+        expect(mm.priceCompat({ sellerAskPrice: 8000, sellerCurrency: 'TWD' }).reason).toBe('no_price_fallback');
+        expect(mm.priceCompat({ buyerMaxPrice: 5000, buyerCurrency: 'TWD' }).reason).toBe('no_price_fallback');
+        expect(mm.priceCompat({}).reason).toBe('no_price_fallback');
+        // A buyer max below the ask but NO seller ask ⇒ still fallback (not excluded).
+        expect(mm.priceCompat({ buyerMaxPrice: 1, buyerCurrency: 'TWD' }).compatible).toBe(true);
+    });
+    it('DIFFERENT currencies ⇒ cannot compare (no FX) ⇒ fallback', () => {
+        const d = mm.priceCompat({ buyerMaxPrice: 100, buyerCurrency: 'USD', sellerAskPrice: 8000, sellerCurrency: 'TWD' });
+        expect(d).toEqual({ compatible: true, reason: 'currency_mismatch_fallback' });
+    });
+    it('INVALID price (NaN/negative/absurd) is treated as ABSENT ⇒ fallback, never a false-compatible', () => {
+        // A garbage buyer max must NOT make an incompatible pair look compatible.
+        expect(mm.priceCompat({ buyerMaxPrice: 'abc', buyerCurrency: 'TWD', sellerAskPrice: 8000, sellerCurrency: 'TWD' }).reason).toBe('no_price_fallback');
+        expect(mm.priceCompat({ buyerMaxPrice: -5, buyerCurrency: 'TWD', sellerAskPrice: 8000, sellerCurrency: 'TWD' }).reason).toBe('no_price_fallback');
+        expect(mm.priceCompat({ buyerMaxPrice: Infinity, buyerCurrency: 'TWD', sellerAskPrice: 8000, sellerCurrency: 'TWD' }).reason).toBe('no_price_fallback');
+    });
+    it('numeric strings are accepted (upstream sends strings)', () => {
+        expect(mm.priceCompat({ buyerMaxPrice: '9000', buyerCurrency: 'twd', sellerAskPrice: '8000', sellerCurrency: 'TWD' }).compatible).toBe(true);
+        expect(mm.priceCompat({ buyerMaxPrice: '5000', buyerCurrency: 'twd', sellerAskPrice: '8000', sellerCurrency: 'TWD' }).compatible).toBe(false);
+    });
+});
+
+// ── 2) P2 /invite REAL control path ─────────────────────────────────────────
+
+describe('P2 /invite — price-aware, on the real control path', () => {
+    it('COMPATIBLE (buyer 9000 >= ask 8000, TWD) ⇒ invite FIRES + envelope carries price', async () => {
+        const { app, sent } = buildP2();
+        const res = await p2invite(app, {
+            sellerPublicCode: SELLER.publicCode, itemId: 1, itemName: 'Sony WH-1000XM5',
+            buyerMaxPrice: 9000, sellerAskPrice: 8000, priceCurrency: 'TWD',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe('invited');
+        expect(sent).toHaveLength(1);
+        // The invite envelope carries the price BASIS so the recipient can judge.
+        expect(sent[0].envelope.price).toEqual({ buyerMaxPrice: 9000, sellerAskPrice: 8000, currency: 'TWD' });
+    });
+
+    it('INCOMPATIBLE (buyer 5000 < ask 8000, TWD) ⇒ 409 price_incompatible + NO send', async () => {
+        const { app, sent } = buildP2();
+        const res = await p2invite(app, {
+            sellerPublicCode: SELLER.publicCode, itemId: 1, itemName: 'Sony WH-1000XM5',
+            buyerMaxPrice: 5000, sellerAskPrice: 8000, priceCurrency: 'TWD',
+        });
+        expect(res.status).toBe(409);
+        expect(res.body.reason).toBe('price_incompatible');
+        expect(sent).toHaveLength(0); // the load-bearing assertion: nothing sent
+    });
+
+    it('ONE SIDE MISSING price ⇒ name-only fallback: invite STILL fires', async () => {
+        const { app, sent } = buildP2();
+        // Seller ask present, buyer max absent — must NOT exclude.
+        const res = await p2invite(app, {
+            sellerPublicCode: SELLER.publicCode, itemId: 2, itemName: 'thing',
+            sellerAskPrice: 8000, priceCurrency: 'TWD',
+        });
+        expect(res.status).toBe(200);
+        expect(sent).toHaveLength(1);
+        // Only the seller ask is echoed in the envelope; no buyer max.
+        expect(sent[0].envelope.price).toEqual({ sellerAskPrice: 8000, currency: 'TWD' });
+    });
+
+    it('MISMATCHED currency (buyer USD vs seller TWD) ⇒ name-only fallback: invite fires', async () => {
+        const { app, sent } = buildP2();
+        const res = await p2invite(app, {
+            sellerPublicCode: SELLER.publicCode, itemId: 3, itemName: 'thing',
+            buyerMaxPrice: 100, buyerCurrency: 'USD', sellerAskPrice: 8000, sellerCurrency: 'TWD',
+        });
+        expect(res.status).toBe(200);
+        expect(sent).toHaveLength(1);
+    });
+
+    it('NO prices at all ⇒ classic behaviour: invite fires, no price in envelope', async () => {
+        const { app, sent } = buildP2();
+        const res = await p2invite(app, { sellerPublicCode: SELLER.publicCode, itemId: 4, itemName: 'thing' });
+        expect(res.status).toBe(200);
+        expect(sent).toHaveLength(1);
+        expect(sent[0].envelope.price).toBeUndefined();
+    });
+
+    it('price filter can NEVER bypass opt-in: compatible price + buyer opt-in OFF ⇒ still no send', async () => {
+        const { app, sent } = buildP2({ prefs: { [BUYER.deviceId]: {}, [SELLER.deviceId]: { wishlist_matchmaking_enabled: true } } });
+        const res = await p2invite(app, {
+            sellerPublicCode: SELLER.publicCode, itemId: 5, itemName: 'thing',
+            buyerMaxPrice: 9000, sellerAskPrice: 8000, priceCurrency: 'TWD',
+        });
+        expect(res.status).toBe(403);
+        expect(res.body.reason).toBe('opt_in_off');
+        expect(sent).toHaveLength(0);
+    });
+});
+
+// ── 3) P3 seller-listing-scan + rescan price filtering (real governed path) ──
+
+// A price-threading governed sink that mirrors index.js runP2InviteInProcess
+// (caller = P2 principal) AND forwards the price basis into P2 /invite.
+function buildP3(over = {}) {
+    const sent = [];
+    const prefs = {
+        [BUYER.deviceId]: { wishlist_matchmaking_enabled: true },
+        [SELLER.deviceId]: { wishlist_matchmaking_enabled: true },
+    };
+    const roster = {
+        [SELLER.publicCode]: { publicCode: SELLER.publicCode, entityId: SELLER.entityId, state: 'IDLE', lastUpdated: Date.now(), isBound: true },
+        [BUYER.publicCode]: { publicCode: BUYER.publicCode, entityId: BUYER.entityId, state: 'IDLE', lastUpdated: Date.now(), isBound: true },
+    };
+    const resolveMap = {
+        [SELLER.publicCode]: { deviceId: SELLER.deviceId, entityId: SELLER.entityId, entity: {} },
+        [BUYER.publicCode]: { deviceId: BUYER.deviceId, entityId: BUYER.entityId, entity: {} },
+    };
+    const store = mm.createMatchStore();
+    const p2app = express();
+    p2app.use(express.json());
+    p2app.use('/mm', mm.createRouter({
+        authenticateCaller: fakeAuth(),
+        searchItems: async () => ({ items: [] }),
+        resolvePublicCode: (code) => resolveMap[code] || null,
+        getRosterEntry: (code) => roster[code] || null,
+        getDevicePrefs: async (deviceId) => prefs[deviceId] || {},
+        sendB2bMessage: async (m) => { sent.push(m); return { success: true }; },
+        matchStore: store,
+    }));
+
+    async function governedInvite({ callerCreds, toPublicCode, itemId, itemName, note, bypassFriendsOnly, buyerMaxPrice, buyerCurrency, sellerAskPrice, sellerCurrency }) {
+        const res = await request(p2app).post(`/mm/${bypassFriendsOnly ? 'connect' : 'invite'}`).send({
+            deviceId: callerCreds.deviceId, entityId: callerCreds.entityId, botSecret: callerCreds.botSecret,
+            sellerPublicCode: toPublicCode, itemId, itemName, note,
+            buyerMaxPrice, buyerCurrency, sellerAskPrice, sellerCurrency,
+        });
+        if (res.status === 200) return { status: res.body.deduped ? 'invited' : (res.body.status || 'invited'), matchId: res.body.matchId, deduped: !!res.body.deduped };
+        return { status: 'blocked', reason: res.body && res.body.reason };
+    }
+
+    const router = p3.createRouter({
+        authenticateCaller: fakeAuth(),
+        searchItems: over.searchItems || (async () => ({ items: [] })),
+        governedInvite,
+        matchStore: store,
+    });
+    const app = express();
+    app.use(express.json());
+    app.use('/p3', router);
+    return { app, sent, store };
+}
+
+describe('P3 seller-listing-scan — price filter on invites', () => {
+    // The reverse buyer search returns a buyer wish carrying maxPrice + priceCurrency.
+    const buyerWish = (maxPrice, priceCurrency) => ({
+        items: [{ id: 11, name: 'Sony WH-1000XM5', publicCode: BUYER.publicCode, maxPrice, priceCurrency }],
+    });
+
+    it('buyer maxPrice 9000 >= seller ask 8000 (TWD) ⇒ buyer INVITED', async () => {
+        const { app, sent } = buildP3({ searchItems: async () => buyerWish(9000, 'TWD') });
+        const res = await request(app).post('/p3/seller-listing-scan').send({
+            ...SELLER, itemId: 1, itemName: 'Sony WH-1000XM5', askPrice: 8000, priceCurrency: 'TWD',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.invitedCount).toBe(1);
+        expect(sent).toHaveLength(1);
+        expect(sent[0].envelope.price).toEqual({ buyerMaxPrice: 9000, sellerAskPrice: 8000, currency: 'TWD' });
+    });
+
+    it('buyer maxPrice 5000 < seller ask 8000 (TWD) ⇒ NOT invited (no send)', async () => {
+        const { app, sent } = buildP3({ searchItems: async () => buyerWish(5000, 'TWD') });
+        const res = await request(app).post('/p3/seller-listing-scan').send({
+            ...SELLER, itemId: 1, itemName: 'Sony WH-1000XM5', askPrice: 8000, priceCurrency: 'TWD',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.invitedCount).toBe(0);
+        expect(res.body.skipped.some((s) => s.reason === 'price_incompatible')).toBe(true);
+        expect(sent).toHaveLength(0); // load-bearing: nothing sent
+    });
+
+    it('seller sets NO askPrice ⇒ name-only fallback: buyer still invited even if maxPrice is low', async () => {
+        const { app, sent } = buildP3({ searchItems: async () => buyerWish(5000, 'TWD') });
+        const res = await request(app).post('/p3/seller-listing-scan').send({
+            ...SELLER, itemId: 1, itemName: 'Sony WH-1000XM5', // no askPrice
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.invitedCount).toBe(1);
+        expect(sent).toHaveLength(1);
+    });
+});
+
+describe('P3 rescan — price filter on invites', () => {
+    it('compatible wish ⇒ ONE invite; incompatible wish ⇒ none', async () => {
+        const { app, sent } = buildP3();
+        const res = await request(app).post('/p3/rescan').send({
+            ...BUYER,
+            wishes: [
+                { itemId: 1, sellerPublicCode: SELLER.publicCode, itemName: 'a', maxPrice: 9000, sellerAskPrice: 8000, priceCurrency: 'TWD' }, // ok
+            ],
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.sentCount).toBe(1);
+        expect(sent).toHaveLength(1);
+
+        // Fresh app for the incompatible case (own store).
+        const { app: app2, sent: sent2 } = buildP3();
+        const res2 = await request(app2).post('/p3/rescan').send({
+            ...BUYER,
+            wishes: [
+                { itemId: 2, sellerPublicCode: SELLER.publicCode, itemName: 'b', maxPrice: 5000, sellerAskPrice: 8000, priceCurrency: 'TWD' }, // buyer < ask
+            ],
+        });
+        expect(res2.status).toBe(200);
+        expect(res2.body.sentCount).toBe(0);
+        expect(res2.body.invalid.some((i) => i.reason === 'price_incompatible')).toBe(true);
+        expect(sent2).toHaveLength(0);
+    });
+
+    it('wish with no prices ⇒ name-only fallback: invite still fires', async () => {
+        const { app, sent } = buildP3();
+        const res = await request(app).post('/p3/rescan').send({
+            ...BUYER,
+            wishes: [{ itemId: 3, sellerPublicCode: SELLER.publicCode, itemName: 'c' }],
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.sentCount).toBe(1);
+        expect(sent).toHaveLength(1);
+    });
+});

--- a/backend/wishlist-matchmaking-p3.js
+++ b/backend/wishlist-matchmaking-p3.js
@@ -213,7 +213,7 @@ function createRouter(opts = {}) {
     // (buyer,item,seller) SYMMETRICALLY regardless of who initiated. P3 owns this
     // dedup at the shared store (P2's internal matchId is keyed on ITS caller, which
     // differs by direction), checking BEFORE the send and stamping AFTER a real send.
-    async function sendGovernedInvite(caller, { fromPublicCode, toPublicCode, buyerPublicCode, sellerPublicCode, itemId, itemName, note, bypassFriendsOnly, rescan }) {
+    async function sendGovernedInvite(caller, { fromPublicCode, toPublicCode, buyerPublicCode, sellerPublicCode, itemId, itemName, note, bypassFriendsOnly, rescan, buyerMaxPrice, buyerCurrency, sellerAskPrice, sellerCurrency }) {
         const from = mm.normalizeCode(fromPublicCode);
         const to = mm.normalizeCode(toPublicCode);
         const buyer = mm.normalizeCode(buyerPublicCode);
@@ -224,6 +224,21 @@ function createRouter(opts = {}) {
         }
         if (!mm.isValidPublicCode(to) || to === from) {
             return { ok: false, reason: 'invalid_or_self_target' };
+        }
+
+        // PRICE-COMPAT FILTER (card_e1b8af79). Only filters when BOTH the buyer's max
+        // and the seller's ask are present in the SAME currency; otherwise falls back
+        // to name/tags-only (never excludes). An ADDITIONAL filter, never a bypass —
+        // it can only BLOCK a send. Enforced here (before we consume anything) AND
+        // again inside P2 handleInvite (defense-in-depth via the wired governedInvite).
+        const priceDecision = mm.priceCompat({
+            buyerMaxPrice,
+            buyerCurrency,
+            sellerAskPrice,
+            sellerCurrency,
+        });
+        if (!priceDecision.compatible) {
+            return { ok: false, reason: 'price_incompatible' };
         }
 
         // Canonical dedup pre-check on the SHARED store (symmetric across directions).
@@ -246,6 +261,12 @@ function createRouter(opts = {}) {
             itemId,
             itemName,
             note,
+            // Price BASIS threaded to P2 so the invite envelope carries it AND P2
+            // re-checks price-compat on the real control path (never trusts P3 alone).
+            buyerMaxPrice,
+            buyerCurrency,
+            sellerAskPrice,
+            sellerCurrency,
             bypassFriendsOnly: !!bypassFriendsOnly,
             rescan: !!rescan,
         });
@@ -337,6 +358,10 @@ function createRouter(opts = {}) {
                 itemName: r.cleanName,
                 sellerPublicCode: mm.normalizeCode((r.item && (r.item.publicCode || r.item.ownerPublicCode)) || ''),
                 score: r.score,
+                // Price-aware matchmaking (card_e1b8af79): surface the seller's ask so
+                // the caller's agent can supply the price basis on the follow-up invite.
+                sellerAskPrice: mm.coercePrice(r.item && r.item.askPrice),
+                priceCurrency: mm.normalizeCurrency(r.item && r.item.priceCurrency) || null,
             }));
 
         return res.status(200).json({
@@ -387,6 +412,11 @@ function createRouter(opts = {}) {
             return res.status(502).json({ error: 'buyer search failed', reason: 'search_error' });
         }
 
+        // The SELLER's own asking price for THIS listing (caller-supplied). Optional;
+        // absent → every match falls back to name-only (price never excludes).
+        const sellerAskPrice = req.body.askPrice;
+        const sellerCurrency = req.body.priceCurrency;
+
         // Rank buyer wishes against the listing (reuse P2 rerank). Each candidate is
         // a buyer entity whose wish matches. We invite the BUYER, from the SELLER.
         const ranked = mm.rerank(listingText, items).filter((r) => r.score > 0).slice(0, 10);
@@ -402,6 +432,11 @@ function createRouter(opts = {}) {
                 skipped.push({ buyerPublicCode: buyerCode || null, reason: 'invalid_or_self' });
                 continue;
             }
+
+            // The matched BUYER's intended/max price comes from THEIR wish item (the
+            // search result). Absent/invalid → price-compat falls back to name-only.
+            const buyerMaxPrice = r.item && r.item.maxPrice;
+            const buyerCurrency = r.item && r.item.priceCurrency;
 
             // Canonical matchId (buyer,item,seller) for reporting; sendGovernedInvite
             // owns the authoritative dedup on the SHARED store using this same key, so
@@ -424,6 +459,12 @@ function createRouter(opts = {}) {
                     itemId,
                     itemName: r.cleanName,
                     note: mm.sanitizeUntrusted(req.body.note, 200),
+                    // Price basis: buyer max from the matched wish, seller ask from
+                    // the caller's own listing. price-compat filters this pair.
+                    buyerMaxPrice,
+                    buyerCurrency,
+                    sellerAskPrice,
+                    sellerCurrency,
                     bypassFriendsOnly: false,
                 });
                 if (!sent.ok) {
@@ -516,6 +557,13 @@ function createRouter(opts = {}) {
                     itemId,
                     itemName: mm.sanitizeUntrusted(w.itemName, 120),
                     note: mm.sanitizeUntrusted(w.note, 200),
+                    // Price basis: the caller's own wish declares its max price + the
+                    // seller listing's asking price it is reaching out about. Both
+                    // caller-supplied per wish; price-compat filters the pair.
+                    buyerMaxPrice: w.maxPrice,
+                    buyerCurrency: w.buyerCurrency || w.priceCurrency,
+                    sellerAskPrice: w.sellerAskPrice,
+                    sellerCurrency: w.sellerCurrency || w.priceCurrency,
                     bypassFriendsOnly: false,
                     rescan: true,
                 });

--- a/backend/wishlist-matchmaking.js
+++ b/backend/wishlist-matchmaking.js
@@ -132,6 +132,87 @@ function sanitizeUntrusted(raw, maxLen = 200) {
     return s;
 }
 
+// ── Price-aware matchmaking (card_e1b8af79) ─────────────────────────────────
+//
+// Hank's confirmed defaults:
+//   - Price is OPTIONAL: only filter on price when BOTH sides have one; if either
+//     side lacks a price, fall back to name/tags-only match (do NOT exclude).
+//   - Currency default TWD; if the two sides' currencies DIFFER, treat as "cannot
+//     compare" → fall back to name-only (NO FX — we never convert).
+//   - Compatibility: buyer's max/willing price >= seller's asking price.
+//
+// Price is an ADDITIONAL match filter, never a bypass, and no money flows through
+// the platform (官方不介入) — this is match metadata only.
+
+// Bound prices defensively so an absurd upstream value can't poison a comparison.
+// Matches the wishlist-app writer's MAX_PRICE (1e12).
+const MM_MAX_PRICE = 1_000_000_000_000;
+const MM_DEFAULT_CURRENCY = 'TWD';
+
+/**
+ * Coerce an untrusted price to a valid non-negative bounded number, or null when
+ * it is absent/invalid. We treat an INVALID price (NaN / negative / absurd) the
+ * same as ABSENT for filtering — a garbage price must never make an incompatible
+ * pair look compatible; it just drops us into the name-only fallback. (The write
+ * path already rejects invalid prices at 400; this is defense-in-depth for values
+ * arriving from the catalogue / a counterparty.)
+ */
+function coercePrice(raw) {
+    if (raw === undefined || raw === null || raw === '') return null;
+    if (typeof raw !== 'number' && typeof raw !== 'string') return null;
+    const n = typeof raw === 'number' ? raw : Number(String(raw).trim());
+    if (!Number.isFinite(n) || n < 0 || n > MM_MAX_PRICE) return null;
+    return n;
+}
+
+/** Normalise a currency code to a short upper-case token, or '' if unusable. */
+function normalizeCurrency(raw) {
+    if (raw === undefined || raw === null || raw === '') return MM_DEFAULT_CURRENCY;
+    if (typeof raw !== 'string') return '';
+    const c = raw.trim().toUpperCase();
+    // Short allowlist-shaped guard: 3–4 letters. Anything else is "unusable" and
+    // routes to the name-only fallback (never crashes, never compares garbage).
+    return /^[A-Z]{3,4}$/.test(c) ? c : '';
+}
+
+/**
+ * Decide whether a (buyer, seller) pair is price-compatible ENOUGH to proceed to
+ * an invite. Returns { compatible, reason }:
+ *   - compatible=true, reason='no_price_fallback'        — one/both sides lack a
+ *     usable price → name/tags-only match (do NOT exclude).
+ *   - compatible=true, reason='currency_mismatch_fallback' — both priced but in
+ *     DIFFERENT currencies → cannot compare (no FX) → name-only fallback.
+ *   - compatible=true, reason='price_compatible'         — both priced, same
+ *     currency, buyerMax >= sellerAsk.
+ *   - compatible=false, reason='price_incompatible'      — both priced, same
+ *     currency, buyerMax < sellerAsk → NO invite.
+ *
+ * Inputs are untrusted; coercePrice/normalizeCurrency validate them. A missing
+ * currency on one side while the other is present is a mismatch → fallback.
+ */
+function priceCompat({ buyerMaxPrice, buyerCurrency, sellerAskPrice, sellerCurrency } = {}) {
+    const buyerMax = coercePrice(buyerMaxPrice);
+    const sellerAsk = coercePrice(sellerAskPrice);
+
+    // OPTIONAL: only filter when BOTH sides have a usable price.
+    if (buyerMax === null || sellerAsk === null) {
+        return { compatible: true, reason: 'no_price_fallback' };
+    }
+
+    const buyerCur = normalizeCurrency(buyerCurrency);
+    const sellerCur = normalizeCurrency(sellerCurrency);
+    // Unusable currency on either side, or the two differ → cannot compare (no FX).
+    if (!buyerCur || !sellerCur || buyerCur !== sellerCur) {
+        return { compatible: true, reason: 'currency_mismatch_fallback' };
+    }
+
+    // Both priced, same currency: buyer's max must cover the seller's ask.
+    if (buyerMax >= sellerAsk) {
+        return { compatible: true, reason: 'price_compatible' };
+    }
+    return { compatible: false, reason: 'price_incompatible' };
+}
+
 /**
  * Cheap keyword rerank (LLM optional / off by default — keep it cheap). Scores
  * each item by overlap of query tokens against the item name+notes, with a small
@@ -170,8 +251,8 @@ function tokenize(s) {
 
 // ── Envelope builders (P0 protocol; all public-code keyed) ──────────────────
 
-function buildInviteEnvelope({ matchId, fromPublicCode, toPublicCode, itemId, itemName, note }) {
-    return {
+function buildInviteEnvelope({ matchId, fromPublicCode, toPublicCode, itemId, itemName, note, buyerMaxPrice, sellerAskPrice, priceCurrency }) {
+    const env = {
         type: ENVELOPE_TYPES.INVITE,
         matchId,
         fromPublicCode: normalizeCode(fromPublicCode),
@@ -181,6 +262,20 @@ function buildInviteEnvelope({ matchId, fromPublicCode, toPublicCode, itemId, it
         itemName: sanitizeUntrusted(itemName, 120),
         note: sanitizeUntrusted(note, 200),
     };
+    // Price-aware matchmaking (card_e1b8af79): carry the price BASIS so the
+    // recipient can judge the offer. Only include validated, present values; a
+    // garbage/absent price is simply omitted (never echoes untrusted junk). No
+    // money moves through here — this is match metadata only.
+    const buyerMax = coercePrice(buyerMaxPrice);
+    const sellerAsk = coercePrice(sellerAskPrice);
+    const cur = normalizeCurrency(priceCurrency);
+    if (buyerMax !== null || sellerAsk !== null) {
+        env.price = {};
+        if (buyerMax !== null) env.price.buyerMaxPrice = buyerMax;
+        if (sellerAsk !== null) env.price.sellerAskPrice = sellerAsk;
+        if (cur) env.price.currency = cur;
+    }
+    return env;
 }
 
 function buildAcceptEnvelope({ matchId, fromPublicCode, toPublicCode }) {
@@ -475,6 +570,11 @@ function createRouter(opts = {}) {
                 itemName: r.cleanName,
                 sellerPublicCode: normalizeCode((r.item && (r.item.publicCode || r.item.ownerPublicCode)) || ''),
                 score: r.score,
+                // Price-aware matchmaking (card_e1b8af79): surface the seller's ask so
+                // the buyer's agent can pass buyerMaxPrice/sellerAskPrice into /invite.
+                // coercePrice returns null for absent/invalid (name-only fallback).
+                sellerAskPrice: coercePrice(r.item && r.item.askPrice),
+                priceCurrency: (function () { const c = normalizeCurrency(r.item && r.item.priceCurrency); return c || null; })(),
             }));
 
         return res.status(200).json({
@@ -509,6 +609,29 @@ function createRouter(opts = {}) {
         }
         if (sellerCode === caller.publicCode) {
             return res.status(400).json({ error: 'cannot invite yourself' });
+        }
+
+        // (a0) PRICE-COMPAT FILTER (card_e1b8af79). Only filter when BOTH sides have
+        // a usable price in the SAME currency; otherwise fall back to name/tags-only
+        // (never exclude). This is an ADDITIONAL filter, never a bypass — it can only
+        // BLOCK a send, never enable one a governance gate would stop. Running it
+        // BEFORE opt-in/quota means a price-incompatible pair never consumes quota.
+        //   - buyer's max/willing price = the buyer (caller) supplies buyerMaxPrice.
+        //   - seller's asking price = sellerAskPrice (from the seller listing search
+        //     result the buyer is inviting on).
+        const priceDecision = priceCompat({
+            buyerMaxPrice: req.body.buyerMaxPrice,
+            buyerCurrency: req.body.buyerCurrency || req.body.priceCurrency,
+            sellerAskPrice: req.body.sellerAskPrice,
+            sellerCurrency: req.body.sellerCurrency || req.body.priceCurrency,
+        });
+        if (!priceDecision.compatible) {
+            metricBlock('price_incompatible');
+            // NO send. The buyer's max is below the seller's ask (same currency).
+            return res.status(409).json({
+                error: 'buyer max price is below the seller asking price',
+                reason: 'price_incompatible',
+            });
         }
 
         // (a) Buyer's OWN kill-switch / opt-in. Matchmaking must not fire unless
@@ -568,6 +691,10 @@ function createRouter(opts = {}) {
             itemId,
             itemName: req.body.itemName,
             note: req.body.note,
+            // Carry the price BASIS so the recipient can judge the offer.
+            buyerMaxPrice: req.body.buyerMaxPrice,
+            sellerAskPrice: req.body.sellerAskPrice,
+            priceCurrency: req.body.priceCurrency || req.body.buyerCurrency || req.body.sellerCurrency,
         });
 
         try {
@@ -939,7 +1066,13 @@ module.exports = {
     isKillSwitchOn,
     createQuotaTracker,
     createMatchStore,
+    // price-aware matchmaking (card_e1b8af79)
+    priceCompat,
+    coercePrice,
+    normalizeCurrency,
     // constants
+    MM_MAX_PRICE,
+    MM_DEFAULT_CURRENCY,
     ENVELOPE_TYPES,
     SAFETY_DISCLAIMER,
     CONTACT_PII_KEYS,

--- a/backend/wishlist-route.js
+++ b/backend/wishlist-route.js
@@ -230,6 +230,11 @@ function createRouter({ log, fetchImpl, mintAgentToken, authenticateCaller, rate
             name: body.name,
             notes: body.notes,
             price: body.price,
+            // Price-aware matchmaking (card_e1b8af79): a seller's ASKING price +
+            // currency. The upstream validates them (finite/>=0/bounded, allowlisted
+            // currency) — never trusted here; this is match metadata only (官方不介入).
+            askPrice: body.askPrice,
+            priceCurrency: body.priceCurrency,
         };
         const upstreamUrl = `${WISHLIST_BASE}/api/items/upsert-listing`;
         try {


### PR DESCRIPTION
Cross-repo **half #2 of 2** for price-aware wishlist×EClaw matchmaking (card_e1b8af79). Pairs with wishlist-app PR **HankHuang0516/wishlist-app#3** (adds `askPrice`/`maxPrice`/`priceCurrency` + returns them from search). **Do not merge — #2 reviews then merges.**

## What
After the name/tags match, filter invites on a price BASIS so agents match on grounds, not everyone blindly knocking. Builds on the merged P0–P4 + write-auth + reachability + 官方不介入 design (branched off current `origin/main`).

## Match predicate (`wishlist-matchmaking.js`)
New pure `priceCompat({buyerMaxPrice, buyerCurrency, sellerAskPrice, sellerCurrency})`, Hank's confirmed defaults:
- **OPTIONAL** — filter ONLY when BOTH sides have a usable price. Either side missing ⇒ **name/tags-only fallback** (`no_price_fallback`), never excluded.
- **Currency TWD default**; DIFFERENT currencies ⇒ cannot compare, **no FX** ⇒ name-only fallback (`currency_mismatch_fallback`).
- Compatible ⇔ `buyer.maxPrice >= seller.askPrice` (same currency).
- Untrusted price coerced (finite/≥0/bounded 1e12); NaN/negative/absurd/Infinity treated as **ABSENT** ⇒ fallback, so garbage can never fake a compatible pair.

## Wiring (all on the REAL control path)
- **P2 `handleInvite`** runs `priceCompat` BEFORE opt-in/quota (an incompatible pair never consumes quota) → `409 price_incompatible` + **NO send** on hard reject. The invite envelope carries the price basis so the recipient can judge.
- **P3 `/seller-listing-scan`** (buyer max from the matched wish, seller ask from the caller's listing) and **`/rescan`** (both caller-supplied per wish) filter each candidate via the same predicate before `sendGovernedInvite`; price is threaded through `runP2InviteInProcess` so **P2 re-checks it** (defense-in-depth — never trusts P3 alone).
- **P2 `/search` + P3 `/photo-search`** surface `sellerAskPrice`/`priceCurrency` so a buyer's agent can pass the basis into the follow-up invite.
- **`wishlist-route`** write proxy forwards `askPrice`/`priceCurrency` upstream (validated there).

## Controls preserved
Price is an **ADDITIONAL** filter, never a bypass: it can only BLOCK a send, never enable one a gate would stop. Opt-in-only reachability, kill-switch, quota, dual-consent, GA dark-launch gate, P3 from-binding (no other-entity botSecret), device-scoped fileId, and no-money-flow (官方不介入) all unchanged. A dedicated test asserts a compatible price with opt-in OFF still sends nothing.

## Tests
17 new (`wishlist-matchmaking-price.test.js`) on real paths: compatible⇒invite fires (+envelope price); incompatible (buyer<ask)⇒409/skip + **assert NO send**; one-side-missing⇒name-only invite; mismatched currency⇒name-only invite; invalid price⇒fallback; opt-in-OFF guard. Full matchmaking suite **109/109 green**.

## Open question
`priceCurrency` on P3 `/rescan` currently uses a single per-wish currency (buyer & seller assumed same unless the wish supplies `buyerCurrency`/`sellerCurrency` explicitly); happy to tighten if you want per-side currencies required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN