### PR TITLE
fix(tests): accept shell-safe X_PUBLISHER_KEY — hyphenated .env key leaked secret on source

### DIFF
--- a/backend/tests/test-publisher-platforms.js
+++ b/backend/tests/test-publisher-platforms.js
@@ -16,6 +16,11 @@ function loadPublisherKey() {
     const lines = fs.readFileSync(envPath, 'utf8').split('\n');
     for (const line of lines) {
         const trimmed = line.trim();
+        // Accept both the legacy hyphenated key and the shell-safe identifier.
+        // The hyphenated form makes backend/.env un-sourceable in zsh/bash
+        // (invalid identifier -> "command not found" that ECHOES the secret to
+        // stderr), so .env now uses X_PUBLISHER_KEY (card follow-up 2026-07-06).
+        if (trimmed.startsWith('X_PUBLISHER_KEY=')) return trimmed.slice('X_PUBLISHER_KEY='.length).trim();
         if (trimmed.startsWith('X-Publisher-Key=')) return trimmed.slice('X-Publisher-Key='.length).trim();
     }
     return '';


### PR DESCRIPTION
Found by today's weekly-audit agent: `backend/.env` had `X-Publisher-Key=<value>` — a hyphenated name is not a valid shell identifier, so `set -a; source backend/.env` (used by multiple cron SOPs) makes zsh treat the line as a command and the *error message echoes the secret to stderr*.

- Local .env renamed to `X_PUBLISHER_KEY=` (verified: sourcing now exits 0 with 0 bytes stderr)
- This PR updates the one code consumer that string-parses the raw line (tests/test-publisher-platforms.js) to accept both names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuABXFYP3EofvYeqXW6ncn