### PR TITLE
[codex] feat(needyou): widget and app badge pending count

### DIFF
--- a/app/src/main/java/com/hank/clawlive/ChatActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/ChatActivity.kt
@@ -20,6 +20,7 @@ import com.google.android.material.button.MaterialButton
 import com.hank.clawlive.data.local.ChatPreferences
 import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.remote.TelemetryHelper
+import com.hank.clawlive.data.repository.ActionRequestBadgeSync
 import com.hank.clawlive.ui.AiChatFabHelper
 import com.hank.clawlive.ui.BottomNavHelper
 import com.hank.clawlive.ui.NavItem
@@ -110,6 +111,7 @@ class ChatActivity : AppCompatActivity() {
         RecordingIndicatorHelper.attach(this)
         // Persist current tab so process-death restart can restore here (card_489a8836).
         navResume.onNavigatedTo(NavItem.CHAT)
+        ActionRequestBadgeSync.refreshAsync(this)
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/hank/clawlive/ClawApplication.kt
+++ b/app/src/main/java/com/hank/clawlive/ClawApplication.kt
@@ -5,13 +5,16 @@ import android.content.Context
 import com.google.firebase.messaging.FirebaseMessaging
 import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.remote.NetworkModule
+import com.hank.clawlive.data.remote.SocketManager
 import com.hank.clawlive.data.remote.TelemetryHelper
+import com.hank.clawlive.data.repository.ActionRequestBadgeSync
 import com.hank.clawlive.debug.CrashLogManager
 import com.hank.clawlive.fcm.ClawFcmService
 import com.hank.clawlive.debug.FileTimberTree
 import com.hank.clawlive.integrity.PlayIntegrityReporter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.OutputStreamWriter
@@ -21,6 +24,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 class ClawApplication : Application() {
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     override fun onCreate() {
         super.onCreate()
@@ -96,7 +100,20 @@ class ClawApplication : Application() {
         // Console can monitor genuine installs without adding user-visible work.
         reportPlayIntegrityStartup()
 
+        // 8. Keep "需要你" widget/icon badge current at startup and whenever the
+        // already-established native socket reports inbox changes.
+        ActionRequestBadgeSync.refreshAsync(this)
+        observeActionRequestBadgeChanges()
+
         Timber.i("ClawApplication initialized")
+    }
+
+    private fun observeActionRequestBadgeChanges() {
+        applicationScope.launch {
+            SocketManager.actionRequestChangedFlow.collect {
+                ActionRequestBadgeSync.refreshAsync(this@ClawApplication)
+            }
+        }
     }
 
     private fun reportPlayIntegrityStartup() {

--- a/app/src/main/java/com/hank/clawlive/MainActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MainActivity.kt
@@ -26,6 +26,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.remote.NetworkModule
 import com.hank.clawlive.data.remote.TelemetryHelper
+import com.hank.clawlive.data.repository.ActionRequestBadgeSync
 import com.hank.clawlive.fcm.ClawFcmService
 import com.hank.clawlive.ui.AiChatFabHelper
 import com.hank.clawlive.ui.BottomNavHelper
@@ -183,6 +184,7 @@ class MainActivity : AppCompatActivity() {
         // Record HOME as the current tab so process-death restart doesn't jump
         // to a stale non-home tab when the user deliberately navigated back here.
         navResume.onNavigatedTo(NavItem.HOME)
+        ActionRequestBadgeSync.refreshAsync(this)
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -448,6 +448,12 @@ interface ClawApiService {
         @Query("deviceSecret") deviceSecret: String
     ): NotificationCountResponse
 
+    @GET("api/action-requests/pending-count")
+    suspend fun getActionRequestPendingCount(
+        @Query("deviceId") deviceId: String,
+        @Query("deviceSecret") deviceSecret: String
+    ): ActionRequestPendingCountResponse
+
     @POST("api/notifications/read")
     suspend fun markNotificationRead(@Body body: Map<String, String>): ApiResponse
 
@@ -891,6 +897,13 @@ data class NotificationItem(
 data class NotificationCountResponse(
     val success: Boolean,
     val count: Int = 0,
+    val error: String? = null
+)
+
+data class ActionRequestPendingCountResponse(
+    val success: Boolean,
+    val count: Int = 0,
+    val deviceId: String? = null,
     val error: String? = null
 )
 

--- a/app/src/main/java/com/hank/clawlive/data/remote/SocketManager.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/SocketManager.kt
@@ -32,6 +32,9 @@ object SocketManager {
     private val _notificationFlow = MutableSharedFlow<JSONObject>(extraBufferCapacity = 16)
     val notificationFlow: SharedFlow<JSONObject> = _notificationFlow
 
+    private val _actionRequestChangedFlow = MutableSharedFlow<JSONObject>(extraBufferCapacity = 16)
+    val actionRequestChangedFlow: SharedFlow<JSONObject> = _actionRequestChangedFlow
+
     private val _screenRequestFlow = MutableSharedFlow<JSONObject>(extraBufferCapacity = 4)
     val screenRequestFlow: SharedFlow<JSONObject> = _screenRequestFlow
 
@@ -98,6 +101,11 @@ object SocketManager {
                 on("notification") { args ->
                     val json = args.firstOrNull() as? JSONObject ?: return@on
                     _notificationFlow.tryEmit(json)
+                }
+
+                on("action_request:changed") { args ->
+                    val json = args.firstOrNull() as? JSONObject ?: return@on
+                    _actionRequestChangedFlow.tryEmit(json)
                 }
 
                 on("device:screen-request") { args ->

--- a/app/src/main/java/com/hank/clawlive/data/repository/ActionRequestBadgeSync.kt
+++ b/app/src/main/java/com/hank/clawlive/data/repository/ActionRequestBadgeSync.kt
@@ -1,0 +1,136 @@
+package com.hank.clawlive.data.repository
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.hank.clawlive.ChatActivity
+import com.hank.clawlive.R
+import com.hank.clawlive.data.local.DeviceManager
+import com.hank.clawlive.data.remote.NetworkModule
+import com.hank.clawlive.fcm.ClawFcmService
+import com.hank.clawlive.widget.ChatWidgetProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/**
+ * Keeps the device-level "需要你" pending count visible outside the app.
+ *
+ * Android does not expose a universal launcher-badge count API, so the launcher
+ * badge is driven through a silent summary notification with setNumber().
+ */
+object ActionRequestBadgeSync {
+    private const val PREFS_NAME = "action_request_badge_prefs"
+    private const val KEY_PENDING_COUNT = "pending_count"
+    private const val SUMMARY_NOTIFICATION_ID = 61006
+
+    fun getCachedCount(context: Context): Int =
+        context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getInt(KEY_PENDING_COUNT, 0)
+            .coerceAtLeast(0)
+
+    fun refreshAsync(context: Context) {
+        val appContext = context.applicationContext
+        CoroutineScope(Dispatchers.IO).launch {
+            refresh(appContext)
+        }
+    }
+
+    suspend fun refresh(context: Context): Int? {
+        val appContext = context.applicationContext
+        return try {
+            val dm = DeviceManager.getInstance(appContext)
+            val response = withContext(Dispatchers.IO) {
+                NetworkModule.api.getActionRequestPendingCount(
+                    deviceId = dm.deviceId,
+                    deviceSecret = dm.deviceSecret
+                )
+            }
+            if (!response.success) {
+                Timber.w("[NeedYouBadge] pending-count returned success=false: ${response.error}")
+                return null
+            }
+            val count = response.count.coerceAtLeast(0)
+            applyCount(appContext, count)
+            count
+        } catch (e: Exception) {
+            Timber.w(e, "[NeedYouBadge] pending-count refresh failed")
+            null
+        }
+    }
+
+    fun applyCount(context: Context, count: Int) {
+        val appContext = context.applicationContext
+        val safeCount = count.coerceAtLeast(0)
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putInt(KEY_PENDING_COUNT, safeCount)
+            .apply()
+
+        ChatWidgetProvider.updateWidgets(appContext)
+        updateLauncherBadge(appContext, safeCount)
+    }
+
+    private fun updateLauncherBadge(context: Context, count: Int) {
+        val notificationManager = NotificationManagerCompat.from(context)
+        if (count <= 0) {
+            notificationManager.cancel(SUMMARY_NOTIFICATION_ID)
+            return
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
+                != PackageManager.PERMISSION_GRANTED
+        ) {
+            Timber.d("[NeedYouBadge] POST_NOTIFICATIONS denied; widget updated but launcher badge cannot be posted")
+            return
+        }
+
+        ClawFcmService.createChannels(context)
+
+        val openInboxIntent = Intent(context, ChatActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            SUMMARY_NOTIFICATION_ID,
+            openInboxIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val displayCount = formatCount(count)
+        val notification = NotificationCompat.Builder(context, ClawFcmService.CHANNEL_ACTION_REQUESTS)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(context.getString(R.string.needs_you_badge_notification_title))
+            .setContentText(context.getString(R.string.needs_you_badge_notification_body, displayCount))
+            .setContentIntent(pendingIntent)
+            .setNumber(count)
+            .setBadgeIconType(NotificationCompat.BADGE_ICON_SMALL)
+            .setOnlyAlertOnce(true)
+            .setOngoing(false)
+            .setAutoCancel(false)
+            .setSilent(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .build()
+
+        try {
+            notificationManager.notify(SUMMARY_NOTIFICATION_ID, notification)
+        } catch (e: SecurityException) {
+            Timber.w(e, "[NeedYouBadge] launcher badge notification blocked")
+        }
+    }
+
+    fun formatCount(count: Int): String = if (count > 99) "99+" else count.toString()
+}

--- a/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
+++ b/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
@@ -17,6 +17,7 @@ import com.hank.clawlive.MissionControlActivity
 import com.hank.clawlive.R
 import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.remote.NetworkModule
+import com.hank.clawlive.data.repository.ActionRequestBadgeSync
 import com.hank.clawlive.location.LocationHelper
 import com.hank.clawlive.ui.nav.EClawNativeNavBridge
 import org.json.JSONObject
@@ -31,6 +32,7 @@ class ClawFcmService : FirebaseMessagingService() {
         const val CHANNEL_CHAT = "eclaw_chat"
         const val CHANNEL_SYSTEM = "eclaw_system"
         const val CHANNEL_FEEDBACK = "eclaw_feedback"
+        const val CHANNEL_ACTION_REQUESTS = "eclaw_action_requests"
 
         fun createChannels(context: Context) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
@@ -44,6 +46,14 @@ class ClawFcmService : FirebaseMessagingService() {
             nm.createNotificationChannel(NotificationChannel(
                 CHANNEL_FEEDBACK, context.getString(R.string.fcm_channel_feedback_name), NotificationManager.IMPORTANCE_DEFAULT
             ).apply { description = context.getString(R.string.fcm_channel_feedback_desc) })
+            nm.createNotificationChannel(NotificationChannel(
+                CHANNEL_ACTION_REQUESTS,
+                context.getString(R.string.fcm_channel_action_requests_name),
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = context.getString(R.string.fcm_channel_action_requests_desc)
+                setShowBadge(true)
+            })
         }
     }
 
@@ -81,6 +91,9 @@ class ClawFcmService : FirebaseMessagingService() {
         val title = data["title"] ?: message.notification?.title ?: "E-Claw"
         val body = data["body"] ?: message.notification?.body ?: ""
         val category = data["category"] ?: "system"
+        if (data["type"] == "action_request" || data["metadata"]?.contains("\"ownerDecision\":true") == true) {
+            ActionRequestBadgeSync.refreshAsync(applicationContext)
+        }
 
         // TTS category: start TtsService to speak aloud instead of showing notification
         if (category == "tts") {

--- a/app/src/main/java/com/hank/clawlive/widget/ChatWidgetProvider.kt
+++ b/app/src/main/java/com/hank/clawlive/widget/ChatWidgetProvider.kt
@@ -6,10 +6,12 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.view.View
 import android.widget.RemoteViews
 import com.hank.clawlive.ChatActivity
 import com.hank.clawlive.R
 import com.hank.clawlive.data.local.ChatPreferences
+import com.hank.clawlive.data.repository.ActionRequestBadgeSync
 
 /**
  * Simple 1x1 resizable chat widget
@@ -26,6 +28,14 @@ class ChatWidgetProvider : AppWidgetProvider() {
 
         appWidgetIds.forEach { appWidgetId ->
             updateAppWidget(context, appWidgetManager, appWidgetId, chatPrefs)
+        }
+        ActionRequestBadgeSync.refreshAsync(context)
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        if (intent.action == ACTION_RENDER_BADGE) {
+            renderAllWidgets(context)
         }
     }
 
@@ -59,6 +69,20 @@ class ChatWidgetProvider : AppWidgetProvider() {
         }
         views.setTextColor(R.id.widget_text, textColor)
 
+        val pendingCount = ActionRequestBadgeSync.getCachedCount(context)
+        if (pendingCount > 0) {
+            val displayCount = ActionRequestBadgeSync.formatCount(pendingCount)
+            val badgeText = context.getString(R.string.widget_needs_you_count, displayCount)
+            views.setViewVisibility(R.id.widget_pending_badge, View.VISIBLE)
+            views.setTextViewText(R.id.widget_pending_badge, badgeText)
+            views.setContentDescription(
+                R.id.widget_pending_badge,
+                context.getString(R.string.widget_needs_you_count_desc, displayCount)
+            )
+        } else {
+            views.setViewVisibility(R.id.widget_pending_badge, View.GONE)
+        }
+
         // On Click -> Launch ChatActivity floating dialog
         views.setOnClickPendingIntent(R.id.widget_root, pendingIntent)
         views.setOnClickPendingIntent(R.id.widget_send_btn, pendingIntent)
@@ -67,18 +91,25 @@ class ChatWidgetProvider : AppWidgetProvider() {
     }
 
     companion object {
+        private const val ACTION_RENDER_BADGE = "com.hank.clawlive.widget.RENDER_BADGE"
+
         fun updateWidgets(context: Context) {
             val intent = Intent(context, ChatWidgetProvider::class.java).apply {
-                action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+                action = ACTION_RENDER_BADGE
             }
+            context.sendBroadcast(intent)
+        }
 
+        private fun renderAllWidgets(context: Context) {
             val widgetManager = AppWidgetManager.getInstance(context)
             val widgetIds = widgetManager.getAppWidgetIds(
                 ComponentName(context, ChatWidgetProvider::class.java)
             )
-
-            intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, widgetIds)
-            context.sendBroadcast(intent)
+            val chatPrefs = ChatPreferences.getInstance(context)
+            val provider = ChatWidgetProvider()
+            widgetIds.forEach { appWidgetId ->
+                provider.updateAppWidget(context, widgetManager, appWidgetId, chatPrefs)
+            }
         }
     }
 }

--- a/app/src/main/res/drawable/bg_needs_you_badge.xml
+++ b/app/src/main/res/drawable/bg_needs_you_badge.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#E53935" />
+    <corners android:radius="14dp" />
+</shape>

--- a/app/src/main/res/layout/widget_claw_chat.xml
+++ b/app/src/main/res/layout/widget_claw_chat.xml
@@ -31,6 +31,22 @@
 
     </LinearLayout>
 
+    <TextView
+        android:id="@+id/widget_pending_badge"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/bg_needs_you_badge"
+        android:gravity="center"
+        android:minWidth="56dp"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp"
+        android:text="@string/widget_needs_you_preview"
+        android:textColor="@android:color/white"
+        android:textSize="12sp"
+        android:textStyle="bold"
+        android:visibility="gone" />
+
     <!-- Send Button -->
     <ImageView
         android:id="@+id/widget_send_btn"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -805,6 +805,9 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="webhook_test_success">Webhook 测试通过！机器人已就绪~</string>
     <string name="webhook_testing">正在测试 Webhook 连接，准备好后会通知你，先别发消息哦~</string>
     <string name="widget_chat_hint">点击与角色聊天...</string>
+    <string name="widget_needs_you_preview">需要你 1</string>
+    <string name="widget_needs_you_count">需要你 %1$s</string>
+    <string name="widget_needs_you_count_desc">需要你处理的项目：%1$s</string>
     <string name="xd_allowed_media">允许的媒体类型</string>
     <string name="xd_blacklist">黑名单（公开代码）</string>
     <string name="xd_codes_sep">以逗号分隔的公开代码</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -896,6 +896,9 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="webhook_test_success">Webhook 測試通過！Bot 已就緒~</string>
     <string name="webhook_testing">正在測試 Webhook 連線，好了會通知你，先別傳訊息喔~</string>
     <string name="widget_chat_hint">點擊與角色聊天...</string>
+    <string name="widget_needs_you_preview">需要你 1</string>
+    <string name="widget_needs_you_count">需要你 %1$s</string>
+    <string name="widget_needs_you_count_desc">需要你處理的項目：%1$s</string>
     <string name="xd_allowed_media">允許的媒體類型</string>
     <string name="xd_blacklist">黑名單（公開代碼）</string>
     <string name="xd_codes_sep">以逗號分隔的公開代碼</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -816,6 +816,10 @@ If you have any questions, please contact us via our official email.
     <string name="fcm_channel_system_desc">System notifications</string>
     <string name="fcm_channel_feedback_name">Feedback Updates</string>
     <string name="fcm_channel_feedback_desc">Feedback status updates</string>
+    <string name="fcm_channel_action_requests_name">Needs you</string>
+    <string name="fcm_channel_action_requests_desc">Pending action-request badge updates</string>
+    <string name="needs_you_badge_notification_title">Needs you</string>
+    <string name="needs_you_badge_notification_body">%1$s pending item(s)</string>
 
     <!-- Broadcast Settings -->
     <string name="broadcast_settings_title">Broadcast Settings</string>
@@ -904,6 +908,9 @@ If you have any questions, please contact us via our official email.
 
     <!-- Widget -->
     <string name="widget_chat_hint">Tap to chat with entities...</string>
+    <string name="widget_needs_you_preview">Needs 1</string>
+    <string name="widget_needs_you_count">Needs %1$s</string>
+    <string name="widget_needs_you_count_desc">Needs you pending items: %1$s</string>
 
     <!-- Soul Templates (names and descriptions) -->
     <string name="soul_name_friendly">Friendly Assistant</string>

--- a/app/src/main/res/xml/claw_chat_widget_info.xml
+++ b/app/src/main/res/xml/claw_chat_widget_info.xml
@@ -7,7 +7,7 @@
     android:minResizeWidth="40dp"
     android:minResizeHeight="40dp"
     android:resizeMode="horizontal|vertical"
-    android:updatePeriodMillis="86400000"
+    android:updatePeriodMillis="1800000"
     android:description="@string/app_name"
     android:initialLayout="@layout/widget_claw_chat"
     android:widgetCategory="home_screen">

--- a/ios-app/app/_layout.tsx
+++ b/ios-app/app/_layout.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import { PaperProvider, MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
-import { useColorScheme, View, ActivityIndicator, LogBox } from 'react-native';
+import { AppState, useColorScheme, View, ActivityIndicator, LogBox } from 'react-native';
 
 // Silence dev warnings overlay so it doesn't cover the tab bar.
 LogBox.ignoreAllLogs();
@@ -70,8 +70,26 @@ export default function RootLayout() {
 
     socketService.connect();
     notificationService.registerForPushNotifications();
+    notificationService.refreshActionRequestBadgeCount();
+
+    const unsubscribeActionRequests = socketService.on('action_request:changed', () => {
+      notificationService.refreshActionRequestBadgeCount();
+    });
+    const unsubscribeForegroundNotification = notificationService.setForegroundNotificationHandler((payload) => {
+      if (payload.type === 'action_request') {
+        notificationService.refreshActionRequestBadgeCount();
+      }
+    });
+    const appStateSubscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        notificationService.refreshActionRequestBadgeCount();
+      }
+    });
 
     return () => {
+      unsubscribeActionRequests();
+      unsubscribeForegroundNotification();
+      appStateSubscription.remove();
       socketService.disconnect();
     };
   }, [deviceId, authToken]);

--- a/ios-app/services/api.ts
+++ b/ios-app/services/api.ts
@@ -358,6 +358,12 @@ export const notificationApi = {
     apiClient.put('/api/notification-preferences', prefs),
 };
 
+// ── Action Request APIs ("需要你" HITL inbox) ──────────────────
+
+export const actionRequestApi = {
+  getPendingCount: () => apiClient.get('/api/action-requests/pending-count'),
+};
+
 // ── Subscription APIs ────────────────────────────────────────
 
 export const subscriptionApi = {

--- a/ios-app/services/notificationService.ts
+++ b/ios-app/services/notificationService.ts
@@ -1,22 +1,25 @@
 import * as Notifications from 'expo-notifications';
 import * as Device from 'expo-device';
 import { Platform } from 'react-native';
-import { deviceApi } from './api';
+import { actionRequestApi, deviceApi } from './api';
 
 // Configure notification display behavior
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
     shouldShowAlert: true,
+    shouldShowBanner: true,
+    shouldShowList: true,
     shouldPlaySound: true,
     shouldSetBadge: true,
   }),
 });
 
 export interface PushNotificationPayload {
-  type: 'bot_reply' | 'broadcast' | 'speak_to' | 'feedback_reply' | 'app_update';
+  type: 'bot_reply' | 'broadcast' | 'speak_to' | 'feedback_reply' | 'app_update' | 'action_request';
   entityId?: string;
   message?: string;
   title?: string;
+  category?: string;
 }
 
 class NotificationService {
@@ -79,7 +82,7 @@ class NotificationService {
     handler: (payload: PushNotificationPayload, notificationId: string) => void
   ): () => void {
     const subscription = Notifications.addNotificationResponseReceivedListener((response) => {
-      const data = response.notification.request.content.data as PushNotificationPayload;
+      const data = response.notification.request.content.data as unknown as PushNotificationPayload;
       const notificationId = response.notification.request.identifier;
       handler(data, notificationId);
     });
@@ -92,7 +95,7 @@ class NotificationService {
     handler: (payload: PushNotificationPayload) => void
   ): () => void {
     const subscription = Notifications.addNotificationReceivedListener((notification) => {
-      const data = notification.request.content.data as PushNotificationPayload;
+      const data = notification.request.content.data as unknown as PushNotificationPayload;
       handler(data);
     });
 
@@ -102,6 +105,20 @@ class NotificationService {
   /** Set app badge count */
   async setBadgeCount(count: number): Promise<void> {
     await Notifications.setBadgeCountAsync(count);
+  }
+
+  /** Refresh the app icon badge from the "需要你" pending-count endpoint. */
+  async refreshActionRequestBadgeCount(): Promise<number | null> {
+    try {
+      const response = await actionRequestApi.getPendingCount();
+      const rawCount = Number(response.data?.count ?? 0);
+      const count = Number.isFinite(rawCount) ? Math.max(0, Math.floor(rawCount)) : 0;
+      await this.setBadgeCount(count);
+      return count;
+    } catch (error) {
+      console.error('[NOTIF] Failed to refresh action-request badge count:', error);
+      return null;
+    }
   }
 
   /** Clear all notifications */

--- a/ios-app/services/socketService.ts
+++ b/ios-app/services/socketService.ts
@@ -9,6 +9,7 @@ export type SocketEvent =
   | 'entity:update'
   | 'chat:message'
   | 'notification'
+  | 'action_request:changed'
   | 'screen:request'
   | 'control:command';
 
@@ -80,6 +81,7 @@ class SocketService {
       'entity:update',
       'chat:message',
       'notification',
+      'action_request:changed',
     ];
 
     domainEvents.forEach((event) => {


### PR DESCRIPTION
## Summary
- Wire the merged `GET /api/action-requests/pending-count` endpoint into Android and iOS clients.
- Add Android `ActionRequestBadgeSync` to cache pending counts, refresh on startup/chat/home/socket/FCM triggers, update the home-screen widget, and drive launcher badge state through a silent summary notification.
- Add a visible pending-count badge to the Android chat widget plus EN/ZH strings.
- Refresh the iOS app badge on app startup, foreground resume, socket `action_request:changed`, and foreground `action_request` notifications.

## Validation
- `git diff --check`
- `npm test -- --runInBand services/__tests__/miscApi.getVersion.test.ts services/__tests__/settingsManifest.test.ts services/__tests__/updateChip.test.ts`
- `ANDROID_HOME=/Users/hank/Library/Android/sdk ANDROID_SDK_ROOT=/Users/hank/Library/Android/sdk ./gradlew :app:compileDebugKotlin -x :app:processDebugGoogleServices`

## Notes
- Backend pending-count endpoint was already merged in PR #3893; this PR covers the mobile/widget surface.
- Full Android Gradle test/compile without `-x :app:processDebugGoogleServices` is blocked in this worktree because `app/google-services.json` is intentionally absent. I did not copy secret/config material into the worktree.
- Full `npx tsc --noEmit` still fails on existing unrelated TS issues in pages/wallet/hooks; the errors are not in the files changed here.