### PR TITLE
feat(info): wishlist matchmaking promo block on info page (owner-approved copy)

### DIFF
--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -127,6 +127,25 @@
                 <a class="qs-promo-link" href="https://www.youtube.com/watch?v=CAvRd9PyQlg" target="_blank" rel="noopener" style="font-size: 0.85em;">📺 在 YouTube 開啟</a>
             </section>
 
+            <!-- Feature promo: 願望清單牽線 — 讓你的 AI 夥伴替你找東西、賣東西 -->
+            <section class="qs-promo-section qs-daily-highlight" aria-labelledby="qs-wishlist-promo-heading"
+                style="margin-top: 12px; padding-top: 8px; border-top: 1px dashed rgba(124,58,237,0.25);">
+                <h2 id="qs-wishlist-promo-heading" class="qs-promo-title" style="font-size: 1.05em; color: #42d4f4;"
+                    data-i18n="info_wishlist_promo_title">讓你的 AI 夥伴替你找東西、賣東西</h2>
+                <p class="qs-promo-lede" style="font-size: 0.92em; opacity: 0.85;"
+                    data-i18n="info_wishlist_promo_body_1">你只要跟你的 AI 說一聲「我想買○○」或「我想賣○○」,它就會幫你去看看有沒有人剛好想賣或想買,然後幫你們牽線。</p>
+                <p class="qs-promo-lede" style="font-size: 0.92em; margin-bottom: 4px;"
+                    data-i18n="info_wishlist_promo_points_title">三個讓你安心的地方:</p>
+                <p class="qs-promo-lede" style="font-size: 0.92em; opacity: 0.85; margin-bottom: 4px;"
+                    data-i18n="info_wishlist_promo_point_1">① 錢我們完全不碰——只幫你們牽線,不經手你的錢。</p>
+                <p class="qs-promo-lede" style="font-size: 0.92em; opacity: 0.85; margin-bottom: 4px;"
+                    data-i18n="info_wishlist_promo_point_2">② 要不要把聯絡方式給對方,一定是你本人點頭才算,對方也一樣。</p>
+                <p class="qs-promo-lede" style="font-size: 0.92em; opacity: 0.85;"
+                    data-i18n="info_wishlist_promo_point_3">③ 你的 AI 只能替「你這邊」答應,不會偷偷替對方答應,也不會自己一個人把兩邊都答應了。</p>
+                <p class="qs-promo-lede" style="font-size: 0.92em; opacity: 0.85;"
+                    data-i18n="info_wishlist_promo_footer">這個功能一開始是關著的,你想用再自己打開就好。</p>
+            </section>
+
             <!-- Hero: 你想做什麼？ -->
             <div class="qs-hero">
                 <h1 data-i18n="qs_hero_title">你想做什麼？</h1>

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650722,6 +650722,14 @@ const TRANSLATIONS = {
         "common_block": "Block",
         "common_reset": "Reset",
         "common_archive": "Archive",
+
+        "info_wishlist_promo_title": "Let your AI buddy find things and sell things for you",
+        "info_wishlist_promo_body_1": "Just tell your AI \"I want to buy something\" or \"I want to sell something\", and it will go check whether someone out there happens to want to sell or buy that very thing — then help the two of you get in touch.",
+        "info_wishlist_promo_points_title": "Three things to put your mind at ease:",
+        "info_wishlist_promo_point_1": "① We never touch your money — we only make the introduction. Your money never passes through us.",
+        "info_wishlist_promo_point_2": "② Your contact info is only shared with the other person if you personally say yes — and the same goes for them.",
+        "info_wishlist_promo_point_3": "③ Your AI can only say yes for your side. It will never quietly say yes for the other person, and it can never say yes for both sides on its own.",
+        "info_wishlist_promo_footer": "This feature starts out switched off. If you want to use it, just switch it on yourself.",
 },
 
 
@@ -1235907,6 +1235915,14 @@ const TRANSLATIONS = {
         "common_block": "封鎖",
         "common_reset": "重設",
         "common_archive": "封存",
+
+        "info_wishlist_promo_title": "讓你的 AI 夥伴替你找東西、賣東西",
+        "info_wishlist_promo_body_1": "你只要跟你的 AI 說一聲「我想買○○」或「我想賣○○」,它就會幫你去看看有沒有人剛好想賣或想買,然後幫你們牽線。",
+        "info_wishlist_promo_points_title": "三個讓你安心的地方:",
+        "info_wishlist_promo_point_1": "① 錢我們完全不碰——只幫你們牽線,不經手你的錢。",
+        "info_wishlist_promo_point_2": "② 要不要把聯絡方式給對方,一定是你本人點頭才算,對方也一樣。",
+        "info_wishlist_promo_point_3": "③ 你的 AI 只能替「你這邊」答應,不會偷偷替對方答應,也不會自己一個人把兩邊都答應了。",
+        "info_wishlist_promo_footer": "這個功能一開始是關著的,你想用再自己打開就好。",
 },
 
 


### PR DESCRIPTION
## What

Adds the owner-approved promotional block for the new **wishlist matchmaking** feature to the EClaw info page (`backend/public/portal/info.html`), placed directly after the existing Day 158 highlight section inside `#panel-quickstart`.

## Copy

- **zh (Traditional Chinese)**: owner-approved copy, verbatim — 「讓你的 AI 夥伴替你找東西、賣東西」 + 3 reassurance points (we never touch money / contact info shared only on personal yes from both sides / your AI can only say yes for your side) + opt-in note (feature ships OFF).
- **en**: faithful plain-English translation of the same copy. No jargon, no "world's first" claims.

## i18n

- 7 new keys `info_wishlist_promo_*` inserted into the **en** and **zh** locale blocks using the AST-safe `backend/scripts/i18n-insert-locale-keys.js` helper (avoids the PR #3253 brace-miscount failure class).
- Other locales intentionally NOT machine-translated: the runtime i18n resolver falls back to `en` for missing keys (and `zh-TW`/`zh-CN` → `zh`), and the CI strict gate hard-fails only on missing EN keys. English fallback for the remaining locales is per the owner's direction.

## Styling

Reuses existing `qs-promo-section qs-daily-highlight` classes and the inline-style pattern of the neighboring Day 158 block. No new CSS.

## Local verification

- `node --check backend/public/shared/i18n.js` — OK
- `node backend/scripts/i18n-check.js` — ✅ all referenced keys resolve in EN (pre-existing settings-help fanout warnings unchanged)
- `node backend/scripts/i18n-lint-dup-keys.js` — 16/16 locale blocks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuABXFYP3EofvYeqXW6ncn