### PR TITLE
fix(usage-warning): entity-scoped usage attribution — #2's claude warning no longer prefixes #6 heartbeat (card_2f6a5659)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -10568,7 +10568,10 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
                     if (_r.rows[0] && _r.rows[0].language) _lang = _r.rows[0].language;
                 } catch (_) { /* keep en */ }
                 const _uw = require('./lib/usage-warning');
-                const _prefix = await _uw.getWarningPrefix(chatPool, deviceId, _cfg, _lang);
+                // Entity-scoped (card_2f6a5659): pass the SPEAKING entity so #2's
+                // Claude quota warning can't ride #6's Codex heartbeat on a
+                // multi-entity device — lookup prefers this entity's snapshot row.
+                const _prefix = await _uw.getWarningPrefix(chatPool, deviceId, _cfg, _lang, eId);
                 if (_prefix) {
                     finalMessage = _prefix + '\n\n' + finalMessage;
                 }

--- a/backend/lib/usage-warning.js
+++ b/backend/lib/usage-warning.js
@@ -5,6 +5,13 @@
  * remaining quota crossed the per-device threshold, and formats an i18n
  * system-warning prefix that /api/transform prepends to outbound messages.
  *
+ * Entity attribution (card_2f6a5659): the lookup is ENTITY-scoped. Multiple
+ * entities share one device (e.g. #2 Claude + #6 Codex on 480def4c…), so the
+ * "latest row by device_id" heuristic attributed #2's Claude quota warning to
+ * #6's heartbeat. We now prefer the row captured for the SPEAKING entity and
+ * only fall back to legacy unscoped rows (entity_id IS NULL) — mirroring
+ * backend/kanban.js getEntityUsagePct().
+ *
  * Spec: device opts in via usage_warning_config pref
  *   { enabled: bool, threshold_5h_pct: 0..100, threshold_7d_pct: 0..100 }
  *
@@ -19,10 +26,16 @@
 const STALE_THRESHOLD_MS = 6 * 60 * 60 * 1000;  // 6 hours
 const DEFAULT_COOLDOWN_MS = 30 * 60 * 1000;     // 30 min — one warning per device per window
 
-// Per-device last-attached timestamp (ms epoch). In-memory is sufficient: a missed
-// cooldown across a process restart at most lets one extra warning through, which is
-// harmless. Keyed by deviceId.
+// Per-device/entity last-attached timestamp (ms epoch). In-memory is sufficient:
+// a missed cooldown across a process restart at most lets one extra warning
+// through, which is harmless. Keyed by `${deviceId}::${entityId}` (entity-scoped
+// warnings must not suppress a DIFFERENT entity's legitimate warning on the same
+// device — card_2f6a5659); unscoped callers fall back to the bare deviceId key.
 const _lastWarnedAt = new Map();
+
+function cooldownKey(deviceId, entityId) {
+    return Number.isFinite(entityId) ? `${deviceId}::${entityId}` : String(deviceId);
+}
 
 const WARNING_TEMPLATES = {
     'zh': '⚠️ 系統訊息：本 Agent 5h 剩餘 {five}% / 7d 剩餘 {seven}%。已達警戒閾值。',
@@ -133,22 +146,38 @@ function resolveCooldownMs(config) {
 /**
  * Convenience wrapper: query the latest snapshot, decide, format.
  * Returns the warning prefix string, or null if no warning should be attached.
- * Applies a per-device cooldown so the prefix piggybacks at most once per window
- * instead of riding every message (card_a69e8ffa). Never throws — quota warnings
- * must not break the message-send path.
+ * Applies a per-device/entity cooldown so the prefix piggybacks at most once per
+ * window instead of riding every message (card_a69e8ffa). Never throws — quota
+ * warnings must not break the message-send path.
+ *
+ * @param {number|null} entityId — the entity currently SPEAKING through
+ *   /api/transform. When finite, the snapshot lookup is entity-scoped
+ *   (prefer entity_id = entityId, fall back to legacy entity_id IS NULL rows)
+ *   so one entity's quota warning never rides another entity's message on the
+ *   same device (card_2f6a5659 — #2's Claude warning prefixed #6's heartbeat).
+ *   Pattern mirrors backend/kanban.js getEntityUsagePct().
  */
-async function getWarningPrefix(pool, deviceId, config, lang, nowMs = Date.now()) {
+async function getWarningPrefix(pool, deviceId, config, lang, entityId = null, nowMs = Date.now()) {
     if (!pool || !deviceId) return null;
     if (!config || config.enabled === false) return null;
     try {
-        const r = await pool.query(
-            `SELECT captured_at, claude_json, codex_json
-             FROM usage_snapshots
-             WHERE device_id = $1
-             ORDER BY captured_at DESC
-             LIMIT 1`,
-            [deviceId]
-        );
+        // NOTE: Number(null) === 0, so guard null/undefined explicitly —
+        // a legacy unscoped caller must NOT be misread as entity 0.
+        const eid = (entityId === null || entityId === undefined) ? NaN : Number(entityId);
+        const useEid = Number.isFinite(eid);
+        const sql = useEid
+            ? `SELECT captured_at, claude_json, codex_json
+               FROM usage_snapshots
+               WHERE device_id = $1 AND (entity_id = $2 OR entity_id IS NULL)
+               ORDER BY (entity_id = $2) DESC, captured_at DESC
+               LIMIT 1`
+            : `SELECT captured_at, claude_json, codex_json
+               FROM usage_snapshots
+               WHERE device_id = $1
+               ORDER BY captured_at DESC
+               LIMIT 1`;
+        const params = useEid ? [deviceId, eid] : [deviceId];
+        const r = await pool.query(sql, params);
         const row = r.rows[0] || null;
         const snapshot = row ? {
             captured_at: row.captured_at instanceof Date ? row.captured_at.toISOString() : row.captured_at,
@@ -157,12 +186,14 @@ async function getWarningPrefix(pool, deviceId, config, lang, nowMs = Date.now()
         } : null;
         const decision = shouldWarnNow(snapshot, config, nowMs);
         if (!decision.warn) return null;
-        // Cooldown: suppress if we already attached a warning for this device
-        // inside the window — keeps it a one-off piggyback, not a per-message echo.
-        if (withinCooldown(_lastWarnedAt.get(deviceId), nowMs, resolveCooldownMs(config))) {
+        // Cooldown: suppress if we already attached a warning for this
+        // device+entity inside the window — keeps it a one-off piggyback,
+        // not a per-message echo.
+        const ck = cooldownKey(deviceId, useEid ? eid : null);
+        if (withinCooldown(_lastWarnedAt.get(ck), nowMs, resolveCooldownMs(config))) {
             return null;
         }
-        _lastWarnedAt.set(deviceId, nowMs);
+        _lastWarnedAt.set(ck, nowMs);
         return formatWarningText(lang, decision.five_hour_remaining_pct, decision.seven_day_remaining_pct);
     } catch (err) {
         // Quota warnings are advisory — swallow errors so we never block delivery.

--- a/backend/tests/jest/transform-usage-warning-entity-scope.test.js
+++ b/backend/tests/jest/transform-usage-warning-entity-scope.test.js
@@ -1,0 +1,178 @@
+/**
+ * transform-usage-warning-entity-scope.test.js — card_2f6a565982885f34b0cd3ed9
+ *
+ * REAL-control-path regression for the usage-warning entity-attribution bug:
+ * #2 (Claude) and #6 (Codex) share one device; the latest usage_snapshots row
+ * belonged to entity 2 (Claude 7d used 100%), and the old device-only lookup
+ * in getWarningPrefix() prefixed #2's quota warning onto #6's heartbeat.
+ *
+ * These tests boot the actual Express app and POST /api/transform:
+ *   1. entity 6 speaks while the only (latest) snapshot row is entity 2's
+ *      breach → NO warning prefix may be attached.        [FAILS on old code]
+ *   2. entity 2 speaks → the warning prefix IS attached.  [guards the feature]
+ *
+ * The fake usage_snapshots emulation is faithful to SQL semantics for BOTH
+ * query shapes (device-only vs entity-scoped), so it does not hardcode the
+ * fix — old code genuinely goes red on test 1.
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+const pg = require('pg');
+const usageWarning = require('../../lib/usage-warning');
+// mock-setup stubs device-preferences with getPrefs → {} — opt this device in
+// to usage warnings (spec defaults) so the transform gate opens.
+const devicePrefs = require('../../device-preferences');
+
+let app;
+
+// jest.config has clearMocks:true which wipes pg.Pool.mock.results before
+// every test — snapshot Pool instances at require-time (see transform-delivery).
+const pgPools = [];
+
+const post = (path) => request(app).post(path).set('Host', 'localhost').set('Accept-Encoding', 'identity');
+
+const DEVICE_ID = 'dev-usage-scope-e2e';
+const DEVICE_SECRET = 'secret-usage-scope-e2e';
+
+/**
+ * In-memory usage_snapshots table. Emulates both lookup shapes:
+ *   params [deviceId]        → latest by captured_at            (old code path)
+ *   params [deviceId, eid]   → entity_id = eid OR NULL,
+ *                              ORDER BY (entity_id = eid) DESC, captured_at DESC
+ */
+const SNAPSHOT_ROWS = [];
+function usageSnapshotsQueryImpl(sql, params) {
+    const text = typeof sql === 'string' ? sql : (sql && sql.text) || '';
+    if (/FROM\s+usage_snapshots/i.test(text) && /SELECT/i.test(text)) {
+        let cand = SNAPSHOT_ROWS.filter(r => r.device_id === params[0]);
+        if (params && params.length >= 2) {
+            const eid = params[1];
+            cand = cand
+                .filter(r => r.entity_id === eid || r.entity_id == null)
+                .sort((a, b) =>
+                    ((b.entity_id === eid) - (a.entity_id === eid)) ||
+                    (Date.parse(b.captured_at) - Date.parse(a.captured_at)));
+        } else {
+            cand = cand.slice().sort((a, b) => Date.parse(b.captured_at) - Date.parse(a.captured_at));
+        }
+        return Promise.resolve({ rows: cand.slice(0, 1), rowCount: Math.min(1, cand.length) });
+    }
+    // Everything else keeps the mock-setup default (empty result set).
+    return Promise.resolve({ rows: [], rowCount: 0 });
+}
+
+function installQueryImpl() {
+    for (const pool of pgPools) {
+        pool.query.mockImplementation(usageSnapshotsQueryImpl);
+    }
+}
+
+/** Register + bind an entity slot, return its botSecret. */
+async function bindEntity(entityId) {
+    const regRes = await post('/api/device/register')
+        .send({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET, entityId });
+    const code = regRes.body.bindingCode;
+    expect(code).toBeTruthy();
+    const bindRes = await post('/api/bind').send({ code });
+    expect(bindRes.body.botSecret).toBeTruthy();
+    return bindRes.body.botSecret;
+}
+
+let botSecret2;
+let botSecret6;
+
+beforeAll(async () => {
+    app = require('../../index');
+    for (const r of pg.Pool.mock.results) {
+        if (r.value && !pgPools.includes(r.value)) pgPools.push(r.value);
+    }
+    installQueryImpl();
+
+    // Create the device with entity 0, then add slots 1..6 so entity ids 2
+    // and 6 exist (mirrors the real multi-entity device 480def4c…).
+    await bindEntity(0);
+    for (let i = 1; i <= 6; i++) {
+        const addRes = await post('/api/device/add-entity')
+            .send({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+        expect(addRes.body.success).toBe(true);
+    }
+    botSecret2 = await bindEntity(2);
+    botSecret6 = await bindEntity(6);
+});
+
+beforeEach(() => {
+    // clearMocks:true wipes call history but keeps implementations; re-install
+    // defensively anyway, and reset the in-memory warning cooldown so each
+    // test starts from "never warned".
+    installQueryImpl();
+    devicePrefs.getPrefs.mockResolvedValue({
+        usage_warning_config: { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5 },
+    });
+    usageWarning._resetCooldownState();
+    SNAPSHOT_ROWS.length = 0;
+    // Latest (and only) snapshot row: ENTITY 2's Claude usage — 7d used 100%
+    // → remaining 0 ≤ default threshold 5 → breach. This is the exact prod
+    // shape from the card RCA (2026-07-07: entityId=2, seven_day_used_pct=100).
+    SNAPSHOT_ROWS.push({
+        device_id: DEVICE_ID,
+        entity_id: 2,
+        captured_at: new Date(Date.now() - 60_000).toISOString(),
+        claude_json: { live: { five_hour_pct: 10, seven_day_pct: 100 } },
+        codex_json: null,
+    });
+});
+
+describe('POST /api/transform — usage warning entity attribution (card_2f6a5659)', () => {
+    const HEARTBEAT = 'Codex #6 status heartbeat: all lanes nominal.';
+
+    test('entity 6 heartbeat gets NO warning prefix when the breaching snapshot belongs to entity 2', async () => {
+        const res = await post('/api/transform').send({
+            deviceId: DEVICE_ID,
+            entityId: 6,
+            botSecret: botSecret6,
+            state: 'IDLE',
+            message: HEARTBEAT,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        const delivered = res.body.currentState.message;
+        expect(delivered).toBe(HEARTBEAT);
+        expect(delivered).not.toContain('System notice');
+        expect(delivered).not.toContain('系統訊息');
+        expect(delivered).not.toContain('⚠️');
+    });
+
+    test('entity 2 (owner of the breaching snapshot) still gets the warning prefix', async () => {
+        const MSG = 'PR #3901 merged, kanban card closed.';
+        const res = await post('/api/transform').send({
+            deviceId: DEVICE_ID,
+            entityId: 2,
+            botSecret: botSecret2,
+            state: 'IDLE',
+            message: MSG,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        const delivered = res.body.currentState.message;
+        expect(delivered).toContain('System notice');
+        expect(delivered.endsWith(MSG)).toBe(true);
+        expect(delivered.startsWith('⚠️')).toBe(true);
+    });
+
+    test('order-independence: after #2 was warned, #6 is STILL clean (per-entity cooldown, not device-wide)', async () => {
+        const res2 = await post('/api/transform').send({
+            deviceId: DEVICE_ID, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE', message: 'first send from #2',
+        });
+        expect(res2.body.currentState.message).toContain('System notice');
+
+        const res6 = await post('/api/transform').send({
+            deviceId: DEVICE_ID, entityId: 6, botSecret: botSecret6,
+            state: 'IDLE', message: HEARTBEAT,
+        });
+        expect(res6.status).toBe(200);
+        expect(res6.body.currentState.message).toBe(HEARTBEAT);
+    });
+});

--- a/backend/tests/jest/usage-warning.test.js
+++ b/backend/tests/jest/usage-warning.test.js
@@ -18,6 +18,8 @@ const {
     pickClaudeLivePct,
     withinCooldown,
     resolveCooldownMs,
+    getWarningPrefix,
+    _resetCooldownState,
 } = require('../../lib/usage-warning');
 
 const DEFAULT_CFG = { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5 };
@@ -156,6 +158,100 @@ describe('withinCooldown / resolveCooldownMs (card_a69e8ffa)', () => {
     });
     test('cooldown_min: 0 → every breach allowed (no suppression)', () => {
         expect(withinCooldown(NOW - 1, NOW, resolveCooldownMs({ cooldown_min: 0 }))).toBe(false);
+    });
+});
+
+describe('getWarningPrefix — entity-scoped attribution (card_2f6a5659)', () => {
+    /**
+     * Fake pool that EMULATES the usage_snapshots table semantics for both
+     * query shapes the module can send:
+     *   - device-only  (params [deviceId])         → latest row by captured_at
+     *   - entity-scoped (params [deviceId, eid])   → WHERE entity_id = eid OR NULL,
+     *                                                 ORDER BY (entity_id = eid) DESC, captured_at DESC
+     * Because the emulation is faithful to the SQL semantics (not to the code
+     * under test), these tests FAIL on the old device-only lookup and PASS on
+     * the entity-scoped one.
+     */
+    function mkSnapshotPool(rows) {
+        return {
+            query: jest.fn().mockImplementation(async (sql, params) => {
+                if (!/FROM\s+usage_snapshots/i.test(sql)) return { rows: [], rowCount: 0 };
+                let cand = rows.filter(r => r.device_id === params[0]);
+                if (params.length >= 2) {
+                    const eid = params[1];
+                    cand = cand
+                        .filter(r => r.entity_id === eid || r.entity_id == null)
+                        .sort((a, b) =>
+                            ((b.entity_id === eid) - (a.entity_id === eid)) ||
+                            (Date.parse(b.captured_at) - Date.parse(a.captured_at)));
+                } else {
+                    cand = cand.slice().sort((a, b) => Date.parse(b.captured_at) - Date.parse(a.captured_at));
+                }
+                return { rows: cand.slice(0, 1), rowCount: Math.min(1, cand.length) };
+            }),
+        };
+    }
+
+    const DEV = 'dev-usage-scope';
+    // #2's Claude snapshot: 7d used 100% → remaining 0 ≤ 5 → breach.
+    const entity2Breach = (ageMs = 60_000) => ({
+        device_id: DEV, entity_id: 2, captured_at: fresh(ageMs),
+        claude_json: { live: { five_hour_pct: 10, seven_day_pct: 100 } }, codex_json: null,
+    });
+
+    beforeEach(() => _resetCooldownState());
+
+    test('latest row belongs to entity 2 → entity 6 transform gets NO prefix (the card_2f6a5659 bug)', async () => {
+        const pool = mkSnapshotPool([entity2Breach()]);
+        const prefix = await getWarningPrefix(pool, DEV, DEFAULT_CFG, 'en', 6, NOW);
+        expect(prefix).toBeNull();
+    });
+
+    test('same table → entity 2 (the actual owner of the breach) still gets the prefix', async () => {
+        const pool = mkSnapshotPool([entity2Breach()]);
+        const prefix = await getWarningPrefix(pool, DEV, DEFAULT_CFG, 'en', 2, NOW);
+        expect(prefix).toContain('System notice');
+        expect(prefix).toContain('0%'); // 7d remaining
+    });
+
+    test('legacy unscoped row (entity_id IS NULL) still warns any entity — daemon back-compat', async () => {
+        const pool = mkSnapshotPool([{
+            device_id: DEV, entity_id: null, captured_at: fresh(60_000),
+            claude_json: { live: { seven_day_pct: 97 } }, codex_json: null,
+        }]);
+        const prefix = await getWarningPrefix(pool, DEV, DEFAULT_CFG, 'en', 6, NOW);
+        expect(prefix).toContain('System notice');
+    });
+
+    test('entity-scoped row is preferred over a NEWER unscoped row', async () => {
+        const pool = mkSnapshotPool([
+            entity2Breach(10 * 60_000),                       // older, breaching, entity 2
+            { device_id: DEV, entity_id: null, captured_at: fresh(1_000),
+              claude_json: { live: { five_hour_pct: 5, seven_day_pct: 5 } }, codex_json: null }, // newer, healthy
+        ]);
+        // ORDER BY (entity_id = $2) DESC → entity-2 row wins despite being older.
+        const prefix = await getWarningPrefix(pool, DEV, DEFAULT_CFG, 'en', 2, NOW);
+        expect(prefix).toContain('System notice');
+    });
+
+    test('cooldown is per-entity: #2 warning does not suppress #6, but does suppress #2 itself', async () => {
+        const entity6Breach = {
+            device_id: DEV, entity_id: 6, captured_at: fresh(60_000),
+            claude_json: { live: { seven_day_pct: 98 } }, codex_json: null,
+        };
+        const pool = mkSnapshotPool([entity2Breach(), entity6Breach]);
+        expect(await getWarningPrefix(pool, DEV, DEFAULT_CFG, 'en', 2, NOW)).toContain('System notice');
+        // Within the same cooldown window:
+        expect(await getWarningPrefix(pool, DEV, DEFAULT_CFG, 'en', 2, NOW + 1_000)).toBeNull();
+        expect(await getWarningPrefix(pool, DEV, DEFAULT_CFG, 'en', 6, NOW + 1_000)).toContain('System notice');
+    });
+
+    test('no entityId (legacy caller) falls back to device-latest lookup', async () => {
+        const pool = mkSnapshotPool([entity2Breach()]);
+        const prefix = await getWarningPrefix(pool, DEV, DEFAULT_CFG, 'en', null, NOW);
+        expect(prefix).toContain('System notice');
+        // and the SQL sent was the single-param shape
+        expect(pool.query.mock.calls[0][1]).toEqual([DEV]);
     });
 });
 


### PR DESCRIPTION
## Root cause (card_2f6a565982885f34b0cd3ed9, RCA by #6)

`backend/lib/usage-warning.js getWarningPrefix()` picked the latest `usage_snapshots` row by **device_id only**, ignoring which entity is speaking. On the shared multi-entity device, #2's Claude snapshot (7d used 100%) was the device-latest row, so `/api/transform` prefixed **#2's** quota warning onto **#6's** Codex status heartbeat (prod occurrence 2026-07-07T04:54Z) — which the codex bridge then misread as a #6 `resource_warning`.

## Fix

- **Entity-scoped lookup** (mirrors `backend/kanban.js getEntityUsagePct()`):
  `WHERE device_id=$1 AND (entity_id=$2 OR entity_id IS NULL) ORDER BY (entity_id=$2) DESC, captured_at DESC LIMIT 1`
  - legacy unscoped rows (`entity_id IS NULL`) still warn — daemon back-compat
  - `null`/`undefined` entityId keeps the old device-latest behavior (guarded: `Number(null)===0` must not silently scope to entity 0)
- **`/api/transform` passes the speaking `eId`** into `getWarningPrefix` (backend/index.js)
- **Cooldown key is per device+entity** — #2's attached warning no longer suppresses a legitimate #6 warning on the same device

## Regression tests — fails-old → passes-new

The fake `usage_snapshots` pool emulates the **SQL semantics** of both query shapes (device-only vs entity-scoped), so it doesn't hardcode the fix — old code genuinely goes red.

On `origin/main` (fix stashed): **4 failed / 32 passed**
- ✕ transform: entity 6 heartbeat gets NO warning prefix when the breaching snapshot belongs to entity 2  ← the bug
- ✕ lib: latest row belongs to entity 2 → entity 6 gets NO prefix
- ✕ lib: entity-scoped row preferred over a NEWER unscoped row
- ✕ lib: cooldown is per-entity

With the fix: **63/63 pass** across `usage-warning.test.js` (33), `transform-usage-warning-entity-scope.test.js` (3, boots the REAL Express app + route table via supertest and asserts the delivered `currentState.message`), `device-preferences-usage-warning.test.js`, `transform-delivery.test.js` (no transform regressions). `eslint` on changed files: 0 errors.

## Out of scope
- RCA item 4 (runtime blocker detector matching historical "Computer Use approval blocked" text → spurious `#6_PERMISSION_HANDOFF`) — separate detector, separate card.
- codex-bridge status/smoke classification hardening — the trigger disappears once the misattributed prefix is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuABXFYP3EofvYeqXW6ncn