### PR TITLE
fix(publisher): Tumblr NPF CTA ranges in code points — emoji overrun caused 400 on every post (card_2992f6a2)

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -241,12 +241,16 @@ function buildReferralCTA({ format = 'md', locale = 'zh-TW', url = REFERRAL_CTA_
         return `\n<hr/>\n<p><strong>${t.header}</strong></p>\n<p>${t.rewards}</p>\n<p><a href="${url}">${t.cta}</a></p>\n<p><em>${t.disclaimer}</em></p>\n`;
     }
     if (format === 'npf') {
-        // Tumblr Neue Post Format — return array of blocks to append to content array
+        // Tumblr Neue Post Format — return array of blocks to append to content array.
+        // NPF formatting ranges are in UNICODE CODE POINTS, not UTF-16 code units:
+        // `.length` overcounts emoji (surrogate pairs) and Tumblr 400s the whole
+        // post on an out-of-range end (card_2992f6a2). Count via code points.
+        const cp = (str) => [...str].length;
         return [
             { type: 'text', subtype: 'heading2', text: t.header },
             { type: 'text', text: t.rewards },
-            { type: 'text', text: t.cta, formatting: [{ type: 'link', start: 0, end: t.cta.length, url }] },
-            { type: 'text', text: t.disclaimer, formatting: [{ type: 'italic', start: 0, end: t.disclaimer.length }] }
+            { type: 'text', text: t.cta, formatting: [{ type: 'link', start: 0, end: cp(t.cta), url }] },
+            { type: 'text', text: t.disclaimer, formatting: [{ type: 'italic', start: 0, end: cp(t.disclaimer) }] }
         ];
     }
     if (format === 'telegraph-nodes') {

--- a/backend/tests/jest/publisher-npf-cta.test.js
+++ b/backend/tests/jest/publisher-npf-cta.test.js
@@ -1,0 +1,35 @@
+/**
+ * Tumblr NPF referral-CTA formatting ranges must be in UNICODE CODE POINTS,
+ * not JS UTF-16 code units (card_2992f6a2). The zh-TW CTA text starts with an
+ * emoji (surrogate pair), so `.length`-based ranges overrun by 1 and Tumblr
+ * rejects the whole post with 400 Bad Request.
+ *
+ * Repro: fails on old code (end === UTF-16 length 8 > code points 7),
+ * passes on the fix (ranges counted via [...text].length).
+ */
+const { buildReferralCTA } = require('../../article-publisher');
+
+const codePoints = (s) => [...s].length;
+
+describe('buildReferralCTA npf formatting ranges (Tumblr code-point rule)', () => {
+    for (const locale of ['zh-TW', 'en']) {
+        test(`${locale}: every formatting range fits within the code-point length`, () => {
+            const blocks = buildReferralCTA({ format: 'npf', locale });
+            expect(Array.isArray(blocks)).toBe(true);
+            for (const b of blocks) {
+                for (const f of b.formatting || []) {
+                    expect(f.start).toBeGreaterThanOrEqual(0);
+                    // end is exclusive; must not exceed the code-point count
+                    expect(f.end).toBeLessThanOrEqual(codePoints(b.text));
+                }
+            }
+        });
+    }
+
+    test('zh-TW link range covers the FULL cta text in code points (emoji-safe)', () => {
+        const blocks = buildReferralCTA({ format: 'npf', locale: 'zh-TW' });
+        const link = blocks.find(b => (b.formatting || []).some(f => f.type === 'link'));
+        const f = link.formatting.find(f => f.type === 'link');
+        expect(f.end).toBe(codePoints(link.text)); // old code: UTF-16 length ⇒ mismatch when emoji present
+    });
+});


### PR DESCRIPTION
Found while publishing today's promo: `POST /api/publisher/tumblr/publish` 400'd on every default post. Root cause: NPF formatting ranges built with JS `.length` (UTF-16 units) — the zh-TW CTA starts with 👉 (surrogate pair), so the link range end=8 overran the 7-code-point text and Tumblr rejected the post.

- Repro test `publisher-npf-cta.test.js`: **fails on old code, passes on fix** (verified red→green locally)
- Fix: count ranges via `[...str].length` (code points), per Tumblr NPF spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuABXFYP3EofvYeqXW6ncn