### PR TITLE
fix(portal): settings device-secret masked by default + copyNotePageLink active-entity verified landed (card_091d24a5, card_c7917c15)

### DIFF
--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -837,6 +837,9 @@
                 <span class="info-label" data-i18n="settings_device_secret">Device Secret</span>
                 <span class="info-value-mono-group">
                     <span class="info-value mono" id="accountDeviceSecret">--</span>
+                    <button class="settings-icon-btn" id="btnRevealDeviceSecret" type="button"
+                        onclick="toggleDeviceSecretReveal()" aria-pressed="false"
+                        data-i18n-title="common_toggle_visibility" title="顯示/隱藏">👁</button>
                     <button class="settings-icon-btn" onclick="copyDeviceSecret()"
                         data-i18n-title="common_copy" title="複製">📋</button>
                 </span>
@@ -2160,10 +2163,45 @@
             return id.substring(0, 8) + '·····' + id.slice(-4);
         }
 
+        // card_c7917c15: the Device Secret must never sit in the DOM as (even
+        // partial) plaintext — the old mask showed first-8/last-4, which leaks
+        // through shoulder-surfing / screenshots / screen shares. Display is
+        // FULLY masked by default (fixed-width dots: leaks neither content nor
+        // length); 👁 click-to-reveal auto re-masks after ~10s and whenever the
+        // tab/window loses focus. Copy buttons keep copying the real value
+        // from the in-memory variable, so UX is unchanged.
+        const DEVICE_SECRET_MASK = '••••••••••••••••';
+        const DEVICE_SECRET_REVEAL_MS = 10000;
+        let _secretRemaskTimer = null;
+
         function maskSecret(s) {
-            if (!s || s.length < 12) return s || '--';
-            return s.substring(0, 8) + '··············' + s.slice(-4);
+            if (!s) return '--';
+            return DEVICE_SECRET_MASK;
         }
