### PR TITLE
fix: contacts POST avatar enrich + copyNotePageLink active-entity (card_7ced13ac, card_091d24a5)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -15644,7 +15644,11 @@ app.post('/api/contacts', async (req, res) => {
     });
     if (!card) return res.status(500).json({ success: false, error: 'Failed to add card' });
 
-    res.json({ success: true, contact: enrichCardHolderEntry(card) });
+    // card_7ced13ac: align with the 5 read-path siblings (/contacts /recent
+    // /search /friends /friend-requests) which all enrich petdxAvatarUrl. The
+    // sync enrichCardHolderEntry omits it, so the freshly-added row flashed
+    // from the partner avatar to the emoji fallback until reload.
+    res.json({ success: true, contact: (await enrichCardHolderEntriesWithPetdx([card]))[0] });
 });
 
 /**

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -2494,7 +2494,20 @@
 
         function copyNotePageLink() {
             if (!viewerNoteId) return;
-            const pc = (boundEntities.find(e => e.publicCode) || {}).publicCode;
+            // card_091d24a5: bind the share link to the ACTIVE entity's public
+            // code, not bound[0] (/api/entities sorts ascending, so bound[0] is
+            // always the lowest entityId → wrong link on multi-entity devices).
+            // Same pattern as the exam.html fix (card_cea91e58): prefer the
+            // shared active-entity key; fall back to the first bound entity
+            // with a code only when it's unset / unbound / has no public code.
+            // (Notes carry no entity attribution, so active entity is the best
+            // owner signal for the copied link.)
+            let activeId = NaN;
+            try { activeId = Number(localStorage.getItem('eclaw_petdex_active_entity_id')); } catch (_) { /* private mode */ }
+            const activeEntity = Number.isFinite(activeId)
+                ? boundEntities.find(e => Number(e.entityId || e.id) === activeId && e.publicCode)
+                : null;
+            const pc = ((activeEntity || boundEntities.find(e => e.publicCode)) || {}).publicCode;
             if (!pc) { showToast(i18n.t('mc_note_no_public_code') || 'No public code available', 'error'); return; }
             const url = `https://eclawbot.com/p/${pc}/${viewerNoteId}`;
             const btn = document.getElementById('wvCopyLinkBtn');

--- a/backend/tests/jest/card-holder-avatar-enrichment-static.test.js
+++ b/backend/tests/jest/card-holder-avatar-enrichment-static.test.js
@@ -32,6 +32,19 @@ describe('card-holder my-cards must enrich rows with petdxAvatarUrl (index.js)',
         expect(body).toMatch(/cards:\s*enrichedCards/);
     });
 
