### PR TITLE
sec: requireAdmin requires deviceSecret proof, constant-time (card_bb9f0e5c)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -70,12 +70,23 @@ function getAdminDeviceIds() {
 }
 
 /**
- * Check admin-device gate. Extracts deviceId from query / body / x-device-id header
- * (mirroring existing auth param conventions) and verifies it's in ADMIN_DEVICE_IDS.
+ * Check admin-device gate. Extracts deviceId/deviceSecret from query / body /
+ * x-device-* headers (mirroring existing auth param conventions), verifies the
+ * deviceId is in ADMIN_DEVICE_IDS, then proves possession of the matching
+ * deviceSecret with a constant-time compare (card_bb9f0e5c: deviceId is NOT a
+ * secret — it appears in logs/URLs/portal pages — so allowlist membership alone
+ * is no authentication). Missing or mismatched deviceSecret → 401. Fail closed.
+ *
+ * opts.verifyDeviceSecret=false skips ONLY the secret-proof step, for callers
+ * that layer their own credential verification immediately after the allowlist
+ * check (e.g. /api/monitoring/rental-health accepts deviceSecret OR
+ * entityId+botSecret). Never use it on an endpoint that does not verify a
+ * secret itself.
+ *
  * Returns { ok: true, deviceId } on success, or { ok: false, status, error } on failure.
  * Never throws — caller writes the response.
  */
-function requireAdmin(req) {
+function requireAdmin(req, opts = {}) {
     const deviceId = (req.query && req.query.deviceId)
         || (req.body && req.body.deviceId)
         || req.headers['x-device-id'];
@@ -88,6 +99,18 @@ function requireAdmin(req) {
     }
     if (!adminSet.has(deviceId)) {
         return { ok: false, status: 403, error: 'admin access required' };
+    }
+    if (opts.verifyDeviceSecret !== false) {
+        const deviceSecret = (req.query && req.query.deviceSecret)
+            || (req.body && req.body.deviceSecret)
+            || req.headers['x-device-secret'];
+        if (!deviceSecret) {
+            return { ok: false, status: 401, error: 'deviceSecret required for admin-gated endpoint' };
+        }
+        const device = devices[deviceId];
+        if (!device || !safeEqual(device.deviceSecret, deviceSecret)) {
+            return { ok: false, status: 401, error: 'invalid credentials' };
+        }
     }
     return { ok: true, deviceId };
 }
@@ -7846,7 +7869,10 @@ app.get('/api/monitoring/rental-health', async (req, res) => {
     const providedKey = req.query.key || req.headers['x-monitoring-key'];
     const keyOk = monitoringKey && providedKey && safeEqual(monitoringKey, String(providedKey));
     if (!keyOk) {
-        const gate = requireAdmin(req);
+        // verifyDeviceSecret:false — allowlist check only; this endpoint verifies
+        // its own secret proof right below (deviceSecret OR entityId+botSecret,
+        // both constant-time), preserving the documented dual-credential contract.
+        const gate = requireAdmin(req, { verifyDeviceSecret: false });
         if (!gate.ok) return res.status(gate.status).json({ success: false, error: gate.error });
         const { deviceSecret, botSecret, entityId } = req.query;
         if (!deviceSecret && !botSecret) {

--- a/backend/public/portal/admin/index.html
+++ b/backend/public/portal/admin/index.html
@@ -180,7 +180,7 @@
             }
         }
 
-        function getAuthQuery() {
+        function getAdminCredentials() {
             const u = window.currentUser || {};
             let deviceId = u.deviceId;
             let deviceSecret = u.deviceSecret;
@@ -190,15 +190,20 @@
                     deviceSecret = deviceSecret || localStorage.getItem('deviceSecret');
                 } catch (_) { /* ignore */ }
             }
-            if (!deviceId) return null;
-            return `deviceId=${encodeURIComponent(deviceId)}`;
+            if (!deviceId || !deviceSecret) return null;
+            return { deviceId, deviceSecret };
         }
 
         async function verifyAdminGate() {
-            const auth = getAuthQuery();
-            if (!auth) return false;
+            const creds = getAdminCredentials();
+            if (!creds) return false;
             try {
-                const res = await fetch(`/api/admin/ping?${auth}`, { credentials: 'include' });
+                // deviceSecret goes in a header (not the query string) so it never
+                // lands in access logs / browser history (card_bb9f0e5c).
+                const res = await fetch(`/api/admin/ping?deviceId=${encodeURIComponent(creds.deviceId)}`, {
+                    credentials: 'include',
+                    headers: { 'X-Device-Secret': creds.deviceSecret }
+                });
                 return res.status === 200;
             } catch (_) { return false; }
         }

--- a/backend/tests/jest/admin-auth.test.js
+++ b/backend/tests/jest/admin-auth.test.js
@@ -165,6 +165,8 @@ jest.mock('../../subscription', () => {
     });
 });
 
