### PR TITLE
feat: sync needs-you widget and app badges

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
     // Google Play Core In-App Update (Settings update-available chip — card_28a8290a)
     implementation(libs.play.app.update)
     implementation(libs.play.app.update.ktx)
+    implementation(libs.shortcut.badger)
 
     // Room Database for chat history
     implementation(libs.room.runtime)

--- a/app/src/main/java/com/hank/clawlive/ClawApplication.kt
+++ b/app/src/main/java/com/hank/clawlive/ClawApplication.kt
@@ -10,6 +10,7 @@ import com.hank.clawlive.debug.CrashLogManager
 import com.hank.clawlive.fcm.ClawFcmService
 import com.hank.clawlive.debug.FileTimberTree
 import com.hank.clawlive.integrity.PlayIntegrityReporter
+import com.hank.clawlive.needyou.NeedYouIndicatorSync
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -91,6 +92,10 @@ class ClawApplication : Application() {
         // the device would stay unregistered forever. Pulling the current token at startup
         // and POSTing it unconditionally fixes that class of silent failures.
         refreshAndRegisterFcmToken()
+
+        // Keep the home-screen widget + supported launcher badges aligned with
+        // the server-side 需要你 unresolved count as soon as the process wakes.
+        NeedYouIndicatorSync.refreshAsync(this, "app_start")
 
         // 7. Report a Play Integrity startup signal in release builds so Play
         // Console can monitor genuine installs without adding user-visible work.

--- a/app/src/main/java/com/hank/clawlive/MainActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MainActivity.kt
@@ -27,6 +27,7 @@ import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.remote.NetworkModule
 import com.hank.clawlive.data.remote.TelemetryHelper
 import com.hank.clawlive.fcm.ClawFcmService
+import com.hank.clawlive.needyou.NeedYouIndicatorSync
 import com.hank.clawlive.ui.AiChatFabHelper
 import com.hank.clawlive.ui.BottomNavHelper
 import com.hank.clawlive.ui.NavItem
@@ -92,6 +93,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         observeLocationRequests()
+        observeActionRequestChanges()
 
         ClawFcmService.createChannels(this)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -180,6 +182,7 @@ class MainActivity : AppCompatActivity() {
         super.onResume()
         TelemetryHelper.trackPageView(this, "main")
         RecordingIndicatorHelper.attach(this)
+        NeedYouIndicatorSync.refreshAsync(this, "main_resume")
         // Record HOME as the current tab so process-death restart doesn't jump
         // to a stale non-home tab when the user deliberately navigated back here.
         navResume.onNavigatedTo(NavItem.HOME)
@@ -198,6 +201,14 @@ class MainActivity : AppCompatActivity() {
                 com.hank.clawlive.location.LocationHelper.fetchAndReportAsync(
                     applicationContext, requestId
                 )
+            }
+        }
+    }
+
+    private fun observeActionRequestChanges() {
+        lifecycleScope.launch {
+            com.hank.clawlive.data.remote.SocketManager.actionRequestChangedFlow.collect {
+                NeedYouIndicatorSync.refreshAsync(this@MainActivity, "socket_action_request_changed")
             }
         }
     }

