### PR TITLE
fix(kanban): census excludes automation parent cards (phantom 封鎖9)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -4858,11 +4858,25 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             // census columns below). assigned_bots is a jsonb array of entity
             // ids; `@> to_jsonb($n::int)` is the containment filter used
             // elsewhere in this file (e.g. lines ~4296/4529).
+            //
+            // Exclude automation PARENT cards (is_automation = true) so the
+            // census matches what the entity actually sees on its board. The
+            // board endpoint (GET /api/mission/cards) hides automation cards by
+            // default (see the `automation` filter, default `AND (is_automation
+            // = false OR is_automation IS NULL)`), but the census used to count
+            // them — so a recurring cron母卡 that an older stale-auto-blocker had
+            // parked in 'blocked' months ago showed up as a phantom "封鎖9" in
+            // every nudge while being invisible on the board (owner-reported
+            // 2026-07-10: "封鎖9張怎麼回事" — 9 automation parents, 0 real blocked
+            // cards). Automation CHILDREN (is_auto_generated, is_automation =
+            // false) are the real spawned work and STILL count — only the
+            // schedule-definition parents are filtered here.
             const res = await pool.query(
                 `SELECT status, status_changed_at
                    FROM kanban_cards
                   WHERE device_id = $1
                     AND archived = false
+                    AND (is_automation = false OR is_automation IS NULL)
                     AND status IN ('todo','in_progress','review','blocked')
                     AND assigned_bots @> to_jsonb($2::int)`,
                 [deviceId, Number(entityId)]

--- a/backend/tests/jest/kanban-nudge-task-census.test.js
+++ b/backend/tests/jest/kanban-nudge-task-census.test.js
@@ -68,6 +68,21 @@ describe('buildEntityTaskCensus — source invariants', () => {
         expect(body).toMatch(/try \{/);
         expect(body).toMatch(/catch \(err\)/);
     });
+
+    test('census query EXCLUDES automation parent cards (aligns with the board default view)', () => {
+        // Regression: 2026-07-10 owner-reported phantom "封鎖9" — 9 recurring
+        // automation母卡 an older stale-auto-blocker had parked in 'blocked' were
+        // counted by the census while being HIDDEN from the board (GET
+        // /api/mission/cards defaults to excluding is_automation cards). The census
+        // must apply the SAME is_automation filter so its counts match what the
+        // entity actually sees on its board. Fails on the pre-fix query (no
+        // is_automation clause); passes once the filter is added.
+        const body = extractFunctionBody(
+            kanbanSrc,
+            'async function buildEntityTaskCensus(deviceId, entityId)'
+        );
+        expect(body).toMatch(/is_automation = false OR is_automation IS NULL/);
+    });
 });
 
 describe('buildEntityTaskCensus — behavioural', () => {


### PR DESCRIPTION
## Problem (owner-reported 2026-07-10: 「封鎖9張怎麼回事」)

The per-entity task-load census (`buildEntityTaskCensus`, prepended to L1 stale nudges as `【#N 未完成｜待辦a·進行中b·審查c·封鎖d｜最舊停留Hh】`) counted **automation parent cards** (`is_automation = true`), but the board endpoint `GET /api/mission/cards` **hides** automation cards by default. The two views diverged:

- Board (what the owner opens): **0** blocked cards for #2.
- Census (in every nudge): **封鎖9**.

Those 9 were recurring automation母卡 (API Health E2E, 任務巡查, Daily 9AM Report, growth flywheel, SEO, channel expansion, destructive-modals E2E, MiniGame feedback, video daily) that an **older** stale-auto-blocker parked in `blocked` 39–77 days ago and never cleaned up. The current stale-checker already skips recurring automation parents (`kanban.js` ~4179), so they don't get *re-*blocked — but nothing swept the historical rows, and the census kept surfacing them as a phantom count invisible on the board.

## Fix

Add the **same** `AND (is_automation = false OR is_automation IS NULL)` filter the board default uses to the census query, so the census counts exactly what the entity sees on its board. Automation **children** (`is_auto_generated`, `is_automation = false`) are the real spawned work and still count.

Separately (ops, not in this diff): the 9 stale parents were moved `blocked → backlog` (parked; schedule keeps firing — the cron trigger is status-independent, and `backlog`/`done` are census-excluded). Confirmed live: the next nudge showed **封鎖0**.

## Test

`kanban-nudge-task-census.test.js`: new source-invariant assertion that the census query carries the `is_automation` filter — fails on `origin/main` (no such clause), passes here. Full suite **12/12 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)