+const fs = require('fs');
+const path = require('path');
 const request = require('supertest');
 let app;
 
@@ -181,6 +183,114 @@ afterAll(async () => {
     const { httpServer } = require('../../index');
     await new Promise(resolve => httpServer.close(resolve));
     jest.resetModules();
+});
+
+// ════════════════════════════════════════════════════════════════
+// Admin-device gate must prove possession of deviceSecret
+// (card_bb9f0e5c — deviceId is not a secret; allowlist membership
+// alone must never authenticate an admin endpoint)
+// ════════════════════════════════════════════════════════════════
+describe('requireAdmin — deviceSecret proof required', () => {
+    const adminDeviceId = 'jest-admin-device';
+    const adminDeviceSecret = 'jest-admin-device-secret';
+    let originalAdminDeviceIds;
+
+    const makeReq = ({ query = {}, body = {}, headers = {} } = {}) => ({
+        query,
+        body,
+        headers,
+    });
+
+    beforeEach(() => {
+        originalAdminDeviceIds = process.env.ADMIN_DEVICE_IDS;
+        process.env.ADMIN_DEVICE_IDS = adminDeviceId;
+        app.devices[adminDeviceId] = {
+            deviceSecret: adminDeviceSecret,
+            entities: {},
+        };
+    });
+
+    afterEach(() => {
+        if (originalAdminDeviceIds === undefined) {
+            delete process.env.ADMIN_DEVICE_IDS;
+        } else {
+            process.env.ADMIN_DEVICE_IDS = originalAdminDeviceIds;
+        }
+        delete app.devices[adminDeviceId];
+    });
+
+    it('rejects an allowlisted deviceId without deviceSecret', () => {
+        const gate = app._requireAdmin(makeReq({
+            query: { deviceId: adminDeviceId },
+        }));
+
+        expect(gate).toMatchObject({
+            ok: false,
+            status: 401,
+            error: 'deviceSecret required for admin-gated endpoint',
+        });
+    });
+
+    it('rejects an allowlisted deviceId with the wrong deviceSecret', () => {
+        const gate = app._requireAdmin(makeReq({
+            query: { deviceId: adminDeviceId, deviceSecret: 'wrong-secret' },
+        }));
+
+        expect(gate).toMatchObject({
+            ok: false,
+            status: 401,
+            error: 'invalid credentials',
+        });
+    });
+
+    it('rejects an allowlisted deviceId whose device record is missing (no oracle)', () => {
+        delete app.devices[adminDeviceId];
+        const gate = app._requireAdmin(makeReq({
+            query: { deviceId: adminDeviceId, deviceSecret: adminDeviceSecret },
+        }));
+
+        expect(gate).toMatchObject({ ok: false, status: 401, error: 'invalid credentials' });
+    });
+
+    it('accepts only the matching deviceSecret for an allowlisted deviceId', () => {
+        const gate = app._requireAdmin(makeReq({
+            headers: {
+                'x-device-id': adminDeviceId,
+                'x-device-secret': adminDeviceSecret,
+            },
+        }));
+
+        expect(gate).toEqual({ ok: true, deviceId: adminDeviceId });
+    });
+
+    it('still rejects non-allowlisted deviceIds with 403 even with a secret', () => {
+        const gate = app._requireAdmin(makeReq({
+            query: { deviceId: 'not-an-admin', deviceSecret: 'whatever' },
+        }));
+
+        expect(gate).toMatchObject({ ok: false, status: 403 });
+    });
+
+    it('opts.verifyDeviceSecret:false skips only the secret step (rental-health layers its own proof)', () => {
+        const gate = app._requireAdmin(
+            makeReq({ query: { deviceId: adminDeviceId } }),
+            { verifyDeviceSecret: false }
+        );
+
+        expect(gate).toEqual({ ok: true, deviceId: adminDeviceId });
+    });
+
+    it('compares deviceSecret with safeEqual (constant-time) in the requireAdmin gate', () => {
+        const src = fs.readFileSync(path.join(__dirname, '../../index.js'), 'utf8');
+        const start = src.indexOf('function requireAdmin');
+        const end = src.indexOf('const app = express()', start);
+        const requireAdminBody = src.slice(start, end);
+
+        // The secret proof must go through the timing-safe helper — a plain
+        // `===` compare here would be a timing-oracle regression.
+        expect(requireAdminBody).toMatch(/safeEqual\(device\.deviceSecret,\s*deviceSecret\)/);
+        expect(requireAdminBody).not.toMatch(/device\.deviceSecret\s*===/);
+    });
 });
 
 // ════════════════════════════════════════════════════════════════

