### PR TITLE
chore(app): bump to 1.1.16 (vc127) — release wallpaper walk-config + notification deep-link

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 126
-        versionName = "1.1.15"
+        versionCode = 127
+        versionName = "1.1.16"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Version bump for the Play release train (staged 20%).

**Ships (already merged to main, emulator+vision verified):**
- #3902 wallpaper walk-config: per-entity independent 10–30s random stop cadence + negative-action authorization
- #3896/#3898/#3899 task-completed notification deep-links to the card (incl. portal self-loop fix)

Verification: both features verified on Pixel_9a emulator (vc126+#3902 build) per owner directive — wallpaper renders/walks with independent cadence; /r/card deep-link opens the exact card, no home-only, no loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuABXFYP3EofvYeqXW6ncn