### PR TITLE
fix(routing): Opt1 up-forward default-on + fix routing chip all-pointing-to-#10 (card_d199b41c, card_a0485399)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -20765,13 +20765,19 @@ async function orgChartForward(entity, deviceId, message, opts = {}) {
 
     try {
         const orgData = await orgChartModule.getOrgChart(deviceId);
-        // Dormant-when-no-org-chart path (card_3ce0080a): with the default
-        // taskForward:false + no configured hierarchy, the org-chart forward does
-        // nothing, so a subordinate's substantive output never reaches a commander.
-        // The DEFAULT-OFF commander_forward_fallback_enabled pref (checked inside the
-        // helper) routes it to a bound commander (#2, else #1) instead. Behavior is
-        // byte-for-byte unchanged while the pref is false (helper no-ops).
-        if (!orgData.options.taskForward && !orgData.options.allForward) {
+        // Opt1 (card_d199b41c, owner-ratified 2026-07-10): up-forward defaults ON
+        // when a real hierarchy is configured, even if the allForward option was
+        // never explicitly set — so a subordinate's un-@mentioned report reaches
+        // its superior instead of being dropped. An explicit taskForward-only
+        // choice is still respected (effectiveAllForward → false). See org-chart.js.
+        const forwardAllUp = orgChartModule.effectiveAllForward(orgData.hierarchy, orgData.options);
+        // Dormant-when-no-org-chart path (card_3ce0080a): with taskForward off AND
+        // no effective up-forward (no allForward, no configured hierarchy), the
+        // org-chart forward does nothing, so a subordinate's substantive output
+        // never reaches a commander. The DEFAULT-OFF commander_forward_fallback_enabled
+        // pref (checked inside the helper) routes it to a bound commander (#2, else
+        // #1) instead. Byte-for-byte unchanged while the pref is false (helper no-ops).
+        if (!orgData.options.taskForward && !forwardAllUp) {
             return commanderForwardFallback(entity, deviceId, message, opts);
         }
         if (!orgData.hierarchy || !orgData.hierarchy.USER) {
@@ -20809,8 +20815,9 @@ async function orgChartForward(entity, deviceId, message, opts = {}) {
         let shouldForward = false;
         let prefix = '';
 
-        if (orgData.options.allForward) {
-            // Option 3: forward everything
+        if (forwardAllUp) {
+            // Option 3 (allForward) OR Opt1 default-on (hierarchy configured):
+            // forward everything up to the superior.
             shouldForward = true;
             prefix = `${ORG_FWD_PREFIX} from #${entity.entityId}] `;
         } else if (orgData.options.taskForward && chatPool) {
@@ -20883,7 +20890,9 @@ async function resolveSelfReplyRoutingMeta(entity, deviceId, eId, message) {
             if (superiorId != null && superiorId !== 'USER') {
                 const superiorEntity = device.entities?.[superiorId];
                 if (superiorEntity && superiorEntity.isBound) {
-                    let willForward = !!options.allForward;
+                    // Mirror orgChartForward's Opt1 default-on decision so the
+                    // routing chip reflects the ACTUAL upward route (card_d199b41c).
+                    let willForward = orgChartModule.effectiveAllForward(hierarchy, options);
                     if (!willForward && options.taskForward && chatPool) {
                         try {
                             const taskCheck = await chatPool.query(

--- a/backend/index.js
+++ b/backend/index.js
@@ -20888,8 +20888,20 @@ async function resolveSelfReplyRoutingMeta(entity, deviceId, eId, message) {
             // A real entity superior (not USER, not orphan) AND auto-forward
             // configured means the reply genuinely routes upward.
             if (superiorId != null && superiorId !== 'USER') {
+                // Mirror orgChartForward's reaches-USER walk (index.js ~20794): a
+                // disconnected sub-tree whose chain never reaches USER is NOT routed
+                // upward, so the chip must not claim an org_upward route that never
+                // fires (card_ecda7243 principle; Opt1 default-on widened this path).
+                let walkId = superiorId;
+                let reachesUser = false;
+                const visited = new Set();
+                while (walkId != null && !visited.has(walkId)) {
+                    visited.add(walkId);
+                    if (walkId === 'USER') { reachesUser = true; break; }
+                    walkId = orgChartModule.getSuperior(hierarchy, walkId);
+                }
                 const superiorEntity = device.entities?.[superiorId];
-                if (superiorEntity && superiorEntity.isBound) {
+                if (reachesUser && superiorEntity && superiorEntity.isBound) {
                     // Mirror orgChartForward's Opt1 default-on decision so the
                     // routing chip reflects the ACTUAL upward route (card_d199b41c).
                     let willForward = orgChartModule.effectiveAllForward(hierarchy, options);

--- a/backend/org-chart.js
+++ b/backend/org-chart.js
@@ -49,6 +49,43 @@ function getSuperior(hierarchy, entityId) {
 }
 
 /**
+ * Is a REAL org-chart hierarchy configured for this device? True when there is a
+ * USER root with at least one report (a real tree exists), false for an empty {}
+ * or a bare USER:[] with no children. Pure — no I/O.
+ */
+function isHierarchyConfigured(hierarchy) {
+    return !!(hierarchy && Array.isArray(hierarchy.USER) && hierarchy.USER.length > 0);
+}
+
+/**
+ * Opt1 (card_d199b41c, owner-ratified 2026-07-10): decide whether a subordinate's
+ * OWN output should auto-forward upward to its superior ("forward everything"
+ * semantics), given the device's hierarchy + options.
+ *
+ * Background: the org structure does NOT drive chat delivery by itself; up-forward
+ * used to require the explicit (default-OFF) `allForward` option, so an
+ * un-@mentioned subordinate→supervisor report was silently dropped by the routing
+ * fail-safe (a COMMON systemic gap; #6 was just the visible case). Opt1 makes
+ * up-forward the DEFAULT whenever a real hierarchy is configured — WITHOUT
+ * overriding an explicit forward-mode choice:
+ *   - allForward explicitly ON              → true  (forward everything; unchanged)
+ *   - taskForward ON (allForward off)       → false (task-gated path; caller keeps it)
+ *   - both OFF (the default) + hierarchy set → true  (Opt1 default-on)
+ *   - both OFF + no hierarchy configured     → false (dormant / commander fallback)
+ *
+ * Low-signal machine noise (heartbeat/ack) is still dropped by classifyLowSignalFwd
+ * at the callsite, so this does not forward spam. The human-safety fail-safe and
+ * the disconnected-branch / superior-binding checks in orgChartForward are
+ * unchanged. Pure function — unit-testable in isolation.
+ */
+function effectiveAllForward(hierarchy, options) {
+    const opts = options || {};
+    if (opts.allForward) return true;        // explicit "forward everything"
+    if (opts.taskForward) return false;      // explicit task-only choice is respected
+    return isHierarchyConfigured(hierarchy); // Opt1: default-on when a hierarchy exists
+}
+
+/**
  * Get direct subordinates of an entity (or "USER").
  */
 function getSubordinates(hierarchy, parentId) {
@@ -393,6 +430,8 @@ module.exports = {
     updateOrgChart,
     getSuperior,
     getSubordinates,
+    isHierarchyConfigured,
+    effectiveAllForward,
     buildDefault,
     pruneHierarchy,
     validateHierarchy,

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -4774,9 +4774,11 @@
             }
         }
 
-        // Mirror of backend org-chart.js getSuperior(): the direct parent entity id
-        // of `entityId` in the cached hierarchy, or 'USER' (reports to owner) or null
-        // (not placed). card_a0485399.
+        // Direct parent entity id of `entityId` in the cached hierarchy, or 'USER'
+        // (reports to owner) or null (not placed). Follows backend org-chart.js
+        // getSuperior(); coerces children via Number defensively (served hierarchies
+        // are already numeric via pruneHierarchy, so this only hardens the client
+        // against a malformed payload). card_a0485399.
         function orgSuperiorOf(entityId) {
             const h = orgChartHierarchy;
             if (!h || typeof h !== 'object') return null;
@@ -11641,11 +11643,10 @@
                 };
             }
 
-            // Floor: org-chart commander id (chip-path floor — chat-html cache).
-            const commanderFloor = (typeof orgChartCommanderId !== 'undefined'
-                && orgChartCommanderId != null
-                && (fallbackId == null || Number(orgChartCommanderId) !== Number(fallbackId)))
-                ? ('#' + orgChartCommanderId) : null;
+            // card_a0485399: NO #USER[0] commander floor here — flooring the
+            // to-side to hierarchy.USER[0] painted a wrong "#10" on the pill. A
+            // truly-unknown side now falls to the neutral label below (the upstream
+            // stub already carries the sender's real superior id when resolvable).
 
             // Neutral last resort: a sender-side label distinct from the
             // generic "Unspecified" so we never paint the same word on BOTH
@@ -11658,7 +11659,6 @@
                 || safeFallbackName
                 || (fallbackId != null && Number.isFinite(Number(fallbackId)) ? '#' + fallbackId : null)
                 || (!isBadName(fallbackCode) ? '#' + fallbackCode : null)
-                || commanderFloor
                 || neutral;
 
             const code = (sum && !isBadName(sum.publicCode)) ? '#' + sum.publicCode

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -4707,6 +4707,12 @@
         // org-chart resolves; if it never does, the chip is hidden.
         // card_29eed229d389e53bfae7d954.
         let orgChartCommanderId = null;
+        // Full org-chart hierarchy (card_a0485399): the routing-chip fallback must
+        // resolve EACH message's real superior via getSuperior(), NOT a single
+        // device-wide "first entity under USER" — that heuristic made every degraded
+        // chip point at whoever was listed first under USER (e.g. #10). null until
+        // /api/device/org-chart resolves.
+        let orgChartHierarchy = null;
 
         // ── @user smart-name filter (card_cb3e56b1) ──
         // The device owner's configured display name. Resolved at boot from
@@ -4756,7 +4762,9 @@
             if (!currentUser?.deviceId || !currentUser?.deviceSecret) return;
             try {
                 const data = await apiCall('GET', `/api/device/org-chart?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`);
-                const root = data?.orgChart?.hierarchy?.USER;
+                const hierarchy = data?.orgChart?.hierarchy;
+                orgChartHierarchy = (hierarchy && typeof hierarchy === 'object' && !Array.isArray(hierarchy)) ? hierarchy : null;
+                const root = orgChartHierarchy?.USER;
                 if (Array.isArray(root) && root.length > 0) {
                     const top = Number(root[0]);
                     if (Number.isFinite(top)) orgChartCommanderId = top;
@@ -4764,6 +4772,35 @@
             } catch (_) {
                 // Chip simply hides on unknown route — never block chat load.
             }
+        }
+
+        // Mirror of backend org-chart.js getSuperior(): the direct parent entity id
+        // of `entityId` in the cached hierarchy, or 'USER' (reports to owner) or null
+        // (not placed). card_a0485399.
+        function orgSuperiorOf(entityId) {
+            const h = orgChartHierarchy;
+            if (!h || typeof h !== 'object') return null;
+            const eid = Number(entityId);
+            for (const parentKey of Object.keys(h)) {
+                const kids = h[parentKey];
+                if (Array.isArray(kids) && kids.map(Number).includes(eid)) {
+                    return parentKey === 'USER' ? 'USER' : Number(parentKey);
+                }
+            }
+            return null;
+        }
+
+        // Resolve the routing-chip fallback target for a bot reply from `entityId`
+        // that carries no explicit routing_meta: its REAL org-chart superior when
+        // that is a distinct bound-or-unbound entity, else the device owner ("User").
+        // NEVER a blanket #USER[0] (the #10 bug, card_a0485399). Returns
+        // { toId:Number|null, isUser:bool }.
+        function degradedTargetFor(entityId) {
+            const sup = orgSuperiorOf(entityId);
+            if (sup != null && sup !== 'USER' && Number(sup) !== Number(entityId)) {
+                return { toId: Number(sup), isUser: false };
+            }
+            return { toId: null, isUser: true };
         }
 
         // ── Chat Integrity Validator ──
@@ -7393,11 +7430,12 @@
                 // no-speakTo bot reply can land). No '?' in any case.
                 if (msg && msg.is_from_bot && msg.entity_id != null) {
                     const senderLabel = '#' + msg.entity_id;
-                    const targetLabel = (orgChartCommanderId != null && orgChartCommanderId !== Number(msg.entity_id))
-                        ? ('#' + orgChartCommanderId)
-                        : (tt('chat_routing_to_user', 'User'));
+                    // card_a0485399: resolve THIS sender's real org-chart superior
+                    // (not a single #USER[0]). USER/orphan → the device owner ("User").
+                    const tgt = degradedTargetFor(msg.entity_id);
+                    const targetLabel = tgt.isUser ? tt('chat_routing_to_user', 'User') : ('#' + tgt.toId);
                     const title = `${tt('chat_routing_label','路由')}: ${senderLabel} → ${targetLabel} · ${tt('chat_routing_client_derived','client-derived')}`;
-                    const stub = { status: 'degraded', from_entity_id: msg.entity_id, from_name: senderFloorName, to_entity_id: (orgChartCommanderId != null && orgChartCommanderId !== Number(msg.entity_id)) ? orgChartCommanderId : null, to_is_user: !(orgChartCommanderId != null && orgChartCommanderId !== Number(msg.entity_id)) };
+                    const stub = { status: 'degraded', from_entity_id: msg.entity_id, from_name: senderFloorName, to_entity_id: tgt.toId, to_is_user: tgt.isUser };
                     return `<span class="routing-chip rc-degraded"${chipClickAttrs('degraded-client', stub)} title="${escapeHtml(title)}"><span class="rc-route">${escapeHtml(senderLabel)} → ${escapeHtml(targetLabel)}</span></span>`;
                 }
                 return '';
@@ -7422,14 +7460,20 @@
             // (cached via loadOrgChartCommander) if available; otherwise
             // hide the chip entirely. Same treatment for an unknown LV.
             const seg = routingLvSegment(rm.to_lv);
-            const fallback = (orgChartCommanderId != null) ? ('#' + orgChartCommanderId) : null;
-            const from = rm.from_name || (rm.from_entity_id != null ? '#' + rm.from_entity_id : fallback);
+            // card_a0485399: never floor a routing target to a blanket #USER[0].
+            // From-side floors to the row's own sender id; to-side floors to the
+            // SENDER'S real superior (or "User"), resolved per-entity.
+            const from = rm.from_name
+                || (rm.from_entity_id != null ? '#' + rm.from_entity_id
+                    : (senderFloorId != null ? '#' + senderFloorId : null));
+            const toFloor = degradedTargetFor(rm.from_entity_id != null ? rm.from_entity_id : senderFloorId);
             // card_ecda7243: a self-reply to the device owner carries to_is_user
             // (mode 'toUser') with to_entity_id null — render the localized "User"
             // label, never the raw to_name or a '?' fallback.
             const to = rm.to_is_user
                 ? tt('chat_routing_to_user', 'User')
-                : (rm.to_name || (rm.to_entity_id != null ? '#' + rm.to_entity_id : fallback));
+                : (rm.to_name || (rm.to_entity_id != null ? '#' + rm.to_entity_id
+                    : (toFloor.isUser ? tt('chat_routing_to_user', 'User') : '#' + toFloor.toId)));
             if (!from || !to) return '';
             const lvNum = Number(rm.to_lv);
             const hasLv = Number.isFinite(lvNum);

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -11643,10 +11643,17 @@
                 };
             }
 
-            // card_a0485399: NO #USER[0] commander floor here — flooring the
-            // to-side to hierarchy.USER[0] painted a wrong "#10" on the pill. A
-            // truly-unknown side now falls to the neutral label below (the upstream
-            // stub already carries the sender's real superior id when resolvable).
+            // Floor: org-chart commander id (chip-path floor — chat-html cache).
+            // NOTE (card_a0485399): this deep last-resort floor is reached only when
+            // a pill has NO sum/name/id/code at all — the inline routing chip's
+            // #10 bug lived upstream (degraded stub target) and is fixed there; the
+            // stub now carries the sender's real superior so this floor is not hit
+            // on the reported path. Left intact as the modal's established
+            // "never-undefined" floor (card_f15eda1e/card_29eed229 regression).
+            const commanderFloor = (typeof orgChartCommanderId !== 'undefined'
+                && orgChartCommanderId != null
+                && (fallbackId == null || Number(orgChartCommanderId) !== Number(fallbackId)))
+                ? ('#' + orgChartCommanderId) : null;
 
             // Neutral last resort: a sender-side label distinct from the
             // generic "Unspecified" so we never paint the same word on BOTH
@@ -11659,6 +11666,7 @@
                 || safeFallbackName
                 || (fallbackId != null && Number.isFinite(Number(fallbackId)) ? '#' + fallbackId : null)
                 || (!isBadName(fallbackCode) ? '#' + fallbackCode : null)
+                || commanderFloor
                 || neutral;
 
             const code = (sum && !isBadName(sum.publicCode)) ? '#' + sum.publicCode

--- a/backend/tests/jest/chat-routing-chip-commander-fallback.test.js
+++ b/backend/tests/jest/chat-routing-chip-commander-fallback.test.js
@@ -40,9 +40,10 @@ describe('routing chip — commander fallback (card_29eed229d389e53bfae7d954)', 
         expect(chipFn).not.toBeNull();
     });
 
-    test('reads cached commander via module-level orgChartCommanderId', () => {
-        // The cache is checked inside the chip — proves the fallback is wired.
-        expect(positiveBranch).toMatch(/orgChartCommanderId/);
+    test('resolves the to-side floor via the sender\'s real superior (card_a0485399, not #USER[0])', () => {
+        // The positive branch floors an unknown to-side to degradedTargetFor(sender)
+        // — the sender's real org-chart superior — never a blanket #USER[0] commander.
+        expect(positiveBranch).toMatch(/degradedTargetFor/);
     });
 
     test('hides chip entirely when both sides remain unknown', () => {
@@ -87,9 +88,10 @@ describe('org-chart commander loader (cache source of truth)', () => {
         expect(loader).not.toBeNull();
         const body = loader[0];
         expect(body).toMatch(/\/api\/device\/org-chart/);
-        // The commander is the first entry under hierarchy.USER (matches
-        // dashboard.html's renderOrgChart() canonical layout).
-        expect(body).toMatch(/orgChart\?\.hierarchy\?\.USER/);
+        // Caches the full hierarchy (card_a0485399) for per-entity superior
+        // resolution, and still derives the legacy commander (first under USER).
+        expect(body).toMatch(/data\?\.orgChart\?\.hierarchy/);
+        expect(body).toMatch(/orgChartHierarchy\?\.USER/);
         expect(body).toMatch(/orgChartCommanderId\s*=\s*top/);
     });
 

--- a/backend/tests/jest/commander-forward-fallback.test.js
+++ b/backend/tests/jest/commander-forward-fallback.test.js
@@ -201,8 +201,8 @@ describe('source invariants — orgChartForward wiring', () => {
             indexSrc,
             'async function orgChartForward(entity, deviceId, message, opts = {})'
         );
-        // taskForward/allForward-off return → fallback
-        expect(fwdSrc).toMatch(/!orgData\.options\.taskForward && !orgData\.options\.allForward\)\s*\{\s*return commanderForwardFallback/);
+        // taskForward off AND no effective up-forward (Opt1 forwardAllUp, card_d199b41c) → fallback
+        expect(fwdSrc).toMatch(/!orgData\.options\.taskForward && !forwardAllUp\)\s*\{\s*return commanderForwardFallback/);
         // no superior for this entity → fallback
         expect(fwdSrc).toMatch(/superiorId == null\)\s*\{\s*return commanderForwardFallback/);
     });

--- a/backend/tests/jest/orgchart-upforward-default-and-routing-chip.test.js
+++ b/backend/tests/jest/orgchart-upforward-default-and-routing-chip.test.js
@@ -1,0 +1,106 @@
+/**
+ * Opt1 up-forward default-on + routing-chip #10 fix
+ *   - card_d199b41c (owner-ratified 2026-07-10): org-chart hierarchy should DRIVE
+ *     up-report routing — up-forward defaults ON when a hierarchy is configured,
+ *     WITHOUT overriding an explicit taskForward-only choice.
+ *   - card_a0485399 (Hank screenshot 2026-07-10): chat routing labels all pointed
+ *     to #10 because the client floored EVERY degraded chip's target to
+ *     hierarchy.USER[0] (the first entity under USER). The fix resolves each
+ *     message's REAL superior via getSuperior(); the backend Opt1 change also
+ *     stamps a proper org_upward routing_meta so rows are not degraded at all.
+ *
+ * RED on origin/main:
+ *   - orgChart.effectiveAllForward is undefined → the behavior assertions throw.
+ *   - chat.html has no `degradedTargetFor` / `orgSuperiorOf`; the degraded chip
+ *     still floors the target to orgChartCommanderId (#USER[0]).
+ * GREEN with the fix: all pass.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const orgChart = require('../../org-chart');
+
+// Hank's real device hierarchy from the bug report / routing-detail:
+//   #2 → #6, #3/#5/#1/#4 → #2, #6 → USER, #10 → USER.
+const HANK_HIERARCHY = { 2: [3, 5, 1, 4], 6: [2], USER: [10, 6] };
+
+describe('org-chart getSuperior resolves Hank\'s hierarchy correctly (the #10 bug\'s ground truth)', () => {
+    it('#2 reports to #6 (not #10)', () => {
+        expect(orgChart.getSuperior(HANK_HIERARCHY, 2)).toBe(6);
+    });
+    it('#3 reports to #2 (not #10)', () => {
+        expect(orgChart.getSuperior(HANK_HIERARCHY, 3)).toBe(2);
+    });
+    it('#5/#1/#4 report to #2', () => {
+        expect(orgChart.getSuperior(HANK_HIERARCHY, 5)).toBe(2);
+        expect(orgChart.getSuperior(HANK_HIERARCHY, 1)).toBe(2);
+        expect(orgChart.getSuperior(HANK_HIERARCHY, 4)).toBe(2);
+    });
+    it('#6 and #10 report to USER (top-level → "User", never #10)', () => {
+        expect(orgChart.getSuperior(HANK_HIERARCHY, 6)).toBe('USER');
+        expect(orgChart.getSuperior(HANK_HIERARCHY, 10)).toBe('USER');
+    });
+});
+
+describe('isHierarchyConfigured()', () => {
+    it('true when a USER root has at least one report', () => {
+        expect(orgChart.isHierarchyConfigured(HANK_HIERARCHY)).toBe(true);
+        expect(orgChart.isHierarchyConfigured({ USER: [6] })).toBe(true);
+    });
+    it('false for empty / no-USER / empty-USER hierarchies', () => {
+        expect(orgChart.isHierarchyConfigured({})).toBe(false);
+        expect(orgChart.isHierarchyConfigured({ USER: [] })).toBe(false);
+        expect(orgChart.isHierarchyConfigured(null)).toBe(false);
+        expect(orgChart.isHierarchyConfigured({ 2: [3] })).toBe(false); // no USER root
+    });
+});
+
+describe('effectiveAllForward() — Opt1 default-on (card_d199b41c)', () => {
+    it('default-ON when a hierarchy is configured and NO forward mode chosen (the fix)', () => {
+        expect(orgChart.effectiveAllForward(HANK_HIERARCHY, { allForward: false, taskForward: false })).toBe(true);
+        expect(orgChart.effectiveAllForward(HANK_HIERARCHY, {})).toBe(true);
+        expect(orgChart.effectiveAllForward(HANK_HIERARCHY, null)).toBe(true);
+    });
+    it('OFF when both options off AND no hierarchy configured (dormant / commander-fallback path unchanged)', () => {
+        expect(orgChart.effectiveAllForward({}, { allForward: false, taskForward: false })).toBe(false);
+        expect(orgChart.effectiveAllForward({ USER: [] }, {})).toBe(false);
+        expect(orgChart.effectiveAllForward(null, {})).toBe(false);
+    });
+    it('respects an EXPLICIT taskForward-only choice (returns false so caller keeps task-gated path)', () => {
+        expect(orgChart.effectiveAllForward(HANK_HIERARCHY, { allForward: false, taskForward: true })).toBe(false);
+    });
+    it('explicit allForward stays true regardless of hierarchy', () => {
+        expect(orgChart.effectiveAllForward(HANK_HIERARCHY, { allForward: true })).toBe(true);
+        expect(orgChart.effectiveAllForward({}, { allForward: true })).toBe(true);
+        // allForward wins even if taskForward is also set
+        expect(orgChart.effectiveAllForward(HANK_HIERARCHY, { allForward: true, taskForward: true })).toBe(true);
+    });
+});
+
+describe('chat.html routing-chip #10 fix (card_a0485399) — static contract', () => {
+    const src = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html'),
+        'utf8'
+    );
+
+    it('caches the full hierarchy and defines per-entity superior resolvers', () => {
+        expect(src).toContain('let orgChartHierarchy = null;');
+        expect(src).toMatch(/function orgSuperiorOf\(/);
+        expect(src).toMatch(/function degradedTargetFor\(/);
+    });
+
+    it('the degraded client-derived chip targets the sender\'s real superior, NOT #USER[0]', () => {
+        // The fixed degraded branch uses degradedTargetFor(...) → tgt.toId.
+        expect(src).toContain('const tgt = degradedTargetFor(msg.entity_id);');
+        expect(src).toContain('to_entity_id: tgt.toId');
+        // The old bug — flooring the degraded target to orgChartCommanderId — is gone.
+        expect(src).not.toMatch(/to_entity_id:\s*\(orgChartCommanderId != null/);
+    });
+
+    it('no routing target is floored to a blanket #USER[0] via a commander "fallback" const', () => {
+        // The positive-branch `const fallback = ... orgChartCommanderId ...` that
+        // painted the to-side with #USER[0] is removed in favor of per-entity floors.
+        expect(src).not.toMatch(/const fallback = \(orgChartCommanderId != null\)/);
+    });
+});

--- a/backend/tests/jest/routing-meta-card-1f8.test.js
+++ b/backend/tests/jest/routing-meta-card-1f8.test.js
@@ -126,11 +126,11 @@ describe('card_1f8 — frontend: sender-fallback chip when source unparseable', 
         // No literal "→ ?" anywhere in the fallback block.
         expect(head).not.toMatch(/→\s*\?/);
         expect(head).not.toMatch(/to_entity_id\s*:\s*null\s*\}.*→ \?/);
-        // The degraded chip consults the cached org-chart commander as the
-        // upper-level fallback target.
+        // The degraded chip resolves THIS sender's real org-chart superior
+        // (card_a0485399 — never a blanket #USER[0] commander) as the target.
         const degradedBlock = head.split('msg.is_from_bot && msg.entity_id != null').pop() || '';
-        expect(degradedBlock).toMatch(/orgChartCommanderId/);
-        // and falls back to a localized User label, not '?'.
+        expect(degradedBlock).toMatch(/degradedTargetFor/);
+        // and falls back to a localized User label (top-level → owner), not '?'.
         expect(degradedBlock).toMatch(/chat_routing_to_user/);
     });
 

--- a/backend/tests/jest/routing-self-reply-card-ecda7243.test.js
+++ b/backend/tests/jest/routing-self-reply-card-ecda7243.test.js
@@ -151,6 +151,21 @@ describe('resolveSelfReplyRoutingMeta — org-parent vs user, never "?"', () => 
         const meta = await resolve(child, 'dev1', 3, 'ok');
         expect(meta.mode).toBe('toUser');
     });
+
+    test('disconnected sub-tree (superior chain never reaches USER) → toUser, chip does not lie (card_d199b41c mirror walk)', async () => {
+        // 3→2→5→(orphan): 5 is not under USER, so orgChartForward would DROP the
+        // message (reachesUser=false). Opt1 default-on (both options off + a
+        // configured hierarchy) would otherwise stamp org_upward — the reaches-USER
+        // walk must prevent that so the chip matches the real (non-)route.
+        const resolve = makeResolver({
+            hierarchy: { USER: [10], 2: [3], 5: [2] },
+            options: {},
+            entities: { 3: child, 2: parent, 5: { name: 'Orphan', isBound: true }, 10: parent },
+        });
+        const meta = await resolve(child, 'dev1', 3, 'status');
+        expect(meta.mode).toBe('toUser');
+        expect(meta.to_is_user).toBe(true);
+    });
 });
 
 describe('backend self-save wiring (static surface)', () => {

--- a/backend/tests/jest/routing-self-reply-card-ecda7243.test.js
+++ b/backend/tests/jest/routing-self-reply-card-ecda7243.test.js
@@ -28,6 +28,9 @@ const path = require('path');
 const indexJs = fs.readFileSync(path.join(__dirname, '..', '..', 'index.js'), 'utf8');
 const chatHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html'), 'utf8');
 const i18nJs = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js'), 'utf8');
+// card_d199b41c: the resolver now consults effectiveAllForward for the Opt1
+// default-on decision — inject the REAL helpers so the mirror matches production.
+const realOrgChart = require('../../org-chart');
 
 // ── Build a runnable resolveSelfReplyRoutingMeta over injected module deps ──
 function makeResolver({ hierarchy, options, entities, hasOpenTask = false, lowSignal = false }) {
@@ -45,6 +48,9 @@ function makeResolver({ hierarchy, options, entities, hasOpenTask = false, lowSi
             }
             return null;
         },
+        // Real Opt1 helpers (card_d199b41c) so willForward mirrors production.
+        effectiveAllForward: realOrgChart.effectiveAllForward,
+        isHierarchyConfigured: realOrgChart.isHierarchyConfigured,
     };
     const devices = { dev1: { entities } };
     const chatPool = { query: async () => ({ rows: hasOpenTask ? [{ '?column?': 1 }] : [] }) };
@@ -174,10 +180,11 @@ describe('frontend chip never renders bare "?" (static surface)', () => {
         expect(chipBody).not.toMatch(/→\s*\?/);
     });
 
-    test('degraded fallback uses org commander or localized User label', () => {
+    test('degraded fallback resolves the sender\'s real superior or localized User label', () => {
         const head = chipBody.split('// Positive:')[0];
         const degraded = head.split('msg.is_from_bot && msg.entity_id != null').pop() || '';
-        expect(degraded).toMatch(/orgChartCommanderId/);
+        // card_a0485399: per-entity superior (degradedTargetFor), never #USER[0].
+        expect(degraded).toMatch(/degradedTargetFor/);
         expect(degraded).toMatch(/chat_routing_to_user/);
     });
 


### PR DESCRIPTION
## Two coupled, owner-directed routing fixes

### 1. Opt1 up-forward default-on — card_d199b41c (ratified by Hank 2026-07-10, entity consensus 4/4)
The org-chart hierarchy did **not** drive chat up-report routing: `orgChartForward` only fired on the explicit **default-OFF** `allForward` option, so an un-@mentioned subordinate→supervisor report hit the routing fail-safe and was silently dropped (a COMMON systemic gap; #6 was just the visible case).

**Fix:** new pure helper `org-chart.js effectiveAllForward(hierarchy, options)` makes up-forward the **default when a real hierarchy is configured**, *without* overriding an explicit `taskForward`-only choice:
- `allForward` explicitly on → true (unchanged)
- `taskForward` on (allForward off) → false (task-gated path kept)
- both off (default) + hierarchy configured → **true** (Opt1)
- both off + no hierarchy → false (dormant / commander-fallback unchanged)

Wired into `orgChartForward`'s dormant gate + forward branch **and** the `resolveSelfReplyRoutingMeta` chip mirror. Low-signal noise still dropped by `classifyLowSignalFwd`; the human-safety fail-safe is untouched.

### 2. Routing chip "all → #10" — card_a0485399 (Hank screenshot)
Per the org chart #2 should → #6 and #3 → #2, but every routing label showed **→ #10**. Root cause: `chat.html` floored **every** degraded chip's target to `orgChartCommanderId = hierarchy.USER[0]` (the first entity under USER = #10). Exposed because up-forward was OFF, so all replies were degraded/toUser.

**Fix:** cache the full hierarchy and resolve each message's **real superior** via `orgSuperiorOf()`/`degradedTargetFor()` — #2→#6, #3→#2, top-level (#6/#10)→"User" — never a blanket `#USER[0]`. Fix #1 also stamps proper `org_upward` routing_meta so most rows are no longer degraded at all.

## Tests (red→green)
`backend/tests/jest/orgchart-upforward-default-and-routing-chip.test.js`:
- `effectiveAllForward` 4-case matrix + edges (null/empty/`USER:[]`)
- `isHierarchyConfigured`
- `getSuperior` on Hank's real hierarchy `{2:[3,5,1,4],6:[2],USER:[10,6]}` → #2→6, #3→2, #6→USER, #10→USER
- `chat.html` static contract: uses `degradedTargetFor`/`orgSuperiorOf`, no `#USER[0]` target floor

**58/58 pass** (13 new + 45 existing org-chart). eslint clean. RED on origin/main (new exports undefined; `degradedTargetFor` string absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)