### PR TITLE
feat(needyou-inbox): 🗂 任務卡 chip click pops the card detail subview (card_29f507ef)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -8560,16 +8560,18 @@
                     actions.appendChild(anchor);
                 }
                 // 計畫D (card_df646877): OPTIONAL 🗂 任務卡 chip — only when the request
-                // carries a relatedCardId. Clicking deep-links to the kanban card via
-                // the shared openKanbanCard() (SmartRouter split / native app /
-                // standalone fallbacks). Absent relatedCardId → no chip, no layout shift.
+                // carries a relatedCardId. card_29f507ef (Hank 2026-07-06): clicking now
+                // POPS UP the card detail subview in place (title/status/comments via the
+                // shared entityPreviewModal smart-chip popup) instead of deep-linking away —
+                // the popup itself carries the 📋 Open-in-Kanban link for board navigation.
+                // Absent relatedCardId → no chip, no layout shift.
                 if (request.relatedCardId) {
                     const cardLink = document.createElement('button');
                     cardLink.type = 'button';
                     cardLink.className = 'action-request-action action-request-card-link';
                     cardLink.textContent = t('action_request_card_link', '🗂 Task card');
                     cardLink.title = t('action_request_card_link_title', 'Open linked card {card}', { card: String(request.relatedCardId) });
-                    cardLink.addEventListener('click', (event) => openKanbanCard(request.relatedCardId, event));
+                    cardLink.addEventListener('click', (event) => openActionRequestCardPopup(request.relatedCardId, event));
                     actions.appendChild(cardLink);
                 }
                 const dismiss = document.createElement('button');
@@ -11841,6 +11843,24 @@
             const url = getKanbanCardUrl(id);
             const opened = window.open(url, '_blank', 'noopener');
             if (!opened) window.location.href = url;