+    it('the POST /api/contacts handler enriches the new contact with petdxAvatarUrl (card_7ced13ac)', () => {
+        const start = idx.indexOf("app.post('/api/contacts'");
+        expect(start).toBeGreaterThan(-1);
+        // scan the handler body up to the next route registration
+        const nextRoute = idx.indexOf("app.delete('/api/contacts'", start);
+        const body = idx.slice(start, nextRoute > 0 ? nextRoute : start + 4000);
+        // FAIL-ON-OLD: old POST did `contact: enrichCardHolderEntry(card)` — the
+        // sync variant omits petdxAvatarUrl, so the freshly-added row flashed
+        // from the partner avatar to the emoji fallback until reload.
+        expect(body).not.toMatch(/contact:\s*enrichCardHolderEntry\(/);
+        expect(body).toMatch(/contact:\s*\(await enrichCardHolderEntriesWithPetdx\(\[card\]\)\)\[0\]/);
+    });
+
     it('petdx enrichment uses same-origin sprite assets when avatar_url is missing', () => {
         expect(idx).toMatch(/function resolvePetdxSelectionAvatarUrl/);
         expect(idx).toMatch(/row\.asset_type === 'spritesheet'/);

--- a/backend/tests/jest/mission-note-link-active-entity.test.js
+++ b/backend/tests/jest/mission-note-link-active-entity.test.js
@@ -1,0 +1,130 @@
+/**
+ * Regression guard for the mission.html note-page share link (card_091d24a5).
+ *
+ * BUG: copyNotePageLink() always built the /p/<code>/<noteId> URL from the
+ * FIRST bound entity's public code (`boundEntities.find(e => e.publicCode)`
+ * — /api/entities sorts entities ascending, so bound[0] is always the lowest
+ * entityId, usually #1). On a multi-entity device the copied share link was
+ * attributed to the wrong entity, regardless of which entity is active.
+ *
+ * FIX (same pattern as the exam.html fix, card_cea91e58): prefer the shared
+ * active-entity localStorage key `eclaw_petdex_active_entity_id`; fall back to
+ * the first bound entity with a public code only when the active id is unset,
+ * no longer bound, or has no public code.
+ *
+ * This test extracts the REAL copyNotePageLink source from mission.html (like
+ * mission-card-deeplink-noloop.test.js) and drives it against a stubbed
+ * clipboard, so it fails on the old bound[0]-only binding and passes on the
+ * active-entity binding.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const MISSION_HTML = path.resolve(__dirname, '../../public/portal/mission.html');
+
+// Extract the exact `function copyNotePageLink() { ... }` block from
+// mission.html so the test exercises the shipped source, not a copy.
+function extractCopyNotePageLinkSource() {
+    const html = fs.readFileSync(MISSION_HTML, 'utf8');
+    const start = html.indexOf('function copyNotePageLink() {');
+    if (start === -1) throw new Error('mission.html: copyNotePageLink not found');
+    // Close on the first 8-space-indented `}` (the declaration terminator —
+    // every line inside the body is indented 12+ spaces).
+    const end = html.indexOf('\n        }', start);
+    if (end === -1) throw new Error('mission.html: copyNotePageLink terminator not found');
+    return html.slice(start, end + '\n        }'.length);
+}
+
+// Instantiate the real function with its free identifiers shadowed by stubs.
+function buildHarness({ activeEntityId, boundEntities }) {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    const showToast = jest.fn();
+    const btn = { textContent: '', style: {} };
+    const localStorage = {
+        getItem: jest.fn((key) => (key === 'eclaw_petdex_active_entity_id' ? activeEntityId : null)),
+    };
+    const src = extractCopyNotePageLinkSource();
+    const factory = new Function(
+        'viewerNoteId', 'boundEntities', 'localStorage', 'navigator',
+        'document', 'i18n', 'showToast', 'setTimeout',
+        src + '\nreturn copyNotePageLink;'
+    );
+    const copyNotePageLink = factory(
+        'note-42',
+        boundEntities,
+        localStorage,
+        { clipboard: { writeText } },
+        { getElementById: () => btn, createElement: () => { throw new Error('fallback path should not run'); }, body: {} },
+        { t: () => '' },
+        showToast,
+        jest.fn() // shadow setTimeout so no timers leak past the test
+    );
+    return { copyNotePageLink, writeText, showToast };
+}
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+const TWO_ENTITIES = [
+    { entityId: 1, publicCode: 'aaa111' },
+    { entityId: 3, publicCode: 'ccc333' },
+];
+
+describe('mission.html copyNotePageLink binds the share link to the ACTIVE entity (card_091d24a5)', () => {
+    test('FAIL-ON-OLD: active entity #3 gets #3\'s public code, not bound[0] (#1)', async () => {
+        const { copyNotePageLink, writeText } = buildHarness({
+            activeEntityId: '3',
+            boundEntities: TWO_ENTITIES,
+        });
+        copyNotePageLink();
+        await flush();
+        expect(writeText).toHaveBeenCalledTimes(1);
+        // Old code copied https://eclawbot.com/p/aaa111/note-42 here.
+        expect(writeText).toHaveBeenCalledWith('https://eclawbot.com/p/ccc333/note-42');
+    });
+
+    test('falls back to the first bound entity with a code when the active key is unset', async () => {
+        const { copyNotePageLink, writeText } = buildHarness({
+            activeEntityId: null,
+            boundEntities: TWO_ENTITIES,
+        });
+        copyNotePageLink();
+        await flush();
+        expect(writeText).toHaveBeenCalledWith('https://eclawbot.com/p/aaa111/note-42');
+    });
+
+    test('falls back to bound[0] when the active entity is no longer bound', async () => {
+        const { copyNotePageLink, writeText } = buildHarness({
+            activeEntityId: '9', // not in boundEntities
+            boundEntities: TWO_ENTITIES,
+        });
+        copyNotePageLink();
+        await flush();
+        expect(writeText).toHaveBeenCalledWith('https://eclawbot.com/p/aaa111/note-42');
+    });
+
+    test('falls back past an active entity that has no public code', async () => {
+        const { copyNotePageLink, writeText } = buildHarness({
+            activeEntityId: '3',
+            boundEntities: [
+                { entityId: 1, publicCode: 'aaa111' },
+                { entityId: 3, publicCode: null },
+            ],
+        });
+        copyNotePageLink();
+        await flush();
+        expect(writeText).toHaveBeenCalledWith('https://eclawbot.com/p/aaa111/note-42');
+    });
+
+    test('shows the no-public-code toast when no bound entity has a code', async () => {
+        const { copyNotePageLink, writeText, showToast } = buildHarness({
+            activeEntityId: '3',
+            boundEntities: [{ entityId: 3, publicCode: null }],
+        });
+        copyNotePageLink();
+        await flush();
+        expect(writeText).not.toHaveBeenCalled();
+        expect(showToast).toHaveBeenCalledWith('No public code available', 'error');
+    });
+});


### PR DESCRIPTION
## Summary

Two small sibling-divergence / first-item-binding fixes, one branch per dispatch.

### card_7ced13ac [P2] — POST /api/contacts omits petdxAvatarUrl
`backend/index.js` POST `/api/contacts` responded with the **synchronous** `enrichCardHolderEntry(card)`, which never sets `petdxAvatarUrl`, while all 5 read-path siblings (`/contacts` `/recent` `/search` `/friends` `/friend-requests`) use the async `enrichCardHolderEntriesWithPetdx`. `card-holder.html addCard()` unshifts the response row and `chCrossDeviceAvatar` only reads `petdxAvatarUrl` → after pressing "+ Add" from Online Agents the new row **flashed from the partner avatar to the emoji fallback** until reload.

**Fix**: respond with `(await enrichCardHolderEntriesWithPetdx([card]))[0]`, aligned with the read siblings.

### card_091d24a5 [P3] — copyNotePageLink always uses bound[0]'s public code
`mission.html copyNotePageLink()` built the `/p/<code>/<noteId>` share URL from the FIRST bound entity's public code (`/api/entities` sorts ascending → always the lowest entityId, usually #1) → wrong-entity share link on multi-entity devices.

**Fix**: prefer the active entity (`localStorage eclaw_petdex_active_entity_id`); fall back to the first bound entity with a code only when the active id is unset / no longer bound / has no public code — mirrors the exam.html fix (card_cea91e58, PR #3856). Notes carry no entity attribution field, so the active entity is the best owner signal (the "note's own entity" leg has nothing to bind to).

## Regression tests (fails-old / passes-new, verified both ways)

- `backend/tests/jest/card-holder-avatar-enrichment-static.test.js` — extended the card_55e811b8 static enrich guard: the POST `/api/contacts` handler body must NOT use `contact: enrichCardHolderEntry(` and MUST await `enrichCardHolderEntriesWithPetdx([card])[0]`.
- `backend/tests/jest/mission-note-link-active-entity.test.js` (new) — extracts the REAL `copyNotePageLink` source from mission.html (same technique as `mission-card-deeplink-noloop.test.js`) and drives it against a stubbed clipboard: active #3 → #3's code (this exact assertion fails on old source), + fallback matrix (unset key / unbound active / code-less active / no code at all → toast).

## Verification

- Old source: 2 new assertions FAIL (confirmed via stash). New source: all pass.
- Related suites 57/57 green: card-holder, friend-system, portal-page-api-map, card-holder-page-ui, mission-card-deeplink-noloop, mission-single-delete-undo, portal-vault-post-sends-etag.
- `eslint .` 0 errors (8 pre-existing warnings), i18n dup-key lint clean, portal smoke check passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuABXFYP3EofvYeqXW6ncn