--- a/backend/tests/jest/admin-hub-self-improvement.test.js
+++ b/backend/tests/jest/admin-hub-self-improvement.test.js
@@ -40,10 +40,17 @@ describe('admin hub self-improvement surface', () => {
         expect(adminHubSrc).toContain('Globe-user: <which role/capability is affected globally; no hardcoded device/entity/user>');
         expect(adminHubSrc).toContain('Setup: <required admin permission/API/runtime condition; graceful degradation if missing>');
         expect(adminHubSrc).toContain('? icon UX: <What this state means / Needs / Next step>');
-        const selfImprovementSlice = adminHubSrc.slice(
-            adminHubSrc.indexOf('id="adminSelfImprovementCard"'),
-            adminHubSrc.indexOf('function getAuthQuery')
-        );
+        const cardStart = adminHubSrc.indexOf('id="adminSelfImprovementCard"');
+        // End the slice at the admin-credentials plumbing that follows the card
+        // (renamed getAuthQuery -> getAdminCredentials in card_bb9f0e5c). Fall back
+        // to the old name, and assert the bounds are sane so a future rename fails
+        // LOUD here instead of silently ballooning the slice to EOF (indexOf -> -1,
+        // which slice() treats as "up to the last char" and sweeps in the creds fns).
+        let cardEnd = adminHubSrc.indexOf('function getAdminCredentials');
+        if (cardEnd < 0) cardEnd = adminHubSrc.indexOf('function getAuthQuery');
+        expect(cardStart).toBeGreaterThanOrEqual(0);
+        expect(cardEnd).toBeGreaterThan(cardStart);
+        const selfImprovementSlice = adminHubSrc.slice(cardStart, cardEnd);
         expect(selfImprovementSlice).not.toMatch(/botSecret|deviceSecret|DATABASE_URL|CLOUDFLARE_API_TOKEN/);
     });
 });

--- a/backend/tests/jest/monitoring.test.js
+++ b/backend/tests/jest/monitoring.test.js
@@ -237,7 +237,22 @@ describe('GET /api/monitoring/rental-health auth', () => {
     });
 });
 
