### PR TITLE
feat(needyou): mobile-push owner-decision inbox items (backend) — card_c7baa7ae

### DIFF
--- a/backend/agent-action-requests.js
+++ b/backend/agent-action-requests.js
@@ -536,7 +536,7 @@ function rowToApi(row) {
 /**
  * Factory. Matches the kanban/scheduled-messages module style so index.js wires it the same way.
  */
-module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, getDevicePrefs } = {}) {
+module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, getDevicePrefs, notifyDevice } = {}) {
     const router = express.Router();
 
     // How the worker reads a device's timeout policy + minutes. Defaults to the
@@ -600,6 +600,70 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
                 });
             }
         } catch (_) { /* socket failure must never break the HTTP response */ }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 需要你 OWNER-DECISION MOBILE PUSH (card_c7baa7ae) — the DELIVERY-leak fix
+    // ──────────────────────────────────────────────────────────────────────
+    // Historically createActionRequest ONLY emitted the portal socket, so an
+    // owner-facing decision died silently in a collapsed inbox on the phone.
+    // We ADDITIVELY fire a mobile push via the injected `notifyDevice` — the same
+    // owner-device path chat/kanban use (socket + sendWebPush + sendFcm fan-out
+    // over device_fcm_tokens / APNs). Targeting is the OWNER's own deviceId, so it
+    // reaches the owner's phone(s) ONLY — never broadcast, never a bot.
+    //
+    // HARD SPAM GATE (err toward UNDER-pushing): push ONLY when this is a genuine
+    // OWNER-FACING decision — decision_context present AND ownerOnly === true. A
+    // bot-to-bot negotiation/consensus item, routine status, or any non-owner
+    // action-request has NO ownerOnly flag → it must NEVER buzz the owner's phone.
+    //
+    // Opt-in pref `needyou_push_enabled` (device-preferences, DEFAULT ON): when a
+    // device sets it to false the push is skipped (the inbox row + socket above
+    // still fire). Fully fire-and-forget + try/catch: a push/pref failure here can
+    // NEVER break inbox-item creation (the caller already committed the INSERT and
+    // emitted the socket before we run).
+    function isOwnerDecision(decisionContext) {
+        return !!decisionContext
+            && typeof decisionContext === 'object'
+            && decisionContext.ownerOnly === true;
+    }
+
+    async function maybePushOwnerDecision(row, decisionContext) {
+        try {
+            if (typeof notifyDevice !== 'function') return;          // push path not wired (e.g. tests without it)
+            if (!row || !row.device_id) return;
+            if (!isOwnerDecision(decisionContext)) return;           // SPAM GATE — owner-only decisions only
+
+            // Opt-in pref (default ON): only an explicit false disables the push.
+            let prefs = {};
+            try { prefs = (await readDevicePrefs(row.device_id)) || {}; } catch (_) { prefs = {}; }
+            if (prefs.needyou_push_enabled === false) return;
+
+            // Reuse the rich-card-question notification category: semantically these
+            // are the SAME blocking-style "an agent needs the owner to pick" asks, so
+            // they share the owner's existing Settings mute toggle for that category.
+            const rawPrompt = typeof row.prompt === 'string' ? row.prompt : '';
+            const body = rawPrompt.length > 240 ? `${rawPrompt.slice(0, 239)}…` : rawPrompt;
+            const notification = {
+                type: 'action_request',
+                category: 'rich_card_question',
+                title: '需要你決策',
+                body,
+                link: 'chat.html', // 需要你 inbox lives on the chat page
+                metadata: {
+                    requestId: String(row.id),
+                    fromEntityId: row.from_entity_id ?? null,
+                    relatedCardId: row.related_card_id ?? null,
+                    ownerDecision: true,
+                },
+            };
+            // Fire-and-forget: notifyDevice already log-and-continues internally, but
+            // wrap the await so a rejected promise can't bubble into createActionRequest.
+            await notifyDevice(row.device_id, notification);
+        } catch (e) {
+            // NEVER let a push failure break inbox-item creation.
+            log('warn', `owner-decision push failed (non-blocking): ${e && e.message}`, { deviceId: row && row.device_id });
+        }
     }
 
     // Best-effort: notify the emitting agent that its request was answered.
