### PR TITLE
fix(admin): gate removeBot DELETE behind shared destructive showConfirm (card_00f9b4d3)

### DIFF
--- a/backend/public/portal/admin.html
+++ b/backend/public/portal/admin.html
@@ -1068,7 +1068,7 @@
                         '<td>' + usersAvg5hCell + '</td>' +
                         '<td style="display:flex;gap:4px;flex-wrap:wrap;">' +
                             '<button class="btn btn-sm" onclick="editBot(\'' + escapeHtml(b.botId) + '\')" style="font-size:11px;">' + i18n.t('admin_btn_edit_bot') + '</button>' +
-                            '<button class="btn btn-danger btn-sm" onclick="confirmRemoveBot(\'' + escapeHtml(b.botId) + '\', \'' + escapeHtml(b.status) + '\')" style="font-size:11px;">' + i18n.t('admin_btn_remove_bot') + '</button>' +
+                            '<button class="btn btn-danger btn-sm" onclick="removeBot(\'' + escapeHtml(b.botId) + '\', \'' + escapeHtml(b.status) + '\', this)" style="font-size:11px;">' + i18n.t('admin_btn_remove_bot') + '</button>' +
                         '</td>' +
                         '</tr>';
                 }
@@ -1697,39 +1697,33 @@
             });
         }
 
