### PR TITLE
fix(portal): showConfirm/showPrompt restore focus on close + LIFO Esc for stacked dialogs (card_8903c41d)

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -178,6 +178,39 @@ function _tFb(k, fb) {
 
 let _eclawDialogId = 0;
 
+// ─── Dialog stack + focus restore (card_8903c41d) ───
+// Every showConfirm/showPrompt attaches its own document-level capture keydown
+// handler, so with STACKED dialogs one Esc used to fire every handler and close
+// the whole stack at once. The shared LIFO stack below makes each handler act
+// only while its own overlay is the TOP entry — one Esc closes only the
+// top-most dialog; the next Esc closes the next one. Entries are the overlay
+// elements; cleanup splices its own entry out so out-of-order closes (backdrop
+// tap / a button click on a lower dialog) keep the stack consistent.
+const _eclawDialogStack = [];
+function _eclawDialogIsTop(overlay) {
+    return _eclawDialogStack[_eclawDialogStack.length - 1] === overlay;
+}
+function _eclawDialogStackRemove(overlay) {
+    const i = _eclawDialogStack.indexOf(overlay);
+    if (i !== -1) _eclawDialogStack.splice(i, 1);
+}
+
+// WAI-ARIA APG dialog pattern: when a dialog closes, focus must return to the
+// element that invoked it. Capture document.activeElement at open; the returned
+// restorer, called after the overlay is removed, focuses that element back IF
+// it is still in the DOM and focusable — otherwise it leaves focus where the
+// browser put it (the previous fallback behaviour). With stacked dialogs this
+// chains naturally: closing the top dialog restores focus into the one below.
+function _eclawCaptureRestoreFocus() {
+    const el = (typeof document !== 'undefined') ? document.activeElement : null;
+    return () => {
+        if (!el || el === document.body || typeof el.focus !== 'function') return;
+        const connected = ('isConnected' in el) ? el.isConnected : (document.contains && document.contains(el));
+        if (!connected) return;
+        try { el.focus(); } catch (_) { /* became unfocusable — keep fallback */ }
+    };
+}
+
 // Body scroll-lock for modal dialogs (showConfirm / showPrompt). Without it the
 // page behind a destructive confirm still scrolls (wheel/touch AND programmatic),
 // so the user can lose the dialog out of view or mis-tap a moved control.
@@ -285,6 +318,8 @@ function showConfirm({ message, title, confirmText, cancelText, danger, itemName
     }
     return new Promise((resolve) => {
         const t = _tFb;
+        // Record the invoking element BEFORE the dialog steals focus (card_8903c41d).
+        const restoreFocus = _eclawCaptureRestoreFocus();
         const overlay = document.createElement('div');
         overlay.className = 'dialog-overlay eclaw-confirm-overlay';
         const dialogId = ++_eclawDialogId;
@@ -321,7 +356,8 @@ function showConfirm({ message, title, confirmText, cancelText, danger, itemName
         _eclawEnsureDialogAnimStyle();
         document.body.appendChild(overlay);
         _eclawLockBodyScroll();
-        const cleanup = (result) => { document.removeEventListener('keydown', _keyHandler, true); overlay.remove(); _eclawUnlockBodyScroll(); resolve(result); };
+        _eclawDialogStack.push(overlay);
+        const cleanup = (result) => { _eclawDialogStackRemove(overlay); document.removeEventListener('keydown', _keyHandler, true); overlay.remove(); _eclawUnlockBodyScroll(); restoreFocus(); resolve(result); };
         const okBtn = overlay.querySelector('.eclaw-confirm-ok');
         const phraseInput = needsPhrase ? overlay.querySelector('.eclaw-confirm-phrase-input') : null;
         const phraseMatches = () => !needsPhrase || (phraseInput && phraseInput.value.trim() === phrase);
@@ -347,6 +383,10 @@ function showConfirm({ message, title, confirmText, cancelText, danger, itemName
             overlay.addEventListener('click', (e) => { if (e.target === overlay) cleanup(false); });
         }
         const _keyHandler = (e) => {
+            // LIFO gate (card_8903c41d): document-level handlers of EVERY open
+            // dialog fire on the same keydown — only the top-most may act, so
+            // one Esc closes one dialog and Enter/Tab can't leak to the stack.
+            if (!_eclawDialogIsTop(overlay)) return;
             if (e.key === 'Escape') cleanup(false);
             // Enter semantics (WAI-ARIA APG: a focused button reacts to Enter
             // and Space identically). Non-danger: Enter confirms. Danger: Enter
@@ -410,6 +450,8 @@ function showConfirm({ message, title, confirmText, cancelText, danger, itemName
 function showPrompt({ message, title, defaultValue, placeholder, confirmText, cancelText } = {}) {
     return new Promise((resolve) => {
         const t = _tFb;
+        // Record the invoking element BEFORE the dialog steals focus (card_8903c41d).
+        const restoreFocus = _eclawCaptureRestoreFocus();
         const overlay = document.createElement('div');
         overlay.className = 'dialog-overlay eclaw-confirm-overlay';
         const dialogId = ++_eclawDialogId;
@@ -432,15 +474,17 @@ function showPrompt({ message, title, defaultValue, placeholder, confirmText, ca
         _eclawEnsureDialogAnimStyle();
         document.body.appendChild(overlay);
         _eclawLockBodyScroll();
+        _eclawDialogStack.push(overlay);
         const input = overlay.querySelector('.eclaw-prompt-input');
         input.focus();
         input.select();
-        const cleanup = (result) => { document.removeEventListener('keydown', _escHandler, true); overlay.remove(); _eclawUnlockBodyScroll(); resolve(result); };
+        const cleanup = (result) => { _eclawDialogStackRemove(overlay); document.removeEventListener('keydown', _escHandler, true); overlay.remove(); _eclawUnlockBodyScroll(); restoreFocus(); resolve(result); };
         overlay.querySelector('.eclaw-confirm-ok').addEventListener('click', () => cleanup(input.value));
         overlay.querySelector('.eclaw-confirm-cancel').addEventListener('click', () => cleanup(null));
         overlay.addEventListener('click', (e) => { if (e.target === overlay) cleanup(null); });
         input.addEventListener('keydown', (e) => { if (e.key === 'Enter') cleanup(input.value); });
-        const _escHandler = (e) => { if (e.key === 'Escape') cleanup(null); };
+        // LIFO gate — see showConfirm's _keyHandler (card_8903c41d).
+        const _escHandler = (e) => { if (!_eclawDialogIsTop(overlay)) return; if (e.key === 'Escape') cleanup(null); };
         // Document-level capture so Esc works even when focus left the dialog. Removed in cleanup.
         document.addEventListener('keydown', _escHandler, true);
     });

--- a/backend/tests/jest/showConfirm-focus-restore-esc-stack.test.js
+++ b/backend/tests/jest/showConfirm-focus-restore-esc-stack.test.js
@@ -1,0 +1,378 @@
+/**
+ * showConfirm / showPrompt — focus restore on close + LIFO Esc for stacked dialogs.
+ *
+ * Card: card_8903c41d8848c182f3aabcab (P2 a11y, Phase 2 finding of the
+ * destructive-modals daily E2E card_b7c1fca2b9107cd8fd3088a8).
+ *
+ * Two defects, both in backend/public/portal/shared/api.js:
+ *   1. FOCUS RESTORE (WAI-ARIA APG dialog pattern violation): closing a dialog
+ *      (Esc or Cancel) dropped document.activeElement to <body> instead of
+ *      returning it to the invoking element.
+ *   2. STACKED ESC: each dialog attaches its own document-level capture
+ *      keydown handler, so ONE Esc fired every handler and closed the whole
+ *      stack. Expected: LIFO — one Esc closes only the top-most dialog.
+ *
+ * jest.config.js uses testEnvironment:'node' with no jsdom dep, so (matching
+ * outbox-ui.test.js / admin-removebot-confirm.test.js) we hand-roll a minimal
+ * DOM stub and EXECUTE the real api.js via a new Function('window','document')
+ * harness — bare `window`/`document` references inside api.js resolve to the
+ * stubs. The stub covers exactly the surface showConfirm/showPrompt touch:
+ * createElement, body/head appendChild, innerHTML (flat parse of tags that
+ * carry a class attr), querySelector('.cls'), element/document add/remove
+ * EventListener, focus()/activeElement (reset to body when the focused element
+ * leaves the DOM, like real browsers), remove(), isConnected, click().
+ * Extend the stub before reaching for a real jsdom dep.
+ *
+ * FAIL-ON-OLD (verified against the pre-fix api.js):
+ *   - "restores focus to the trigger" tests: activeElement stayed on <body>.
+ *   - "one Esc closes ONLY the top-most dialog": one Esc left 0 overlays.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const apiJsSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'shared', 'api.js'),
+    'utf8'
+);
+
+// ── Minimal DOM stub ──────────────────────────────────────────────────────
+function makeDom() {
+    const doc = {};
+    let activeElement = null;
+
+    class StubElement {
+        constructor(tag) {
+            this.tagName = String(tag || 'div').toUpperCase();
+            this.children = [];
+            this.parentNode = null;
+            this.className = '';
+            this.id = '';
+            this.disabled = false;
+            this.value = '';
+            // Real CSSStyleDeclaration reads '' for unset properties — the
+            // scroll-lock save/restore round-trips these, so match that.
+            this.style = { overflow: '', position: '', top: '', width: '' };
+            this._attrs = {};
+            this._text = '';
+            this._innerHTML = null;
+            this._listeners = {};
+        }
+        get textContent() { return this._text; }
+        set textContent(v) { this._text = String(v == null ? '' : v); this._innerHTML = null; }
+        get innerHTML() {
+            // _escHtml() sets textContent then reads innerHTML → serialize escaped.
+            if (this._innerHTML !== null) return this._innerHTML;
+            return this._text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        }
+        set innerHTML(html) {
+            this._innerHTML = String(html);
+            this.children = [];
+            // Flat parse: one child per tag carrying attributes — enough for the
+            // querySelector('.cls') lookups showConfirm/showPrompt perform.
+            const tagRe = /<(button|input|div|p|label|span)\b([^>]*?)\/?>/g;
+            let m;
+            while ((m = tagRe.exec(this._innerHTML))) {
+                const el = new StubElement(m[1]);
+                const attrs = m[2];
+                const cls = /class="([^"]*)"/.exec(attrs);
+                if (cls) el.className = cls[1];
+                const val = /value="([^"]*)"/.exec(attrs);
+                if (val) el.value = val[1];
+                if (/\sdisabled\b/.test(attrs)) el.disabled = true;
+                el.parentNode = this;
+                this.children.push(el);
+            }
+        }
+        appendChild(child) { child.parentNode = this; this.children.push(child); return child; }
+        remove() {
+            if (this.parentNode) {
+                const i = this.parentNode.children.indexOf(this);
+                if (i !== -1) this.parentNode.children.splice(i, 1);
+                this.parentNode = null;
+            }
+            // Real browsers move focus to <body> when the focused element leaves the DOM.
+            if (activeElement && !activeElement.isConnected) activeElement = doc.body;
+        }
+        get isConnected() {
+            let n = this;
+            while (n.parentNode) n = n.parentNode;
+            return n === doc.body || n === doc.head;
+        }
+        querySelector(sel) {
+            const cls = String(sel).replace(/^\./, '');
+            const walk = (el) => {
+                for (const c of el.children) {
+                    if ((c.className || '').split(/\s+/).indexOf(cls) !== -1) return c;
+                    const hit = walk(c);
+                    if (hit) return hit;
+                }
+                return null;
+            };
+            return walk(this);
+        }
+        addEventListener(type, cb) {
+            if (!this._listeners[type]) this._listeners[type] = [];
+            this._listeners[type].push(cb);
+        }
+        removeEventListener(type, cb) {
+            const a = this._listeners[type] || [];
+            const i = a.indexOf(cb);
+            if (i !== -1) a.splice(i, 1);
+        }
+        focus() { if (this.isConnected) activeElement = this; }
+        select() {}
+        click() {
+            const evt = { type: 'click', target: this, preventDefault() {}, stopPropagation() {} };
+            for (const cb of (this._listeners.click || []).slice()) cb(evt);
+        }
+        setAttribute(k, v) { this._attrs[k] = String(v); if (k === 'id') this.id = String(v); }
+        getAttribute(k) {
+            return Object.prototype.hasOwnProperty.call(this._attrs, k) ? this._attrs[k] : null;
+        }
+    }
+
+    const docListeners = { keydown: [] };
+    doc.body = new StubElement('body');
+    doc.head = new StubElement('head');
+    doc.createElement = (t) => new StubElement(t);
+    doc.getElementById = (id) => {
+        const walk = (el) => {
+            for (const c of el.children) {
+                if (c.id === id) return c;
+                const hit = walk(c);
+                if (hit) return hit;
+            }
+            return null;
+        };
+        return walk(doc.head) || walk(doc.body);
+    };
+    doc.addEventListener = (type, cb) => {
+        if (!docListeners[type]) docListeners[type] = [];
+        docListeners[type].push(cb);
+    };
+    doc.removeEventListener = (type, cb) => {
+        const a = docListeners[type] || [];
+        const i = a.indexOf(cb);
+        if (i !== -1) a.splice(i, 1);
+    };
+    doc.contains = (el) => !!(el && el.isConnected);
+    Object.defineProperty(doc, 'activeElement', { get: () => activeElement || doc.body });
+
+    // DOM-spec-faithful document keydown dispatch: iterate a snapshot but skip
+    // handlers that were removed while the event is being dispatched.
+    const dispatchKeydown = (key) => {
+        const evt = { type: 'keydown', key, shiftKey: false, preventDefault() {}, stopPropagation() {} };
+        for (const cb of docListeners.keydown.slice()) {
+            if (docListeners.keydown.indexOf(cb) !== -1) cb(evt);
+        }
+    };
+
+    const win = {
+        location: { origin: 'https://eclawbot.test', hostname: 'eclawbot.test' },
+        scrollY: 0,
+        pageYOffset: 0,
+        scrollTo() {},
+        alert() {},
+        confirm() { return true; },
+        prompt() { return null; },
+    };
+
+    return { doc, win, dispatchKeydown, StubElement };
+}
+
+// ── Harness: execute the REAL api.js against the stub ─────────────────────
+function makeHarness() {
+    const dom = makeDom();
+    const factory = new Function(
+        'window', 'document',
+        `${apiJsSrc}\n;return { showConfirm: showConfirm, showPrompt: showPrompt };`
+    );
+    const api = factory(dom.win, dom.doc);
+    const overlays = () => dom.doc.body.children.filter(
+        (c) => (c.className || '').indexOf('eclaw-confirm-overlay') !== -1
+    );
+    const addTrigger = () => {
+        const trigger = dom.doc.createElement('button');
+        trigger.className = 'test-trigger';
+        dom.doc.body.appendChild(trigger);
+        trigger.focus();
+        return trigger;
+    };
+    return { ...dom, ...api, overlays, addTrigger };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('showConfirm — focus restore to invoking element (card_8903c41d)', () => {
+    it('Esc-close restores focus to the trigger (FAIL-ON-OLD: activeElement dropped to <body>)', async () => {
+        const h = makeHarness();
+        const trigger = h.addTrigger();
+        expect(h.doc.activeElement).toBe(trigger);
+
+        const p = h.showConfirm({ message: 'delete?', danger: true, itemName: 'thing' });
+        // Regression guard (card_31cbbcd8 / card_d2506588): danger initial focus is Cancel.
+        expect(h.doc.activeElement.className).toContain('eclaw-confirm-cancel');
+
+        h.dispatchKeydown('Escape');
+        await expect(p).resolves.toBe(false);
+        expect(h.overlays()).toHaveLength(0);
+        expect(h.doc.activeElement).toBe(trigger); // FAIL-ON-OLD: was doc.body
+    });
+
+    it('Cancel-click close also restores focus to the trigger', async () => {
+        const h = makeHarness();
+        const trigger = h.addTrigger();
+        const p = h.showConfirm({ message: 'delete?', danger: true, itemName: 'thing' });
+        h.overlays()[0].querySelector('.eclaw-confirm-cancel').click();
+        await expect(p).resolves.toBe(false);
+        expect(h.doc.activeElement).toBe(trigger);
+    });
+
+    it('Confirm-click close restores focus to the trigger too', async () => {
+        const h = makeHarness();
+        const trigger = h.addTrigger();
+        const p = h.showConfirm({ message: 'go?', danger: false });
+        h.overlays()[0].querySelector('.eclaw-confirm-ok').click();
+        await expect(p).resolves.toBe(true);
+        expect(h.doc.activeElement).toBe(trigger);
+    });
+
+    it('trigger removed from the DOM while the dialog is open → fallback (no throw, focus to <body>)', async () => {
+        const h = makeHarness();
+        const trigger = h.addTrigger();
+        const p = h.showConfirm({ message: 'delete?', danger: true, itemName: 'thing' });
+        trigger.remove();
+        h.dispatchKeydown('Escape');
+        await expect(p).resolves.toBe(false);
+        expect(h.doc.activeElement).toBe(h.doc.body);
+    });
+});
+
+describe('showConfirm — stacked dialogs close LIFO on Esc (card_8903c41d)', () => {
+    it('one Esc closes ONLY the top-most dialog; the next Esc closes the next (FAIL-ON-OLD: one Esc closed both)', async () => {
+        const h = makeHarness();
+        h.addTrigger();
+        let p1Done = false;
+        const p1 = h.showConfirm({ message: 'first', danger: true, itemName: 'a' });
+        p1.then(() => { p1Done = true; });
+        const p2 = h.showConfirm({ message: 'second', danger: true, itemName: 'b' });
+        expect(h.overlays()).toHaveLength(2);
+
+        h.dispatchKeydown('Escape');
+        await expect(p2).resolves.toBe(false);
+        await flush();
+        expect(h.overlays()).toHaveLength(1); // FAIL-ON-OLD: 0 — both closed
+        expect(p1Done).toBe(false);           // bottom dialog still open
+
+        h.dispatchKeydown('Escape');
+        await expect(p1).resolves.toBe(false);
+        expect(h.overlays()).toHaveLength(0);
+    });
+
+    it('closing the top dialog restores focus into the dialog below, then the original trigger', async () => {
+        const h = makeHarness();
+        const trigger = h.addTrigger();
+        const p1 = h.showConfirm({ message: 'first', danger: true, itemName: 'a' });
+        const bottomCancel = h.overlays()[0].querySelector('.eclaw-confirm-cancel');
+        expect(h.doc.activeElement).toBe(bottomCancel);
+
+        const p2 = h.showConfirm({ message: 'second', danger: true, itemName: 'b' });
+        h.dispatchKeydown('Escape');
+        await expect(p2).resolves.toBe(false);
+        expect(h.doc.activeElement).toBe(bottomCancel); // LIFO focus chain
+
+        h.dispatchKeydown('Escape');
+        await expect(p1).resolves.toBe(false);
+        expect(h.doc.activeElement).toBe(trigger);
+    });
+
+    it('Enter cannot leak to a lower stacked dialog (top gate covers all keys)', async () => {
+        const h = makeHarness();
+        h.addTrigger();
+        let p1Done = false;
+        // Bottom dialog is NON-danger: pre-fix, a document-level Enter resolved it true.
+        const p1 = h.showConfirm({ message: 'first' });
+        p1.then(() => { p1Done = true; });
+        const p2 = h.showConfirm({ message: 'second', danger: true, itemName: 'b' });
+
+        h.dispatchKeydown('Enter'); // top is danger + focus on Cancel → resolves false
+        await expect(p2).resolves.toBe(false);
+        await flush();
+        expect(p1Done).toBe(false); // FAIL-ON-OLD: bottom dialog confirmed by the same Enter
+        expect(h.overlays()).toHaveLength(1);
+
+        h.dispatchKeydown('Escape');
+        await expect(p1).resolves.toBe(false);
+    });
+
+    it('scroll-lock ref-count returns to 0 after the whole stack closes (body styles restored)', async () => {
+        const h = makeHarness();
+        h.addTrigger();
+        h.doc.body.style.overflow = '';
+        const p1 = h.showConfirm({ message: 'first', danger: true, itemName: 'a' });
+        const p2 = h.showConfirm({ message: 'second', danger: true, itemName: 'b' });
+        expect(h.doc.body.style.position).toBe('fixed');
+
+        h.dispatchKeydown('Escape');
+        await expect(p2).resolves.toBe(false);
+        expect(h.doc.body.style.position).toBe('fixed'); // still locked — one dialog open
+
+        h.dispatchKeydown('Escape');
+        await expect(p1).resolves.toBe(false);
+        expect(h.doc.body.style.position).toBe(''); // count back to 0 → restored
+        expect(h.doc.body.style.overflow).toBe('');
+    });
+});
+
+describe('showConfirm — Enter/Esc semantics unchanged for a single dialog (card_d2506588 regression guard)', () => {
+    it('non-danger: Enter confirms (resolves true)', async () => {
+        const h = makeHarness();
+        h.addTrigger();
+        const p = h.showConfirm({ message: 'go?' });
+        h.dispatchKeydown('Enter');
+        await expect(p).resolves.toBe(true);
+    });
+
+    it('danger: stray Enter with focus on Cancel still cancels (resolves false)', async () => {
+        const h = makeHarness();
+        h.addTrigger();
+        const p = h.showConfirm({ message: 'delete?', danger: true, itemName: 'x' });
+        expect(h.doc.activeElement.className).toContain('eclaw-confirm-cancel');
+        h.dispatchKeydown('Enter');
+        await expect(p).resolves.toBe(false);
+    });
+});
+
+describe('showPrompt — same fixes apply (shared dialog stack + focus restore)', () => {
+    it('Esc-close restores focus to the trigger (FAIL-ON-OLD: dropped to <body>)', async () => {
+        const h = makeHarness();
+        const trigger = h.addTrigger();
+        const p = h.showPrompt({ message: 'name?' });
+        expect(h.doc.activeElement.className).toContain('eclaw-prompt-input');
+        h.dispatchKeydown('Escape');
+        await expect(p).resolves.toBe(null);
+        expect(h.doc.activeElement).toBe(trigger);
+    });
+
+    it('showPrompt stacked on showConfirm: one Esc closes only the prompt', async () => {
+        const h = makeHarness();
+        h.addTrigger();
+        let p1Done = false;
+        const p1 = h.showConfirm({ message: 'confirm', danger: true, itemName: 'a' });
+        p1.then(() => { p1Done = true; });
+        const p2 = h.showPrompt({ message: 'name?' });
+        expect(h.overlays()).toHaveLength(2);
+
+        h.dispatchKeydown('Escape');
+        await expect(p2).resolves.toBe(null);
+        await flush();
+        expect(h.overlays()).toHaveLength(1); // FAIL-ON-OLD: 0
+        expect(p1Done).toBe(false);
+
+        h.dispatchKeydown('Escape');
+        await expect(p1).resolves.toBe(false);
+        expect(h.overlays()).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Card
card_8903c41d8848c182f3aabcab (P2 a11y) — source: destructive-modals daily E2E card_b7c1fca2 Phase 2.

## Defects fixed (both in `backend/public/portal/shared/api.js`)
1. **Focus not restored on close (WAI-ARIA APG violation)** — closing `showConfirm`/`showPrompt` (Esc / Cancel / Confirm) dropped `document.activeElement` to `<body>`. Keyboard/SR users lost their place in the page after cancelling a destructive flow.
2. **Stacked dialogs all closed on ONE Esc** — each dialog attaches its own document-level capture keydown handler, so a single Esc fired every handler and closed the whole stack.

## Fix
- `_eclawCaptureRestoreFocus()`: records `document.activeElement` at open; cleanup focuses it back **iff still in the DOM and focusable** (`isConnected` + `focus` check, try/catch), else previous fallback behaviour unchanged. With stacked dialogs the restore chains LIFO: top close → dialog below → original trigger.
- `_eclawDialogStack` (shared module-level LIFO stack): each dialog's document-level keydown handler acts **only while its own overlay is the top entry** — one Esc closes only the top-most dialog, the next Esc the next. The gate covers the whole handler, so Enter/Tab can no longer leak into lower stacked dialogs either. Out-of-order closes (button click / backdrop tap) splice their own entry.

## Acceptance mapping
1. ✅ activeElement recorded at open, restored on cleanup if connected+focusable, else fallback unchanged.
2. ✅ One Esc closes only the top-most dialog (LIFO via shared stack; handler top-check).
3. ✅ New Jest suite `showConfirm-focus-restore-esc-stack.test.js` — executes the REAL `api.js` via a `new Function('window','document')` harness + hand-rolled DOM stub (same convention as `outbox-ui.test.js` / `admin-removebot-confirm.test.js`).
4. ✅ No regressions: danger initial focus on Cancel, Enter semantics (card_d2506588), focus trap, scroll-lock ref-count → 0 — all behaviour-tested in the new suite AND the existing static suites still pass untouched.

## Red → green evidence
Ran the NEW suite against the **original** api.js (`git stash` of the fix):
```
Tests: 9 failed, 3 passed, 12 total   ← pre-fix (the 3 passers are behaviour-preservation guards)
  ✕ Esc-close restores focus to the trigger (activeElement dropped to <body>)
  ✕ one Esc closes ONLY the top-most dialog (one Esc closed both)
  ✕ showPrompt stacked on showConfirm: one Esc closes only the prompt
  ... (all focus-restore + stack tests fail)
```
After restoring the fix:
```
Tests: 12 passed, 12 total            ← post-fix
```

## Regression suites
Full backend jest suite: **469 suites / 6451 passed, 17 skipped, 0 failed** — includes `showConfirm-scroll-lock`, `showConfirm-danger-default-focus`, `showConfirm-a11y-attrs`, `showConfirm-confirm-phrase`, `showConfirm-entrance-anim`, `showConfirm-destructive-thumb-zone`, `dialog-mobile-safe-area`, `destructive-confirm-verbs`, `portal-vault-post-sends-etag`. ESLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuABXFYP3EofvYeqXW6ncn