@@ -918,6 +982,11 @@ module.exports = function (devices, { pushToBot, unifiedPush, serverLog, io, get
         );
         const row = result.rows[0];
         emitChanged(deviceId, 'emitted', row.id, row.from_entity_id);
+        // 需要你 owner-decision MOBILE PUSH (card_c7baa7ae): ADDITIVE to the socket
+        // above — buzz the owner's phone ONLY for a genuine owner-only decision, and
+        // only when needyou_push_enabled (default ON). Fully failure-isolated: a
+        // push/pref error can never fail this create (the INSERT already committed).
+        await maybePushOwnerDecision(row, decisionContext);
         // ON-ARRIVAL negotiation open (需要你 negotiation): best-effort, AFTER the
         // committed INSERT + 'emitted'. A prefs/push error here must NOT fail request
         // creation — fully wrapped in try/catch. Only fires when isNegotiable (device

--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -168,6 +168,19 @@ const DEFAULTS = {
     // every matchmaking send (invite/accept/decline/contact) is refused regardless of
     // the opt-in flag. DEFAULT FALSE (not killed). Same string-safe coercion.
     wishlist_matchmaking_killswitch: false,
+    // 需要你 owner-decision inbox MOBILE PUSH (card_c7baa7ae). When ON, creating an
+    // OWNER-FACING decision inbox item (decision_context.ownerOnly === true) ALSO
+    // fires a mobile push to THIS owner's device tokens (reusing notifyDevice →
+    // sendWebPush/sendFcm fan-out over device_fcm_tokens). The portal socket +
+    // inbox row are created regardless; the push is purely ADDITIVE. Bot-to-bot
+    // negotiation / non-owner action-requests NEVER push (the gate is ownerOnly,
+    // not merely "has options"). ⚠️ DEFAULT-ON (Hank asked opt-in default-enable so
+    // owner decisions reach the phone out of the box): an UNSET pref ENABLES the
+    // push; only an explicit `false` / string 'false' disables it (then the inbox
+    // item + socket still fire, just no phone buzz). Same string-safe boolean
+    // coercion as action_request_reply_resize_enabled (a bare `!!raw` would turn the
+    // string 'false' true). Consumed by createActionRequest in agent-action-requests.js.
+    needyou_push_enabled: true,
 };
 
 const ENTITY_IDLE_AFTER_SECONDS_MIN = 15;
@@ -221,6 +234,7 @@ function coerceValue(key, raw) {
         || key === 'waiting_state_surfacer_enabled'
         || key === 'wishlist_matchmaking_enabled'
         || key === 'wishlist_matchmaking_killswitch'
+        || key === 'needyou_push_enabled'
         || key === 'action_request_reply_resize_enabled') {
         // 計畫E: ratify master switch — same string-safe boolean coercion (a bare
         // `!!raw` would turn the string 'false' true, fail-OPEN for an auto-merge gate).

--- a/backend/index.js
+++ b/backend/index.js
@@ -2021,6 +2021,12 @@ try {
         unifiedPush,
         serverLog,
         io, // real-time inbox push: emits 'action_request:changed' to device:<id> (card_8151054f)
+        // 需要你 owner-decision MOBILE PUSH (card_c7baa7ae): reuse the existing owner-
+        // device notify path (socket + sendWebPush + sendFcm fan-out over
+        // device_fcm_tokens) so an owner-only inbox item ALSO buzzes the owner's
+        // phone. notifyDevice is a hoisted async function declaration (defined far
+        // below) — safe to reference here. Gated ownerOnly + pref inside the module.
+        notifyDevice,
     });
     app.use('/api/action-requests', agentActionRequestsModule.router);
     console.log('[AgentActionRequests] Module loaded successfully');

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -2999,6 +2999,14 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                             options: ['核可', '退回', '延後'], // RECORD-ONLY — no auto-execute
                             relatedCardId: cardId,
                             decisionContext: {
+                                // ownerOnly: this move-hook ONLY reaches here when the
+                                // classifier verdict.ownerOnly is true (guarded above),
+                                // so stamp the marker into the stored decision_context.
+                                // This makes the row a genuine owner-facing decision for
+                                // downstream consumers — the 需要你 mobile push gate
+                                // (card_c7baa7ae) and waiting-state.js — instead of
+                                // relying on a flag that was checked but never persisted.
+                                ownerOnly: true,
                                 whatWasDone,
                                 recommendation: whatWasDone,
                                 evidence,

--- a/backend/tests/jest/needyou-owner-decision-push.test.js
+++ b/backend/tests/jest/needyou-owner-decision-push.test.js
@@ -1,0 +1,146 @@
+// 需要你 owner-decision MOBILE PUSH (card_c7baa7ae).
+//
+// createActionRequest historically ONLY emitted the portal socket; an owner-only
+// decision died silently in a collapsed phone inbox. This wires an ADDITIVE mobile
+// push via the injected notifyDevice (the same owner-device socket + sendWebPush +
+// sendFcm fan-out over device_fcm_tokens the rest of the app uses). These tests
+// exercise the REAL createActionRequest path (exported by the module) with the pg
+// INSERT mocked and notifyDevice mocked, asserting the 4 required behaviours:
+//
+//   (a) owner-only decision item created → notifyDevice called once with the
+//       owner's deviceId as the target.
+//   (b) bot-to-bot / non-owner item (no ownerOnly) created → notifyDevice NOT called.
+//   (c) needyou_push_enabled=false → notifyDevice NOT called, but the inbox row is
+//       still created (INSERT ran) + the socket still emitted.
+//   (d) notifyDevice throws → createActionRequest STILL resolves with the row (the
+//       push failure can never break inbox-item creation).
+//
+// Mocks pg so the module's Pool() is captured (mirrors agent-action-requests.test.js).
+
+const mockPoolQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockPoolQuery,
+        connect: jest.fn().mockResolvedValue({ query: mockPoolQuery, release: jest.fn() }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const deviceId = 'owner-dev';
+const UUID = '99999999-8888-7777-6666-555555555555';
+
+const devices = {
+    [deviceId]: {
+        deviceSecret: 'dev-secret',
+        entities: { 2: { isBound: true, botSecret: 'bot-2' } },
+    },
+};
+
+function rowFixture(over = {}) {
+    return {
+        id: UUID, device_id: deviceId, from_entity_id: 2, anchor_message_id: null,
+        type: 'decision', prompt: 'Approve merge of PR #123?', options: ['核可', '退回', '延後'],
+        related_card_id: 'card_abc123', decision_context: null,
+        status: 'pending', answer: null, consensus_triggered_at: null,
+        created_at: new Date('2026-07-05T00:00:00Z'), resolved_at: null, ...over,
+    };
+}
+
+// Build a module wired with a mocked notifyDevice + an injected getDevicePrefs so
+// no real device-preferences / negotiation DB traffic fires. Policy 'keep' keeps
+// isNegotiable() false → the INSERT is the ONLY pg query createActionRequest issues.
+function buildMod({ notifyDevice, prefs = {} } = {}) {
+    // Fresh require so the pg mock's call log is per-suite clean.
+    const factory = require('../../agent-action-requests');
+    const io = { to: () => ({ emit: () => {} }) }; // socket emit is a no-op sink here
+    return factory(devices, {
+        serverLog: () => {},
+        io,
+        notifyDevice,
+        getDevicePrefs: () => ({ action_request_timeout_policy: 'keep', ...prefs }),
+    });
+}
+
+afterEach(() => mockPoolQuery.mockReset());
+
+describe('需要你 owner-decision mobile push — createActionRequest wiring (card_c7baa7ae)', () => {
+    it('(a) owner-only decision → notifyDevice called once targeting the owner deviceId', async () => {
+        const dc = { ownerOnly: true, whatWasDone: 'merged PR', recommendedOptionIndex: 0 };
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ decision_context: dc })] }); // INSERT RETURNING *
+        const notifyDevice = jest.fn().mockResolvedValue(undefined);
+        const mod = buildMod({ notifyDevice });
+
+        const api = await mod.createActionRequest({
+            deviceId, fromEntityId: 2, type: 'decision', prompt: 'Approve merge of PR #123?',
+            options: ['核可', '退回', '延後'], relatedCardId: 'card_abc123', decisionContext: dc,
+        });
+
+        expect(api).toBeTruthy();
+        expect(api.id).toBe(UUID);
+        expect(notifyDevice).toHaveBeenCalledTimes(1);
+        const [targetDeviceId, notification] = notifyDevice.mock.calls[0];
+        // Targets the OWNER's own device — not a broadcast, not a bot.
+        expect(targetDeviceId).toBe(deviceId);
+        expect(notification.category).toBe('rich_card_question');
+        expect(notification.metadata.requestId).toBe(UUID);
+        expect(notification.metadata.ownerDecision).toBe(true);
+        // No token/secret leaked into the notification payload.
+        expect(JSON.stringify(notification)).not.toMatch(/secret|token/i);
+    });
+
+    it('(b) bot-to-bot / non-owner item (no ownerOnly) → notifyDevice NOT called', async () => {
+        // A negotiation-style item: has options but NO ownerOnly flag → must not buzz.
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ decision_context: { whatWasDone: 'x' } })] });
+        const notifyDevice = jest.fn().mockResolvedValue(undefined);
+        const mod = buildMod({ notifyDevice });
+
+        await mod.createActionRequest({
+            deviceId, fromEntityId: 2, type: 'consensus', prompt: 'entities vote',
+            options: ['A', 'B'], decisionContext: { whatWasDone: 'x' },
+        });
+        expect(notifyDevice).not.toHaveBeenCalled();
+
+        // Also: a plain item with NO decision_context at all → no push.
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ decision_context: null, options: null })] });
+        await mod.createActionRequest({ deviceId, fromEntityId: 2, type: 'input', prompt: 'status' });
+        expect(notifyDevice).not.toHaveBeenCalled();
+    });
+
+    it('(c) needyou_push_enabled=false → notifyDevice NOT called, but the inbox row IS still created', async () => {
+        const dc = { ownerOnly: true, whatWasDone: 'merged PR' };
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ decision_context: dc })] }); // INSERT still runs
+        const notifyDevice = jest.fn().mockResolvedValue(undefined);
+        const mod = buildMod({ notifyDevice, prefs: { needyou_push_enabled: false } });
+
+        const api = await mod.createActionRequest({
+            deviceId, fromEntityId: 2, type: 'decision', prompt: 'Approve?',
+            options: ['核可', '退回'], decisionContext: dc,
+        });
+
+        // Push suppressed…
+        expect(notifyDevice).not.toHaveBeenCalled();
+        // …but the inbox item was still created (INSERT ran + row returned).
+        expect(api).toBeTruthy();
+        expect(api.id).toBe(UUID);
+        const insertCall = mockPoolQuery.mock.calls.find(c => /INSERT INTO agent_action_requests/.test(c[0]));
+        expect(insertCall).toBeTruthy();
+    });
+
+    it('(d) notifyDevice throws → createActionRequest still returns the row (push failure is isolated)', async () => {
+        const dc = { ownerOnly: true, whatWasDone: 'merged PR' };
+        mockPoolQuery.mockResolvedValueOnce({ rows: [rowFixture({ decision_context: dc })] });
+        const notifyDevice = jest.fn().mockRejectedValue(new Error('FCM exploded'));
+        const mod = buildMod({ notifyDevice });
+
+        const api = await mod.createActionRequest({
+            deviceId, fromEntityId: 2, type: 'decision', prompt: 'Approve?',
+            options: ['核可', '退回'], decisionContext: dc,
+        });
+
+        // Attempted the push…
+        expect(notifyDevice).toHaveBeenCalledTimes(1);
+        // …but the throw did NOT break creation — the row still came back.
+        expect(api).toBeTruthy();
+        expect(api.id).toBe(UUID);
+    });
+});