--- a/app/src/main/java/com/hank/clawlive/data/local/NeedYouIndicatorPrefs.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/NeedYouIndicatorPrefs.kt
@@ -1,0 +1,35 @@
+package com.hank.clawlive.data.local
+
+import android.content.Context
+import kotlin.math.max
+
+class NeedYouIndicatorPrefs private constructor(context: Context) {
+    private val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    var pendingCount: Int
+        get() = prefs.getInt(KEY_PENDING_COUNT, 0)
+        set(value) {
+            prefs.edit()
+                .putInt(KEY_PENDING_COUNT, max(0, value))
+                .putLong(KEY_UPDATED_AT, System.currentTimeMillis())
+                .apply()
+        }
+
+    val updatedAt: Long
+        get() = prefs.getLong(KEY_UPDATED_AT, 0L)
+
+    companion object {
+        private const val PREFS_NAME = "needyou_indicator_prefs"
+        private const val KEY_PENDING_COUNT = "pending_count"
+        private const val KEY_UPDATED_AT = "updated_at"
+
+        @Volatile
+        private var instance: NeedYouIndicatorPrefs? = null
+
+        fun getInstance(context: Context): NeedYouIndicatorPrefs {
+            return instance ?: synchronized(this) {
+                instance ?: NeedYouIndicatorPrefs(context.applicationContext).also { instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hank/clawlive/data/model/ApiModels.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/ApiModels.kt
@@ -68,6 +68,13 @@ data class GenericResponse(
     @SerializedName("message") val message: String? = null
 )
 
+data class ActionRequestPendingCountResponse(
+    @SerializedName("success") val success: Boolean = false,
+    @SerializedName("count") val count: Int = 0,
+    @SerializedName("deviceId") val deviceId: String? = null,
+    @SerializedName("error") val error: String? = null
+)
+
 // Avatar upload response (includes Flickr URL)
 data class AvatarUploadResponse(
     @SerializedName("success") val success: Boolean = false,

--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -448,6 +448,12 @@ interface ClawApiService {
         @Query("deviceSecret") deviceSecret: String
     ): NotificationCountResponse
 
+    @GET("api/action-requests/pending-count")
+    suspend fun getActionRequestPendingCount(
+        @Query("deviceId") deviceId: String,
+        @Query("deviceSecret") deviceSecret: String
+    ): ActionRequestPendingCountResponse
+
     @POST("api/notifications/read")
     suspend fun markNotificationRead(@Body body: Map<String, String>): ApiResponse
 

--- a/app/src/main/java/com/hank/clawlive/data/remote/SocketManager.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/SocketManager.kt
@@ -32,6 +32,9 @@ object SocketManager {
     private val _notificationFlow = MutableSharedFlow<JSONObject>(extraBufferCapacity = 16)
     val notificationFlow: SharedFlow<JSONObject> = _notificationFlow
 
+    private val _actionRequestChangedFlow = MutableSharedFlow<JSONObject>(extraBufferCapacity = 16)
+    val actionRequestChangedFlow: SharedFlow<JSONObject> = _actionRequestChangedFlow
+
     private val _screenRequestFlow = MutableSharedFlow<JSONObject>(extraBufferCapacity = 4)
     val screenRequestFlow: SharedFlow<JSONObject> = _screenRequestFlow
 
@@ -98,6 +101,11 @@ object SocketManager {
                 on("notification") { args ->
                     val json = args.firstOrNull() as? JSONObject ?: return@on
                     _notificationFlow.tryEmit(json)
+                }
+
+                on("action_request:changed") { args ->
+                    val json = args.firstOrNull() as? JSONObject ?: JSONObject()
+                    _actionRequestChangedFlow.tryEmit(json)
                 }
 
                 on("device:screen-request") { args ->

--- a/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
+++ b/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
@@ -18,6 +18,7 @@ import com.hank.clawlive.R
 import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.remote.NetworkModule
 import com.hank.clawlive.location.LocationHelper
+import com.hank.clawlive.needyou.NeedYouIndicatorSync
 import com.hank.clawlive.ui.nav.EClawNativeNavBridge
 import org.json.JSONObject
 import kotlinx.coroutines.CoroutineScope
@@ -81,6 +82,11 @@ class ClawFcmService : FirebaseMessagingService() {
         val title = data["title"] ?: message.notification?.title ?: "E-Claw"
         val body = data["body"] ?: message.notification?.body ?: ""
         val category = data["category"] ?: "system"
+        val type = data["type"]
+
+        if (category == "rich_card_question" || type == "action_request") {
+            NeedYouIndicatorSync.refreshAsync(applicationContext, "fcm_action_request")
+        }
 
         // TTS category: start TtsService to speak aloud instead of showing notification
         if (category == "tts") {

--- a/app/src/main/java/com/hank/clawlive/needyou/NeedYouIndicatorSync.kt
+++ b/app/src/main/java/com/hank/clawlive/needyou/NeedYouIndicatorSync.kt
@@ -1,0 +1,69 @@
+package com.hank.clawlive.needyou
+
+import android.content.Context
+import com.hank.clawlive.data.local.DeviceManager
+import com.hank.clawlive.data.local.NeedYouIndicatorPrefs
+import com.hank.clawlive.data.remote.NetworkModule
+import com.hank.clawlive.widget.ChatWidgetProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import me.leolin.shortcutbadger.ShortcutBadger
+import timber.log.Timber
+import kotlin.math.max
+
+object NeedYouIndicatorSync {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    fun refreshAsync(context: Context, reason: String) {
+        val appContext = context.applicationContext
+        scope.launch {
+            refresh(appContext, reason)
+        }
+    }
+
+    suspend fun refresh(context: Context, reason: String): Int? {
+        val appContext = context.applicationContext
+        val dm = DeviceManager.getInstance(appContext)
+        val deviceId = dm.deviceId
+        val deviceSecret = dm.deviceSecret
+        if (deviceId.isBlank() || deviceSecret.isBlank()) return null
+
+        return try {
+            val response = NetworkModule.api.getActionRequestPendingCount(deviceId, deviceSecret)
+            if (!response.success) {
+                Timber.w("[NeedYouIndicator] pending-count failed reason=%s error=%s", reason, response.error)
+                return null
+            }
+            applyCount(appContext, response.count, reason)
+            response.count
+        } catch (e: Exception) {
+            Timber.w(e, "[NeedYouIndicator] pending-count sync failed reason=%s", reason)
+            null
+        }
+    }
+
+    fun applyCount(context: Context, rawCount: Int, reason: String) {
+        val appContext = context.applicationContext
+        val count = max(0, rawCount)
+        NeedYouIndicatorPrefs.getInstance(appContext).pendingCount = count
+        updateLauncherBadge(appContext, count, reason)
+        ChatWidgetProvider.updateWidgets(appContext)
+    }
+
+    private fun updateLauncherBadge(context: Context, count: Int, reason: String) {
+        try {
+            val ok = if (count > 0) {
+                ShortcutBadger.applyCount(context, count)
+            } else {
+                ShortcutBadger.removeCount(context)
+            }
+            if (!ok) {
+                Timber.d("[NeedYouIndicator] launcher badge unsupported reason=%s count=%d", reason, count)
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "[NeedYouIndicator] launcher badge update failed reason=%s count=%d", reason, count)
+        }
+    }
+}

--- a/app/src/main/java/com/hank/clawlive/widget/ChatWidgetProvider.kt
+++ b/app/src/main/java/com/hank/clawlive/widget/ChatWidgetProvider.kt
@@ -6,16 +6,27 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.view.View
 import android.widget.RemoteViews
 import com.hank.clawlive.ChatActivity
 import com.hank.clawlive.R
 import com.hank.clawlive.data.local.ChatPreferences
+import com.hank.clawlive.data.local.NeedYouIndicatorPrefs
+import com.hank.clawlive.needyou.NeedYouIndicatorSync
 
 /**
  * Simple 1x1 resizable chat widget
  * Clicking opens ChatActivity as a floating dialog
  */
 class ChatWidgetProvider : AppWidgetProvider() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == AppWidgetManager.ACTION_APPWIDGET_UPDATE &&
+            !intent.getBooleanExtra(EXTRA_SKIP_REMOTE_REFRESH, false)
+        ) {
+            NeedYouIndicatorSync.refreshAsync(context, "widget_update")
+        }
+        super.onReceive(context, intent)
+    }
 
     override fun onUpdate(
         context: Context,
@@ -23,9 +34,10 @@ class ChatWidgetProvider : AppWidgetProvider() {
         appWidgetIds: IntArray
     ) {
         val chatPrefs = ChatPreferences.getInstance(context)
+        val needYouPrefs = NeedYouIndicatorPrefs.getInstance(context)
 
         appWidgetIds.forEach { appWidgetId ->
-            updateAppWidget(context, appWidgetManager, appWidgetId, chatPrefs)
+            updateAppWidget(context, appWidgetManager, appWidgetId, chatPrefs, needYouPrefs)
         }
     }
 
@@ -33,7 +45,8 @@ class ChatWidgetProvider : AppWidgetProvider() {
         context: Context,
         appWidgetManager: AppWidgetManager,
         appWidgetId: Int,
-        chatPrefs: ChatPreferences
+        chatPrefs: ChatPreferences,
+        needYouPrefs: NeedYouIndicatorPrefs
     ) {
         // Create intent to launch ChatActivity as floating dialog
         val intent = Intent(context, ChatActivity::class.java).apply {
@@ -48,11 +61,25 @@ class ChatWidgetProvider : AppWidgetProvider() {
 
         val views = RemoteViews(context.packageName, R.layout.widget_claw_chat)
 
-        // Set dynamic text from last message
-        val displayText = chatPrefs.getWidgetDisplayText()
-        views.setTextViewText(R.id.widget_text, displayText)
+        val pendingCount = needYouPrefs.pendingCount
+        val hasPendingNeedsYou = pendingCount > 0
 
-        val textColor = if (chatPrefs.lastMessage.isNullOrEmpty()) {
+        val displayText = if (hasPendingNeedsYou) {
+            context.resources.getQuantityString(R.plurals.widget_needyou_pending, pendingCount, pendingCount)
+        } else {
+            chatPrefs.getWidgetDisplayText()
+        }
+        views.setTextViewText(R.id.widget_text, displayText)
+        views.setTextViewText(R.id.widget_needyou_badge, formatBadgeCount(pendingCount))
+        views.setViewVisibility(R.id.widget_needyou_badge, if (hasPendingNeedsYou) View.VISIBLE else View.GONE)
+        views.setContentDescription(
+            R.id.widget_needyou_badge,
+            context.getString(R.string.widget_needyou_badge_content_description)
+        )
+
+        val textColor = if (hasPendingNeedsYou) {
+            0xFFFFFFFF.toInt()
+        } else if (chatPrefs.lastMessage.isNullOrEmpty()) {
             0xFFAAAAAA.toInt()
         } else {
             0xFFFFFFFF.toInt()
@@ -67,9 +94,12 @@ class ChatWidgetProvider : AppWidgetProvider() {
     }
 
     companion object {
+        private const val EXTRA_SKIP_REMOTE_REFRESH = "com.hank.clawlive.widget.SKIP_REMOTE_REFRESH"
+
         fun updateWidgets(context: Context) {
             val intent = Intent(context, ChatWidgetProvider::class.java).apply {
                 action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+                putExtra(EXTRA_SKIP_REMOTE_REFRESH, true)
             }
 
             val widgetManager = AppWidgetManager.getInstance(context)
@@ -80,5 +110,8 @@ class ChatWidgetProvider : AppWidgetProvider() {
             intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, widgetIds)
             context.sendBroadcast(intent)
         }
+
+        private fun formatBadgeCount(count: Int): String =
+            if (count > 99) "99+" else count.coerceAtLeast(0).toString()
     }
 }

--- a/app/src/main/res/drawable/widget_needyou_badge_bg.xml
+++ b/app/src/main/res/drawable/widget_needyou_badge_bg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#E53935" />
+    <stroke
+        android:width="2dp"
+        android:color="#FFFFFFFF" />
+</shape>

--- a/app/src/main/res/layout/widget_claw_chat.xml
+++ b/app/src/main/res/layout/widget_claw_chat.xml
@@ -8,6 +8,20 @@
     android:gravity="center_vertical"
     android:padding="12dp">
 
+    <TextView
+        android:id="@+id/widget_needyou_badge"
+        android:layout_width="42dp"
+        android:layout_height="42dp"
+        android:layout_marginEnd="8dp"
+        android:background="@drawable/widget_needyou_badge_bg"
+        android:gravity="center"
+        android:maxLines="1"
+        android:text="!"
+        android:textColor="@android:color/white"
+        android:textSize="15sp"
+        android:textStyle="bold"
+        android:visibility="gone" />
+
     <!-- Fake Input Field (Clickable) -->
     <LinearLayout
         android:layout_width="0dp"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -805,6 +805,11 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="webhook_test_success">Webhook 测试通过！机器人已就绪~</string>
     <string name="webhook_testing">正在测试 Webhook 连接，准备好后会通知你，先别发消息哦~</string>
     <string name="widget_chat_hint">点击与角色聊天...</string>
+    <plurals name="widget_needyou_pending">
+        <item quantity="one">需要你 待处理 %d</item>
+        <item quantity="other">需要你 待处理 %d</item>
+    </plurals>
+    <string name="widget_needyou_badge_content_description">需要你待处理数量</string>
     <string name="xd_allowed_media">允许的媒体类型</string>
     <string name="xd_blacklist">黑名单（公开代码）</string>
     <string name="xd_codes_sep">以逗号分隔的公开代码</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -896,6 +896,11 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="webhook_test_success">Webhook 測試通過！Bot 已就緒~</string>
     <string name="webhook_testing">正在測試 Webhook 連線，好了會通知你，先別傳訊息喔~</string>
     <string name="widget_chat_hint">點擊與角色聊天...</string>
+    <plurals name="widget_needyou_pending">
+        <item quantity="one">需要你 待處理 %d</item>
+        <item quantity="other">需要你 待處理 %d</item>
+    </plurals>
+    <string name="widget_needyou_badge_content_description">需要你待處理數量</string>
     <string name="xd_allowed_media">允許的媒體類型</string>
     <string name="xd_blacklist">黑名單（公開代碼）</string>
     <string name="xd_codes_sep">以逗號分隔的公開代碼</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -904,6 +904,11 @@ If you have any questions, please contact us via our official email.
 
     <!-- Widget -->
     <string name="widget_chat_hint">Tap to chat with entities...</string>
+    <plurals name="widget_needyou_pending">
+        <item quantity="one">Needs you: %d pending</item>
+        <item quantity="other">Needs you: %d pending</item>
+    </plurals>
+    <string name="widget_needyou_badge_content_description">Needs-you pending count</string>
 
     <!-- Soul Templates (names and descriptions) -->
     <string name="soul_name_friendly">Friendly Assistant</string>

--- a/app/src/test/java/com/hank/clawlive/NeedYouIndicatorStaticTest.kt
+++ b/app/src/test/java/com/hank/clawlive/NeedYouIndicatorStaticTest.kt
@@ -1,0 +1,68 @@
+package com.hank.clawlive
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class NeedYouIndicatorStaticTest {
+    @Test
+    fun androidApiUsesPendingCountEndpoint() {
+        val api = readSource("com/hank/clawlive/data/remote/ClawApiService.kt")
+        assertTrue(api.contains("@GET(\"api/action-requests/pending-count\")"))
+        assertTrue(api.contains("getActionRequestPendingCount"))
+    }
+
+    @Test
+    fun syncerUpdatesWidgetAndLauncherBadge() {
+        val sync = readSource("com/hank/clawlive/needyou/NeedYouIndicatorSync.kt")
+        assertTrue(sync.contains("NetworkModule.api.getActionRequestPendingCount"))
+        assertTrue(sync.contains("NeedYouIndicatorPrefs.getInstance"))
+        assertTrue(sync.contains("ChatWidgetProvider.updateWidgets"))
+        assertTrue(sync.contains("ShortcutBadger.applyCount"))
+        assertTrue(sync.contains("ShortcutBadger.removeCount"))
+    }
+
+    @Test
+    fun widgetRendersCachedNeedsYouCountWithoutRemoteLoop() {
+        val provider = readSource("com/hank/clawlive/widget/ChatWidgetProvider.kt")
+        val layout = readRes("layout/widget_claw_chat.xml")
+        assertTrue(layout.contains("@+id/widget_needyou_badge"))
+        assertTrue(provider.contains("NeedYouIndicatorPrefs.getInstance"))
+        assertTrue(provider.contains("R.plurals.widget_needyou_pending"))
+        assertTrue(provider.contains("EXTRA_SKIP_REMOTE_REFRESH"))
+        assertTrue(provider.contains("NeedYouIndicatorSync.refreshAsync(context, \"widget_update\")"))
+    }
+
+    @Test
+    fun appFcmAndSocketTriggerNeedsYouRefresh() {
+        val app = readSource("com/hank/clawlive/ClawApplication.kt")
+        val main = readSource("com/hank/clawlive/MainActivity.kt")
+        val fcm = readSource("com/hank/clawlive/fcm/ClawFcmService.kt")
+        val socket = readSource("com/hank/clawlive/data/remote/SocketManager.kt")
+        assertTrue(app.contains("NeedYouIndicatorSync.refreshAsync(this, \"app_start\")"))
+        assertTrue(main.contains("actionRequestChangedFlow.collect"))
+        assertTrue(main.contains("NeedYouIndicatorSync.refreshAsync(this, \"main_resume\")"))
+        assertTrue(fcm.contains("category == \"rich_card_question\" || type == \"action_request\""))
+        assertTrue(socket.contains("on(\"action_request:changed\")"))
+    }
+
+    private fun readSource(relPath: String): String {
+        val candidates = listOf(
+            File("src/main/java/$relPath"),
+            File("app/src/main/java/$relPath")
+        )
+        val file = candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate $relPath from ${File(".").absolutePath}")
+        return file.readText()
+    }
+
+    private fun readRes(relPath: String): String {
+        val candidates = listOf(
+            File("src/main/res/$relPath"),
+            File("app/src/main/res/$relPath")
+        )
+        val file = candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate $relPath from ${File(".").absolutePath}")
+        return file.readText()
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -32,6 +32,7 @@ import org.junit.runners.Suite
     NotificationPreferenceCatalogTest::class,
     SettingsManifestResolverTest::class,
     SettingsManifestSyncTest::class,
+    NeedYouIndicatorStaticTest::class,
     FcmChannelCreationTest::class,
     KanbanDoneDeepLinkTest::class
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ facebookSdk = "17.0.0"
 playServicesLocation = "21.3.0"
 playIntegrity = "1.6.0"
 playAppUpdate = "2.1.0"
+shortcutBadger = "1.1.22"
 
 [libraries]
 billing = { group = "com.android.billingclient", name = "billing-ktx", version.ref = "billing" }
@@ -80,6 +81,7 @@ play-services-location = { group = "com.google.android.gms", name = "play-servic
 play-integrity = { group = "com.google.android.play", name = "integrity", version.ref = "playIntegrity" }
 play-app-update = { group = "com.google.android.play", name = "app-update", version.ref = "playAppUpdate" }
 play-app-update-ktx = { group = "com.google.android.play", name = "app-update-ktx", version.ref = "playAppUpdate" }
+shortcut-badger = { group = "me.leolin", name = "ShortcutBadger", version.ref = "shortcutBadger" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/ios-app/app.json
+++ b/ios-app/app.json
@@ -68,7 +68,8 @@
       "expo-sharing",
       "expo-sqlite",
       "expo-apple-authentication",
-      "expo-web-browser"
+      "expo-web-browser",
+      "./plugins/withNeedsYouWidget"
     ],
     "experiments": {
       "typedRoutes": true

--- a/ios-app/app/_layout.tsx
+++ b/ios-app/app/_layout.tsx
@@ -67,7 +67,7 @@ function isNeedsYouNotification(payload: unknown): boolean {
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? MD3DarkTheme : MD3LightTheme;
-  const { initialize, deviceId, authToken } = useAuthStore();
+  const { initialize, deviceId, deviceSecret } = useAuthStore();
 
   // Initialize auth on startup
   useEffect(() => {
@@ -76,7 +76,7 @@ export default function RootLayout() {
 
   // Connect Socket.IO and register for notifications when authenticated
   useEffect(() => {
-    if (!deviceId && !authToken) return;
+    if (!deviceId || !deviceSecret) return;
 
     socketService.connect();
     notificationService.registerForPushNotifications();
@@ -106,7 +106,7 @@ export default function RootLayout() {
       clearInterval(badgeInterval);
       socketService.disconnect();
     };
-  }, [deviceId, authToken]);
+  }, [deviceId, deviceSecret]);
 
   return (
     <SafeAreaProvider>

--- a/ios-app/app/_layout.tsx
+++ b/ios-app/app/_layout.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import { PaperProvider, MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
-import { useColorScheme, View, ActivityIndicator, LogBox } from 'react-native';
+import { useColorScheme, View, ActivityIndicator, LogBox, AppState } from 'react-native';
 
 // Silence dev warnings overlay so it doesn't cover the tab bar.
 LogBox.ignoreAllLogs();
@@ -54,6 +54,16 @@ function AuthGate({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
+function isNeedsYouNotification(payload: unknown): boolean {
+  if (!payload || typeof payload !== 'object') return false;
+  const p = payload as { category?: unknown; type?: unknown; metadata?: unknown };
+  if (p.category === 'rich_card_question' || p.type === 'action_request') return true;
+  if (p.metadata && typeof p.metadata === 'object') {
+    return (p.metadata as { ownerDecision?: unknown }).ownerDecision === true;
+  }
+  return false;
+}
+
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? MD3DarkTheme : MD3LightTheme;
@@ -70,8 +80,30 @@ export default function RootLayout() {
 
     socketService.connect();
     notificationService.registerForPushNotifications();
+    notificationService.syncNeedsYouBadgeCount();
+
+    const offActionRequest = socketService.on('action_request:changed', () => {
+      notificationService.syncNeedsYouBadgeCount();
+    });
+    const offNotification = socketService.on('notification', (payload) => {
+      if (isNeedsYouNotification(payload)) {
+        notificationService.syncNeedsYouBadgeCount();
+      }
+    });
+    const appStateSubscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        notificationService.syncNeedsYouBadgeCount();
+      }
+    });
+    const badgeInterval = setInterval(() => {
+      notificationService.syncNeedsYouBadgeCount();
+    }, 5 * 60 * 1000);
 
     return () => {
+      offActionRequest();
+      offNotification();
+      appStateSubscription.remove();
+      clearInterval(badgeInterval);
       socketService.disconnect();
     };
   }, [deviceId, authToken]);

--- a/ios-app/plugins/needs-you-widget/NeedsYouWidget-Info.plist
+++ b/ios-app/plugins/needs-you-widget/NeedsYouWidget-Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>E-Claw Needs You</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>__WIDGET_BUNDLE_IDENTIFIER__</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>NeedsYouWidget</string>
+  <key>CFBundlePackageType</key>
+  <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>NSExtension</key>
+  <dict>
+    <key>NSExtensionPointIdentifier</key>
+    <string>com.apple.widgetkit-extension</string>
+  </dict>
+</dict>
+</plist>

--- a/ios-app/plugins/needs-you-widget/NeedsYouWidget-Info.plist
+++ b/ios-app/plugins/needs-you-widget/NeedsYouWidget-Info.plist
@@ -15,9 +15,9 @@
   <key>CFBundlePackageType</key>
   <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.0</string>
+  <string>__WIDGET_SHORT_VERSION__</string>
   <key>CFBundleVersion</key>
-  <string>1</string>
+  <string>__WIDGET_BUILD_VERSION__</string>
   <key>NSExtension</key>
   <dict>
     <key>NSExtensionPointIdentifier</key>

--- a/ios-app/plugins/needs-you-widget/NeedsYouWidget.entitlements
+++ b/ios-app/plugins/needs-you-widget/NeedsYouWidget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.application-groups</key>
+  <array>
+    <string>__APP_GROUP__</string>
+  </array>
+</dict>
+</plist>

--- a/ios-app/plugins/needs-you-widget/NeedsYouWidget.swift
+++ b/ios-app/plugins/needs-you-widget/NeedsYouWidget.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+import WidgetKit
+
+private let appGroupIdentifier = "__APP_GROUP__"
+private let pendingCountKey = "__PENDING_COUNT_KEY__"
+private let updatedAtKey = "__UPDATED_AT_KEY__"
+
+struct NeedsYouEntry: TimelineEntry {
+  let date: Date
+  let pendingCount: Int
+  let updatedAt: Date?
+}
+
+struct NeedsYouProvider: TimelineProvider {
+  func placeholder(in context: Context) -> NeedsYouEntry {
+    NeedsYouEntry(date: Date(), pendingCount: 3, updatedAt: Date())
+  }
+
+  func getSnapshot(in context: Context, completion: @escaping (NeedsYouEntry) -> Void) {
+    completion(loadEntry())
+  }
+
+  func getTimeline(in context: Context, completion: @escaping (Timeline<NeedsYouEntry>) -> Void) {
+    let entry = loadEntry()
+    completion(Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(5 * 60))))
+  }
+
+  private func loadEntry() -> NeedsYouEntry {
+    guard let defaults = UserDefaults(suiteName: appGroupIdentifier) else {
+      return NeedsYouEntry(date: Date(), pendingCount: 0, updatedAt: nil)
+    }
+
+    let pendingCount = max(0, defaults.integer(forKey: pendingCountKey))
+    let updatedAtSeconds = defaults.double(forKey: updatedAtKey)
+    let updatedAt = updatedAtSeconds > 0 ? Date(timeIntervalSince1970: updatedAtSeconds) : nil
+    return NeedsYouEntry(date: Date(), pendingCount: pendingCount, updatedAt: updatedAt)
+  }
+}
+
+struct NeedsYouWidgetView: View {
+  let entry: NeedsYouEntry
+
+  var body: some View {
+    ZStack {
+      LinearGradient(
+        colors: [Color(red: 0.11, green: 0.12, blue: 0.20), Color(red: 0.06, green: 0.32, blue: 0.36)],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+      )
+
+      VStack(alignment: .leading, spacing: 10) {
+        Text("E-Claw")
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(.white.opacity(0.72))
+
+        Spacer(minLength: 0)
+
+        if entry.pendingCount > 0 {
+          Text("\(min(entry.pendingCount, 99))")
+            .font(.system(size: 44, weight: .black, design: .rounded))
+            .foregroundStyle(.white)
+            .minimumScaleFactor(0.72)
+
+          Text("Needs you")
+            .font(.headline.weight(.bold))
+            .foregroundStyle(.white)
+        } else {
+          Image(systemName: "checkmark.circle.fill")
+            .font(.system(size: 34, weight: .bold))
+            .foregroundStyle(.green)
+
+          Text("All clear")
+            .font(.headline.weight(.bold))
+            .foregroundStyle(.white)
+        }
+      }
+      .padding(16)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    }
+    .needsYouWidgetBackground()
+  }
+}
+
+extension View {
+  @ViewBuilder
+  func needsYouWidgetBackground() -> some View {
+    if #available(iOSApplicationExtension 17.0, *) {
+      self.containerBackground(for: .widget) {
+        Color(red: 0.11, green: 0.12, blue: 0.20)
+      }
+    } else {
+      self.background(Color(red: 0.11, green: 0.12, blue: 0.20))
+    }
+  }
+}
+
+struct NeedsYouWidget: Widget {
+  let kind = "__WIDGET_KIND__"
+
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: kind, provider: NeedsYouProvider()) { entry in
+      NeedsYouWidgetView(entry: entry)
+    }
+    .configurationDisplayName("E-Claw Needs You")
+    .description("Shows unresolved Needs-you requests from E-Claw.")
+    .supportedFamilies([.systemSmall])
+  }
+}
+
+@main
+struct NeedsYouWidgetBundle: WidgetBundle {
+  var body: some Widget {
+    NeedsYouWidget()
+  }
+}

--- a/ios-app/plugins/needs-you-widget/NeedsYouWidgetStore.swift
+++ b/ios-app/plugins/needs-you-widget/NeedsYouWidgetStore.swift
@@ -1,0 +1,34 @@
+import Foundation
+import WidgetKit
+import React
+
+@objc(NeedsYouWidgetStore)
+class NeedsYouWidgetStore: NSObject {
+  @objc
+  static func requiresMainQueueSetup() -> Bool {
+    return false
+  }
+
+  @objc(setPendingCount:withResolver:withRejecter:)
+  func setPendingCount(
+    _ count: NSNumber,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let defaults = UserDefaults(suiteName: "__APP_GROUP__") else {
+      reject("ERR_NEEDS_YOU_WIDGET_STORE", "Unable to open Needs-you app group defaults", nil)
+      return
+    }
+
+    let clampedCount = max(0, count.intValue)
+    defaults.set(clampedCount, forKey: "__PENDING_COUNT_KEY__")
+    defaults.set(Date().timeIntervalSince1970, forKey: "__UPDATED_AT_KEY__")
+    defaults.synchronize()
+
+    if #available(iOS 14.0, *) {
+      WidgetCenter.shared.reloadTimelines(ofKind: "__WIDGET_KIND__")
+    }
+
+    resolve(true)
+  }
+}

--- a/ios-app/plugins/needs-you-widget/NeedsYouWidgetStoreBridge.m
+++ b/ios-app/plugins/needs-you-widget/NeedsYouWidgetStoreBridge.m
@@ -1,0 +1,9 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(NeedsYouWidgetStore, NSObject)
+
+RCT_EXTERN_METHOD(setPendingCount:(nonnull NSNumber *)count
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject)
+
+@end

--- a/ios-app/plugins/withNeedsYouWidget.js
+++ b/ios-app/plugins/withNeedsYouWidget.js
@@ -1,0 +1,212 @@
+const fs = require('fs');
+const path = require('path');
+const {
+  IOSConfig,
+  withEntitlementsPlist,
+  withXcodeProject,
+} = require('@expo/config-plugins');
+
+const NEEDS_YOU_WIDGET_CONFIG = {
+  appGroup: 'group.com.eclawbot.app.needyou',
+  widgetKind: 'NeedsYouWidget',
+  widgetTargetName: 'NeedsYouWidgetExtension',
+  widgetDirectory: 'NeedsYouWidget',
+  nativeModuleFile: 'NeedsYouWidgetStore.swift',
+  nativeModuleExternFile: 'NeedsYouWidgetStoreBridge.m',
+  pendingCountKey: 'pendingCount',
+  updatedAtKey: 'updatedAt',
+};
+
+function withNeedsYouWidget(config, props = {}) {
+  const options = { ...NEEDS_YOU_WIDGET_CONFIG, ...props };
+
+  config = withEntitlementsPlist(config, (entitlementsConfig) => {
+    const existing =
+      entitlementsConfig.modResults['com.apple.security.application-groups'] || [];
+    entitlementsConfig.modResults['com.apple.security.application-groups'] = [
+      ...new Set([...existing, options.appGroup]),
+    ];
+    return entitlementsConfig;
+  });
+
+  return withXcodeProject(config, (projectConfig) => {
+    const project = projectConfig.modResults;
+    const iosRoot = projectConfig.modRequest.platformProjectRoot;
+    const projectRoot = projectConfig.modRequest.projectRoot;
+    const projectName = IOSConfig.XcodeUtils.getProjectName(projectRoot);
+    const bundleIdentifier =
+      projectConfig.ios?.bundleIdentifier ||
+      projectConfig.exp?.ios?.bundleIdentifier ||
+      config.ios?.bundleIdentifier;
+
+    if (!bundleIdentifier) {
+      throw new Error('[withNeedsYouWidget] Missing expo.ios.bundleIdentifier');
+    }
+
+    writeNativeModuleFiles({ iosRoot, projectName, options });
+    linkBuildSource(project, iosRoot, path.join(projectName, options.nativeModuleFile));
+    linkBuildSource(project, iosRoot, path.join(projectName, options.nativeModuleExternFile));
+    ensureSwiftBuildSettings(project, project.getFirstTarget().uuid);
+
+    writeWidgetFiles({ iosRoot, bundleIdentifier, options });
+    const widgetTarget = ensureWidgetTarget(project, bundleIdentifier, options);
+    ensureSwiftBuildSettings(project, widgetTarget.uuid);
+    ensureWidgetBuildSettings(project, widgetTarget.uuid, bundleIdentifier, options);
+
+    return projectConfig;
+  });
+}
+
+function writeNativeModuleFiles({ iosRoot, projectName, options }) {
+  const replacements = buildReplacements(options);
+  writeTemplate(
+    'NeedsYouWidgetStore.swift',
+    path.join(iosRoot, projectName, options.nativeModuleFile),
+    replacements
+  );
+  writeTemplate(
+    'NeedsYouWidgetStoreBridge.m',
+    path.join(iosRoot, projectName, options.nativeModuleExternFile),
+    replacements
+  );
+}
+
+function writeWidgetFiles({ iosRoot, bundleIdentifier, options }) {
+  const widgetRoot = path.join(iosRoot, options.widgetDirectory);
+  const replacements = {
+    ...buildReplacements(options),
+    __WIDGET_BUNDLE_IDENTIFIER__: `${bundleIdentifier}.${options.widgetTargetName}`,
+  };
+  writeTemplate(
+    'NeedsYouWidget.swift',
+    path.join(widgetRoot, 'NeedsYouWidget.swift'),
+    replacements
+  );
+  writeTemplate(
+    'NeedsYouWidget-Info.plist',
+    path.join(widgetRoot, 'NeedsYouWidget-Info.plist'),
+    replacements
+  );
+  writeTemplate(
+    'NeedsYouWidget.entitlements',
+    path.join(widgetRoot, 'NeedsYouWidget.entitlements'),
+    replacements
+  );
+}
+
+function ensureWidgetTarget(project, bundleIdentifier, options) {
+  const existing = findNativeTarget(project, options.widgetTargetName);
+  const target =
+    existing ||
+    project.addTarget(
+      options.widgetTargetName,
+      'app_extension',
+      options.widgetDirectory,
+      `${bundleIdentifier}.${options.widgetTargetName}`
+    );
+
+  if (!hasBuildPhase(project, target.uuid, 'PBXSourcesBuildPhase', 'Sources')) {
+    project.addBuildPhase(
+      [`${options.widgetDirectory}/NeedsYouWidget.swift`],
+      'PBXSourcesBuildPhase',
+      'Sources',
+      target.uuid
+    );
+  }
+
+  if (!hasBuildPhase(project, target.uuid, 'PBXFrameworksBuildPhase', 'Frameworks')) {
+    project.addBuildPhase(
+      ['WidgetKit.framework', 'SwiftUI.framework'],
+      'PBXFrameworksBuildPhase',
+      'Frameworks',
+      target.uuid
+    );
+  }
+
+  return target;
+}
+
+function ensureWidgetBuildSettings(project, targetUuid, bundleIdentifier, options) {
+  updateTargetBuildSettings(project, targetUuid, (settings) => {
+    settings.APPLICATION_EXTENSION_API_ONLY = 'YES';
+    settings.CODE_SIGN_ENTITLEMENTS = `${options.widgetDirectory}/NeedsYouWidget.entitlements`;
+    settings.INFOPLIST_FILE = `${options.widgetDirectory}/NeedsYouWidget-Info.plist`;
+    settings.IPHONEOS_DEPLOYMENT_TARGET = settings.IPHONEOS_DEPLOYMENT_TARGET || '15.1';
+    settings.LD_RUNPATH_SEARCH_PATHS =
+      '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"';
+    settings.PRODUCT_BUNDLE_IDENTIFIER = `${bundleIdentifier}.${options.widgetTargetName}`;
+    settings.PRODUCT_NAME = `"${options.widgetTargetName}"`;
+    settings.SKIP_INSTALL = 'YES';
+  });
+}
+
+function ensureSwiftBuildSettings(project, targetUuid) {
+  updateTargetBuildSettings(project, targetUuid, (settings) => {
+    settings.ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES =
+      settings.ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES || 'YES';
+    settings.SWIFT_VERSION = settings.SWIFT_VERSION || '5.0';
+  });
+}
+
+function updateTargetBuildSettings(project, targetUuid, updater) {
+  const target = project.pbxNativeTargetSection()[targetUuid];
+  const configs = IOSConfig.XcodeUtils.getBuildConfigurationsForListId(project, target.buildConfigurationList);
+  for (const [, buildConfig] of configs) {
+    updater(buildConfig.buildSettings);
+  }
+}
+
+function linkBuildSource(project, iosRoot, relativePath) {
+  const absolutePath = path.join(iosRoot, relativePath);
+  const source = fs.readFileSync(absolutePath, 'utf8');
+  IOSConfig.XcodeProjectFile.createBuildSourceFile({
+    project,
+    nativeProjectRoot: iosRoot,
+    filePath: relativePath,
+    fileContents: source,
+    overwrite: true,
+  });
+}
+
+function findNativeTarget(project, name) {
+  const entry = Object.entries(project.pbxNativeTargetSection()).find(([, target]) => {
+    if (!target || typeof target !== 'object') return false;
+    return stripQuotes(target.name) === name;
+  });
+  if (!entry) return null;
+  return { uuid: entry[0], pbxNativeTarget: entry[1] };
+}
+
+function hasBuildPhase(project, targetUuid, phaseType, comment) {
+  const target = project.pbxNativeTargetSection()[targetUuid];
+  return (target.buildPhases || []).some((phase) => {
+    const buildPhase = project.hash.project.objects[phaseType]?.[phase.value];
+    return buildPhase && (!comment || phase.comment === comment);
+  });
+}
+
+function writeTemplate(templateName, destination, replacements) {
+  const source = fs.readFileSync(path.join(__dirname, 'needs-you-widget', templateName), 'utf8');
+  let output = source;
+  for (const [token, value] of Object.entries(replacements)) {
+    output = output.split(token).join(value);
+  }
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(destination, output, 'utf8');
+}
+
+function buildReplacements(options) {
+  return {
+    __APP_GROUP__: options.appGroup,
+    __WIDGET_KIND__: options.widgetKind,
+    __PENDING_COUNT_KEY__: options.pendingCountKey,
+    __UPDATED_AT_KEY__: options.updatedAtKey,
+  };
+}
+
+function stripQuotes(value) {
+  return String(value || '').replace(/^"|"$/g, '');
+}
+
+module.exports = withNeedsYouWidget;
+module.exports.NEEDS_YOU_WIDGET_CONFIG = NEEDS_YOU_WIDGET_CONFIG;

--- a/ios-app/plugins/withNeedsYouWidget.js
+++ b/ios-app/plugins/withNeedsYouWidget.js
@@ -48,7 +48,13 @@ function withNeedsYouWidget(config, props = {}) {
     linkBuildSource(project, iosRoot, path.join(projectName, options.nativeModuleExternFile));
     ensureSwiftBuildSettings(project, project.getFirstTarget().uuid);
 
-    writeWidgetFiles({ iosRoot, bundleIdentifier, options });
+    const appVersion = projectConfig.exp?.version || config.version || '1.0';
+    const buildNumber =
+      projectConfig.exp?.ios?.buildNumber ||
+      config.ios?.buildNumber ||
+      '1';
+
+    writeWidgetFiles({ iosRoot, bundleIdentifier, options, appVersion, buildNumber });
     const widgetTarget = ensureWidgetTarget(project, bundleIdentifier, options);
     ensureSwiftBuildSettings(project, widgetTarget.uuid);
     ensureWidgetBuildSettings(project, widgetTarget.uuid, bundleIdentifier, options);
@@ -71,11 +77,13 @@ function writeNativeModuleFiles({ iosRoot, projectName, options }) {
   );
 }
 
-function writeWidgetFiles({ iosRoot, bundleIdentifier, options }) {
+function writeWidgetFiles({ iosRoot, bundleIdentifier, options, appVersion, buildNumber }) {
   const widgetRoot = path.join(iosRoot, options.widgetDirectory);
   const replacements = {
     ...buildReplacements(options),
     __WIDGET_BUNDLE_IDENTIFIER__: `${bundleIdentifier}.${options.widgetTargetName}`,
+    __WIDGET_SHORT_VERSION__: appVersion,
+    __WIDGET_BUILD_VERSION__: buildNumber,
   };
   writeTemplate(
     'NeedsYouWidget.swift',

--- a/ios-app/services/__tests__/needyouBadge.test.ts
+++ b/ios-app/services/__tests__/needyouBadge.test.ts
@@ -85,6 +85,8 @@ describe('Needs-you pending badge sync', () => {
 
   test('RootLayout refreshes badge on socket, notification, foreground, and interval', () => {
     const root = fs.readFileSync(path.join(__dirname, '../../app/_layout.tsx'), 'utf8');
+    expect(root).toContain('deviceSecret');
+    expect(root).toContain('if (!deviceId || !deviceSecret) return;');
     expect(root).toContain("socketService.on('action_request:changed'");
     expect(root).toContain("socketService.on('notification'");
     expect(root).toContain("AppState.addEventListener('change'");

--- a/ios-app/services/__tests__/needyouBadge.test.ts
+++ b/ios-app/services/__tests__/needyouBadge.test.ts
@@ -42,7 +42,15 @@ jest.mock('expo-notifications', () => ({
 }));
 
 jest.mock('expo-device', () => ({ isDevice: true }));
-jest.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+const mockSetPendingCount = jest.fn(() => Promise.resolve(true));
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  NativeModules: {
+    NeedsYouWidgetStore: {
+      setPendingCount: mockSetPendingCount,
+    },
+  },
+}));
 
 import fs from 'fs';
 import path from 'path';
@@ -53,6 +61,7 @@ describe('Needs-you pending badge sync', () => {
   beforeEach(() => {
     mockGet.mockClear();
     mockSetBadgeCountAsync.mockClear();
+    mockSetPendingCount.mockClear();
   });
 
   test('actionRequestApi uses the pending-count endpoint', async () => {
@@ -64,12 +73,14 @@ describe('Needs-you pending badge sync', () => {
     mockGet.mockResolvedValueOnce({ data: { success: true, count: 7 } });
     await expect(notificationService.syncNeedsYouBadgeCount()).resolves.toBe(7);
     expect(mockSetBadgeCountAsync).toHaveBeenCalledWith(7);
+    expect(mockSetPendingCount).toHaveBeenCalledWith(7);
   });
 
   test('syncNeedsYouBadgeCount clamps invalid counts to zero', async () => {
     mockGet.mockResolvedValueOnce({ data: { success: true, count: -4 } });
     await expect(notificationService.syncNeedsYouBadgeCount()).resolves.toBe(0);
     expect(mockSetBadgeCountAsync).toHaveBeenCalledWith(0);
+    expect(mockSetPendingCount).toHaveBeenCalledWith(0);
   });
 
   test('RootLayout refreshes badge on socket, notification, foreground, and interval', () => {

--- a/ios-app/services/__tests__/needyouBadge.test.ts
+++ b/ios-app/services/__tests__/needyouBadge.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Needs-you badge sync: iOS launcher badge should mirror
+ * GET /api/action-requests/pending-count while the app is active.
+ */
+
+const mockGet = jest.fn(() => Promise.resolve({ data: { success: true, count: 0 } }));
+const mockInstance = {
+  get: mockGet,
+  post: jest.fn(() => Promise.resolve({ data: {} })),
+  put: jest.fn(() => Promise.resolve({ data: {} })),
+  patch: jest.fn(() => Promise.resolve({ data: {} })),
+  delete: jest.fn(() => Promise.resolve({ data: {} })),
+  interceptors: {
+    request: { use: jest.fn() },
+    response: { use: jest.fn() },
+  },
+};
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { create: jest.fn(() => mockInstance) },
+  create: jest.fn(() => mockInstance),
+}));
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  setItemAsync: jest.fn(() => Promise.resolve()),
+  deleteItemAsync: jest.fn(() => Promise.resolve()),
+}));
+
+const mockSetBadgeCountAsync = jest.fn(() => Promise.resolve(true));
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: jest.fn(),
+  setBadgeCountAsync: mockSetBadgeCountAsync,
+  dismissAllNotificationsAsync: jest.fn(() => Promise.resolve()),
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  getDevicePushTokenAsync: jest.fn(() => Promise.resolve({ data: 'apns-token' })),
+  getExpoPushTokenAsync: jest.fn(() => Promise.resolve({ data: 'expo-token' })),
+  addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+  addNotificationReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+}));
+
+jest.mock('expo-device', () => ({ isDevice: true }));
+jest.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+
+import fs from 'fs';
+import path from 'path';
+import { actionRequestApi } from '../api';
+import { notificationService } from '../notificationService';
+
+describe('Needs-you pending badge sync', () => {
+  beforeEach(() => {
+    mockGet.mockClear();
+    mockSetBadgeCountAsync.mockClear();
+  });
+
+  test('actionRequestApi uses the pending-count endpoint', async () => {
+    await actionRequestApi.getPendingCount();
+    expect(mockGet).toHaveBeenCalledWith('/api/action-requests/pending-count');
+  });
+
+  test('syncNeedsYouBadgeCount writes the launcher badge count', async () => {
+    mockGet.mockResolvedValueOnce({ data: { success: true, count: 7 } });
+    await expect(notificationService.syncNeedsYouBadgeCount()).resolves.toBe(7);
+    expect(mockSetBadgeCountAsync).toHaveBeenCalledWith(7);
+  });
+
+  test('syncNeedsYouBadgeCount clamps invalid counts to zero', async () => {
+    mockGet.mockResolvedValueOnce({ data: { success: true, count: -4 } });
+    await expect(notificationService.syncNeedsYouBadgeCount()).resolves.toBe(0);
+    expect(mockSetBadgeCountAsync).toHaveBeenCalledWith(0);
+  });
+
+  test('RootLayout refreshes badge on socket, notification, foreground, and interval', () => {
+    const root = fs.readFileSync(path.join(__dirname, '../../app/_layout.tsx'), 'utf8');
+    expect(root).toContain("socketService.on('action_request:changed'");
+    expect(root).toContain("socketService.on('notification'");
+    expect(root).toContain("AppState.addEventListener('change'");
+    expect(root).toContain('setInterval');
+    expect(root).toContain('syncNeedsYouBadgeCount');
+  });
+});

--- a/ios-app/services/__tests__/needyouWidgetKit.test.ts
+++ b/ios-app/services/__tests__/needyouWidgetKit.test.ts
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+
+const repoRoot = path.join(__dirname, '../..');
+
+describe('Needs-you WidgetKit prebuild wiring', () => {
+  test('app config installs the local WidgetKit config plugin', () => {
+    const appJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'app.json'), 'utf8'));
+    expect(appJson.expo.plugins).toContain('./plugins/withNeedsYouWidget');
+  });
+
+  test('config plugin creates WidgetKit extension and shared app group', () => {
+    const plugin = fs.readFileSync(path.join(repoRoot, 'plugins/withNeedsYouWidget.js'), 'utf8');
+    expect(plugin).toContain("withEntitlementsPlist");
+    expect(plugin).toContain("withXcodeProject");
+    expect(plugin).toContain("group.com.eclawbot.app.needyou");
+    expect(plugin).toContain("project.addTarget");
+    expect(plugin).toContain("'app_extension'");
+    expect(plugin).toContain("PBXSourcesBuildPhase");
+    expect(plugin).toContain("PBXFrameworksBuildPhase");
+    expect(plugin).toContain("WidgetKit.framework");
+    expect(plugin).toContain("NeedsYouWidgetStore.swift");
+  });
+
+  test('native store writes pending count to the WidgetKit app group', () => {
+    const swift = fs.readFileSync(
+      path.join(repoRoot, 'plugins/needs-you-widget/NeedsYouWidgetStore.swift'),
+      'utf8'
+    );
+    expect(swift).toContain('UserDefaults(suiteName: "__APP_GROUP__")');
+    expect(swift).toContain('defaults.set(clampedCount, forKey: "__PENDING_COUNT_KEY__")');
+    expect(swift).toContain('WidgetCenter.shared.reloadTimelines(ofKind: "__WIDGET_KIND__")');
+  });
+
+  test('WidgetKit template renders pending and all-clear states from app group storage', () => {
+    const widget = fs.readFileSync(
+      path.join(repoRoot, 'plugins/needs-you-widget/NeedsYouWidget.swift'),
+      'utf8'
+    );
+    expect(widget).toContain('StaticConfiguration(kind: kind, provider: NeedsYouProvider())');
+    expect(widget).toContain('UserDefaults(suiteName: appGroupIdentifier)');
+    expect(widget).toContain('pendingCountKey');
+    expect(widget).toContain('Needs you');
+    expect(widget).toContain('All clear');
+  });
+});

--- a/ios-app/services/__tests__/needyouWidgetKit.test.ts
+++ b/ios-app/services/__tests__/needyouWidgetKit.test.ts
@@ -20,6 +20,9 @@ describe('Needs-you WidgetKit prebuild wiring', () => {
     expect(plugin).toContain("PBXFrameworksBuildPhase");
     expect(plugin).toContain("WidgetKit.framework");
     expect(plugin).toContain("NeedsYouWidgetStore.swift");
+    expect(plugin).toContain("__WIDGET_SHORT_VERSION__");
+    expect(plugin).toContain("__WIDGET_BUILD_VERSION__");
+    expect(plugin).toContain("projectConfig.exp?.ios?.buildNumber");
   });
 
   test('native store writes pending count to the WidgetKit app group', () => {
@@ -42,5 +45,14 @@ describe('Needs-you WidgetKit prebuild wiring', () => {
     expect(widget).toContain('pendingCountKey');
     expect(widget).toContain('Needs you');
     expect(widget).toContain('All clear');
+  });
+
+  test('WidgetKit Info.plist keeps extension version aligned with app config', () => {
+    const plist = fs.readFileSync(
+      path.join(repoRoot, 'plugins/needs-you-widget/NeedsYouWidget-Info.plist'),
+      'utf8'
+    );
+    expect(plist).toContain('__WIDGET_SHORT_VERSION__');
+    expect(plist).toContain('__WIDGET_BUILD_VERSION__');
   });
 });

--- a/ios-app/services/api.ts
+++ b/ios-app/services/api.ts
@@ -358,6 +358,11 @@ export const notificationApi = {
     apiClient.put('/api/notification-preferences', prefs),
 };
 
+export const actionRequestApi = {
+  getPendingCount: () =>
+    apiClient.get<{ success: boolean; count: number; deviceId?: string }>('/api/action-requests/pending-count'),
+};
+
 // ── Subscription APIs ────────────────────────────────────────
 
 export const subscriptionApi = {

--- a/ios-app/services/needsYouWidgetStore.ts
+++ b/ios-app/services/needsYouWidgetStore.ts
@@ -1,0 +1,17 @@
+import { NativeModules, Platform } from 'react-native';
+
+type NeedsYouWidgetStoreModule = {
+  setPendingCount?: (count: number) => Promise<boolean>;
+};
+
+const nativeModule = NativeModules.NeedsYouWidgetStore as NeedsYouWidgetStoreModule | undefined;
+
+export async function syncNeedsYouWidgetCount(count: number): Promise<boolean> {
+  if (Platform.OS !== 'ios' || !nativeModule?.setPendingCount) {
+    return false;
+  }
+
+  const safeCount = Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+  await nativeModule.setPendingCount(safeCount);
+  return true;
+}

--- a/ios-app/services/notificationService.ts
+++ b/ios-app/services/notificationService.ts
@@ -2,6 +2,7 @@ import * as Notifications from 'expo-notifications';
 import * as Device from 'expo-device';
 import { Platform } from 'react-native';
 import { actionRequestApi, deviceApi } from './api';
+import { syncNeedsYouWidgetCount } from './needsYouWidgetStore';
 
 // Configure notification display behavior
 Notifications.setNotificationHandler({
@@ -113,6 +114,7 @@ class NotificationService {
       const raw = Number(res.data?.count ?? 0);
       const count = Number.isFinite(raw) ? Math.max(0, Math.floor(raw)) : 0;
       await this.setBadgeCount(count);
+      await syncNeedsYouWidgetCount(count);
       return count;
     } catch (error) {
       console.warn('[NOTIF] Failed to sync Needs-you badge count:', error);
@@ -124,6 +126,7 @@ class NotificationService {
   async clearAllNotifications(): Promise<void> {
     await Notifications.dismissAllNotificationsAsync();
     await Notifications.setBadgeCountAsync(0);
+    await syncNeedsYouWidgetCount(0);
   }
 }
 

--- a/ios-app/services/notificationService.ts
+++ b/ios-app/services/notificationService.ts
@@ -1,19 +1,21 @@
 import * as Notifications from 'expo-notifications';
 import * as Device from 'expo-device';
 import { Platform } from 'react-native';
-import { deviceApi } from './api';
+import { actionRequestApi, deviceApi } from './api';
 
 // Configure notification display behavior
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
     shouldShowAlert: true,
+    shouldShowBanner: true,
+    shouldShowList: true,
     shouldPlaySound: true,
     shouldSetBadge: true,
   }),
 });
 
 export interface PushNotificationPayload {
-  type: 'bot_reply' | 'broadcast' | 'speak_to' | 'feedback_reply' | 'app_update';
+  type: 'bot_reply' | 'broadcast' | 'speak_to' | 'feedback_reply' | 'app_update' | 'action_request';
   entityId?: string;
   message?: string;
   title?: string;
@@ -79,7 +81,7 @@ class NotificationService {
     handler: (payload: PushNotificationPayload, notificationId: string) => void
   ): () => void {
     const subscription = Notifications.addNotificationResponseReceivedListener((response) => {
-      const data = response.notification.request.content.data as PushNotificationPayload;
+      const data = response.notification.request.content.data as unknown as PushNotificationPayload;
       const notificationId = response.notification.request.identifier;
       handler(data, notificationId);
     });
@@ -92,7 +94,7 @@ class NotificationService {
     handler: (payload: PushNotificationPayload) => void
   ): () => void {
     const subscription = Notifications.addNotificationReceivedListener((notification) => {
-      const data = notification.request.content.data as PushNotificationPayload;
+      const data = notification.request.content.data as unknown as PushNotificationPayload;
       handler(data);
     });
 
@@ -102,6 +104,20 @@ class NotificationService {
   /** Set app badge count */
   async setBadgeCount(count: number): Promise<void> {
     await Notifications.setBadgeCountAsync(count);
+  }
+
+  /** Sync launcher badge to the unresolved 需要你 inbox count. */
+  async syncNeedsYouBadgeCount(): Promise<number | null> {
+    try {
+      const res = await actionRequestApi.getPendingCount();
+      const raw = Number(res.data?.count ?? 0);
+      const count = Number.isFinite(raw) ? Math.max(0, Math.floor(raw)) : 0;
+      await this.setBadgeCount(count);
+      return count;
+    } catch (error) {
+      console.warn('[NOTIF] Failed to sync Needs-you badge count:', error);
+      return null;
+    }
   }
 
   /** Clear all notifications */

--- a/ios-app/services/socketService.ts
+++ b/ios-app/services/socketService.ts
@@ -9,6 +9,7 @@ export type SocketEvent =
   | 'entity:update'
   | 'chat:message'
   | 'notification'
+  | 'action_request:changed'
   | 'screen:request'
   | 'control:command';
 
@@ -80,6 +81,7 @@ class SocketService {
       'entity:update',
       'chat:message',
       'notification',
+      'action_request:changed',
     ];
 
     domainEvents.forEach((event) => {


### PR DESCRIPTION
## Summary
- Sync unresolved 需要你 pending count from `/api/action-requests/pending-count` into Android home-screen chat widget and supported launcher badges.
- Refresh Android indicators on app start, widget update, FCM action-request pushes, and socket `action_request:changed` events.
- Sync iOS launcher badge from the same pending-count endpoint on app start, foreground, socket changes, notifications, and interval refresh.
- Add iOS WidgetKit support through a local Expo config plugin: prebuild creates `NeedsYouWidgetExtension`, App Group entitlements, WidgetKit Swift templates, and a native bridge that writes the pending count to shared UserDefaults and reloads widget timelines.

## Tests
- `ANDROID_HOME=/Users/hank/Library/Android/sdk ./gradlew :app:testDebugUnitTest --tests com.hank.clawlive.NeedYouIndicatorStaticTest`
- `cd ios-app && npm test -- --runInBand services/__tests__/needyouBadge.test.ts services/__tests__/needyouWidgetKit.test.ts`
- `cd ios-app && node -e "const p=require('./plugins/withNeedsYouWidget'); console.log(p.NEEDS_YOU_WIDGET_CONFIG.widgetTargetName)"`
- Temp clean `npx expo prebuild --platform ios --no-install --clean`
- Temp generated project `xcodebuild -project ios/EClaw.xcodeproj -scheme NeedsYouWidgetExtension -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build`

## Notes
- No PR template exists under `.github`.
- Backend pending-count endpoint and `action_request:changed` event already exist on `origin/main`; this PR wires the native clients and iOS WidgetKit generation.
- Unrelated local line-ending dirt in `backend/device-telemetry.js` and `backend/eslint.config.js` was left unstaged and is not in the PR diff.
- Full visual done-gate evidence still needs a controllable native device/Simulator run; see latest #6 handoff comment.