+        }
+
+        // card_29f507ef (Hank 2026-07-06): the 需要你 inbox 🗂 任務卡 chip pops the
+        // card DETAIL subview in place — the same entityPreviewModal smart-chip
+        // popup chat-message card chips use (openEntityModal→fetchCardData:
+        // title/status/comments/screenshots) — instead of deep-linking to the
+        // board. The popup keeps the 📋 Open-in-Kanban link for owners who do
+        // want the board. Falls back to the legacy openKanbanCard deep-link only
+        // if the modal helper is somehow unavailable, so the chip is never dead.
+        function openActionRequestCardPopup(cardId, event) {
+            if (event && typeof event.preventDefault === 'function') event.preventDefault();
+            const id = String(cardId || '').trim();
+            if (!id) return;
+            if (typeof openEntityModal === 'function') {
+                openEntityModal('card', id);
+                return;
+            }
+            openKanbanCard(id, event);
         }
 
         async function fetchCardData(auth, cardId) {

--- a/backend/tests/jest/chat-action-request-inbox-behavior.test.js
+++ b/backend/tests/jest/chat-action-request-inbox-behavior.test.js
@@ -203,6 +203,13 @@ function makeInbox(opts = {}) {
     // showToast spy — tests assert error toasts are/aren't raised.
     const showToast = opts.showToast || jest.fn();
 
+    // card_29f507ef: the 🗂 任務卡 chip pops the shared entityPreviewModal via
+    // openEntityModal('card', id) — spied so the click test proves the wiring.
+    // openKanbanCard remains only as openActionRequestCardPopup's defensive
+    // fallback (modal helper missing) — also a spy.
+    const openEntityModal = opts.openEntityModal !== undefined ? opts.openEntityModal : jest.fn();
+    const openKanbanCard = opts.openKanbanCard || jest.fn();
+
     const i18nStub = {
         t(key, vars) {
             const dict = {
@@ -289,6 +296,8 @@ function makeInbox(opts = {}) {
         extractFunction('actionRequestMatchesFilter'),
         // 計畫E ratify-loop badge builder (renamed from actionRequestRatificationBadgeMeta on main).
         extractFunction('buildRatifyBadge'),
+        // card_29f507ef: the REAL chip-click handler (popup-first, deep-link fallback).
+        extractFunction('openActionRequestCardPopup'),
         extractFunction('renderActionRequestInbox'),
         // The inbox render entry point loadActionRequests/dismissActionRequest
         // funnel through (replaced EclawGreeting.maybeShow; card_cc9700b7).
@@ -301,12 +310,10 @@ function makeInbox(opts = {}) {
     const socketSrc = chatHtml.slice(socketStart, socketEnd);
 
     // Stubs for helpers the spliced bodies reference but we don't exercise.
+    // (openEntityModal / openKanbanCard are injected as sandbox params — spies.)
     const stubs = `
         function renderReplyPreviews() {}
         function recomputeAutoReceivers() {}
-        // 計畫D: the 🗂 任務卡 chip click handler calls openKanbanCard — not invoked
-        // during render, stubbed so a click test could spy on it if needed.
-        function openKanbanCard() {}
         const CHAT_MESSAGE_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     `;
 
@@ -337,14 +344,16 @@ function makeInbox(opts = {}) {
     const factory = new Function(
         'document', 'window', 'i18n', 'localStorage',
         'apiCall', 'currentUser', 'showToast',
+        'openEntityModal', 'openKanbanCard',
         body
     );
     const api = factory(
         document, windowStub, i18nStub, localStorageStub,
-        apiCallMock, currentUser, showToast
+        apiCallMock, currentUser, showToast,
+        openEntityModal, openKanbanCard
     );
 
-    return { api, banner, document, localStorage: localStorageStub, apiCall: apiCallMock, showToast, currentUser };
+    return { api, banner, document, localStorage: localStorageStub, apiCall: apiCallMock, showToast, currentUser, openEntityModal, openKanbanCard };
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -693,7 +702,7 @@ describe('計畫C — 需要你 inbox 篩選條件 facet (All / Consensus)', () 
     });
 });
 
-describe('計畫D — 需要你 inbox 🗂 任務卡 deep-link chip', () => {
+describe('計畫D — 需要你 inbox 🗂 任務卡 chip (popup per card_29f507ef)', () => {
     test('renders the card chip ONLY when relatedCardId is present', () => {
         const { api, banner } = makeInbox();
         api.setActionRequests([
@@ -705,7 +714,9 @@ describe('計畫D — 需要你 inbox 🗂 任務卡 deep-link chip', () => {
         const links = findAllByClass(banner, 'action-request-card-link');
         expect(links.length).toBe(1);
         expect(links[0]._text).toBe('🗂 Task card');
+        // a REAL <button> → natively keyboard-activatable (Enter/Space)
         expect(links[0].tagName).toBe('BUTTON');
+        expect(links[0].type).toBe('button');
     });
 
     test('no card chip at all when no request carries relatedCardId (no layout change)', () => {
@@ -713,6 +724,49 @@ describe('計畫D — 需要你 inbox 🗂 任務卡 deep-link chip', () => {
         api.setActionRequests([makeRequest(REQ_A), makeRequest(REQ_B)]);
         api.renderActionRequestInbox(banner);
         expect(findAllByClass(banner, 'action-request-card-link').length).toBe(0);
+    });
+
+    // card_29f507ef (Hank 2026-07-06): 「任務chip要能在需要你收件夾中可以點擊彈跳出
+    // 任務子卡」 — clicking the chip must POP UP the card detail subview (the shared
+    // entityPreviewModal, openEntityModal('card', id)), not deep-link away.
+    test('clicking the chip opens the card DETAIL POPUP (openEntityModal card,<id>) — no deep-link away', () => {
+        const { api, banner, openEntityModal, openKanbanCard } = makeInbox();
+        api.setActionRequests([makeRequest(REQ_A, { relatedCardId: 'card_29f507ef' })]);
+        api.renderActionRequestInbox(banner);
+
+        const chip = findByClass(banner, 'action-request-card-link');
+        expect(chip).not.toBeNull();
+        chip.click();
+
+        expect(openEntityModal).toHaveBeenCalledTimes(1);
+        expect(openEntityModal).toHaveBeenCalledWith('card', 'card_29f507ef');
+        // the inbox stays put — no board navigation on the primary path
+        expect(openKanbanCard).not.toHaveBeenCalled();
+    });
+
+    test('chip click prevents the default action (stays inside the chat surface)', () => {
+        const { api, banner, openEntityModal } = makeInbox();
+        api.setActionRequests([makeRequest(REQ_A, { relatedCardId: 'card_29f507ef' })]);
+        api.renderActionRequestInbox(banner);
+
+        const chip = findByClass(banner, 'action-request-card-link');
+        const preventDefault = jest.fn();
+        (chip._listeners.click || []).forEach(cb => cb({ target: chip, preventDefault }));
+
+        expect(preventDefault).toHaveBeenCalled();
+        expect(openEntityModal).toHaveBeenCalledWith('card', 'card_29f507ef');
+    });
+
+    test('fallback: openEntityModal unavailable → chip still works via openKanbanCard deep-link', () => {
+        // openEntityModal: null → typeof !== 'function' inside the sandbox.
+        const { api, banner, openKanbanCard } = makeInbox({ openEntityModal: null });
+        api.setActionRequests([makeRequest(REQ_A, { relatedCardId: 'card_29f507ef' })]);
+        api.renderActionRequestInbox(banner);
+
+        findByClass(banner, 'action-request-card-link').click();
+
+        expect(openKanbanCard).toHaveBeenCalledTimes(1);
+        expect(openKanbanCard.mock.calls[0][0]).toBe('card_29f507ef');
     });
 });
 

--- a/backend/tests/jest/chat-action-request-inbox.test.js
+++ b/backend/tests/jest/chat-action-request-inbox.test.js
@@ -244,20 +244,32 @@ describe('需要你 inbox 篩選條件 facet (計畫C, card_2a6f260f)', () => {
     });
 });
 
-describe('需要你 inbox related-card chip (計畫D, card_df646877)', () => {
-    test('the chip renders ONLY when a request has relatedCardId and opens the card via openKanbanCard', () => {
+describe('需要你 inbox related-card chip (計畫D, card_df646877; popup card_29f507ef)', () => {
+    test('the chip renders ONLY when a request has relatedCardId and pops the card detail subview', () => {
         const fn = chatHtml.slice(chatHtml.indexOf('function renderActionRequestInbox('), chatHtml.indexOf('function collectActionRequestReplyContexts('));
         // gated on relatedCardId — absent → no chip, no layout shift
         expect(fn).toContain('if (request.relatedCardId) {');
         expect(fn).toContain("cardLink.className = 'action-request-action action-request-card-link';");
         expect(fn).toContain("cardLink.textContent = t('action_request_card_link', '🗂 Task card');");
-        // clicking deep-links to the kanban card via the shared open mechanism
-        expect(fn).toContain('openKanbanCard(request.relatedCardId, event)');
+        // card_29f507ef: clicking pops the card detail subview in place (the shared
+        // entityPreviewModal smart-chip popup), NOT a deep-link away from the inbox
+        expect(fn).toContain('openActionRequestCardPopup(request.relatedCardId, event)');
+        expect(fn).not.toContain('openKanbanCard(request.relatedCardId, event)');
         // the chip lives in the actions row (after Show source, before Dismiss)
         expect(fn.indexOf('action-request-card-link')).toBeLessThan(fn.indexOf("dismiss.className = 'action-request-action danger';"));
     });
 
-    test('openKanbanCard exists as the shared deep-link entry', () => {
+    test('openActionRequestCardPopup routes to the shared entityPreviewModal (openEntityModal) with a deep-link fallback', () => {
+        const start = chatHtml.indexOf('function openActionRequestCardPopup(cardId, event)');
+        expect(start).toBeGreaterThan(-1);
+        const fn = chatHtml.slice(start, chatHtml.indexOf('async function fetchCardData(', start));
+        // primary path: the SAME popup component chat-message card chips use
+        expect(fn).toContain("openEntityModal('card', id)");
+        // defensive fallback keeps the chip alive if the modal helper is missing
+        expect(fn).toContain('openKanbanCard(id, event)');
+    });
+
+    test('openKanbanCard still exists as the shared deep-link entry (used inside the popup)', () => {
         expect(chatHtml).toMatch(/function openKanbanCard\(cardId, event\)/);
     });
 

--- a/backend/tests/jest/chat-needyou-inbox-card-chip-popup.test.js
+++ b/backend/tests/jest/chat-needyou-inbox-card-chip-popup.test.js
@@ -1,0 +1,260 @@
+/**
+ * chat-needyou-inbox-card-chip-popup — card_29f507ef (Hank 2026-07-06):
+ * 「任務chip要能在需要你收件夾中可以點擊彈跳出任務子卡」.
+ *
+ * The 需要你 inbox 🗂 任務卡 chip (rendered when an action-request carries
+ * relatedCardId) must POP UP that card's detail subview (title / status /
+ * comments) in place — the shared entityPreviewModal smart-chip popup that
+ * chat-message card chips already use — instead of deep-linking the owner
+ * away to the kanban board.
+ *
+ * This file EXECUTES the real chain end-to-end inside a `new Function(...)`
+ * sandbox (same harness technique as chat-action-request-inbox-behavior.test.js:
+ * extractFunction brace-counting; jest testEnvironment is 'node', no jsdom):
+ *
+ *   openActionRequestCardPopup  (the chip's click handler — NEW)
+ *     → openEntityModal('card', id)   (existing shared popup opener)
+ *       → fetchCardData               (existing: GET card + comments + files)
+ *         → entityPreviewModal DOM    (title via textContent, body via
+ *                                      escapeHtml'd HTML — XSS-safe)
+ *
+ * Red→green: on origin/main openActionRequestCardPopup does not exist —
+ * extractFunction throws and this whole suite FAILS. On the fix it passes.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const chatHtmlPath = path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html');
+const chatHtml = fs.readFileSync(chatHtmlPath, 'utf8');
+
+// ── extractFunction: brace-count a top-level function body out of chat.html ──
+function extractFunction(name) {
+    const re = new RegExp(`(?:async\\s+)?function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`, 'g');
+    const m = re.exec(chatHtml);
+    if (!m) throw new Error(`function ${name} not found in chat.html`);
+    let depth = 1;
+    let i = m.index + m[0].length;
+    while (i < chatHtml.length && depth > 0) {
+        const ch = chatHtml[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+        i++;
+    }
+    return chatHtml.slice(m.index, i);
+}
+
+// ── minimal element shim ─────────────────────────────────────────────────────
+// Supports what openEntityModal/fetchCardData/escapeHtml touch: textContent,
+// innerHTML (reading innerHTML after a textContent write returns the ESCAPED
+// text — mirroring the real-DOM contract escapeHtml relies on), dataset, style,
+// classList.
+function htmlEscape(s) {
+    return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+function makeElement(tag) {
+    const el = {
+        tagName: String(tag || 'div').toUpperCase(),
+        dataset: {},
+        style: {},
+        attrs: {},
+        _text: '',
+        _innerHTML: undefined,
+    };
+    Object.defineProperty(el, 'textContent', {
+        get() { return el._text; },
+        set(v) { el._text = String(v); el._innerHTML = undefined; },
+    });
+    Object.defineProperty(el, 'innerHTML', {
+        get() { return el._innerHTML !== undefined ? el._innerHTML : htmlEscape(el._text); },
+        set(v) { el._innerHTML = String(v); el._text = String(v); },
+    });
+    const classes = new Set();
+    el.classList = {
+        add(c) { classes.add(c); },
+        remove(c) { classes.delete(c); },
+        contains(c) { return classes.has(c); },
+    };
+    el.setAttribute = (k, v) => { el.attrs[k] = String(v); };
+    return el;
+}
+
+// ── sandbox: splice the REAL functions out of chat.html ─────────────────────
+function makePopupHarness(opts = {}) {
+    const modal = makeElement('div');
+    const typeEl = makeElement('div');
+    const titleEl = makeElement('div');
+    const idEl = makeElement('div');
+    const bodyEl = makeElement('div');
+    const elementsById = {
+        entityPreviewModal: modal,
+        entityModalType: typeEl,
+        entityModalTitle: titleEl,
+        entityModalId: idEl,
+        entityModalBody: bodyEl,
+    };
+    const documentStub = {
+        getElementById: (id) => elementsById[id] || null,
+        createElement: (tag) => makeElement(tag),
+    };
+    const windowStub = {}; // no EntityLinkRender → openEntityModal falls back to {}
+    const i18nStub = {
+        t(key) {
+            const dict = {
+                chat_card_modal_comments: 'Comments',
+                chat_card_modal_comments_empty: 'No comments yet',
+                mm_preview_open_task: 'Open in Kanban',
+            };
+            return dict[key] || '';
+        },
+    };
+    const apiCall = opts.apiCall || jest.fn(async () => ({}));
+    const currentUser = { deviceId: 'dev-1', deviceSecret: 'sec-1' };
+    const openKanbanCardSpy = jest.fn();
+
+    const stubs = `
+        const entityTypeLabels = { card: '📋 Task Card' };
+        const statusEmojis = { todo: '📥', in_progress: '🚧', review: '👀', blocked: '🧱', done: '✅' };
+        function eclawNavigateMissionCard() { return false; }
+        function fetchDashboardItem() {}
+        function fetchListingData() {}
+        function fetchExamData() {}
+        function fetchContractData() {}
+        function fetchMindmapNodeData() {}
+    `;
+    const fnBodies = [
+        extractFunction('escapeHtml'),
+        extractFunction('escapeJs'),
+        extractFunction('getKanbanCardUrl'),
+        extractFunction('openModal'),
+        extractFunction('fetchCardData'),
+        extractFunction('openEntityModal'),
+        // the NEW chip click handler under test (fails extraction on origin/main)
+        extractFunction('openActionRequestCardPopup'),
+    ].join('\n');
+
+    const body = `
+        ${stubs}
+        ${fnBodies}
+        return { openActionRequestCardPopup, openEntityModal, fetchCardData, escapeHtml };
+    `;
+    /* eslint-disable no-new-func */
+    const factory = new Function(
+        'document', 'window', 'i18n', 'apiCall', 'currentUser', 'openKanbanCard',
+        body
+    );
+    const api = factory(documentStub, windowStub, i18nStub, apiCall, currentUser, openKanbanCardSpy);
+    return { api, modal, typeEl, titleEl, idEl, bodyEl, apiCall, openKanbanCard: openKanbanCardSpy };
+}
+
+// flush the async openEntityModal → fetchCardData microtask chain
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+const CARD_ID = 'card_29f507ef9dcdc0a2bc3ce5f2';
+
+function cardApiMock(cardOver = {}, comments = null) {
+    return jest.fn(async (method, url) => {
+        expect(method).toBe('GET');
+        if (/\/comments\?/.test(url)) {
+            return { comments: comments || [] };
+        }
+        if (/\/files\?/.test(url)) {
+            return { files: [] };
+        }
+        expect(url).toMatch(new RegExp(`/api/mission/card/${CARD_ID}\\?`));
+        return {
+            card: Object.assign({
+                id: CARD_ID,
+                title: '[Enhance/P2] 需要你收件夾：任務 chip 可點擊彈出任務子卡',
+                status: 'in_progress',
+                priority: 'P2',
+                assignedBots: [2],
+                description: 'Pop the card detail subview from the inbox chip.',
+                createdAt: '2026-07-06T10:00:00Z',
+                updatedAt: '2026-07-06T11:00:00Z',
+                commentCount: 1,
+                requiresScreenshotReview: false,
+            }, cardOver),
+        };
+    });
+}
+
+describe('card_29f507ef — 需要你 inbox 🗂 chip pops the card detail subview', () => {
+    test('chip handler → entityPreviewModal opens with the FETCHED card (title/status/comments)', async () => {
+        const apiCall = cardApiMock({}, [
+            { text: 'First pass shipped', fromEntityId: 2, createdAt: '2026-07-06T10:30:00Z' },
+        ]);
+        const { api, modal, titleEl, idEl, bodyEl } = makePopupHarness({ apiCall });
+
+        api.openActionRequestCardPopup(CARD_ID, { preventDefault: jest.fn() });
+        await flush();
+
+        // popup is OPEN (openModal added .active to #entityPreviewModal)
+        expect(modal.classList.contains('active')).toBe(true);
+        expect(modal.dataset.entityType).toBe('card');
+        expect(modal.dataset.entityId).toBe(CARD_ID);
+
+        // the three fetches went out with the owner auth pair
+        expect(apiCall).toHaveBeenCalledTimes(3);
+        expect(apiCall.mock.calls[0][1]).toContain('deviceId=dev-1&deviceSecret=sec-1');
+
+        // title (via textContent), short id, and detail body rendered
+        expect(titleEl.textContent).toBe('[Enhance/P2] 需要你收件夾：任務 chip 可點擊彈出任務子卡');
+        expect(idEl.textContent).toBe(CARD_ID.substring(0, 8));
+        expect(bodyEl.innerHTML).toContain('🚧 in_progress');            // status
+        expect(bodyEl.innerHTML).toContain('P2');                        // priority
+        expect(bodyEl.innerHTML).toContain('First pass shipped');        // comment text
+        expect(bodyEl.innerHTML).toContain('#2');                        // comment author
+        expect(bodyEl.innerHTML).toContain('Open in Kanban');            // board link kept INSIDE the popup
+        expect(bodyEl.innerHTML).toContain(`kanban.html?card=${encodeURIComponent(CARD_ID)}`);
+    });
+
+    test('empty comments → the popup shows the comments empty-state', async () => {
+        const { api, bodyEl } = makePopupHarness({ apiCall: cardApiMock({}, []) });
+        api.openActionRequestCardPopup(CARD_ID, { preventDefault: jest.fn() });
+        await flush();
+        expect(bodyEl.innerHTML).toContain('No comments yet');
+    });
+
+    test('XSS: hostile title/description/comment stay inert (textContent + escapeHtml)', async () => {
+        const hostile = '<img src=x onerror=alert(1)>';
+        const apiCall = cardApiMock(
+            { title: hostile, description: '<script>steal()</script>' },
+            [{ text: '<b>bold</b> & <script>x</script>', fromEntityId: 5, createdAt: '2026-07-06T10:30:00Z' }]
+        );
+        const { api, titleEl, bodyEl } = makePopupHarness({ apiCall });
+
+        api.openActionRequestCardPopup(CARD_ID, { preventDefault: jest.fn() });
+        await flush();
+
+        // title assigned via textContent — raw string, never parsed as HTML
+        expect(titleEl.textContent).toBe(hostile);
+        expect(titleEl.innerHTML).not.toContain('<img');
+        // description + comments pass through escapeHtml before innerHTML
+        expect(bodyEl.innerHTML).toContain('&lt;script&gt;steal()&lt;/script&gt;');
+        expect(bodyEl.innerHTML).not.toContain('<script>steal()');
+        expect(bodyEl.innerHTML).toContain('&lt;b&gt;bold&lt;/b&gt;');
+        expect(bodyEl.innerHTML).not.toContain('<b>bold</b>');
+    });
+
+    test('blank/whitespace cardId → no popup, no fetch (guard)', async () => {
+        const apiCall = jest.fn(async () => ({}));
+        const { api, modal } = makePopupHarness({ apiCall });
+        api.openActionRequestCardPopup('   ', { preventDefault: jest.fn() });
+        api.openActionRequestCardPopup(null, { preventDefault: jest.fn() });
+        await flush();
+        expect(apiCall).not.toHaveBeenCalled();
+        expect(modal.classList.contains('active')).toBe(false);
+    });
+
+    test('fetch failure → popup opens with the error state, not a crash', async () => {
+        const apiCall = jest.fn(async () => { throw new Error('boom'); });
+        const { api, modal, bodyEl } = makePopupHarness({ apiCall });
+        api.openActionRequestCardPopup(CARD_ID, { preventDefault: jest.fn() });
+        await flush();
+        expect(modal.classList.contains('active')).toBe(true);
+        expect(bodyEl.innerHTML).toContain('Failed to load');
+        expect(bodyEl.innerHTML).toContain('boom');
+    });
+});


### PR DESCRIPTION
## Summary
- **card_29f507ef9dcdc0a2bc3ce5f2 (P2, Hank 2026-07-06)**:「任務chip要能在需要你收件夾中可以點擊彈跳出任務子卡」
- The 需要你 inbox **🗂 任務卡 chip** (rendered when an action-request carries `relatedCardId`) used to deep-link away to the kanban board. It now **pops the card's detail subview in place** — reusing the existing `entityPreviewModal` smart-chip popup that chat-message card chips already use (`openEntityModal('card', id)` → `fetchCardData`: title / status / comments / screenshots).
- New `openActionRequestCardPopup(cardId, event)` handler: popup-first, falls back to the legacy `openKanbanCard` deep-link only if the modal helper is unavailable (chip never dead). The popup keeps its 📋 Open-in-Kanban link, so board navigation is one extra tap, not lost.
- Mobile + desktop: the modal overlay (`z-index: 9999`) stacks above the mobile inbox fixed overlay (`z-index: 6000`); `.modal-box` is `width:90%; max-height:80vh; overflow-y:auto` → fine at 390x844 and 1280x800. Chip stays a real `<button type=button>` → natively keyboard-activatable (Enter/Space).
- XSS-safe by reuse: title via `textContent`, description/comments through `escapeHtml` (covered by a new hostile-payload test).

## Tests — red on origin/main → green here
On origin/main (old chat.html): **3 suites fail, 33 failed / 29 passed of 62** (new suite can't extract `openActionRequestCardPopup`; updated pins reject the old deep-link wiring). On this branch: **3 suites pass, 62/62**.
- **NEW** `chat-needyou-inbox-card-chip-popup.test.js` — executes the REAL chain `openActionRequestCardPopup → openEntityModal → fetchCardData` (extracted from chat.html, same `new Function` sandbox convention): popup opens with the fetched card (title/status/comments/Open-in-Kanban link), comments empty-state, XSS-inert hostile title/description/comment, blank-id guard, fetch-failure error state.
- `chat-action-request-inbox-behavior.test.js` — chip click → `openEntityModal('card', id)` and **no** deep-link; `preventDefault`; fallback path when the modal helper is missing; chip renders **only** with `relatedCardId` (unchanged behavior preserved).
- `chat-action-request-inbox.test.js` — source pins updated from `openKanbanCard(request.relatedCardId, …)` to the popup wiring.

Full local jest run: unrelated suites fail in this fresh worktree with `Cannot find module 'pg'` (deps not installed locally) — pre-existing/environmental, not touched by this diff; CI is authoritative.

## Post-merge note
Portal assets sit behind a ~4h Cloudflare edge cache — prod render verification happens after edge propagation (or with a cache-busted load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuABXFYP3EofvYeqXW6ncn