### PR TITLE
[codex] Harden agent identity token signing

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,9 @@ NODE_ENV=development
 
 # Security (auto-generated if not set)
 JWT_SECRET=your-secure-jwt-secret-here
+# Dedicated HMAC key for short-lived /api/agent-identity tokens. Required:
+# this endpoint fails loud instead of reusing JWT_SECRET when unset.
+AGENT_IDENTITY_SECRET=your-dedicated-agent-identity-secret-here
 WEBHOOK_SECRET=your-secure-webhook-secret-here
 SEAL_KEY=your-64-hex-char-seal-key-here
 

--- a/backend/agent-identity.js
+++ b/backend/agent-identity.js
@@ -51,6 +51,15 @@ const DEFAULT_TOKEN_TTL_MS = 5 * 60 * 1000;
 // (e.g. after a secret rotation or a format change) — verification pins it.
 const TOKEN_VERSION = 'v1';
 
+// Dedicated secret only. Do not silently reuse JWT_SECRET: these tokens are a
+// separate cross-service trust plane and should fail loud when not configured.
+const SIGNING_SECRET_ENV = 'AGENT_IDENTITY_SECRET';
+
+const DEFAULT_BOT_SECRET_RATE_LIMIT = {
+    max: 10,
+    windowMs: 60 * 1000,
+};
+
 // Public codes are 6 lowercase-alnum chars (channel-api generatePublicCode).
 const PUBLIC_CODE_PATTERN = /^[a-z0-9]{6}$/;
 
