### PR TITLE
fix(kanban): cold-start wrong-card guard for GET /api/mission/card/:id (card_0f406678)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1870,6 +1870,11 @@ try {
         pushToBot,
         orgChart: orgChartModule,
         notifyDevice,
+        // Cold-start readiness thunk (card_0f406678e04b7246b24e4a50). Late-bound
+        // to `persistenceReady` (declared above at module load) so card
+        // detail-by-id can return the 503 "Server starting up" path instead of a
+        // possibly-wrong row during warmup. Same convention as passiveHealth.init.
+        isReady: () => persistenceReady,
         emitDevicePreferences: (deviceId, prefs) => {
             io.to(`device:${deviceId}`).emit('device:preferences', { deviceId, prefs });
         },

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -528,8 +528,21 @@ function buildDispatchCapabilityWarning(card, assignedBots) {
 /**
  * Factory: receives in-memory devices object from index.js
  */
-function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, pushToChannelCallback, saveChatMessage, getMissionApiHints, pushToBot, orgChart, notifyDevice, emitDevicePreferences, createActionRequest, dismissActionRequestsForCard, dismissSurfacerActionRequestsForCard } = {}) {
+function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, pushToChannelCallback, saveChatMessage, getMissionApiHints, pushToBot, orgChart, notifyDevice, emitDevicePreferences, createActionRequest, dismissActionRequestsForCard, dismissSurfacerActionRequestsForCard, isReady } = {}) {
     const router = express.Router();
+
+    // Readiness thunk (late-bound to index.js `persistenceReady`). During a
+    // Railway cold-start the in-memory persistence + DB reads can be
+    // half-initialised — the same window in which the global /api gate returns
+    // "Server starting up". Card detail-by-id reads the kanban Postgres pool
+    // directly (NOT gated by that middleware in every replica), so a request
+    // that slips through during warmup could resolve to / return a stale or
+    // wrong row with 200 + success:true. Callers can't detect that (unlike a
+    // 503). `isCardStoreReady()` lets read handlers mirror the 503 path instead
+    // of trusting a not-ready data source. Defaults to ready when the dep is
+    // absent (e.g. tests / older mounts) so behaviour is unchanged there.
+    // See card_0f406678e04b7246b24e4a50.
+    const isCardStoreReady = () => (typeof isReady === 'function' ? !!isReady() : true);
 
     // Health check
     router.get("/kanban-health", (req, res) => res.json({ ok: true, module: "kanban", cron: !!CronExpressionParser }));
@@ -2031,6 +2044,14 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         const { deviceId } = { ...req.query, ...req.body };
         const rawId = req.params.id;
 
+        // Cold-start readiness guard (card_0f406678e04b7246b24e4a50). If
+        // persistence/data isn't ready yet, mirror the global /api gate's 503
+        // instead of serving a possibly-wrong row from a half-initialised store.
+        // A 503 is retryable; a 200 with the wrong card is silently corrupting.
+        if (!isCardStoreReady()) {
+            return res.status(503).json({ success: false, message: 'Server starting up — please retry in a few seconds' });
+        }
+
         try {
             // Resolve short-ID prefixes to the full card ID, scoped to this device.
             // Users commonly mention cards in chat with 8-hex shorthand (e.g. `card_7b7dd9e3`);
@@ -2069,6 +2090,26 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             );
 
             if (cardResult.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            // Belt-and-suspenders id-mismatch assertion (card_0f406678e04b7246b24e4a50).
+            // The exact-match query above is keyed on `cardId`, so a correctly-
+            // functioning DB always returns the requested row. But during a
+            // cold-start / not-ready window a request has (once, in prod)
+            // returned a *different* card's full JSON with 200 + success:true.
+            // Never hand the caller a row whose id doesn't match what they asked
+            // for: an orchestrator can't tell 200-wrong-card from 200-right-card,
+            // so a wrong SOP/evidence read or a close-out written to the wrong
+            // card would go undetected. `cardId` is either `rawId` verbatim or a
+            // short-ID that legitimately resolved to a longer full id; accept
+            // only an exact match or that valid shorthand expansion. Otherwise
+            // fail closed with 404 (never a wrong 200).
+            const returnedId = cardResult.rows[0].id;
+            const isExactRequested = returnedId === rawId;
+            const isResolvedFromShorthand = returnedId === cardId && cardId !== rawId;
+            if (!isExactRequested && !isResolvedFromShorthand) {
+                console.error('[Kanban] Card id mismatch — refusing to return wrong card:', { rawId, cardId, returnedId, deviceId });
                 return res.status(404).json({ success: false, error: 'Card not found' });
             }
 

--- a/backend/tests/jest/kanban-card-coldstart-guard.test.js
+++ b/backend/tests/jest/kanban-card-coldstart-guard.test.js
@@ -1,0 +1,174 @@
+/**
+ * Regression: GET /api/mission/card/:id must NEVER return a different card's
+ * JSON with 200 + success:true during a cold-start window.
+ *
+ * card_0f406678e04b7246b24e4a50 (P2 data-integrity bug):
+ *   On 2026-07-09 00:58 TW, during a Railway cold-start (the same window the
+ *   global /api gate returns "Server starting up"), a request for
+ *   card_a1dcb6f8e7aba2656c2469a5 returned the FULL JSON of a DIFFERENT card
+ *   (card_2f6a565982885f34b0cd3ed9) with HTTP 200 + success:true. A retry a few
+ *   seconds later returned the 503 "Server starting up" message; after warmup
+ *   the same request returned the correct card. Because 200+success:true is
+ *   undetectable by callers (unlike a 503), an orchestrator could pick up the
+ *   wrong SOP/evidence or write a close-out to the wrong card.
+ *
+ * Two guards under test:
+ *   1. Readiness guard — when persistence is not ready (isReady() === false),
+ *      the handler must return the 503 "Server starting up" path, NOT trust the
+ *      half-initialised store.
+ *   2. Id-mismatch assertion — even when ready, if the DB returns a row whose id
+ *      does not match the requested id (nor a valid short-ID resolution), the
+ *      handler must fail closed (404), NEVER return 200 with the wrong card.
+ *
+ * Fails-old / passes-new: on the pristine handler (before the fix) the
+ * id-mismatch case returns 200 + the wrong card's JSON, and the not-ready case
+ * returns 200 as well — both assertions below fail. With the fix they return
+ * 503 / 404 respectively.
+ */
+
+const mockQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockQuery,
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../safe-equal', () => (a, b) => a === b);
+
+const express = require('express');
+const request = require('supertest');
+
+const mockDevices = {
+    'test-dev': {
+        deviceSecret: 'test-secret',
+        entities: {
+            0: { isBound: true, botSecret: 'bot-sec', character: 'Bot0' },
+            1: { isBound: true, botSecret: 'bot-sec-1', character: 'Bot1' },
+        },
+    },
+};
+
+const AUTH = { deviceId: 'test-dev', deviceSecret: 'test-secret' };
+
+// Readiness flag flipped per-test. Wired into the module as a late-bound thunk
+// exactly like index.js wires `() => persistenceReady`.
+let ready = true;
+
+let app;
+beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    const kanbanModule = require('../../kanban')(mockDevices, {
+        isReady: () => ready,
+    });
+    app.use('/api/mission', kanbanModule.router);
+});
+
+beforeEach(() => {
+    ready = true;
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+const get = (path) => request(app).get(path);
+
+// The full-length id the caller asks for (24 hex body → NOT a short-ID, so the
+// handler goes straight to the exact-match query).
+const REQUESTED_ID = 'card_a1dcb6f8e7aba2656c2469a5';
+// A completely different card the not-ready DB (wrongly) hands back.
+const WRONG_CARD = {
+    id: 'card_2f6a565982885f34b0cd3ed9',
+    device_id: 'test-dev',
+    title: '[P2][調查] 用量警告錯掛卡',
+    description: 'totally different card',
+    priority: 'P2',
+    status: 'todo',
+    assigned_bots: [0],
+    created_by: 2,
+    created_at: new Date(),
+    updated_at: new Date(),
+    status_changed_at: new Date(),
+    archived: false,
+    comment_count: 0,
+    note_count: 0,
+    file_count: 0,
+};
+
+describe('GET /card/:id — cold-start wrong-card guard (card_0f406678)', () => {
+    // ── Guard 1: readiness ──────────────────────────────────────────────────
+    it('returns 503 "Server starting up" when persistence is NOT ready', async () => {
+        ready = false;
+        // Even if the (not-ready) DB would hand back a card, the handler must
+        // never reach it — return the retryable 503 instead.
+        mockQuery.mockResolvedValue({ rows: [WRONG_CARD] });
+
+        const res = await get(`/api/mission/card/${REQUESTED_ID}`).query({ ...AUTH });
+
+        expect(res.status).toBe(503);
+        expect(res.body.success).toBe(false);
+        expect(res.body.message).toMatch(/starting up/i);
+        // Must NOT have leaked the wrong card.
+        expect(res.body.card).toBeUndefined();
+    });
+
+    // ── Guard 2: id-mismatch assertion (the exact prod repro) ───────────────
+    it('NEVER returns 200 with a different card when the DB hands back a wrong-id row', async () => {
+        ready = true;
+        // Simulate the cold-start data corruption: the exact-match SELECT
+        // returns a row whose id is NOT the requested id.
+        mockQuery.mockResolvedValueOnce({ rows: [WRONG_CARD] }); // main card query
+
+        const res = await get(`/api/mission/card/${REQUESTED_ID}`).query({ ...AUTH });
+
+        // The core assertion: the bug returned 200 + WRONG_CARD. It must not.
+        expect(res.status).not.toBe(200);
+        // Fail-closed: a mismatch is treated as not-found.
+        expect(res.status).toBe(404);
+        // The wrong card's payload must NOT be returned under any status.
+        expect(res.body.card).toBeUndefined();
+        expect(JSON.stringify(res.body)).not.toContain(WRONG_CARD.id);
+    });
+
+    // ── Happy path still works: correct row → 200 ───────────────────────────
+    it('returns 200 with the correct card when the DB returns the requested row', async () => {
+        ready = true;
+        const rightCard = { ...WRONG_CARD, id: REQUESTED_ID, title: 'Correct card' };
+        mockQuery
+            .mockResolvedValueOnce({ rows: [rightCard] }) // main card query
+            .mockResolvedValueOnce({ rows: [] })          // comments
+            .mockResolvedValueOnce({ rows: [] })          // notes
+            .mockResolvedValueOnce({ rows: [] })          // linked mission notes
+            .mockResolvedValueOnce({ rows: [] });         // files
+
+        const res = await get(`/api/mission/card/${REQUESTED_ID}`).query({ ...AUTH });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.card.id).toBe(REQUESTED_ID);
+    });
+
+    // ── Legitimate short-ID resolution is NOT flagged as a mismatch ─────────
+    it('still resolves a legitimate short-ID to its full card (not a false mismatch)', async () => {
+        ready = true;
+        const fullId = 'card_d3cdda1455152e3caee8d4ac';
+        const fullCard = { ...WRONG_CARD, id: fullId, title: 'Resolved from shorthand' };
+        mockQuery
+            .mockResolvedValueOnce({ rows: [{ id: fullId }] }) // prefix lookup
+            .mockResolvedValueOnce({ rows: [fullCard] })       // main card query
+            .mockResolvedValueOnce({ rows: [] })               // comments
+            .mockResolvedValueOnce({ rows: [] })               // notes
+            .mockResolvedValueOnce({ rows: [] })               // linked mission notes
+            .mockResolvedValueOnce({ rows: [] });              // files
+
+        const res = await get('/api/mission/card/card_d3cdda14').query({ ...AUTH });
+
+        expect(res.status).toBe(200);
+        expect(res.body.card.id).toBe(fullId);
+    });
+});


### PR DESCRIPTION
## The bug (card_0f406678e04b7246b24e4a50, P2 — data integrity)

During a Railway cold-start (the same window `/api` returns `{"success":false,"message":"Server starting up — please retry in a few seconds"}`), `GET /api/mission/card/:id` returned a **different card's full JSON with HTTP 200 + success:true**.

Concretely on 2026-07-09 00:58 TW: a request for `card_a1dcb6f8e7aba2656c2469a5` returned the complete JSON of `card_2f6a565982885f34b0cd3ed9`. A retry a few seconds later gave the "Server starting up" message; after warmup the same request returned the correct card. The danger: `200 + success:true` is **undetectable by callers** (unlike a 503), so an orchestrator can pick up the wrong SOP/evidence or write a close-out to the wrong card.

## Root cause

`router.get('/card/:id', ...)` in `backend/kanban.js` (was line 2029):

1. **No readiness guard.** The global `/api` startup gate (`index.js`, `if (persistenceReady) return next(); … 503 "Server starting up"`) protects *in-memory device state*, but this handler reads the kanban module's **own `pg.Pool` directly** — a read that is not gated by `persistenceReady`. A request served while the store is half-initialised during warmup can resolve to / return an inconsistent row.
2. **No id-mismatch assertion.** The handler runs the query, calls `serializeCard(rows[0])`, and returns `{ success: true, card }` — it **never asserts the returned row's id equals the requested id**. So a wrong row (from a not-ready read) is handed back with 200.

## The fix — two defensive guards (belt-and-suspenders)

- **Readiness guard** (`backend/kanban.js` + wiring in `backend/index.js`): a late-bound `isReady` thunk (`() => persistenceReady`, same convention as `passiveHealth.init`) is injected into the kanban module. When not ready, `/card/:id` returns the same **503 "Server starting up"** path instead of trusting a half-initialised store. A 503 is retryable; a 200-with-the-wrong-card is silently corrupting.
- **Id-mismatch assertion** (`backend/kanban.js`): before returning, assert the returned row's id is the **exact requested id** (or a valid short-ID resolution `card.id === resolvedCardId && resolvedCardId !== rawId`). On any mismatch, **fail closed with 404** and `console.error` the mismatch — never a wrong 200.

Legitimate 8-hex short-ID resolution (`card_a1dcb6f8` → `card_a1dcb6f8e7…`) is explicitly allowed and covered by a test, so this is not a behaviour regression for shorthand lookups.

## Regression test (red → green) — `backend/tests/jest/kanban-card-coldstart-guard.test.js`

Supertest against the real kanban router with a mocked `pg` pool and a per-test `isReady` thunk. Four cases:
- not-ready → **503** (guard 1)
- DB returns a wrong-id row → **404, never 200-with-wrong-card** (guard 2; the exact prod repro `card_a1dcb6f8…` → `card_2f6a5659…`)
- correct row → 200 (happy path preserved)
- legitimate short-ID → 200 resolves to the full id (no false mismatch)

**Fails-old / passes-new evidence** (ran the test against the pristine `origin/main` handler, then the fix):

```
# PRISTINE handler (fix reverted):
✕ returns 503 … when persistence is NOT ready   → Expected: 503, Received: 200
✕ NEVER returns 200 with a different card …      → Expected: not 200, Received: 200
Tests: 2 failed, 2 passed   ← the two failure-path guards reproduce the bug

# WITH fix:
✓ returns 503 "Server starting up" when persistence is NOT ready
✓ NEVER returns 200 with a different card when the DB hands back a wrong-id row
✓ returns 200 with the correct card when the DB returns the requested row
✓ still resolves a legitimate short-ID to its full card (not a false mismatch)
Tests: 4 passed, 4 total
```

Existing `backend/tests/jest/kanban-card.test.js` — **45/45 still pass**. `eslint kanban.js index.js` — **0 errors** (the one pre-existing `no-unused-vars` warning at the tail of kanban.js is on `origin/main`, not in this diff).

## Endpoint-sensitivity note

`GET /api/mission/card/:id` is the **card detail-by-id** read that orchestrators/agents use to fetch a card's SOP, evidence, and status before acting on it. A silent wrong-card response here is high-blast-radius: it can drive an agent to run the wrong SOP or write a close-out/comment to the wrong card. That is why the fix fails **closed** (503/404) rather than best-effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)