+// card_bb9f0e5c: deviceId alone is NOT a credential. Every requireAdmin-gated
+// endpoint must demand deviceSecret proof (constant-time) — allowlisted
+// deviceId with a missing/wrong secret is a 401.
 describe('GET /api/admin/ping', () => {
+    const { devices } = require('../../index');
+
+    beforeEach(() => {
+        devices['admin-device-1'] = { deviceSecret: 'admin-secret-xyz', entities: {} };
+        devices['admin-device-2'] = { deviceSecret: 'admin-secret-abc', entities: {} };
+    });
+
+    afterEach(() => {
+        delete devices['admin-device-1'];
+        delete devices['admin-device-2'];
+    });
+
     it('rejects missing deviceId with 401', async () => {
         const res = await request(app).get('/api/admin/ping');
         expect(res.status).toBe(401);
@@ -248,16 +263,84 @@ describe('GET /api/admin/ping', () => {
         expect(res.status).toBe(403);
     });
 
-    it('accepts admin deviceId and echoes it back', async () => {
+    it('rejects admin deviceId WITHOUT deviceSecret with 401 (deviceId is not a secret)', async () => {
         const res = await request(app).get('/api/admin/ping?deviceId=admin-device-1');
+        expect(res.status).toBe(401);
+        expect(res.body.success).toBe(false);
+    });
+
+    it('rejects admin deviceId with WRONG deviceSecret with 401', async () => {
+        const res = await request(app)
+            .get('/api/admin/ping?deviceId=admin-device-1&deviceSecret=wrong-secret');
+        expect(res.status).toBe(401);
+    });
+
+    it('accepts admin deviceId + matching deviceSecret and echoes deviceId back', async () => {
+        const res = await request(app)
+            .get('/api/admin/ping?deviceId=admin-device-1&deviceSecret=admin-secret-xyz');
         expect(res.status).toBe(200);
         expect(res.body).toMatchObject({ success: true, admin: true, deviceId: 'admin-device-1' });
     });
 
-    it('accepts deviceId via x-device-id header', async () => {
-        const res = await request(app).get('/api/admin/ping').set('X-Device-Id', 'admin-device-2');
+    it('accepts credentials via x-device-id + x-device-secret headers', async () => {
+        const res = await request(app)
+            .get('/api/admin/ping')
+            .set('X-Device-Id', 'admin-device-2')
+            .set('X-Device-Secret', 'admin-secret-abc');
         expect(res.status).toBe(200);
         expect(res.body.deviceId).toBe('admin-device-2');
+    });
+
+    it('rejects x-device-id header without x-device-secret with 401', async () => {
+        const res = await request(app).get('/api/admin/ping').set('X-Device-Id', 'admin-device-2');
+        expect(res.status).toBe(401);
+    });
+});
+
+describe('wishlist-matchmaking admin endpoints require deviceSecret proof (card_bb9f0e5c)', () => {
+    const { devices } = require('../../index');
+
+    beforeEach(() => {
+        devices['admin-device-1'] = { deviceSecret: 'admin-secret-xyz', entities: {} };
+    });
+
+    afterEach(() => {
+        delete devices['admin-device-1'];
+    });
+
+    it('GET /api/wishlist-matchmaking/metrics rejects admin deviceId without deviceSecret (401)', async () => {
+        const res = await request(app)
+            .get('/api/wishlist-matchmaking/metrics?deviceId=admin-device-1');
+        expect(res.status).toBe(401);
+        expect(res.body.success).toBe(false);
+    });
+
+    it('GET /api/wishlist-matchmaking/metrics rejects wrong deviceSecret (401)', async () => {
+        const res = await request(app)
+            .get('/api/wishlist-matchmaking/metrics?deviceId=admin-device-1&deviceSecret=wrong');
+        expect(res.status).toBe(401);
+    });
+
+    it('GET /api/wishlist-matchmaking/metrics accepts matching deviceSecret (200)', async () => {
+        const res = await request(app)
+            .get('/api/wishlist-matchmaking/metrics?deviceId=admin-device-1&deviceSecret=admin-secret-xyz');
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    it('POST /api/wishlist-matchmaking/offline/drain rejects admin deviceId without deviceSecret (401)', async () => {
+        const res = await request(app)
+            .post('/api/wishlist-matchmaking/offline/drain')
+            .send({ deviceId: 'admin-device-1' });
+        expect(res.status).toBe(401);
+    });
+
+    it('POST /api/wishlist-matchmaking/offline/drain accepts matching deviceSecret in body (200)', async () => {
+        const res = await request(app)
+            .post('/api/wishlist-matchmaking/offline/drain')
+            .send({ deviceId: 'admin-device-1', deviceSecret: 'admin-secret-xyz' });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
     });
 });
 


### PR DESCRIPTION
## Problem (card_bb9f0e5c7c2b116d3ee9a4db, P0)

`requireAdmin` (backend/index.js) gated admin endpoints on **deviceId ∈ ADMIN_DEVICE_IDS alone**. A deviceId is not a secret — it appears in logs, URLs, portal pages, and device logcat — so knowing the admin deviceId string was enough to pass the gate. Affected endpoints (all `requireAdmin` call sites on main):

| Endpoint | Sensitivity before fix |
|---|---|
| `GET /api/admin/ping` | Admin-portal gate check; allowlist-membership oracle (recon) |
| `GET /api/wishlist-matchmaking/metrics` | Ops metrics + GA flag + offline-queue stats disclosure |
| `POST /api/wishlist-matchmaking/offline/drain` | Attacker-timed re-drive of queued governed sends |
| `GET /api/monitoring/rental-health` | **Not exposed** — already verified deviceSecret OR entityId+botSecret itself |

(The card says "~5 endpoints"; on current main there are exactly these 4 call sites.)

## Fix — fail closed

- `requireAdmin` now **requires proof of possession of `devices[deviceId].deviceSecret`** (query / body / `X-Device-Secret` header), compared **constant-time** via the repo's `safeEqual` helper (`crypto.timingSafeEqual`). Missing secret → `401 deviceSecret required`; mismatch or unknown device record → `401 invalid credentials`. Non-allowlisted deviceId still → 403.
- `/api/monitoring/rental-health` passes `{ verifyDeviceSecret: false }`: it keeps its own documented dual-proof (deviceSecret OR entityId+botSecret, both `safeEqual`) immediately after the allowlist check, so the cron/bot contract is preserved and it remains fail-closed.

## Callers updated

- `portal/admin/index.html`: `getAuthQuery()` (deviceId-only) → `getAdminCredentials()`; sends the secret via `X-Device-Secret` **header** so it never lands in access logs / browser history.
- `portal/admin/rental-monitor.html`: already sends `deviceId+deviceSecret` in its auth query (and bails without both) — works unchanged.
- No other in-repo callers (swept portal/scripts/app/tests for all 4 paths).

## Tests (fails-old / passes-new)

- `admin-auth.test.js`: unit tests on the gate — reject missing secret, reject wrong secret, reject missing device record (no oracle), accept matching secret via headers, 403 for non-allowlisted, opts escape hatch, and a source assertion that the compare goes through `safeEqual` (not `===`).
- `monitoring.test.js`: endpoint tests — `admin/ping`, `wishlist-matchmaking/metrics`, `offline/drain` each 401 without / with wrong secret and 200 with the right one; rental-health suites unchanged and green.
- Verified against unmodified `origin/main` index.js: **10 new tests fail on old code**, all 63 pass with the fix.
- `npx eslint index.js` clean (test dir is eslint-ignored by repo config).

Salvages the interrupted prior session's `requireAdmin(req, opts)` design, portal header pattern, and gate unit-test skeleton (credit: uncommitted WIP in the main working tree).

⚠️ Do not merge yet — awaiting review per card workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuABXFYP3EofvYeqXW6ncn