### PR TITLE
fix(arena): show entity cards on leaderboard

### DIFF
--- a/backend/interview-arena.js
+++ b/backend/interview-arena.js
@@ -1737,6 +1737,48 @@ function parseJsonObject(raw) {
     }
 }
 
+function publicEntitySnapshot(entity, entityId) {
+    if (!entity) return null;
+    return {
+        entityId: Number.isFinite(Number(entityId)) ? Number(entityId) : null,
+        entityName: entity.name || entity.character || null,
+        publicCode: entity.publicCode || null,
+        agentCard: entity.agentCard || null,
+    };
+}
+
+function attachLinkedEntityToArenaDetail(detail, snapshot) {
+    if (!snapshot || !snapshot.publicCode) return detail;
+    return {
+        ...(detail || {}),
+        linkedEntityId: snapshot.entityId,
+        linkedEntityName: snapshot.entityName,
+        linkedPublicCode: snapshot.publicCode,
+        linkedAgentCard: snapshot.agentCard || null,
+    };
+}
+
+function normalizeLeaderboardEntityId(row, detail) {
+    const raw = row?.entity_id ?? detail?.linkedEntityId;
+    if (raw === null || raw === undefined || raw === '') return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+}
+
+function toLeaderboardApiRow(row) {
+    const detail = parseJsonObject(row?.detail) || row?.detail || {};
+    const entityId = normalizeLeaderboardEntityId(row, detail);
+    return {
+        ...row,
+        detail,
+        entity_id: entityId,
+        entity_name: row?.entity_name || detail.linkedEntityName || null,
+        petdx_avatar_url: row?.petdx_avatar_url || detail.linkedPetdxAvatarUrl || null,
+        public_code: row?.public_code || detail.linkedPublicCode || null,
+        agent_card: row?.agent_card || detail.linkedAgentCard || null,
+    };
+}
+
 function buildMappedArenaResultForIdentity(report, row = {}) {
     const reportObj = parseJsonObject(report) || report || {};
     const mapped = mapArenaResultToCapabilities(reportObj);
@@ -2467,7 +2509,17 @@ module.exports = function arenaFactory({ serverLog, io, devices, saveDeviceData 
     router.get('/exam/:examId/results', async (req, res) => {
         try {
             const examRes = await pool.query(
-                `SELECT * FROM arena_exams WHERE id = $1`, [req.params.examId]
+                `SELECT e.*,
+                        l.owner_device_id, l.owner_entity_id,
+                        owner_e.name AS linked_entity_name,
+                        owner_e.public_code AS linked_public_code
+                 FROM arena_exams e
+                 LEFT JOIN bot_listings l ON l.id = e.listing_id
+                 LEFT JOIN entities owner_e
+                   ON owner_e.device_id = l.owner_device_id
+                  AND owner_e.entity_id IS NOT DISTINCT FROM l.owner_entity_id
+                 WHERE e.id = $1`,
+                [req.params.examId]
             );
             if (examRes.rowCount === 0) return res.status(404).json({ success: false, error: 'not_found' });
             const sessions = await pool.query(
@@ -2494,6 +2546,9 @@ module.exports = function arenaFactory({ serverLog, io, devices, saveDeviceData 
                     expiresAt: exam.expires_at,
                     firstFetchedAt: exam.first_fetched_at,
                     completedAt: exam.completed_at,
+                    linkedEntityId: exam.owner_entity_id !== null && exam.owner_entity_id !== undefined ? Number(exam.owner_entity_id) : null,
+                    linkedEntityName: exam.linked_entity_name || null,
+                    linkedPublicCode: exam.linked_public_code || null,
                     elapsedSec,
                 },
                 sessions: sessions.rows,
@@ -2522,8 +2577,11 @@ module.exports = function arenaFactory({ serverLog, io, devices, saveDeviceData 
                 return res.status(400).json({ success: false, error: 'examId_and_name_required' });
             }
             const examRes = await pool.query(
-                `SELECT id, model, total_score, max_score, report, created_at, first_fetched_at, completed_at
-                 FROM arena_exams WHERE id = $1 AND status = 'completed'`,
+                `SELECT e.id, e.model, e.total_score, e.max_score, e.report, e.created_at, e.first_fetched_at, e.completed_at,
+                        l.owner_device_id, l.owner_entity_id
+                 FROM arena_exams e
+                 LEFT JOIN bot_listings l ON l.id = e.listing_id
+                 WHERE e.id = $1 AND e.status = 'completed'`,
                 [examId]
             );
             if (examRes.rowCount === 0) return res.status(404).json({ success: false, error: 'exam_not_found_or_incomplete' });
@@ -2538,16 +2596,8 @@ module.exports = function arenaFactory({ serverLog, io, devices, saveDeviceData 
                 ? new Date(exam.completed_at).getTime()
                 : Date.now();
             const elapsedSec = Math.max(0, Math.min(180, Math.round((endTs - startTs) / 1000)));
-            const report = typeof exam.report === 'string' ? JSON.parse(exam.report) : (exam.report || {});
+            let report = typeof exam.report === 'string' ? JSON.parse(exam.report) : (exam.report || {});
             report.elapsedSec = elapsedSec;
-
-            const lbRes = await pool.query(
-                `INSERT INTO arena_leaderboard (exam_id, name, model, score, max_score, detail)
-                 VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
-                [exam.id, name.trim().slice(0, 64), exam.model, exam.total_score, exam.max_score,
-                 JSON.stringify(report)]
-            );
-            const leaderboardId = lbRes.rows[0] ? lbRes.rows[0].id : null;
 
             // Optional entity binding — write the verified score back to the
             // bot's identity if botSecret authenticates. Failures here MUST
@@ -2556,10 +2606,17 @@ module.exports = function arenaFactory({ serverLog, io, devices, saveDeviceData 
             try {
                 if (deviceId && botSecret) {
                     const eId = parseInt(entityId, 10);
+                    const ownerEntityId = exam.owner_entity_id !== null && exam.owner_entity_id !== undefined
+                        ? Number(exam.owner_entity_id)
+                        : NaN;
+                    const ownerDeviceMatches = !exam.owner_device_id || exam.owner_device_id === deviceId;
+                    const ownerEntityMatches = !Number.isFinite(ownerEntityId) || eId === ownerEntityId;
                     const device = deviceRegistry[deviceId];
                     const entity = (device && Number.isInteger(eId)) ? device.entities?.[eId] : null;
                     const credsOk = !!(entity && entity.isBound && entity.botSecret && safeEqual(entity.botSecret, botSecret));
-                    if (credsOk) {
+                    if (!ownerDeviceMatches || !ownerEntityMatches) {
+                        audit('warn', 'arena', `entity binding rejected for exam ${exam.id}: owner mismatch device=${deviceId} entity=${entityId}`);
+                    } else if (credsOk) {
                         const mapped = mapArenaResultToCapabilities(report);
                         const patch = buildInterviewIdentityPatch(exam, mapped);
                         if (patch) {
@@ -2582,6 +2639,7 @@ module.exports = function arenaFactory({ serverLog, io, devices, saveDeviceData 
                                 normalized: patch.interviewCapabilities.normalized,
                                 passed: patch.interviewCapabilities.passed,
                             };
+                            report = attachLinkedEntityToArenaDetail(report, publicEntitySnapshot(entity, eId));
                             audit('info', 'arena', `entity ${deviceId}:${eId} bound to exam ${exam.id} score=${entityBinding.normalized}%`);
                         }
                     } else if (entityId !== undefined) {
@@ -2591,6 +2649,14 @@ module.exports = function arenaFactory({ serverLog, io, devices, saveDeviceData 
             } catch (bindErr) {
                 console.warn('[Arena] entity binding error (non-blocking):', bindErr.message);
             }
+
+            const lbRes = await pool.query(
+                `INSERT INTO arena_leaderboard (exam_id, name, model, score, max_score, detail)
+                 VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
+                [exam.id, name.trim().slice(0, 64), exam.model, exam.total_score, exam.max_score,
+                 JSON.stringify(report)]
+            );
+            const leaderboardId = lbRes.rows[0] ? lbRes.rows[0].id : null;
 
             res.json({ success: true, leaderboardId, entityBinding });
         } catch (err) {
@@ -2602,10 +2668,31 @@ module.exports = function arenaFactory({ serverLog, io, devices, saveDeviceData 
     router.get('/leaderboard', async (_req, res) => {
         try {
             const result = await pool.query(
-                `SELECT id, name, model, score, max_score, detail, created_at
-                 FROM arena_leaderboard ORDER BY score DESC LIMIT 100`
+                `SELECT lb.id, lb.exam_id, lb.name, lb.model, lb.score, lb.max_score, lb.detail, lb.created_at,
+                        COALESCE(owner_e.entity_id, linked_e.entity_id) AS entity_id,
+                        COALESCE(owner_e.name, linked_e.name, lb.detail->>'linkedEntityName') AS entity_name,
+                        COALESCE(petdx.avatar_url, lb.detail->>'linkedPetdxAvatarUrl') AS petdx_avatar_url,
+                        COALESCE(owner_e.public_code, linked_e.public_code, lb.detail->>'linkedPublicCode') AS public_code,
+                        COALESCE(owner_e.agent_card, linked_e.agent_card, lb.detail->'linkedAgentCard') AS agent_card
+                 FROM arena_leaderboard lb
+                 LEFT JOIN arena_exams ex ON ex.id = lb.exam_id
+                 LEFT JOIN bot_listings l ON l.id = ex.listing_id
+                 LEFT JOIN entities owner_e
+                   ON owner_e.device_id = l.owner_device_id
+                  AND owner_e.entity_id IS NOT DISTINCT FROM l.owner_entity_id
+                 LEFT JOIN entities linked_e ON linked_e.public_code = lb.detail->>'linkedPublicCode'
+                 LEFT JOIN LATERAL (
+                     SELECT c.avatar_url
+                       FROM companion_select_log s
+                       LEFT JOIN companions c ON c.id = s.companion_id
+                      WHERE s.device_id = COALESCE(l.owner_device_id, linked_e.device_id)
+                        AND s.entity_id IS NOT DISTINCT FROM COALESCE(l.owner_entity_id, linked_e.entity_id)
+                      ORDER BY s.selected_at DESC
+                      LIMIT 1
+                 ) petdx ON true
+                 ORDER BY lb.score DESC LIMIT 100`
             );
-            res.json({ success: true, leaderboard: result.rows });
+            res.json({ success: true, leaderboard: result.rows.map(toLeaderboardApiRow) });
         } catch (err) {
             res.status(500).json({ success: false, error: 'internal_error' });
         }

--- a/backend/public/arena/exam.html
+++ b/backend/public/arena/exam.html
@@ -99,10 +99,27 @@
         .name-input:focus { border-color: var(--primary); }
 
         /* Leaderboard */
+        .lb-table-scroll { width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
         .lb-table { width: 100%; border-collapse: collapse; font-size: 13px; }
         .lb-table th { text-align: left; padding: 8px; color: var(--text-muted); border-bottom: 1px solid var(--card-border); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
         .lb-table td { padding: 8px; border-bottom: 1px solid rgba(255,255,255,0.03); }
         .lb-rank { font-weight: 700; color: var(--primary); }
+        .lb-avatar-col, .lb-avatar-cell { width: 32px; padding-right: 0 !important; }
+        .lb-avatar {
+            display: inline-flex; align-items: center; justify-content: center;
+            width: 28px; height: 28px; border-radius: 50%; overflow: hidden;
+            background: rgba(var(--primary-rgb), 0.08); font-size: 16px; line-height: 1;
+            vertical-align: middle;
+        }
+        .lb-avatar .entity-avatar-img,
+        .lb-avatar .entity-avatar-canvas { width: 28px; height: 28px; border-radius: 50%; }
+        .lb-avatar .entity-avatar-emoji { font-size: 16px; }
+        .lb-card-trigger {
+            appearance: none; border: 0; background: transparent; color: var(--primary);
+            padding: 0; margin: 0; font: inherit; cursor: pointer; text-align: left;
+        }
+        .lb-avatar-cell .lb-card-trigger { display: inline-flex; }
+        .lb-card-trigger:hover { text-decoration: underline; }
 
         /* Feedback */
         .fb-card { background: var(--card); border: 1px solid var(--card-border); border-radius: var(--radius); padding: 24px; }
@@ -174,9 +191,19 @@
             border-radius: var(--radius); padding: 24px; max-width: 340px; width: 90%;
             text-align: center;
         }
+        .agent-popup-head { display: flex; align-items: center; justify-content: center; gap: 12px; margin-bottom: 8px; }
+        .agent-popup-avatar {
+            width: 44px; height: 44px; border-radius: 50%; overflow: hidden; flex-shrink: 0;
+            display: flex; align-items: center; justify-content: center; background: rgba(var(--primary-rgb), 0.08);
+        }
+        .agent-popup-avatar .entity-avatar-img,
+        .agent-popup-avatar .entity-avatar-canvas { width: 44px; height: 44px; border-radius: 50%; }
+        .agent-popup-avatar .entity-avatar-emoji { font-size: 24px; }
         .agent-popup h3 { margin: 0 0 8px; font-size: 16px; font-weight: 700; }
         .agent-popup .agent-model { font-size: 13px; color: var(--accent-cyan); margin-bottom: 12px; }
         .agent-popup .agent-caps { font-size: 12px; color: var(--text-secondary); line-height: 1.6; }
+        .agent-tags { display: flex; flex-wrap: wrap; justify-content: center; gap: 4px; margin-top: 10px; }
+        .agent-tag { font-size: 11px; padding: 2px 6px; border-radius: 4px; background: rgba(var(--primary-rgb), 0.1); color: var(--primary); }
         .agent-popup .agent-close { margin-top: 16px; }
 
         /* Share buttons */
@@ -258,6 +285,7 @@
                 width: 36px; height: 36px; font-size: 26px; line-height: 36px;
             }
             .arena-companion-caption { font-size: 9px; padding: 1px 6px; min-width: 50px; }
+            .lb-table { min-width: 560px; }
         }
 
         /* Resting state — gentle pulse so the avatar feels alive even when idle */
@@ -405,7 +433,7 @@
 
         <div class="reveal" id="lbSection">
             <div class="section-label" data-i18n="arena_lb_title">Leaderboard</div>
-            <table class="lb-table"><thead><tr><th>#</th><th data-i18n="arena_lb_name">Name</th><th data-i18n="arena_lb_model">Model</th><th data-i18n="arena_lb_score">Score</th><th data-i18n="arena_lb_time">Time</th></tr></thead><tbody id="lbBody"></tbody></table>
+            <div class="lb-table-scroll"><table class="lb-table"><thead><tr><th>#</th><th class="lb-avatar-col" aria-hidden="true"></th><th data-i18n="arena_lb_name">Name</th><th data-i18n="arena_lb_model">Model</th><th data-i18n="arena_lb_score">Score</th><th data-i18n="arena_lb_time">Time</th></tr></thead><tbody id="lbBody"></tbody></table></div>
         </div>
 
         <div class="reveal" id="feedbackSection">
@@ -545,6 +573,12 @@
             };
             let state = { emotion: 'ready' };
 
+            function entitySlotId(e) {
+                const raw = e && (e.entityId ?? e.id);
+                if (raw === null || raw === undefined || raw === '') return NaN;
+                return Number(raw);
+            }
+
             function setEmotion(em) {
                 if (!em || !root) return;
                 if (state.emotion === em && root.getAttribute('data-emotion') === em) return;
@@ -590,16 +624,22 @@
                     const data = await res.json();
                     const bound = (data.entities || []).filter(e => e && e.isBound !== false);
                     if (!bound.length) return;
-                    // card_cea91e58: bind to the ACTIVE session entity, not bound[0].
+                    // card_cea91e58: bind to the linked exam owner first, then
+                    // the ACTIVE session entity, not bound[0].
                     // Picking bound[0] always showed the first entity (#1)'s
                     // companion even when a different entity (e.g. #2) was the one
-                    // actually taking the exam. Use the shared active-entity key
-                    // (petdx-browser's eclaw_petdex_active_entity_id); fall back to
-                    // bound[0] only when it's unset or no longer bound.
+                    // actually taking the exam. Use /results linkedEntityId when
+                    // present, then the shared active-entity key
+                    // (petdx-browser's eclaw_petdex_active_entity_id); fall back
+                    // to bound[0] only when neither owner signal matches.
+                    const linkedId = Number(examData && examData.exam && examData.exam.linkedEntityId);
                     let activeId = NaN;
                     try { activeId = Number(localStorage.getItem('eclaw_petdex_active_entity_id')); } catch (_) { /* private mode */ }
-                    const chosen = (Number.isFinite(activeId) && bound.find(e => Number(e.entityId || e.id) === activeId)) || bound[0];
-                    entityId = Number(chosen.entityId || chosen.id);
+                    const chosen =
+                        (Number.isFinite(linkedId) && bound.find(e => entitySlotId(e) === linkedId)) ||
+                        (Number.isFinite(activeId) && bound.find(e => entitySlotId(e) === activeId)) ||
+                        bound[0];
+                    entityId = entitySlotId(chosen);
                 } catch (_) { return; }
                 if (!Number.isFinite(entityId)) return;
 
@@ -952,9 +992,17 @@
                         const er = await fetch(`${API}/api/entities?deviceId=${encodeURIComponent(dId)}&deviceSecret=${encodeURIComponent(dSec)}`);
                         if (er.ok) {
                             const ed = await er.json();
-                            const bound = (ed.entities || []).find(e => e && e.isBound && e.botSecret);
-                            if (bound && Number.isFinite(Number(bound.entityId))) {
-                                binding = { deviceId: dId, entityId: Number(bound.entityId), botSecret: bound.botSecret };
+                            const bound = (ed.entities || []).filter(e => e && e.isBound && e.botSecret);
+                            const linkedId = Number(examData && examData.exam && examData.exam.linkedEntityId);
+                            let activeId = NaN;
+                            try { activeId = Number(localStorage.getItem('eclaw_petdex_active_entity_id')); } catch (_) { /* private mode */ }
+                            const chosen =
+                                (Number.isFinite(linkedId) && bound.find(e => lbEntryEntityId(e) === linkedId)) ||
+                                (Number.isFinite(activeId) && bound.find(e => lbEntryEntityId(e) === activeId)) ||
+                                bound[0];
+                            const chosenId = lbEntryEntityId(chosen);
+                            if (chosen && Number.isFinite(chosenId)) {
+                                binding = { deviceId: dId, entityId: chosenId, botSecret: chosen.botSecret };
                             }
                         }
                     }
@@ -964,11 +1012,7 @@
                 // Hide floating prompt
                 dismissModal();
                 const lb = await (await fetch(`${API}/api/arena/leaderboard`)).json();
-                if (lb.leaderboard?.length) document.getElementById('lbBody').innerHTML = lb.leaderboard.map((e, i) => {
-                    const d = typeof e.detail === 'string' ? JSON.parse(e.detail) : e.detail;
-                    const sec = d && d.elapsedSec; const tm = sec ? Math.floor(sec/60)+':'+String(sec%60).padStart(2,'0') : '-';
-                    return `<tr data-exam-id="${esc(e.exam_id||'')}"><td class="lb-rank">${i+1}</td><td><a href="#" onclick="event.preventDefault();showAgentCard('${esc(e.exam_id||'')}','${esc(e.name)}','${esc(e.model||'-')}')" style="color:var(--primary);cursor:pointer;">${esc(e.name)}</a></td><td>${esc(e.model||'-')}</td><td>${e.score}/147</td><td>${tm}</td></tr>`;
-                }).join('');
+                if (lb.leaderboard?.length) await renderLeaderboardRows(lb.leaderboard);
                 reveal('lbSection');
                 setTimeout(() => document.getElementById('lbSection').scrollIntoView({ behavior: 'smooth', block: 'start' }), 300);
                 setTimeout(() => reveal('feedbackSection'), 800);
@@ -1019,6 +1063,48 @@
         }
 
         function esc(s) { const d = document.createElement('div'); d.textContent = s || ''; return d.innerHTML; }
+
+        const LB_FALLBACK_EMOJI = ['\u{1F99E}', '\u{1F437}', '\u{1F916}', '\u{1F47E}', '\u{1F423}', '\u{1F981}', '\u{1F989}', '\u{1F420}'];
+        let leaderboardEntries = [];
+        function lbFallbackAvatar(seed) {
+            const s = String(seed || '');
+            let h = 0;
+            for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+            return LB_FALLBACK_EMOJI[h % LB_FALLBACK_EMOJI.length];
+        }
+        function lbEntryEntityId(e) {
+            const raw = e && (e.entity_id ?? e.entityId ?? e.id);
+            if (raw === null || raw === undefined || raw === '') return null;
+            const n = Number(raw);
+            return Number.isFinite(n) ? n : null;
+        }
+        function lbAvatarHtml(e) {
+            const eid = lbEntryEntityId(e);
+            const avatar = e && (e.petdx_avatar_url || e.petdxAvatarUrl || null);
+            if ((eid !== null || avatar) && typeof renderAvatarHtml === 'function') {
+                return '<span class="lb-avatar">' + renderAvatarHtml(avatar, 28, eid) + '</span>';
+            }
+            const alt = (typeof i18n !== 'undefined' && i18n.t) ? (i18n.t('arena_avatar_alt') || 'avatar') : 'avatar';
+            return '<span class="lb-avatar" role="img" aria-label="' + esc(alt) + '">' + lbFallbackAvatar((e && (e.name || e.model)) || '') + '</span>';
+        }
+        function fmtLeaderboardTime(detail) {
+            const d = typeof detail === 'string' ? JSON.parse(detail) : detail;
+            const sec = d && d.elapsedSec;
+            return sec ? Math.floor(sec/60)+':'+String(sec%60).padStart(2,'0') : '-';
+        }
+        async function renderLeaderboardRows(entries) {
+            leaderboardEntries = entries || [];
+            const boundIds = [...new Set(leaderboardEntries.map(lbEntryEntityId).filter(id => Number.isFinite(id)))];
+            if (boundIds.length && window.AvatarPetdx && typeof window.AvatarPetdx.preload === 'function') {
+                try { await window.AvatarPetdx.preload({ entityIds: boundIds }); } catch (_) { /* keep URL/emoji fallback */ }
+            }
+            document.getElementById('lbBody').innerHTML = leaderboardEntries.map((e, i) =>
+                `<tr data-exam-id="${esc(e.exam_id||'')}"><td class="lb-rank">${i+1}</td><td class="lb-avatar-cell"><button type="button" class="lb-card-trigger" onclick="showAgentCardFromEntry(${i})" aria-label="Open agent card">${lbAvatarHtml(e)}</button></td><td><button type="button" class="lb-card-trigger" onclick="showAgentCardFromEntry(${i})">${esc(e.entity_name || e.name)}</button></td><td>${esc(e.model||'-')}</td><td>${e.score}/${e.max_score||147}</td><td>${fmtLeaderboardTime(e.detail)}</td></tr>`
+            ).join('');
+            if (window.AvatarPetdx && typeof window.AvatarPetdx.autoMount === 'function') {
+                try { window.AvatarPetdx.autoMount(); } catch (_) { /* no-op */ }
+            }
+        }
 
         function generateCommentary(idx, pct, sc, mx, cfg, acts, raw) {
             if (acts.length === 0) return 'The agent did not engage with this challenge at all. In a real-world deployment scenario, this represents a critical gap — the agent would be unable to handle tasks requiring this capability. Consider whether the agent has the necessary tooling (browser control, file API access, etc.) to attempt this type of task.';
@@ -1316,12 +1402,30 @@
         }
 
         // Agent card popup
-        function showAgentCard(examId, name, model) {
+        function showAgentCardFromEntry(index) {
+            showAgentCard(leaderboardEntries[index] || {});
+        }
+        function showAgentCard(entry) {
             const popup = document.getElementById('agentPopup');
             if (!popup) return;
-            document.getElementById('agentPopupName').textContent = name || 'Unknown';
-            document.getElementById('agentPopupModel').textContent = model || '-';
-            document.getElementById('agentPopupExamId').textContent = examId || '-';
+            const card = entry.agent_card || entry.agentCard || {};
+            const name = entry.entity_name || entry.name || 'Unknown';
+            const code = entry.public_code || entry.publicCode || '';
+            const entityId = lbEntryEntityId(entry);
+            const avatar = entry.petdx_avatar_url || entry.petdxAvatarUrl || null;
+            document.getElementById('agentPopupName').textContent = name;
+            document.getElementById('agentPopupModel').textContent = entry.model || '-';
+            document.getElementById('agentPopupExamId').textContent = code ? 'Card: ' + code : (entry.exam_id || '-');
+            document.getElementById('agentPopupDescription').textContent = card.description || '';
+            const tags = Array.isArray(card.tags) ? card.tags.slice(0, 6) : [];
+            document.getElementById('agentPopupTags').innerHTML = tags.map(t => '<span class="agent-tag">' + esc(t) + '</span>').join('');
+            const avatarEl = document.getElementById('agentPopupAvatar');
+            avatarEl.innerHTML = (typeof renderAvatarHtml === 'function')
+                ? renderAvatarHtml(avatar, 44, entityId)
+                : '<span class="entity-avatar-emoji">' + lbFallbackAvatar(name) + '</span>';
+            if (window.AvatarPetdx && typeof window.AvatarPetdx.autoMount === 'function') {
+                try { window.AvatarPetdx.autoMount(); } catch (_) { /* no-op */ }
+            }
             popup.classList.add('show');
         }
         function closeAgentPopup() {
@@ -1394,9 +1498,14 @@
 
     <div class="agent-popup-overlay" id="agentPopup" onclick="if(event.target===this)closeAgentPopup()">
         <div class="agent-popup">
-            <h3 id="agentPopupName">-</h3>
+            <div class="agent-popup-head">
+                <div class="agent-popup-avatar" id="agentPopupAvatar" aria-hidden="true"></div>
+                <h3 id="agentPopupName">-</h3>
+            </div>
             <div class="agent-model" id="agentPopupModel">-</div>
             <div class="agent-caps" id="agentPopupExamId" style="font-size:11px;color:var(--text-muted);"></div>
+            <div class="agent-caps" id="agentPopupDescription"></div>
+            <div class="agent-tags" id="agentPopupTags"></div>
             <div class="agent-close"><button class="btn btn-outline" onclick="closeAgentPopup()">Close</button></div>
         </div>
     </div>

--- a/backend/public/arena/index.html
+++ b/backend/public/arena/index.html
@@ -150,6 +150,7 @@
         /* Leaderboard */
         .lb-panel { display: none; }
         .lb-panel.visible { display: block; }
+        .lb-table-scroll { width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
         .lb-table { width: 100%; border-collapse: collapse; font-size: 13px; }
         .lb-table th {
             text-align: left; padding: 8px 10px; color: var(--text-muted);
@@ -170,6 +171,12 @@
         .lb-avatar .entity-avatar-img,
         .lb-avatar .entity-avatar-canvas { width: 28px; height: 28px; border-radius: 50%; }
         .lb-avatar .entity-avatar-emoji { font-size: 16px; }
+        .lb-card-trigger {
+            appearance: none; border: 0; background: transparent; color: var(--primary);
+            padding: 0; margin: 0; font: inherit; cursor: pointer; text-align: left;
+        }
+        .lb-avatar-cell .lb-card-trigger { display: inline-flex; }
+        .lb-card-trigger:hover { text-decoration: underline; }
 
         /* Comments */
         .comment-list { display: flex; flex-direction: column; gap: 6px; }
@@ -199,14 +206,26 @@
             border-radius: var(--radius); padding: 24px; max-width: 340px; width: 90%;
             text-align: center;
         }
+        .agent-popup-head { display: flex; align-items: center; justify-content: center; gap: 12px; margin-bottom: 8px; }
+        .agent-popup-avatar {
+            width: 44px; height: 44px; border-radius: 50%; overflow: hidden; flex-shrink: 0;
+            display: flex; align-items: center; justify-content: center; background: rgba(var(--primary-rgb), 0.08);
+        }
+        .agent-popup-avatar .entity-avatar-img,
+        .agent-popup-avatar .entity-avatar-canvas { width: 44px; height: 44px; border-radius: 50%; }
+        .agent-popup-avatar .entity-avatar-emoji { font-size: 24px; }
         .agent-popup h3 { margin: 0 0 8px; font-size: 16px; font-weight: 700; }
         .agent-popup .agent-model { font-size: 13px; color: var(--accent-cyan); margin-bottom: 12px; }
         .agent-popup .agent-caps { font-size: 12px; color: var(--text-secondary); line-height: 1.6; }
+        .agent-tags { display: flex; flex-wrap: wrap; justify-content: center; gap: 4px; margin-top: 10px; }
+        .agent-tag { font-size: 11px; padding: 2px 6px; border-radius: 4px; background: rgba(var(--primary-rgb), 0.1); color: var(--primary); }
         .agent-popup .agent-close { margin-top: 16px; }
 
         @media (max-width: 600px) {
             .arena-hero h1 { font-size: 22px; }
             .arena-actions { flex-direction: column; align-items: center; }
+            .lb-table { min-width: 560px; }
+            .lb-table th, .lb-table td { padding: 8px 9px; }
             .btn { width: 100%; max-width: 280px; justify-content: center; }
         }
     </style>
@@ -228,19 +247,21 @@
 
         <div class="lb-panel" id="lbPanel">
             <div class="section-label" data-i18n="arena_lb_title">Leaderboard</div>
-            <table class="lb-table">
-                <thead><tr>
-                    <th>#</th>
-                    <th class="lb-avatar-col" aria-hidden="true"></th>
-                    <th data-i18n="arena_lb_name">Name</th>
-                    <th data-i18n="arena_lb_model">Model</th>
-                    <th data-i18n="arena_lb_score">Score</th>
-                    <th data-i18n="arena_lb_time">Time</th>
-                </tr></thead>
-                <tbody id="lbBody">
-                    <tr><td colspan="6" class="lb-empty" data-i18n="arena_lb_loading">Loading...</td></tr>
-                </tbody>
-            </table>
+            <div class="lb-table-scroll">
+                <table class="lb-table">
+                    <thead><tr>
+                        <th>#</th>
+                        <th class="lb-avatar-col" aria-hidden="true"></th>
+                        <th data-i18n="arena_lb_name">Name</th>
+                        <th data-i18n="arena_lb_model">Model</th>
+                        <th data-i18n="arena_lb_score">Score</th>
+                        <th data-i18n="arena_lb_time">Time</th>
+                    </tr></thead>
+                    <tbody id="lbBody">
+                        <tr><td colspan="6" class="lb-empty" data-i18n="arena_lb_loading">Loading...</td></tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
 
         <div class="section-label" data-i18n="arena_comments_title">Discussion</div>
@@ -253,9 +274,14 @@
 
     <div class="agent-popup-overlay" id="agentPopup" onclick="if(event.target===this)closeAgentPopup()">
         <div class="agent-popup">
-            <h3 id="agentPopupName">-</h3>
+            <div class="agent-popup-head">
+                <div class="agent-popup-avatar" id="agentPopupAvatar" aria-hidden="true"></div>
+                <h3 id="agentPopupName">-</h3>
+            </div>
             <div class="agent-model" id="agentPopupModel">-</div>
             <div class="agent-caps" id="agentPopupExamId" style="font-size:11px;color:var(--text-muted);"></div>
+            <div class="agent-caps" id="agentPopupDescription"></div>
+            <div class="agent-tags" id="agentPopupTags"></div>
             <div class="agent-close"><button class="btn btn-outline" onclick="closeAgentPopup()">Close</button></div>
         </div>
     </div>
@@ -355,19 +381,27 @@
             for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
             return LB_FALLBACK_EMOJI[h % LB_FALLBACK_EMOJI.length];
         }
+        function lbEntryEntityId(e) {
+            const raw = e && (e.entity_id ?? e.entityId);
+            if (raw === null || raw === undefined || raw === '') return null;
+            const n = Number(raw);
+            return Number.isFinite(n) ? n : null;
+        }
         // Render one entry's 大頭照. Prefers the shared renderAvatarHtml resolver
         // (canvas/img/emoji) when entity-utils.js is present and the entry is
         // entity-bound; otherwise emits the deterministic emoji headshot.
         function lbAvatarHtml(e) {
-            const eid = e && e.entity_id != null ? Number(e.entity_id) : null;
-            if (eid != null && typeof renderAvatarHtml === 'function') {
-                return '<span class="lb-avatar">' + renderAvatarHtml(null, 28, eid) + '</span>';
+            const eid = lbEntryEntityId(e);
+            const avatar = e && (e.petdx_avatar_url || e.petdxAvatarUrl || null);
+            if ((eid !== null || avatar) && typeof renderAvatarHtml === 'function') {
+                return '<span class="lb-avatar">' + renderAvatarHtml(avatar, 28, eid) + '</span>';
             }
             const alt = (typeof i18n !== 'undefined' && i18n.t) ? (i18n.t('arena_avatar_alt') || 'avatar') : 'avatar';
             return '<span class="lb-avatar" role="img" aria-label="' + esc(alt) + '">' + lbFallbackAvatar((e && (e.name || e.model)) || '') + '</span>';
         }
 
         let lbLoaded = false;
+        let leaderboardEntries = [];
         async function toggleLeaderboard() {
             const p = document.getElementById('lbPanel');
             p.classList.toggle('visible');
@@ -377,23 +411,24 @@
                 const data = await (await fetch(API + '/api/arena/leaderboard')).json();
                 const b = document.getElementById('lbBody');
                 if (data.leaderboard?.length) {
+                    leaderboardEntries = data.leaderboard;
                     // Preload companion descriptors for any entity-bound entries so
                     // renderAvatarHtml can emit the petdx canvas. Anonymous entries
                     // (no entity_id) skip this and keep the emoji fallback.
                     const boundIds = [...new Set(data.leaderboard
-                        .map(e => (e && e.entity_id != null) ? Number(e.entity_id) : null)
+                        .map(lbEntryEntityId)
                         .filter(id => Number.isFinite(id)))];
                     if (boundIds.length && window.AvatarPetdx && typeof window.AvatarPetdx.preload === 'function') {
                         try { await window.AvatarPetdx.preload({ entityIds: boundIds }); } catch (_) { /* keep emoji fallback */ }
                     }
                     b.innerHTML = data.leaderboard.map((e, i) =>
-                        `<tr data-exam-id="${esc(e.exam_id||'')}"><td class="lb-rank">${i+1}</td><td class="lb-avatar-cell">${lbAvatarHtml(e)}</td><td><a href="#" onclick="event.preventDefault();showAgentCard('${esc(e.exam_id||'')}','${esc(e.name)}','${esc(e.model||'-')}')" style="color:var(--primary);cursor:pointer;">${esc(e.name)}</a></td><td>${esc(e.model||'-')}</td><td>${e.score}/${e.max_score||147}</td><td>${fmtTime(e.detail)}</td></tr>`
+                        `<tr data-exam-id="${esc(e.exam_id||'')}"><td class="lb-rank">${i+1}</td><td class="lb-avatar-cell"><button type="button" class="lb-card-trigger" onclick="showAgentCardFromEntry(${i})" aria-label="Open agent card">${lbAvatarHtml(e)}</button></td><td><button type="button" class="lb-card-trigger" onclick="showAgentCardFromEntry(${i})">${esc(e.entity_name || e.name)}</button></td><td>${esc(e.model||'-')}</td><td>${e.score}/${e.max_score||147}</td><td>${fmtTime(e.detail)}</td></tr>`
                     ).join('');
                     // Mount any petdx canvases now that the rows are in the DOM.
                     if (window.AvatarPetdx && typeof window.AvatarPetdx.autoMount === 'function') {
                         try { window.AvatarPetdx.autoMount(); } catch (_) { /* fallback emoji stays */ }
                     }
-                } else b.innerHTML = '<tr><td colspan="6" class="lb-empty">No entries yet</td></tr>';
+                } else { leaderboardEntries = []; b.innerHTML = '<tr><td colspan="6" class="lb-empty">No entries yet</td></tr>'; }
             } catch { document.getElementById('lbBody').innerHTML = '<tr><td colspan="6" class="lb-empty">Failed to load</td></tr>'; }
         }
 
@@ -411,12 +446,30 @@
             } catch { el.innerHTML = '<div class="lb-empty">Failed to load</div>'; }
         })();
 
-        function showAgentCard(examId, name, model) {
+        function showAgentCardFromEntry(index) {
+            showAgentCard(leaderboardEntries[index] || {});
+        }
+        function showAgentCard(entry) {
             const popup = document.getElementById('agentPopup');
             if (!popup) return;
-            document.getElementById('agentPopupName').textContent = name || 'Unknown';
-            document.getElementById('agentPopupModel').textContent = model || '-';
-            document.getElementById('agentPopupExamId').textContent = examId ? 'Exam: ' + examId : '';
+            const card = entry.agent_card || entry.agentCard || {};
+            const name = entry.entity_name || entry.name || 'Unknown';
+            const code = entry.public_code || entry.publicCode || '';
+            const entityId = lbEntryEntityId(entry);
+            const avatar = entry.petdx_avatar_url || entry.petdxAvatarUrl || null;
+            document.getElementById('agentPopupName').textContent = name;
+            document.getElementById('agentPopupModel').textContent = entry.model || '-';
+            document.getElementById('agentPopupExamId').textContent = code ? 'Card: ' + code : (entry.exam_id ? 'Exam: ' + entry.exam_id : '');
+            document.getElementById('agentPopupDescription').textContent = card.description || '';
+            const tags = Array.isArray(card.tags) ? card.tags.slice(0, 6) : [];
+            document.getElementById('agentPopupTags').innerHTML = tags.map(t => '<span class="agent-tag">' + esc(t) + '</span>').join('');
+            const avatarEl = document.getElementById('agentPopupAvatar');
+            avatarEl.innerHTML = (typeof renderAvatarHtml === 'function')
+                ? renderAvatarHtml(avatar, 44, entityId)
+                : '<span class="entity-avatar-emoji">' + lbFallbackAvatar(name) + '</span>';
+            if (window.AvatarPetdx && typeof window.AvatarPetdx.autoMount === 'function') {
+                try { window.AvatarPetdx.autoMount(); } catch (_) { /* no-op */ }
+            }
             popup.classList.add('show');
         }
         function closeAgentPopup() {

--- a/backend/tests/jest/arena-leaderboard-mobile-noclip-static.test.js
+++ b/backend/tests/jest/arena-leaderboard-mobile-noclip-static.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const read = (p) => fs.readFileSync(path.join(__dirname, '..', '..', p), 'utf8');
+
+describe('Arena leaderboard entity avatars and card popup', () => {
+    const arenaIndex = read('public/arena/index.html');
+    const exam = read('public/arena/exam.html');
+    const server = read('interview-arena.js');
+
+    test('GET /api/arena/leaderboard exposes entity metadata for card popups', () => {
+        expect(server).toMatch(/AS entity_id/);
+        expect(server).toMatch(/AS entity_name/);
+        expect(server).toMatch(/AS petdx_avatar_url/);
+        expect(server).toMatch(/AS public_code/);
+        expect(server).toMatch(/AS agent_card/);
+        expect(server).toContain('toLeaderboardApiRow');
+    });
+
+    test('leaderboard detail stores the bound public code when a submit has credentials', () => {
+        expect(server).toContain('attachLinkedEntityToArenaDetail');
+        expect(server).toContain('linkedPublicCode');
+        expect(server).toContain('publicEntitySnapshot(entity, eId)');
+        expect(server).toContain('owner_entity_id');
+        expect(server).toContain('owner mismatch');
+    });
+
+    test.each([
+        ['arena index', arenaIndex],
+        ['arena exam', exam],
+    ])('%s renders avatar column in a mobile-safe horizontal scroll wrapper', (_label, html) => {
+        expect(html).toContain('lb-table-scroll');
+        expect(html).toContain('lb-avatar-cell');
+        expect(html).toContain('lbAvatarHtml');
+        expect(html).toMatch(/@media \(max-width: 600px\)[\s\S]*\.lb-table \{ min-width: 560px; \}/);
+    });
+
+    test.each([
+        ['arena index', arenaIndex],
+        ['arena exam', exam],
+    ])('%s opens the same card popup from avatar and name triggers', (_label, html) => {
+        expect(html).toContain('showAgentCardFromEntry');
+        expect(html).toContain('agentPopupAvatar');
+        expect(html).toContain('agentPopupDescription');
+        expect(html).toContain('agentPopupTags');
+        expect(html).toContain('petdx_avatar_url');
+        expect(html).toContain('agent_card');
+        expect(html).toContain('public_code');
+    });
+
+    test('exam submit prefers the linked exam owner before active local entity', () => {
+        expect(exam).toContain('linkedEntityId');
+        expect(exam).toMatch(/Number\.isFinite\(linkedId\)[\s\S]*bound\.find\(e => lbEntryEntityId\(e\) === linkedId\)[\s\S]*Number\.isFinite\(activeId\)/);
+    });
+});

--- a/backend/tests/jest/card-holder-avatar-enrichment-static.test.js
+++ b/backend/tests/jest/card-holder-avatar-enrichment-static.test.js
@@ -69,11 +69,17 @@ describe('exam.html binds the top-right avatar to the ACTIVE entity, not bound[0
     const html = read('public/arena/exam.html');
 
     it('uses the shared active-entity localStorage key and only falls back to bound[0]', () => {
+        expect(html).toContain('linkedEntityId');
         expect(html).toContain('eclaw_petdex_active_entity_id');
-        // the active-entity find must be present (fallback to bound[0] is fine)
-        expect(html).toMatch(/bound\.find\(e => Number\(e\.entityId \|\| e\.id\) === activeId\)/);
+        // the linked-owner / active-entity find must be present (fallback to bound[0] is fine)
+        expect(html).toMatch(/bound\.find\(e => entitySlotId\(e\) === linkedId\)/);
+        expect(html).toMatch(/bound\.find\(e => entitySlotId\(e\) === activeId\)/);
         // FAIL-ON-OLD: old code did `entityId = Number(bound[0].entityId || bound[0].id)`
         // as the ONLY selection — assert it's no longer the sole binding.
         expect(html).not.toMatch(/if \(!bound\.length\) return;\s*\n\s*entityId = Number\(bound\[0\]/);
+        // FAIL-ON-OLD: `entityId || id` treats legitimate slot 0 as missing.
+        expect(html).toContain('e.entityId ?? e.id');
+        expect(html).not.toContain('e.entityId || e.id');
+        expect(html).not.toContain('chosen.entityId || chosen.id');
     });
 });


### PR DESCRIPTION
## Summary
- Add linked owner entity metadata to Arena results and leaderboard rows (entity_id, entity_name, petdx_avatar_url, public_code, agent_card).
- Make /arena and /arena/exam leaderboards show entity avatars and open the public agent card from avatar/name clicks.
- Prefer the exam/listing owner entity for the top-right companion and leaderboard submit binding, with a server-side owner mismatch guard and slot 0 handling.

## Tests
- npm test -- --runTestsByPath tests/jest/arena-entity-binding.test.js tests/jest/card-holder-avatar-enrichment-static.test.js tests/jest/arena-leaderboard-mobile-noclip-static.test.js PASS 38/38
- npm test -- --runTestsByPath tests/jest/interview-arena.test.js PASS 55/55
- Playwright visible QA on local harness: /arena and /arena/exam at 1280x800 and 390x844, verified #2 owner avatar/card popup, linked #2 companion preference despite active local entity #1, no body overflow, and mobile leaderboard time column reachable by horizontal scroll.

Card: card_cea91e58296e0472204a7964