### PR DESCRIPTION
## 需要你 owner-decision inbox → mobile push (BACKEND only) — card_c7baa7ae

**Problem (delivery-leak):** `createActionRequest` only emitted the portal socket. A genuine **owner-only decision** died silently in a collapsed phone inbox — the owner never got buzzed. (Investigation on the card confirmed: no push/FCM, no pref.)

**Fix:** fire an **ADDITIVE** mobile push on `createActionRequest`, reusing the **existing** owner-device `notifyDevice` path (socket + `sendWebPush` + `sendFcm` fan-out over the multi-row `device_fcm_tokens` / APNs). No new push path. The socket + inbox row are unchanged; push is purely additive.

### What changed
- **`backend/agent-action-requests.js`** — inject `notifyDevice`; new `maybePushOwnerDecision()` fires **after** the committed INSERT + `'emitted'` socket.
  - **HARD spam gate:** push ONLY when `decision_context` is present **AND** `ownerOnly === true`. Bot-to-bot negotiation / consensus / non-owner action-requests have no `ownerOnly` flag → **never** buzz the owner. Errs toward under-pushing.
  - **Failure-isolated:** fully wrapped in try/catch, fire-and-forget — a push/pref error can **never** break inbox-item creation (the INSERT already committed + socket already emitted before the push runs).
  - Reuses the `rich_card_question` notification category (identical "agent needs the owner to pick" semantics → shares the owner's existing Settings mute toggle). No secret/token logged.
- **`backend/index.js`** — pass the hoisted `notifyDevice` into the module factory. Single-site, localized edit to minimize conflict with the in-flight price-aware matching PR.
- **`backend/device-preferences.js`** — new opt-in pref **`needyou_push_enabled`, DEFAULT ON**. String-safe boolean coercion (like `action_request_reply_resize_enabled`): only an explicit `false` / `'false'` disables. When off → push skipped, inbox item + socket still fire.
- **`backend/kanban.js`** — the classifier owner-decision move-hook now stamps `ownerOnly: true` into the stored `decision_context` (it only reaches there when `verdict.ownerOnly` is true, but never persisted the flag). So its genuine owner decisions push — and `waiting-state.js` classifies them correctly too.

### FCM targeting (confirmed owner-device-only)
`notifyDevice(deviceId, …)` → `sendFcm(deviceId, …)` → `getDeviceFcmTokens(deviceId)` = `device_fcm_tokens WHERE device_id = $1`. The `deviceId` passed is the action-request row's `device_id` = the **owner's** device. Never broadcast, never a bot.

### Tests (real `createActionRequest` path, `notifyDevice` mocked) — `needyou-owner-decision-push.test.js`
- (a) owner-only decision → `notifyDevice` called **once**, target = owner `deviceId`.
- (b) bot-to-bot / no `ownerOnly` (and no `decision_context` at all) → `notifyDevice` **not** called.
- (c) `needyou_push_enabled=false` → `notifyDevice` **not** called, but the inbox row is **still INSERTed**.
- (d) `notifyDevice` **throws** → `createActionRequest` still returns the row (push failure isolated).

Full backend jest suite green: **463 suites / 6362 pass / 0 fail**. `node -c` clean on all 4 edited files; eslint 0 errors on the diff.

### Deferred (release-chained, out of scope this PR)
- Settings-page toggle UI for `needyou_push_enabled` (shared with matchmaking-UX **card_647fc0ba**).
- App tap → deep-link into the 需要你 inbox item.
- On-device vision verify (no real push fired to Hank's device during dev; push path mocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHz6A5V1KqhMXNFxZ6srN