+
+        function setDeviceSecretVisible(visible) {
+            const el = document.getElementById('accountDeviceSecret');
+            const btn = document.getElementById('btnRevealDeviceSecret');
+            if (!el) return;
+            if (_secretRemaskTimer) { clearTimeout(_secretRemaskTimer); _secretRemaskTimer = null; }
+            const show = !!visible && !!_fullDeviceSecret;
+            el.textContent = _fullDeviceSecret ? (show ? _fullDeviceSecret : maskSecret(_fullDeviceSecret)) : '--';
+            el.dataset.revealed = show ? 'true' : 'false';
+            if (btn) {
+                btn.textContent = show ? '🙈' : '👁';
+                btn.setAttribute('aria-pressed', show ? 'true' : 'false');
+            }
+            if (show) {
+                _secretRemaskTimer = setTimeout(() => setDeviceSecretVisible(false), DEVICE_SECRET_REVEAL_MS);
+            }
+        }
+
+        function remaskDeviceSecretOnBlur() {
+            const el = document.getElementById('accountDeviceSecret');
+            if (el && el.dataset.revealed === 'true') setDeviceSecretVisible(false);
+        }
+        window.addEventListener('blur', remaskDeviceSecretOnBlur);
+        document.addEventListener('visibilitychange', () => { if (document.hidden) remaskDeviceSecretOnBlur(); });
 
         function toggleDeviceIdReveal() {
             const el = document.getElementById('accountDeviceId');
@@ -2182,17 +2220,8 @@
 
         function toggleDeviceSecretReveal() {
             const el = document.getElementById('accountDeviceSecret');
-            const btn = document.getElementById('btnRevealDeviceSecret');
             if (!el || !_fullDeviceSecret) return;
-            if (el.dataset.revealed === 'true') {
-                el.textContent = maskSecret(_fullDeviceSecret);
-                el.dataset.revealed = 'false';
-                btn.textContent = '👁';
-            } else {
-                el.textContent = _fullDeviceSecret;
-                el.dataset.revealed = 'true';
-                btn.textContent = '🙈';
-            }
+            setDeviceSecretVisible(el.dataset.revealed !== 'true');
         }
 
         async function copyDeviceSecret() {
@@ -2256,7 +2285,7 @@
                     u.deviceSecret = data.newDeviceSecret;
                     localStorage.setItem('user', JSON.stringify(u));
                 } catch (_) { }
-                document.getElementById('accountDeviceSecret').textContent = maskSecret(data.newDeviceSecret);
+                setDeviceSecretVisible(false);
                 document.getElementById('rotateRevealDeviceId').textContent = _fullDeviceId;
                 document.getElementById('rotateRevealSecret').textContent = data.newDeviceSecret;
                 closeRotateSecretConfirm();
@@ -2375,7 +2404,7 @@
             _fullDeviceId = user.deviceId || '';
             document.getElementById('accountDeviceId').textContent = maskDeviceId(_fullDeviceId);
             _fullDeviceSecret = user.deviceSecret || '';
-            document.getElementById('accountDeviceSecret').textContent = maskSecret(_fullDeviceSecret);
+            setDeviceSecretVisible(false);
 
             // Connected accounts
             const providers = [];

--- a/backend/tests/jest/settings-device-secret-mask.test.js
+++ b/backend/tests/jest/settings-device-secret-mask.test.js
@@ -1,0 +1,195 @@
+/**
+ * Regression guard for the settings.html Device Secret display (card_c7917c15).
+ *
+ * BUG: the Account card rendered the Device Secret as PARTIAL PLAINTEXT in the
+ * DOM (first 8 + last 4 chars, `maskSecret` = s.substring(0,8) + '…' +
+ * s.slice(-4)) with no way to hide it — a standing shoulder-surf /
+ * screenshot / screen-share leak surface (E2E evidence shots needed manual
+ * DOM-redaction before archiving).
+ *
+ * FIX: display is FULLY masked by default (fixed-width dots — leaks neither
+ * content nor length), with a 👁 click-to-reveal button that auto re-masks
+ * after ~10s and whenever the window blurs / tab hides. The copy buttons keep
+ * copying the real value from the in-memory variable.
+ *
+ * This test extracts the REAL functions from settings.html (like
+ * mission-note-link-active-entity.test.js) and drives them against stubbed
+ * DOM/clipboard/timers, so it fails on the old partial-plaintext rendering
+ * and passes on the masked-by-default one.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const SETTINGS_HTML = path.resolve(__dirname, '../../public/portal/settings.html');
+const html = fs.readFileSync(SETTINGS_HTML, 'utf8');
+
+// A fake secret for the harness — never a real credential.
+const FAKE_SECRET = 'aaaabbbbccccddddeeeeffff11112222';
+
+// Extract an exact `function <name>(...) { ... }` block from settings.html so
+// the test exercises the shipped source, not a copy. Functions in the inline
+// script are 8-space indented; every body line is indented 12+ spaces, so the
+// first `\n        }` after the declaration is the terminator.
+function extractFunction(name) {
+    let start = html.indexOf(`function ${name}(`);
+    if (start === -1) throw new Error(`settings.html: function ${name} not found`);
+    // Include a leading `async ` if present.
+    const asyncPrefix = 'async ';
+    if (html.slice(start - asyncPrefix.length, start) === asyncPrefix) start -= asyncPrefix.length;
+    const end = html.indexOf('\n        }', start);
+    if (end === -1) throw new Error(`settings.html: ${name} terminator not found`);
+    return html.slice(start, end + '\n        }'.length);
+}
+
+function extractConst(name) {
+    const m = html.match(new RegExp(`const ${name} = [^\\n]+;`));
+    if (!m) throw new Error(`settings.html: const ${name} not found`);
+    return m[0];
+}
+
+// Instantiate the real functions with their free identifiers shadowed by stubs.
+function buildHarness({ fullSecret = FAKE_SECRET } = {}) {
+    const secretEl = { textContent: '--', dataset: {} };
+    const btn = {
+        textContent: '👁',
+        attrs: {},
+        setAttribute(k, v) { this.attrs[k] = v; },
+    };
+    const documentStub = {
+        getElementById: (id) => {
+            if (id === 'accountDeviceSecret') return secretEl;
+            if (id === 'btnRevealDeviceSecret') return btn;
+            return null;
+        },
+    };
+    const timers = [];
+    const setTimeoutStub = jest.fn((cb, ms) => { timers.push({ cb, ms }); return timers.length; });
+    const clearTimeoutStub = jest.fn();
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    const showCopyToast = jest.fn();
+
+    const src = [
+        'let _secretRemaskTimer = null;',
+        extractConst('DEVICE_SECRET_MASK'),
+        extractConst('DEVICE_SECRET_REVEAL_MS'),
+        extractFunction('maskSecret'),
+        extractFunction('setDeviceSecretVisible'),
+        extractFunction('toggleDeviceSecretReveal'),
+        extractFunction('remaskDeviceSecretOnBlur'),
+        extractFunction('copyDeviceSecret'),
+        'return { maskSecret, setDeviceSecretVisible, toggleDeviceSecretReveal, remaskDeviceSecretOnBlur, copyDeviceSecret, DEVICE_SECRET_REVEAL_MS };',
+    ].join('\n');
+
+    const factory = new Function(
+        '_fullDeviceSecret', 'document', 'setTimeout', 'clearTimeout',
+        'navigator', 'showCopyToast', 'console',
+        src
+    );
+    const api = factory(
+        fullSecret,
+        documentStub,
+        setTimeoutStub,
+        clearTimeoutStub,
+        { clipboard: { writeText } },
+        showCopyToast,
+        { error: jest.fn() }
+    );
+    return { ...api, secretEl, btn, timers, setTimeoutStub, clearTimeoutStub, writeText, showCopyToast };
+}
+
+describe('settings.html Device Secret is fully masked by default (card_c7917c15)', () => {
+    test('FAIL-ON-OLD: masked display leaks no plaintext fragment of the secret', () => {
+        const { maskSecret } = buildHarness();
+        const masked = maskSecret(FAKE_SECRET);
+        // Old code returned first-8 + dots + last-4 here.
+        expect(masked).not.toContain(FAKE_SECRET.substring(0, 8));
+        expect(masked).not.toContain(FAKE_SECRET.slice(-4));
+        expect(masked).not.toContain(FAKE_SECRET);
+        // Fixed-width dots: independent of the secret's content AND length.
+        expect(masked).toBe(maskSecret('x'.repeat(64)));
+        expect(masked).toMatch(/^[•]+$/);
+    });
+
+    test('FAIL-ON-OLD: the Account row has a click-to-reveal button', () => {
+        expect(html).toContain('id="btnRevealDeviceSecret"');
+        expect(html).toContain('onclick="toggleDeviceSecretReveal()"');
+    });
+
+    test('FAIL-ON-OLD: no DOM sink assigns maskSecret() partial output directly', () => {
+        // Old code had two of these (initial load + after rotate); both must go
+        // through setDeviceSecretVisible(false) now.
+        expect(html).not.toMatch(/getElementById\('accountDeviceSecret'\)\.textContent = maskSecret\(/);
+    });
+
+    test('default state renders the mask, not the secret', () => {
+        const { setDeviceSecretVisible, secretEl, btn } = buildHarness();
+        setDeviceSecretVisible(false);
+        expect(secretEl.textContent).not.toContain(FAKE_SECRET.substring(0, 8));
+        expect(secretEl.textContent).toMatch(/^[•]+$/);
+        expect(secretEl.dataset.revealed).toBe('false');
+        expect(btn.attrs['aria-pressed']).toBe('false');
+    });
+
+    test('click-to-reveal shows the secret and schedules an ~10s auto re-mask', () => {
+        const h = buildHarness();
+        h.setDeviceSecretVisible(false);
+        h.toggleDeviceSecretReveal();
+        expect(h.secretEl.textContent).toBe(FAKE_SECRET);
+        expect(h.secretEl.dataset.revealed).toBe('true');
+        expect(h.btn.attrs['aria-pressed']).toBe('true');
+        // An auto re-mask timer is armed for ~10 seconds.
+        expect(h.timers.length).toBe(1);
+        expect(h.timers[0].ms).toBe(h.DEVICE_SECRET_REVEAL_MS);
+        expect(h.timers[0].ms).toBeGreaterThanOrEqual(5000);
+        expect(h.timers[0].ms).toBeLessThanOrEqual(15000);
+        // Firing the timer re-masks.
+        h.timers[0].cb();
+        expect(h.secretEl.textContent).toMatch(/^[•]+$/);
+        expect(h.secretEl.dataset.revealed).toBe('false');
+    });
+
+    test('second click re-masks immediately and cancels the pending timer', () => {
+        const h = buildHarness();
+        h.setDeviceSecretVisible(false);
+        h.toggleDeviceSecretReveal(); // reveal
+        h.toggleDeviceSecretReveal(); // hide
+        expect(h.secretEl.textContent).toMatch(/^[•]+$/);
+        expect(h.secretEl.dataset.revealed).toBe('false');
+        expect(h.clearTimeoutStub).toHaveBeenCalled();
+    });
+
+    test('window blur re-masks a revealed secret (and is a no-op when masked)', () => {
+        const h = buildHarness();
+        h.setDeviceSecretVisible(false);
+        h.remaskDeviceSecretOnBlur(); // masked → no-op
+        expect(h.secretEl.textContent).toMatch(/^[•]+$/);
+        h.toggleDeviceSecretReveal();
+        expect(h.secretEl.textContent).toBe(FAKE_SECRET);
+        h.remaskDeviceSecretOnBlur(); // revealed → re-mask
+        expect(h.secretEl.textContent).toMatch(/^[•]+$/);
+        // The handler is actually registered on blur + tab-hide.
+        expect(html).toContain("window.addEventListener('blur', remaskDeviceSecretOnBlur)");
+        expect(html).toMatch(/visibilitychange.*remaskDeviceSecretOnBlur/);
+    });
+
+    test('copy button still copies the REAL secret while the display is masked', async () => {
+        const h = buildHarness();
+        h.setDeviceSecretVisible(false);
+        await h.copyDeviceSecret();
+        expect(h.writeText).toHaveBeenCalledWith(FAKE_SECRET);
+        expect(h.showCopyToast).toHaveBeenCalled();
+        // Copying must not reveal the DOM value.
+        expect(h.secretEl.textContent).toMatch(/^[•]+$/);
+    });
+
+    test('empty secret renders -- and reveal is inert', () => {
+        const h = buildHarness({ fullSecret: '' });
+        h.setDeviceSecretVisible(false);
+        expect(h.secretEl.textContent).toBe('--');
+        h.toggleDeviceSecretReveal();
+        expect(h.secretEl.textContent).toBe('--');
+        expect(h.secretEl.dataset.revealed).toBe('false');
+    });
+});


### PR DESCRIPTION
Two portal kanban cards, one branch.

## card_c7917c15 — settings.html Device Secret shown as partial plaintext in DOM

**Before:** the Account card rendered the Device Secret as first-8/last-4 plaintext (`maskSecret` = `s.substring(0,8) + '…' + s.slice(-4)`) permanently in the DOM — a standing shoulder-surf / screenshot / screen-share leak surface (destructive-modals E2E had to manually DOM-redact before archiving evidence shots).

**After:**
- Display is **fully masked by default** (fixed-width `•` dots — leaks neither content nor length).
- New 👁 **click-to-reveal** button (`btnRevealDeviceSecret`, `aria-pressed` managed) that **auto re-masks after ~10s** and **on window blur / tab hide**.
- Copy Device Secret / Copy Credentials still copy the **real** value from the in-memory variable — UX unchanged.
- Rotate-secret flow and initial load both route through the same `setDeviceSecretVisible(false)` sink (no direct `textContent = maskSecret(...)` assignments remain).
- i18n: reuses existing `common_toggle_visibility` key (present in all 15 locales incl. en/zh/zh-TW) — **no new strings added**, so no i18n.js change.

**Regression test** `backend/tests/jest/settings-device-secret-mask.test.js` (jsdom-style extraction of the REAL shipped functions, like `mission-note-link-active-entity.test.js`): 9 cases — mask leaks no fragment, reveal button exists, no direct partial-mask DOM sink, default masked, reveal + ~10s auto re-mask, immediate re-mask + timer cancel, blur re-mask, copy-copies-real-value-while-masked, empty-secret inert.
**Fails-old verified:** with `settings.html` reverted to origin/main, all 9 fail; on this branch all 9 pass.

## card_091d24a5 — mission.html copyNotePageLink bound[0] → active entity

Verified this fix **already landed on main** via PR #3929 (commit `f7ba9f68`, tag v1.1316.1): `copyNotePageLink()` now prefers `eclaw_petdex_active_entity_id`, falls back to the first bound entity with a public code (same pattern as the exam.html fix, card_cea91e58), with regression test `backend/tests/jest/mission-note-link-active-entity.test.js` (5 cases incl. FAIL-ON-OLD). Re-ran the suite on this branch: **5/5 green**. Grepped mission.html — no other `/p/<code>` share-link builder uses bound[0]. **No code change needed here**, so this PR carries the verification record only (avoids a duplicate/competing fix).

## Checks run locally
- `jest`: new test 9/9 + all 18 suites touching settings.html/mission.html → **304 passed, 14 skipped, 0 failed**
- `npm run lint` (eslint): **0 errors** (8 pre-existing warnings in untouched files)
- i18n: no strings added → i18n.js untouched (CI i18n job not triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuABXFYP3EofvYeqXW6ncn