@@ -83,7 +92,7 @@ function signAgentToken({ publicCode, secret, ttlMs = DEFAULT_TOKEN_TTL_MS, now 
     if (!PUBLIC_CODE_PATTERN.test(String(publicCode || ''))) {
         throw new Error('signAgentToken: invalid publicCode');
     }
-    if (!secret) {
+    if (typeof secret !== 'string' || secret.trim().length === 0) {
         throw new Error('signAgentToken: signing secret required');
     }
     const exp = now + ttlMs;
@@ -104,7 +113,7 @@ function signAgentToken({ publicCode, secret, ttlMs = DEFAULT_TOKEN_TTL_MS, now 
  *   reason ∈ 'bad_format' | 'bad_version' | 'bad_signature' | 'expired' | 'bad_claim'
  */
 function verifyAgentTokenSig({ token, secret, now = Date.now() }) {
-    if (typeof token !== 'string' || !secret) {
+    if (typeof token !== 'string' || typeof secret !== 'string' || secret.trim().length === 0) {
         return { ok: false, reason: 'bad_format' };
     }
     const parts = token.split('.');
@@ -142,6 +151,85 @@ function verifyAgentTokenSig({ token, secret, now = Date.now() }) {
     return { ok: true, publicCode: String(payload.pc) };
 }
 
+function readSigningSecretFromEnv(env = process.env) {
+    const secret = env && env[SIGNING_SECRET_ENV];
+    const trimmedSecret = typeof secret === 'string' ? secret.trim() : '';
+    if (!trimmedSecret) return null;
+    // Fail loud if an operator wires this trust plane to the general session JWT
+    // secret. agent-identity tokens must have their own HMAC key.
+    if (typeof env.JWT_SECRET === 'string' && trimmedSecret === env.JWT_SECRET.trim()) return null;
+    return secret;
+}
+
+function normalizeRateLimitConfig(config) {
+    if (config === false) return { disabled: true };
+    const source = config || {};
+    const max = Number.isFinite(Number(source.max))
+        ? Math.max(1, Number(source.max))
+        : DEFAULT_BOT_SECRET_RATE_LIMIT.max;
+    const windowMs = Number.isFinite(Number(source.windowMs))
+        ? Math.max(1000, Number(source.windowMs))
+        : DEFAULT_BOT_SECRET_RATE_LIMIT.windowMs;
+    return { disabled: false, max, windowMs };
+}
+
+function clientIp(req) {
+    return req.ip
+        || (req.socket && req.socket.remoteAddress)
+        || (req.connection && req.connection.remoteAddress)
+        || 'unknown';
+}
+
+function createBotSecretLimiter({ config, now }) {
+    const settings = normalizeRateLimitConfig(config);
+    const hits = new Map();
+    const clock = typeof now === 'function' ? now : () => Date.now();
+
+    function prune(key) {
+        const t = clock();
+        const windowStart = t - settings.windowMs;
+        const arr = (hits.get(key) || []).filter((ts) => ts > windowStart);
+        hits.set(key, arr);
+        return arr;
+    }
+
+    function keysFor(req, body) {
+        const keys = [`ip:${clientIp(req)}`];
+        if (body && body.deviceId && body.entityId !== undefined && body.entityId !== null) {
+            keys.push(`entity:${String(body.deviceId)}:${String(body.entityId)}`);
+        }
+        return keys;
+    }
+
+    function overKey(key) {
+        const arr = prune(key);
+        return arr.length >= settings.max;
+    }
+
+    function recordKey(key) {
+        const arr = prune(key);
+        if (arr.length >= settings.max) {
+            return true;
+        }
+        arr.push(clock());
+        hits.set(key, arr);
+        return false;
+    }
+
+    return {
+        isLimited(req, body) {
+            if (settings.disabled) return false;
+            return keysFor(req, body).some(overKey);
+        },
+        recordFailure(req, body) {
+            if (settings.disabled) return false;
+            const keys = keysFor(req, body);
+            return keys.some(recordKey);
+        },
+        settings,
+    };
+}
+
 /**
  * Build the agent-identity router.
  *
@@ -150,7 +238,8 @@ function verifyAgentTokenSig({ token, secret, now = Date.now() }) {
  *       { ok:false, reason }.  Wired in index.js to authEntityAccess + the live
  *       devices map. This is the ONLY place a long-lived botSecret is checked;
  *       it is never stored or logged here.
- *   - getSecret() → the HMAC signing secret (defaults to process JWT secret).
+ *   - getSecret() → dedicated HMAC signing secret (defaults to
+ *       AGENT_IDENTITY_SECRET; never falls back to JWT_SECRET).
  *   - ttlMs / now — token lifetime + clock (injectable for tests).
  *   - log — serverLog-style (level, tag, msg). Never receives a secret/token.
  *
@@ -166,10 +255,11 @@ function verifyAgentTokenSig({ token, secret, now = Date.now() }) {
  *                 The wishlist backend calls BACK here to check an agent identity
  *                 before a write. Response carries { valid, publicCode } only.
  */
-function createRouter({ authenticateCaller, getSecret, ttlMs, now, log } = {}) {
+function createRouter({ authenticateCaller, getSecret, ttlMs, now, log, botSecretRateLimit } = {}) {
     const router = express.Router();
     const logger = typeof log === 'function' ? log : () => {};
     const clock = typeof now === 'function' ? now : () => Date.now();
+    const botSecretLimiter = createBotSecretLimiter({ config: botSecretRateLimit, now: clock });
     const tokenTtl = Number.isFinite(ttlMs) ? ttlMs : DEFAULT_TOKEN_TTL_MS;
     const authCaller =
         typeof authenticateCaller === 'function'
@@ -179,13 +269,26 @@ function createRouter({ authenticateCaller, getSecret, ttlMs, now, log } = {}) {
     const readSecret =
         typeof getSecret === 'function'
             ? getSecret
-            : () => process.env.JWT_SECRET || null;
+            : () => readSigningSecretFromEnv();
+
+    function rateLimited(res) {
+        res.set('Retry-After', String(Math.ceil(botSecretLimiter.settings.windowMs / 1000)));
+        return res.status(429).json({ valid: false, reason: 'rate_limited' });
+    }
 
     // Mint a short-lived token for an already-authenticated caller.
     router.post('/token', async (req, res) => {
         const { deviceId, entityId, botSecret } = req.body || {};
         if (!deviceId || entityId === undefined || entityId === null || !botSecret) {
             return res.status(400).json({ valid: false, reason: 'missing_credentials' });
+        }
+        const secret = readSecret();
+        if (!secret) {
+            logger('error', 'agent-identity', '[agent-identity] no signing secret configured');
+            return res.status(500).json({ valid: false, reason: 'server_misconfigured' });
+        }
+        if (botSecretLimiter.isLimited(req, req.body || {})) {
+            return rateLimited(res);
         }
         let caller;
         try {
@@ -195,12 +298,8 @@ function createRouter({ authenticateCaller, getSecret, ttlMs, now, log } = {}) {
             return res.status(502).json({ valid: false, reason: 'auth_unavailable' });
         }
         if (!caller || !caller.ok || !caller.publicCode) {
+            botSecretLimiter.recordFailure(req, req.body || {});
             return res.status(403).json({ valid: false, reason: 'not_verified' });
-        }
-        const secret = readSecret();
-        if (!secret) {
-            logger('error', 'agent-identity', '[agent-identity] no signing secret configured');
-            return res.status(500).json({ valid: false, reason: 'server_misconfigured' });
         }
         let minted;
         try {
@@ -246,6 +345,9 @@ function createRouter({ authenticateCaller, getSecret, ttlMs, now, log } = {}) {
         if (!deviceId || entityId === undefined || entityId === null || !botSecret) {
             return res.status(400).json({ valid: false, reason: 'missing_credentials' });
         }
+        if (botSecretLimiter.isLimited(req, body)) {
+            return rateLimited(res);
+        }
         let caller;
         try {
             caller = await authCaller({ deviceId, entityId, botSecret });
@@ -254,6 +356,7 @@ function createRouter({ authenticateCaller, getSecret, ttlMs, now, log } = {}) {
             return res.status(502).json({ valid: false, reason: 'auth_unavailable' });
         }
         if (!caller || !caller.ok || !caller.publicCode) {
+            botSecretLimiter.recordFailure(req, body);
             return res.status(200).json({ valid: false, reason: 'not_verified' });
         }
         // Secret verified → discarded. Only the resolved public code is returned.
@@ -267,7 +370,9 @@ module.exports = {
     createRouter,
     signAgentToken,
     verifyAgentTokenSig,
+    readSigningSecretFromEnv,
     DEFAULT_TOKEN_TTL_MS,
     TOKEN_VERSION,
+    SIGNING_SECRET_ENV,
     PUBLIC_CODE_PATTERN,
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -2592,6 +2592,7 @@ app.use('/api/petdx', petdxRoute.createRouter({ log: serverLog }));
 // short-lived, single-purpose identity token (POST /token) for an authenticated
 // caller and verifies a token OR a transient botSecret triple (POST /verify).
 const agentIdentity = require('./agent-identity');
+const getAgentIdentitySigningSecret = () => agentIdentity.readSigningSecretFromEnv(process.env);
 // Shared caller-auth: resolve {deviceId,entityId,botSecret} → the entity's OWN
 // publicCode (never a client-supplied one), or fail closed.
 const resolveCallerIdentity = async ({ deviceId, entityId, botSecret }) => {
@@ -2608,8 +2609,9 @@ const resolveCallerIdentity = async ({ deviceId, entityId, botSecret }) => {
 app.use('/api/agent-identity', agentIdentity.createRouter({
     log: serverLog,
     authenticateCaller: resolveCallerIdentity,
-    // HMAC the token with the process signing secret (same one used elsewhere).
-    getSecret: () => JWT_SECRET_FALLBACK,
+    // Dedicated signing secret only; missing env fails loud with 500 instead of
+    // silently reusing JWT_SECRET for this cross-service trust plane.
+    getSecret: getAgentIdentitySigningSecret,
 }));
 
 const wishlistRoute = require('./wishlist-route');
@@ -2625,7 +2627,7 @@ app.use('/api/wishlist-bridge', wishlistRoute.createRouter({
     // wishlist backend; the wishlist backend calls back to /api/agent-identity/verify
     // to confirm it. The long-lived botSecret never leaves EClaw.
     mintAgentToken: async ({ publicCode }) =>
-        agentIdentity.signAgentToken({ publicCode, secret: JWT_SECRET_FALLBACK }),
+        agentIdentity.signAgentToken({ publicCode, secret: getAgentIdentitySigningSecret() }),
 }));
 
 // ============================================

--- a/backend/tests/jest/agent-identity.test.js
+++ b/backend/tests/jest/agent-identity.test.js
@@ -19,6 +19,7 @@ const {
     createRouter,
     signAgentToken,
     verifyAgentTokenSig,
+    SIGNING_SECRET_ENV,
     TOKEN_VERSION,
 } = require('../../agent-identity');
 
@@ -129,6 +130,128 @@ describe('POST /token (mint)', () => {
         expect(res.status).toBe(502);
         expect(res.body.valid).toBe(false);
     });
+
+    it('500 when the dedicated signing secret is missing, even if JWT_SECRET exists', async () => {
+        const originalAgentSecret = process.env[SIGNING_SECRET_ENV];
+        const originalJwtSecret = process.env.JWT_SECRET;
+        try {
+            delete process.env[SIGNING_SECRET_ENV];
+            process.env.JWT_SECRET = 'jwt-secret-must-not-be-used';
+
+            const app = express();
+            app.use(express.json());
+            app.use('/api/agent-identity', createRouter({ authenticateCaller: fakeAuth('tbwb9e') }));
+            const res = await request(app).post('/api/agent-identity/token').send(CALLER);
+
+            expect(res.status).toBe(500);
+            expect(res.body).toEqual({ valid: false, reason: 'server_misconfigured' });
+        } finally {
+            if (originalAgentSecret === undefined) delete process.env[SIGNING_SECRET_ENV];
+            else process.env[SIGNING_SECRET_ENV] = originalAgentSecret;
+            if (originalJwtSecret === undefined) delete process.env.JWT_SECRET;
+            else process.env.JWT_SECRET = originalJwtSecret;
+        }
+    });
+
+    it('500 before caller auth when signing secret is missing, so misconfig is not a botSecret oracle', async () => {
+        const originalAgentSecret = process.env[SIGNING_SECRET_ENV];
+        const originalJwtSecret = process.env.JWT_SECRET;
+        let authCalls = 0;
+        try {
+            delete process.env[SIGNING_SECRET_ENV];
+            process.env.JWT_SECRET = 'jwt-secret-must-not-be-used';
+
+            const app = express();
+            app.use(express.json());
+            app.use('/api/agent-identity', createRouter({
+                authenticateCaller: async () => {
+                    authCalls += 1;
+                    return { ok: false, reason: 'not_verified' };
+                },
+            }));
+            const res = await request(app)
+                .post('/api/agent-identity/token')
+                .send({ ...CALLER, botSecret: 'WRONG' });
+
+            expect(res.status).toBe(500);
+            expect(res.body).toEqual({ valid: false, reason: 'server_misconfigured' });
+            expect(authCalls).toBe(0);
+        } finally {
+            if (originalAgentSecret === undefined) delete process.env[SIGNING_SECRET_ENV];
+            else process.env[SIGNING_SECRET_ENV] = originalAgentSecret;
+            if (originalJwtSecret === undefined) delete process.env.JWT_SECRET;
+            else process.env.JWT_SECRET = originalJwtSecret;
+        }
+    });
+
+    it('500 when AGENT_IDENTITY_SECRET is explicitly reused from JWT_SECRET', async () => {
+        const originalAgentSecret = process.env[SIGNING_SECRET_ENV];
+        const originalJwtSecret = process.env.JWT_SECRET;
+        try {
+            process.env[SIGNING_SECRET_ENV] = 'shared-secret-is-not-dedicated';
+            process.env.JWT_SECRET = 'shared-secret-is-not-dedicated';
+
+            const app = express();
+            app.use(express.json());
+            app.use('/api/agent-identity', createRouter({ authenticateCaller: fakeAuth('tbwb9e') }));
+            const res = await request(app).post('/api/agent-identity/token').send(CALLER);
+
+            expect(res.status).toBe(500);
+            expect(res.body).toEqual({ valid: false, reason: 'server_misconfigured' });
+        } finally {
+            if (originalAgentSecret === undefined) delete process.env[SIGNING_SECRET_ENV];
+            else process.env[SIGNING_SECRET_ENV] = originalAgentSecret;
+            if (originalJwtSecret === undefined) delete process.env.JWT_SECRET;
+            else process.env.JWT_SECRET = originalJwtSecret;
+        }
+    });
+
+    it('does not consume the botSecret oracle limiter on successful token mints', async () => {
+        const app = appWith({
+            authenticateCaller: fakeAuth('tbwb9e'),
+            botSecretRateLimit: { max: 1, windowMs: 60000 },
+        });
+
+        const r1 = await request(app).post('/api/agent-identity/token').send(CALLER);
+        const r2 = await request(app).post('/api/agent-identity/token').send(CALLER);
+
+        expect(r1.status).toBe(200);
+        expect(r2.status).toBe(200);
+    });
+
+    it('429: rate-limits repeated botSecret mint attempts to defang oracle probing', async () => {
+        const app = appWith({
+            authenticateCaller: fakeAuth('tbwb9e'),
+            botSecretRateLimit: { max: 2, windowMs: 60000 },
+        });
+
+        const r1 = await request(app).post('/api/agent-identity/token').send({ ...CALLER, botSecret: 'WRONG1' });
+        const r2 = await request(app).post('/api/agent-identity/token').send({ ...CALLER, botSecret: 'WRONG2' });
+        const r3 = await request(app).post('/api/agent-identity/token').send({ ...CALLER, botSecret: 'WRONG3' });
+
+        expect(r1.status).toBe(403);
+        expect(r2.status).toBe(403);
+        expect(r3.status).toBe(429);
+        expect(r3.body).toEqual({ valid: false, reason: 'rate_limited' });
+    });
+
+    it('429: does not re-check authenticateCaller once botSecret probing is limited', async () => {
+        let authCalls = 0;
+        const app = appWith({
+            authenticateCaller: async () => {
+                authCalls += 1;
+                return { ok: false, reason: 'not_verified' };
+            },
+            botSecretRateLimit: { max: 1, windowMs: 60000 },
+        });
+
+        const r1 = await request(app).post('/api/agent-identity/token').send({ ...CALLER, botSecret: 'WRONG1' });
+        const r2 = await request(app).post('/api/agent-identity/token').send({ ...CALLER, botSecret: 'WRONG2' });
+
+        expect(r1.status).toBe(403);
+        expect(r2.status).toBe(429);
+        expect(authCalls).toBe(1);
+    });
 });
 
 describe('POST /verify', () => {
@@ -145,6 +268,28 @@ describe('POST /verify', () => {
         const res = await request(app).post('/api/agent-identity/verify').send({ token: 'v1.forged.sig' });
         expect(res.status).toBe(200);
         expect(res.body.valid).toBe(false);
+    });
+
+    it('500 when token verification has no dedicated signing secret, even if JWT_SECRET exists', async () => {
+        const originalAgentSecret = process.env[SIGNING_SECRET_ENV];
+        const originalJwtSecret = process.env.JWT_SECRET;
+        try {
+            delete process.env[SIGNING_SECRET_ENV];
+            process.env.JWT_SECRET = 'jwt-secret-must-not-be-used';
+
+            const app = express();
+            app.use(express.json());
+            app.use('/api/agent-identity', createRouter({ authenticateCaller: fakeAuth('tbwb9e') }));
+            const res = await request(app).post('/api/agent-identity/verify').send({ token: 'v1.forged.sig' });
+
+            expect(res.status).toBe(500);
+            expect(res.body).toEqual({ valid: false, reason: 'server_misconfigured' });
+        } finally {
+            if (originalAgentSecret === undefined) delete process.env[SIGNING_SECRET_ENV];
+            else process.env[SIGNING_SECRET_ENV] = originalAgentSecret;
+            if (originalJwtSecret === undefined) delete process.env.JWT_SECRET;
+            else process.env.JWT_SECRET = originalJwtSecret;
+        }
     });
 
     it('botSecret path (fallback): a good triple → { valid:true, publicCode }', async () => {
@@ -168,6 +313,36 @@ describe('POST /verify', () => {
         const res = await request(app).post('/api/agent-identity/verify').send(CALLER);
         expect(res.status).toBe(502);
         expect(res.body.valid).toBe(false);
+    });
+
+    it('429: rate-limits repeated transient botSecret verify attempts', async () => {
+        const app = appWith({
+            authenticateCaller: fakeAuth('tbwb9e'),
+            botSecretRateLimit: { max: 1, windowMs: 60000 },
+        });
+
+        const r1 = await request(app).post('/api/agent-identity/verify').send({ ...CALLER, botSecret: 'WRONG1' });
+        const r2 = await request(app).post('/api/agent-identity/verify').send({ ...CALLER, botSecret: 'WRONG2' });
+
+        expect(r1.status).toBe(200);
+        expect(r1.body.valid).toBe(false);
+        expect(r2.status).toBe(429);
+        expect(r2.body).toEqual({ valid: false, reason: 'rate_limited' });
+    });
+
+    it('does not consume the botSecret oracle limiter on successful transient verifies', async () => {
+        const app = appWith({
+            authenticateCaller: fakeAuth('tbwb9e'),
+            botSecretRateLimit: { max: 1, windowMs: 60000 },
+        });
+
+        const r1 = await request(app).post('/api/agent-identity/verify').send(CALLER);
+        const r2 = await request(app).post('/api/agent-identity/verify').send(CALLER);
+
+        expect(r1.status).toBe(200);
+        expect(r1.body).toEqual({ valid: true, publicCode: 'tbwb9e' });
+        expect(r2.status).toBe(200);
+        expect(r2.body).toEqual({ valid: true, publicCode: 'tbwb9e' });
     });
 
     it('fails closed when authenticateCaller is not wired at all', async () => {


### PR DESCRIPTION
## Summary
- Require a dedicated `AGENT_IDENTITY_SECRET` for `/api/agent-identity` tokens instead of reusing `JWT_SECRET`.
- Fail loud with `server_misconfigured` when the dedicated secret is missing or explicitly reused from `JWT_SECRET`.
- Add a small in-memory limiter for failed botSecret fallback attempts on `/token` and `/verify`, while successful callers do not consume the oracle limiter.
- Wire wishlist bridge token minting through the same dedicated agent-identity secret and document the env var in `.env.example`.

## Root Cause
The agent-identity trust plane could silently share the broader JWT signing secret and the transient botSecret fallback had no local failure throttle, leaving two avoidable hardening gaps: key reuse and probing surface.

## Validation
- `git diff --check`
- `npm test -- --runTestsByPath tests/jest/agent-identity.test.js tests/jest/wishlist-route.test.js`

## Notes
Opened as draft for review because this changes cross-service identity verification semantics and requires production `AGENT_IDENTITY_SECRET` provisioning before deploy.