-        function confirmRemoveBot(botId, status) {
-            const isAssigned = status === 'assigned';
-            const overlay = document.createElement('div');
-            overlay.className = 'create-bot-overlay';
-            overlay.innerHTML =
-                '<div class="create-bot-dialog">' +
-                '<h3>' + i18n.t('admin_dlg_remove_bot_title') + '</h3>' +
-                '<p style="color:var(--text-secondary);font-size:14px;margin:0 0 8px 0;">' +
-                i18n.t('admin_dlg_remove_bot_desc', { botId: botId }) +
-                '</p>' +
-                (isAssigned ? '<p style="color:var(--warning);font-size:13px;margin:0 0 8px 0;">' + i18n.t('admin_dlg_remove_bot_warn_assigned') + '</p>' : '') +
-                '<div class="dialog-actions">' +
-                '<button class="btn btn-outline" onclick="this.closest(\'.create-bot-overlay\').remove()">' + i18n.t('admin_dlg_cancel') + '</button>' +
-                '<button class="btn btn-danger" id="btnConfirmRemoveBot" onclick="removeBot(\'' + botId + '\', ' + isAssigned + ', this)">' + i18n.t('admin_btn_remove_bot') + '</button>' +
-                '</div>' +
-                '</div>';
-            document.body.appendChild(overlay);
-
-            overlay.addEventListener('click', (e) => {
-                if (e.target === overlay) overlay.remove();
+        // Destructive-confirm gate lives INSIDE removeBot (card_00f9b4d3): the shared
+        // showConfirm modal (shared/api.js — a11y'd destructive family: danger styling,
+        // safe Cancel default focus, Esc, itemName strip) must resolve true before the
+        // DELETE fires. removeBot is a global inline-onclick handler, so gating at the
+        // top of the handler (same pattern as the revoke handlers above) guarantees NO
+        // call path can reach the API without a confirmation.
+        async function removeBot(botId, status, btnEl) {
+            const isAssigned = status === 'assigned' || status === true;
+            const message = i18n.t('admin_dlg_remove_bot_desc', { botId: botId })
+                + (isAssigned ? ' ' + i18n.t('admin_dlg_remove_bot_warn_assigned') : '');
+            const confirmed = await showConfirm({
+                title: i18n.t('admin_dlg_remove_bot_title'),
+                message: message,
+                confirmText: i18n.t('admin_btn_remove_bot'),
+                danger: true,
+                itemName: botId,
             });
-        }
+            if (!confirmed) return;
 
-        async function removeBot(botId, isAssigned, btnEl) {
-            btnEl.disabled = true;
-            btnEl.textContent = i18n.t('admin_dlg_removing');
+            if (btnEl) {
+                btnEl.disabled = true;
+                btnEl.textContent = i18n.t('admin_dlg_removing');
+            }
 
             try {
                 const url = '/api/admin/official-bot/' + encodeURIComponent(botId) + (isAssigned ? '?force=true' : '');
                 await apiCall('DELETE', url);
-
-                const overlay = btnEl.closest('.create-bot-overlay');
-                if (overlay) overlay.remove();
 
                 showToast(i18n.t('admin_msg_bot_removed'), 'success');
 
@@ -1737,8 +1731,10 @@
                 render();
             } catch (e) {
                 showToast(e.message, 'error');
-                btnEl.disabled = false;
-                btnEl.textContent = i18n.t('admin_btn_remove_bot');
+                if (btnEl) {
+                    btnEl.disabled = false;
+                    btnEl.textContent = i18n.t('admin_btn_remove_bot');
+                }
             }
         }
 

--- a/backend/tests/jest/admin-removebot-confirm.test.js
+++ b/backend/tests/jest/admin-removebot-confirm.test.js
@@ -1,0 +1,110 @@
+/**
+ * card_00f9b4d3: admin.html removeBot must gate its destructive DELETE behind
+ * the SHARED destructive-confirm modal (showConfirm, shared/api.js).
+ *
+ * Before: removeBot() fired apiCall('DELETE', /api/admin/official-bot/…)
+ * unconditionally — the confirm lived only in a separate bespoke overlay
+ * (confirmRemoveBot), so removeBot itself (a global inline-onclick handler)
+ * was a one-call data-loss path, and the weekly audit rule
+ * operability-destructive-no-confirm re-flagged admin.html every week.
+ *
+ * This EXECUTES the real removeBot() extracted from admin.html (same
+ * new Function harness as mission-single-delete-undo.test.js) and pins:
+ *   - the DELETE does NOT fire until showConfirm resolves true (FAIL-ON-OLD)
+ *   - showConfirm is the shared destructive family (danger:true + itemName)
+ *   - assigned bots delete with ?force=true, unassigned without
+ *   - the audit rule is quiet on the REAL admin.html (FAIL-ON-OLD: fired)
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const html = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'admin.html'), 'utf8'
+);
+
+function extractFunction(name) {
+    const re = new RegExp(`(?:async\\s+)?function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`, 'g');
+    const m = re.exec(html);
+    if (!m) throw new Error(`function ${name} not found in admin.html`);
+    let depth = 1, i = m.index + m[0].length;
+    while (i < html.length && depth > 0) {
+        const ch = html[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+        i++;
+    }
+    return html.slice(m.index, i);
+}
+
+function makeHarness({ confirm = true, apiError = null } = {}) {
+    const showConfirm = jest.fn(async () => confirm);
+    const apiCall = jest.fn(async (method, url) => {
+        if (apiError) throw apiError;
+        if (method === 'GET') return { bots: [] };
+        return { success: true };
+    });
+    const showToast = jest.fn();
+    const render = jest.fn();
+    const i18n = { t: (k) => k };
+    const btnEl = { disabled: false, textContent: 'remove', closest: () => null };
+
+    const factory = new Function(
+        'showConfirm', 'apiCall', 'showToast', 'render', 'i18n', 'botsData',
+        `${extractFunction('removeBot')}\n return removeBot;`
+    );
+    const removeBot = factory(showConfirm, apiCall, showToast, render, i18n, null);
+    return { removeBot, showConfirm, apiCall, showToast, render, btnEl };
+}
+
+describe('admin removeBot — destructive confirm gate (card_00f9b4d3)', () => {
+    it('does NOT fire the DELETE when the confirm is cancelled (FAIL-ON-OLD: DELETE fired with no confirm at all)', async () => {
+        const h = makeHarness({ confirm: false });
+        await h.removeBot('bot-123', 'assigned', h.btnEl);
+        expect(h.apiCall).not.toHaveBeenCalled();          // FAIL-ON-OLD: was called unconditionally
+        expect(h.showConfirm).toHaveBeenCalledTimes(1);    // FAIL-ON-OLD: never referenced
+        expect(h.btnEl.disabled).toBe(false);              // cancel leaves the row button usable
+    });
+
+    it('asks via the SHARED destructive modal: danger:true and itemName names the bot', async () => {
+        const h = makeHarness({ confirm: true });
+        await h.removeBot('bot-123', 'available', h.btnEl);
+        expect(h.showConfirm).toHaveBeenCalledWith(expect.objectContaining({
+            danger: true,
+            itemName: 'bot-123',
+        }));
+    });
+
+    it('fires the DELETE with ?force=true for an ASSIGNED bot only after confirm resolves true', async () => {
+        const h = makeHarness({ confirm: true });
+        await h.removeBot('bot 123', 'assigned', h.btnEl);
+        expect(h.apiCall).toHaveBeenCalledWith(
+            'DELETE', '/api/admin/official-bot/' + encodeURIComponent('bot 123') + '?force=true'
+        );
+        expect(h.showToast).toHaveBeenCalledWith('admin_msg_bot_removed', 'success');
+        expect(h.render).toHaveBeenCalled();
+    });
+
+    it('fires the DELETE WITHOUT force for an unassigned bot', async () => {
+        const h = makeHarness({ confirm: true });
+        await h.removeBot('bot-9', 'available', h.btnEl);
+        expect(h.apiCall).toHaveBeenCalledWith('DELETE', '/api/admin/official-bot/bot-9');
+    });
+
+    it('API failure surfaces an error toast and re-enables the row button', async () => {
+        const h = makeHarness({ confirm: true, apiError: new Error('boom') });
+        await h.removeBot('bot-9', 'available', h.btnEl);
+        expect(h.showToast).toHaveBeenCalledWith('boom', 'error');
+        expect(h.btnEl.disabled).toBe(false);
+        expect(h.btnEl.textContent).toBe('admin_btn_remove_bot');
+    });
+
+    it('audit rule operability-destructive-no-confirm is QUIET on the real admin.html (FAIL-ON-OLD: fired at removeBot)', () => {
+        const audit = require('../../agent-improvement/audit-rules');
+        const findings = audit
+            .scanText('backend/public/portal/admin.html', html)
+            .filter((r) => r.ruleId === 'operability-destructive-no-confirm');
+        expect(findings).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Problem
Weekly audit's only real recurring finding (2 weeks): `operability-destructive-no-confirm` (P1) at `backend/public/portal/admin.html:1723` — `removeBot()` issues `apiCall('DELETE', /api/admin/official-bot/:id)` with no confirm primitive in its body. The confirmation lived only in a separate bespoke overlay (`confirmRemoveBot`), so `removeBot` itself — a global inline-onclick handler — was a single-call unguarded data-loss path.

## Fix
- Gate the DELETE at the **top of `removeBot`** with the **shared** destructive-confirm modal `showConfirm` (`shared/api.js` family: `danger:true`, `itemName` strip, safe Cancel default focus, Esc/Enter semantics, mobile thumb-zone guard) — same pattern as admin.html's existing revoke handlers (skill/soul/rule contrib).
- Delete the bespoke `confirmRemoveBot` overlay (net simplification; assigned-bot force warning folded into the confirm message).
- Roster button now calls `removeBot(botId, status, this)` directly; no call path reaches the API unconfirmed.

## Repro → regression (engineering charter §bug flow)
`backend/tests/jest/admin-removebot-confirm.test.js` executes the REAL `removeBot()` extracted from admin.html (`new Function` harness, same as `mission-single-delete-undo.test.js`):
- **RED on old code**: 4/6 fail — DELETE fired even when confirm cancelled; `showConfirm` never referenced; audit `scanText` on real admin.html finds the P1 at line 1723.
- **GREEN on fix**: 6/6 pass — API not fired until confirm resolves true; `danger:true` + `itemName`; `?force=true` only for assigned bots; error path restores the button.

## Audit re-scan
`node agent-improvement/audit-run.js --json` → `operability-destructive-no-confirm` no longer lists admin.html; only remaining hit is `settings.html:4248` (`clearKanbanNudgeEntityOverride`, triaged reversible/low — intentionally left).

## Checks run locally
- jest: admin-removebot-confirm + audit-rules + ai-chat-widget-guard + showConfirm suites → all green (96 tests)
- eslint (0 errors), i18n dup lint clean, portal smoke check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuABXFYP3EofvYeqXW6ncn