### PR TITLE
Fix Codex usage source attribution

### DIFF
--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -52,12 +52,15 @@ const DEFAULTS = {
     // 排程觸發母卡 self-recurring (no子卡, only re-trigger self): notify on each fire?
     // Default true — these fire less often (one per cron tick) and the user usually wants to know.
     kanban_cron_recurring_notify: true,
-    // Usage warning (card_9cd84ee7d830b2f76c595f6c): when Claude 5h/7d remaining
-    // drops below the thresholds, each outbound Agent message is prepended with
-    // a system warning so the dialog partner knows quota is tight.
-    // Shape: { enabled: bool, threshold_5h_pct: 0-100, threshold_7d_pct: 0-100 }
+    // Usage warning (card_9cd84ee7d830b2f76c595f6c): when the speaking Agent's
+    // 5h/7d remaining quota drops below the thresholds, each outbound Agent
+    // message is prepended with a system warning so the dialog partner knows
+    // quota is tight. entity_engines pins channel entities to the right quota
+    // source when one device hosts both Claude and Codex channels.
+    // Shape: { enabled: bool, threshold_5h_pct: 0-100, threshold_7d_pct: 0-100,
+    //          entity_engines: { "<entityId>": "claude" | "codex" } }
     // Trigger logic: warn if (5h_remaining ≤ threshold_5h_pct) OR (7d_remaining ≤ threshold_7d_pct).
-    usage_warning_config: { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5 },
+    usage_warning_config: { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5, entity_engines: {} },
     // "需要你" HITL inbox (card_8151054f). Backend stub defaults only — the full
     // settings UI is a separate PR (#6). The backend ALWAYS emits the
     // 'action_request:changed' socket event; the frontend gates live-refresh
@@ -376,10 +379,20 @@ function coerceValue(key, raw) {
             if (!Number.isFinite(n)) return fallback;
             return Math.max(0, Math.min(100, Math.round(n)));
         };
+        const entityEngines = {};
+        if (raw.entity_engines && typeof raw.entity_engines === 'object' && !Array.isArray(raw.entity_engines)) {
+            for (const [entityId, engine] of Object.entries(raw.entity_engines)) {
+                const n = Number(entityId);
+                if (Number.isFinite(n) && n >= 0 && (engine === 'claude' || engine === 'codex')) {
+                    entityEngines[String(n)] = engine;
+                }
+            }
+        }
         return {
             enabled,
             threshold_5h_pct: 'threshold_5h_pct' in raw ? clampPct(raw.threshold_5h_pct, d.threshold_5h_pct) : d.threshold_5h_pct,
             threshold_7d_pct: 'threshold_7d_pct' in raw ? clampPct(raw.threshold_7d_pct, d.threshold_7d_pct) : d.threshold_7d_pct,
+            entity_engines: entityEngines,
         };
     }
     if (key === 'kanban_nudge_per_entity_overrides') {

--- a/backend/index.js
+++ b/backend/index.js
@@ -9064,10 +9064,10 @@ app.post('/api/bind', async (req, res) => {
 /**
  * Classify a channel callback_url into one of the known provider buckets
  * so bots can route dispatches differently (OpenClaw vs Claude Code vs
- * Hermes vs a custom webhook). Heuristic-only — the plugin never tells
+ * Hermes vs Codex vs a custom webhook). Heuristic-only — the plugin never tells
  * us directly what it is, so we read the URL the plugin registered.
  *
- * Returns: 'openclaw' | 'claude' | 'hermes' | 'custom' | null
+ * Returns: 'openclaw' | 'claude' | 'hermes' | 'codex' | 'custom' | null
  * null means the entity is channel-bound but /register hasn't happened
  * yet (callback_url still NULL in channel_accounts).
  */
@@ -9085,6 +9085,7 @@ function deriveChannelProvider(callbackUrl) {
     const hay = `${host}${path}`;
     if (hay.includes('openclaw')) return 'openclaw';
     if (hay.includes('hermes')) return 'hermes';
+    if (hay.includes('codex')) return 'codex';
     if (hay.includes('claude') || hay.includes('claude-code')) return 'claude';
     return 'custom';
 }
@@ -10583,10 +10584,11 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
         routingResolvedVia = null;
     }
     // Usage warning prefix (card_9cd84ee7d830b2f76c595f6c; card_a69e8ffa refinement).
-    // When the device opted in and the latest usage_snapshots row shows
-    // Claude 5h/7d remaining ≤ thresholds, prepend a system warning so the
-    // user knows quota is tight. Best-effort: any failure here (no snapshot /
-    // stale / DB hiccup) silently skips — never blocks delivery.
+    // When the device opted in and the latest usage_snapshots row shows the
+    // speaking entity's provider-specific 5h/7d remaining ≤ thresholds, prepend
+    // a system warning so the user knows quota is tight. Best-effort: any
+    // failure here (no snapshot / stale / DB hiccup) silently skips — never
+    // blocks delivery.
     // Gate to USER-FACING pushes only: skip bot-to-bot directed messages
     // (speakTo targets another entity). Riding bot-to-bot acks made the warning
     // surface via org-chart-forward as a standalone conversational line to the

--- a/backend/lib/usage-warning.js
+++ b/backend/lib/usage-warning.js
@@ -1,7 +1,7 @@
 /**
  * Usage Warning Module (card_9cd84ee7d830b2f76c595f6c)
  *
- * Reads the latest usage_snapshots row for a device, decides whether the
+ * Reads the latest usage_snapshots row for a device/entity, decides whether the
  * remaining quota crossed the per-device threshold, and formats an i18n
  * system-warning prefix that /api/transform prepends to outbound messages.
  *
@@ -12,8 +12,14 @@
  * only fall back to legacy unscoped rows (entity_id IS NULL) — mirroring
  * backend/kanban.js getEntityUsagePct().
  *
+ * Source attribution (card_usage_codex_source): usage snapshots may carry both
+ * Claude and Codex quota blocks for the same device. The speaking entity's
+ * provider decides which source is authoritative via
+ * usage_warning_config.entity_engines["<entityId>"] = "claude" | "codex".
+ *
  * Spec: device opts in via usage_warning_config pref
- *   { enabled: bool, threshold_5h_pct: 0..100, threshold_7d_pct: 0..100 }
+ *   { enabled: bool, threshold_5h_pct: 0..100, threshold_7d_pct: 0..100,
+ *     entity_engines?: { "<entityId>": "claude" | "codex" } }
  *
  * Trigger:  (5h_remaining ≤ threshold_5h_pct) OR (7d_remaining ≤ threshold_7d_pct)
  * Stale:    captured_at older than 6h → skip (no false-positive warnings)
@@ -58,6 +64,33 @@ function pickClaudeLivePct(live, key) {
 }
 
 /**
+ * Pull Codex used-percent quota from the daemon snapshot shape.
+ * backend/tooling/eclaw-usage-daemon/codex_loader.py writes:
+ *   codex_json.rate_limits.five_hour_pct / seven_day_pct
+ * These are USED percentages, matching the Claude picker contract.
+ */
+function pickCodexPct(codexJson, key) {
+    if (!codexJson || typeof codexJson !== 'object') return null;
+    const rateLimits = codexJson.rate_limits || {};
+    const flatKey = key + '_pct';
+    if (typeof rateLimits[flatKey] === 'number') return rateLimits[flatKey];
+    const nested = rateLimits[key];
+    if (nested && typeof nested.used_percentage === 'number') return nested.used_percentage;
+    if (nested && typeof nested.used_percent === 'number') return nested.used_percent;
+    return null;
+}
+
+function resolveEntityEngine(config, entityId) {
+    const cfg = config || {};
+    const engines = cfg.entity_engines;
+    if (!engines || typeof engines !== 'object' || Array.isArray(engines)) return 'claude';
+    const eid = (entityId === null || entityId === undefined) ? NaN : Number(entityId);
+    if (!Number.isFinite(eid)) return 'claude';
+    const raw = engines[String(eid)];
+    return raw === 'codex' ? 'codex' : 'claude';
+}
+
+/**
  * Pure decision function: should we attach the warning right now?
  *
  * @param {object|null} snapshot — { claude_json, codex_json, captured_at } or null
@@ -70,37 +103,51 @@ function pickClaudeLivePct(live, key) {
  *   disabled:    bool — user opted out
  *   five_hour_remaining_pct, seven_day_remaining_pct (number|null)
  */
-function shouldWarnNow(snapshot, config, nowMs = Date.now()) {
+function shouldWarnNow(snapshot, config, nowMs = Date.now(), engine = 'claude') {
     const cfg = config || {};
+    const sourceEngine = engine === 'codex' ? 'codex' : 'claude';
     const enabled = cfg.enabled !== false;
     const t5 = Number.isFinite(cfg.threshold_5h_pct) ? cfg.threshold_5h_pct : 15;
     const t7 = Number.isFinite(cfg.threshold_7d_pct) ? cfg.threshold_7d_pct : 5;
 
     if (!enabled) {
         return { warn: false, disabled: true, stale: false, no_snapshot: false,
-                 five_hour_remaining_pct: null, seven_day_remaining_pct: null };
+                 engine: sourceEngine, five_hour_remaining_pct: null, seven_day_remaining_pct: null };
     }
     if (!snapshot) {
         return { warn: false, disabled: false, stale: false, no_snapshot: true,
-                 five_hour_remaining_pct: null, seven_day_remaining_pct: null };
+                 engine: sourceEngine, five_hour_remaining_pct: null, seven_day_remaining_pct: null };
     }
 
     const capturedAtMs = snapshot.captured_at ? Date.parse(snapshot.captured_at) : NaN;
     if (!Number.isFinite(capturedAtMs) || (nowMs - capturedAtMs) > STALE_THRESHOLD_MS) {
         return { warn: false, disabled: false, stale: true, no_snapshot: false,
-                 five_hour_remaining_pct: null, seven_day_remaining_pct: null };
+                 engine: sourceEngine, five_hour_remaining_pct: null, seven_day_remaining_pct: null };
     }
 
-    const live = (snapshot.claude_json && snapshot.claude_json.live) || {};
-    const used5 = pickClaudeLivePct(live, 'five_hour');
-    const used7 = pickClaudeLivePct(live, 'seven_day');
+    let used5 = null;
+    let used7 = null;
+    if (sourceEngine === 'codex') {
+        const rateLimits = snapshot.codex_json && snapshot.codex_json.rate_limits;
+        const updatedAtMs = rateLimits && rateLimits.updated_at ? Date.parse(rateLimits.updated_at) : NaN;
+        if (Number.isFinite(updatedAtMs) && (nowMs - updatedAtMs) > STALE_THRESHOLD_MS) {
+            return { warn: false, disabled: false, stale: true, no_snapshot: false,
+                     engine: sourceEngine, five_hour_remaining_pct: null, seven_day_remaining_pct: null };
+        }
+        used5 = pickCodexPct(snapshot.codex_json, 'five_hour');
+        used7 = pickCodexPct(snapshot.codex_json, 'seven_day');
+    } else {
+        const live = (snapshot.claude_json && snapshot.claude_json.live) || {};
+        used5 = pickClaudeLivePct(live, 'five_hour');
+        used7 = pickClaudeLivePct(live, 'seven_day');
+    }
 
     const rem5 = (typeof used5 === 'number') ? Math.max(0, 100 - used5) : null;
     const rem7 = (typeof used7 === 'number') ? Math.max(0, 100 - used7) : null;
 
     if (rem5 == null && rem7 == null) {
         return { warn: false, disabled: false, stale: false, no_snapshot: true,
-                 five_hour_remaining_pct: null, seven_day_remaining_pct: null };
+                 engine: sourceEngine, five_hour_remaining_pct: null, seven_day_remaining_pct: null };
     }
 
     const breach5 = rem5 != null && rem5 <= t5;
@@ -111,6 +158,7 @@ function shouldWarnNow(snapshot, config, nowMs = Date.now()) {
         disabled: false,
         stale: false,
         no_snapshot: false,
+        engine: sourceEngine,
         five_hour_remaining_pct: rem5,
         seven_day_remaining_pct: rem7,
     };
@@ -184,7 +232,8 @@ async function getWarningPrefix(pool, deviceId, config, lang, entityId = null, n
             claude_json: row.claude_json,
             codex_json:  row.codex_json,
         } : null;
-        const decision = shouldWarnNow(snapshot, config, nowMs);
+        const engine = resolveEntityEngine(config, useEid ? eid : null);
+        const decision = shouldWarnNow(snapshot, config, nowMs, engine);
         if (!decision.warn) return null;
         // Cooldown: suppress if we already attached a warning for this
         // device+entity inside the window — keeps it a one-off piggyback,
@@ -209,6 +258,8 @@ module.exports = {
     DEFAULT_COOLDOWN_MS,
     WARNING_TEMPLATES,
     pickClaudeLivePct,
+    pickCodexPct,
+    resolveEntityEngine,
     shouldWarnNow,
     formatWarningText,
     withinCooldown,

--- a/backend/passive-health.js
+++ b/backend/passive-health.js
@@ -73,6 +73,7 @@ const OPEN_FAIL_THRESHOLD = 3;
 const STUCK_PENDING_THRESHOLD = 3;
 const HEARTBEAT_STALE_MS = 300_000; // 5 min — matches index.js ENTITY_HEARTBEAT_STALE_MS default
 const HEALTH_PROBE_TIMEOUT_MS = 4_000;
+const USAGE_WARNING_ENGINES = new Set(['claude', 'codex']);
 
 function init(opts) {
     pool = opts.pool || null;
@@ -161,6 +162,76 @@ async function updateSettings(deviceId, patch) {
         console.error('[PassiveHealth] updateSettings error:', err.message);
     }
     return merged;
+}
+
+function normalizeUsageWarningEngine(provider) {
+    return USAGE_WARNING_ENGINES.has(provider) ? provider : null;
+}
+
+function parsePrefs(raw) {
+    if (!raw) return {};
+    if (typeof raw === 'string') {
+        try { return JSON.parse(raw) || {}; } catch { return {}; }
+    }
+    return (typeof raw === 'object' && !Array.isArray(raw)) ? raw : {};
+}
+
+function normalizeEntityEngines(raw) {
+    const out = {};
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return out;
+    for (const [entityId, engine] of Object.entries(raw)) {
+        const n = Number(entityId);
+        if (Number.isFinite(n) && n >= 0 && USAGE_WARNING_ENGINES.has(engine)) {
+            out[String(n)] = engine;
+        }
+    }
+    return out;
+}
+
+async function repairUsageWarningEngine(deviceId, entityId, provider) {
+    const engine = normalizeUsageWarningEngine(provider);
+    const eid = Number(entityId);
+    if (!pool || !deviceId) return { changed: false, reason: 'pool_unavailable' };
+    if (!Number.isFinite(eid) || eid < 0) return { changed: false, reason: 'invalid_entity_id' };
+    if (!engine) return { changed: false, reason: 'provider_not_managed', provider: provider || null };
+
+    try {
+        const r = await pool.query(
+            'SELECT prefs FROM device_preferences WHERE device_id = $1',
+            [deviceId]
+        );
+        const prefs = parsePrefs(r.rows[0] && r.rows[0].prefs);
+        const currentCfg = (prefs.usage_warning_config && typeof prefs.usage_warning_config === 'object' && !Array.isArray(prefs.usage_warning_config))
+            ? prefs.usage_warning_config : {};
+        const entityEngines = normalizeEntityEngines(currentCfg.entity_engines);
+        const key = String(eid);
+        if (entityEngines[key] === engine) {
+            return { changed: false, reason: 'already_current', engine, entityId: eid };
+        }
+        const previous = entityEngines[key] || null;
+        entityEngines[key] = engine;
+        const nextCfg = {
+            ...currentCfg,
+            enabled: currentCfg.enabled !== false,
+            threshold_5h_pct: Number.isFinite(currentCfg.threshold_5h_pct) ? currentCfg.threshold_5h_pct : 15,
+            threshold_7d_pct: Number.isFinite(currentCfg.threshold_7d_pct) ? currentCfg.threshold_7d_pct : 5,
+            entity_engines: entityEngines,
+        };
+
+        await pool.query(`
+            INSERT INTO device_preferences (device_id, prefs, updated_at)
+            VALUES ($1, jsonb_build_object('usage_warning_config', $2::jsonb), $3)
+            ON CONFLICT (device_id) DO UPDATE
+            SET prefs = jsonb_set(
+                    COALESCE(device_preferences.prefs, '{}'::jsonb),
+                    '{usage_warning_config}', $2::jsonb, true),
+                updated_at = $3
+        `, [deviceId, JSON.stringify(nextCfg), Date.now()]);
+        return { changed: true, engine, previous, entityId: eid };
+    } catch (err) {
+        console.error('[PassiveHealth] repairUsageWarningEngine error:', err.message);
+        return { changed: false, reason: 'error', error: err.message };
+    }
 }
 
 // ── Eligibility ───────────────────────────────────────────────────────────────
@@ -457,8 +528,15 @@ async function runEntity(deviceId, deviceSecret, entityId, settings) {
                 : `Passive health: unhealthy (${health.failingSignals.join(', ')})`,
             { healthy: health.healthy, readiness: health.readiness, canReply: health.canReply, callbackActive: health.callbackActive, failingSignals: health.failingSignals, provider: health.provider, signals: health.signals });
 
+        const usageDisplayRepair = await repairUsageWarningEngine(deviceId, entityId, health.provider);
+        if (usageDisplayRepair.changed) {
+            await logEvent(deviceId, entityId, 'usage_warning_self_repair',
+                `Usage display source repaired: entity #${entityId} → ${usageDisplayRepair.engine}`,
+                { engine: usageDisplayRepair.engine, previous: usageDisplayRepair.previous });
+        }
+
         if (health.healthy || !settings.autoRepair) {
-            return { entityId, eligible: true, healthy: health.healthy, readiness: health.readiness, canReply: health.canReply, callbackActive: health.callbackActive, repaired: false, failingSignals: health.failingSignals };
+            return { entityId, eligible: true, healthy: health.healthy, readiness: health.readiness, canReply: health.canReply, callbackActive: health.callbackActive, repaired: false, usageDisplayRepair, failingSignals: health.failingSignals };
         }
 
         // No callback registered is NOT self-repairable — the callback must be
@@ -469,7 +547,7 @@ async function runEntity(deviceId, deviceSecret, entityId, settings) {
             await logEvent(deviceId, entityId, 'self_repair',
                 bug.filed ? `No-callback bug filed (feedback #${bug.feedbackId}) — re-bind required, not self-repairable` : `No-callback bug filing failed: ${bug.reason}`,
                 { filed: bug.filed, feedbackId: bug.feedbackId, issueUrl: bug.issueUrl, reason: 'no_callback', failingSignals: health.failingSignals });
-            return { entityId, eligible: true, healthy: false, readiness: health.readiness, canReply: false, callbackActive: false, repaired: false, bugFiled: bug.filed, feedbackId: bug.feedbackId, failingSignals: health.failingSignals };
+            return { entityId, eligible: true, healthy: false, readiness: health.readiness, canReply: false, callbackActive: false, repaired: false, bugFiled: bug.filed, feedbackId: bug.feedbackId, usageDisplayRepair, failingSignals: health.failingSignals };
         }
 
         // Unhealthy + autoRepair → up to 3 repair attempts, spaced past the cooldown.
@@ -495,7 +573,7 @@ async function runEntity(deviceId, deviceSecret, entityId, settings) {
         }
 
         if (recovered) {
-            return { entityId, eligible: true, healthy: false, repaired: true, failingSignals: health.failingSignals };
+            return { entityId, eligible: true, healthy: false, repaired: true, usageDisplayRepair, failingSignals: health.failingSignals };
         }
 
         // Still unhealthy after all attempts → file a bug.
@@ -504,7 +582,7 @@ async function runEntity(deviceId, deviceSecret, entityId, settings) {
             bug.filed ? `Bug filed after ${MAX_REPAIR_ATTEMPTS} failed repairs (feedback #${bug.feedbackId})` : `Bug filing failed: ${bug.reason}`,
             { filed: bug.filed, feedbackId: bug.feedbackId, issueUrl: bug.issueUrl, failingSignals: health.failingSignals });
 
-        return { entityId, eligible: true, healthy: false, repaired: false, bugFiled: bug.filed, feedbackId: bug.feedbackId, failingSignals: health.failingSignals };
+        return { entityId, eligible: true, healthy: false, repaired: false, bugFiled: bug.filed, feedbackId: bug.feedbackId, usageDisplayRepair, failingSignals: health.failingSignals };
     } finally {
         // Clear the transient flag + push the cleared state, but hold it visible for a
         // minimum duration so the 健檢中 animation is perceptible even on a fast healthy
@@ -698,7 +776,8 @@ module.exports = {
     computePassiveHealth,
     runEntity,
     runDeviceSweep,
+    repairUsageWarningEngine,
     SETTINGS_DEFAULTS,
     MAX_REPAIR_ATTEMPTS,
-    _internal: { collectHeartbeatSignal, authDevice },
+    _internal: { collectHeartbeatSignal, authDevice, normalizeUsageWarningEngine, normalizeEntityEngines },
 };

--- a/backend/tests/jest/device-preferences-usage-warning.test.js
+++ b/backend/tests/jest/device-preferences-usage-warning.test.js
@@ -12,6 +12,7 @@ describe('device-preferences usage_warning_config', () => {
             enabled: true,
             threshold_5h_pct: 15,
             threshold_7d_pct: 5,
+            entity_engines: {},
         });
     });
 
@@ -27,13 +28,15 @@ describe('device-preferences usage_warning_config', () => {
 
         const cases = [
             { in: { enabled: false, threshold_5h_pct: 200, threshold_7d_pct: -3 },
-              out: { enabled: false, threshold_5h_pct: 100, threshold_7d_pct: 0 } },
+              out: { enabled: false, threshold_5h_pct: 100, threshold_7d_pct: 0, entity_engines: {} } },
             { in: { enabled: true, threshold_5h_pct: 25.6 },
-              out: { enabled: true, threshold_5h_pct: 26, threshold_7d_pct: 5 /* keep default */ } },
+              out: { enabled: true, threshold_5h_pct: 26, threshold_7d_pct: 5 /* keep default */, entity_engines: {} } },
             { in: { threshold_7d_pct: 'oops' },
-              out: { enabled: true /* keep default */, threshold_5h_pct: 15, threshold_7d_pct: 5 } },
+              out: { enabled: true /* keep default */, threshold_5h_pct: 15, threshold_7d_pct: 5, entity_engines: {} } },
             { in: 'not-an-object',
-              out: { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5 } },
+              out: { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5, entity_engines: {} } },
+            { in: { entity_engines: { '6': 'codex', '2': 'claude', '-1': 'codex', bad: 'codex', '7': 'openclaw' } },
+              out: { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5, entity_engines: { '2': 'claude', '6': 'codex' } } },
         ];
 
         for (const c of cases) {

--- a/backend/tests/jest/entities-binding-discovery.test.js
+++ b/backend/tests/jest/entities-binding-discovery.test.js
@@ -22,11 +22,12 @@ function slice(anchor, span = 2000) {
 }
 
 describe('deriveChannelProvider helper', () => {
-    it('is defined in index.js and covers the four known providers', () => {
+    it('is defined in index.js and covers the known providers', () => {
         const block = slice('function deriveChannelProvider', 800);
         expect(block).toMatch(/'openclaw'/);
         expect(block).toMatch(/'claude'/);
         expect(block).toMatch(/'hermes'/);
+        expect(block).toMatch(/'codex'/);
         expect(block).toMatch(/'custom'/);
     });
 
@@ -54,6 +55,8 @@ describe('deriveChannelProvider helper', () => {
         ['https://example.com/claude-code/webhook', 'claude'],
         ['https://claude.ai/relay', 'claude'],
         ['https://hermes.example.com/hook', 'hermes'],
+        ['https://codex.eclawbot.com/eclaw-webhook', 'codex'],
+        ['https://eclawbot.com/codex-eclaw-bridge/hook', 'codex'],
         ['https://a.eclawbot.com/eclaw-webhook', 'custom'],
         ['not a url', 'custom'],
     ])('%s -> %s', (url, expected) => {

--- a/backend/tests/jest/passive-health.test.js
+++ b/backend/tests/jest/passive-health.test.js
@@ -27,6 +27,14 @@ function makeMockPool() {
                 const prefs = prefsStore[deviceId] || null;
                 return Promise.resolve({ rows: prefs ? [{ prefs }] : [] });
             }
+            // usage warning source self-repair: INSERT ... usage_warning_config
+            // params: [deviceId, mergedJson, ts]
+            if (/INSERT INTO device_preferences/i.test(sql) && /usage_warning_config/i.test(sql)) {
+                const deviceId = params[0];
+                const merged = JSON.parse(params[1]);
+                prefsStore[deviceId] = { ...(prefsStore[deviceId] || {}), usage_warning_config: merged };
+                return Promise.resolve({ rows: [] });
+            }
             // updateSettings: INSERT ... ON CONFLICT — params: [deviceId, mergedJson, ts]
             if (/INSERT INTO device_preferences/i.test(sql)) {
                 const deviceId = params[0];
@@ -231,6 +239,52 @@ describe('disabled-device no-op', () => {
             .get('/api/passive-health/settings')
             .query({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
         expect(typeof get.body.settings.lastRunAt).toBe('number');
+    });
+});
+
+describe('usage display source self-repair', () => {
+    function buildAppWithProvider(provider) {
+        mockPool = makeMockPool();
+        logCalls = [];
+        passiveHealth.init({
+            pool: mockPool,
+            devices: freshDevices(),
+            entityStatus: {
+                logOperation: (...args) => { logCalls.push(args); return Promise.resolve(); },
+            },
+            feedbackModule: { saveFeedback: jest.fn().mockResolvedValue(null) },
+            deriveChannelProvider: () => provider,
+            getChannelAccountById: jest.fn().mockResolvedValue({ id: 10, callback_url: 'https://codex.eclawbot.com/eclaw-webhook' }),
+            isReady: () => true,
+            selfBaseUrl: 'http://localhost:3999',
+        });
+    }
+
+    it('runEntity repairs Codex channel usage_warning_config.entity_engines', async () => {
+        const origFetch = global.fetch;
+        global.fetch = jest.fn().mockResolvedValue({ ok: true });
+        try {
+            buildAppWithProvider('codex');
+            const result = await passiveHealth.runEntity(DEVICE_ID, DEVICE_SECRET, 2, { autoRepair: true });
+            expect(result.usageDisplayRepair).toMatchObject({ changed: true, engine: 'codex', entityId: 2 });
+            expect(prefsStore[DEVICE_ID].usage_warning_config.entity_engines).toEqual({ '2': 'codex' });
+            expect(logCalls.some(call => call[2] === 'usage_warning_self_repair')).toBe(true);
+        } finally {
+            global.fetch = origFetch;
+        }
+    });
+
+    it('does not rewrite usage source for unmanaged providers', async () => {
+        const origFetch = global.fetch;
+        global.fetch = jest.fn().mockResolvedValue({ ok: true });
+        try {
+            buildAppWithProvider('openclaw');
+            const result = await passiveHealth.runEntity(DEVICE_ID, DEVICE_SECRET, 2, { autoRepair: true });
+            expect(result.usageDisplayRepair).toMatchObject({ changed: false, reason: 'provider_not_managed', provider: 'openclaw' });
+            expect(prefsStore[DEVICE_ID]).toBeUndefined();
+        } finally {
+            global.fetch = origFetch;
+        }
     });
 });
 

--- a/backend/tests/jest/transform-usage-warning-entity-scope.test.js
+++ b/backend/tests/jest/transform-usage-warning-entity-scope.test.js
@@ -108,7 +108,7 @@ beforeEach(() => {
     // test starts from "never warned".
     installQueryImpl();
     devicePrefs.getPrefs.mockResolvedValue({
-        usage_warning_config: { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5 },
+        usage_warning_config: { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5, entity_engines: { '6': 'codex' } },
     });
     usageWarning._resetCooldownState();
     SNAPSHOT_ROWS.length = 0;
@@ -174,5 +174,29 @@ describe('POST /api/transform — usage warning entity attribution (card_2f6a565
         });
         expect(res6.status).toBe(200);
         expect(res6.body.currentState.message).toBe(HEARTBEAT);
+    });
+
+    test('entity 6 mapped to Codex ignores Claude quota breach in the same snapshot row', async () => {
+        SNAPSHOT_ROWS.length = 0;
+        SNAPSHOT_ROWS.push({
+            device_id: DEVICE_ID,
+            entity_id: 6,
+            captured_at: new Date(Date.now() - 60_000).toISOString(),
+            claude_json: { live: { five_hour_pct: 99, seven_day_pct: 100 } },
+            codex_json: { rate_limits: { five_hour_pct: 10, seven_day_pct: 20, updated_at: new Date(Date.now() - 30_000).toISOString() } },
+        });
+
+        const res = await post('/api/transform').send({
+            deviceId: DEVICE_ID,
+            entityId: 6,
+            botSecret: botSecret6,
+            state: 'IDLE',
+            message: HEARTBEAT,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.currentState.message).toBe(HEARTBEAT);
+        expect(res.body.currentState.message).not.toContain('System notice');
+        expect(res.body.currentState.message).not.toContain('⚠️');
     });
 });

--- a/backend/tests/jest/usage-warning.test.js
+++ b/backend/tests/jest/usage-warning.test.js
@@ -16,13 +16,15 @@ const {
     shouldWarnNow,
     formatWarningText,
     pickClaudeLivePct,
+    pickCodexPct,
+    resolveEntityEngine,
     withinCooldown,
     resolveCooldownMs,
     getWarningPrefix,
     _resetCooldownState,
 } = require('../../lib/usage-warning');
 
-const DEFAULT_CFG = { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5 };
+const DEFAULT_CFG = { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5, entity_engines: {} };
 const NOW = 1781500000000;
 const fresh = (msAgo) => new Date(NOW - msAgo).toISOString();
 
@@ -56,6 +58,32 @@ describe('pickClaudeLivePct', () => {
     });
 });
 
+describe('pickCodexPct / resolveEntityEngine', () => {
+    test('reads Codex rate_limits flat shape', () => {
+        const codex = { rate_limits: { five_hour_pct: 42, seven_day_pct: 17 } };
+        expect(pickCodexPct(codex, 'five_hour')).toBe(42);
+        expect(pickCodexPct(codex, 'seven_day')).toBe(17);
+    });
+
+    test('reads Codex nested used percentage shape', () => {
+        const codex = { rate_limits: { five_hour: { used_percentage: 4 } } };
+        expect(pickCodexPct(codex, 'five_hour')).toBe(4);
+    });
+
+    test('invalid Codex shape returns null', () => {
+        expect(pickCodexPct(null, 'five_hour')).toBeNull();
+        expect(pickCodexPct({ rate_limits: { five_hour_pct: 'oops' } }, 'five_hour')).toBeNull();
+    });
+
+    test('entity_engines selects codex only for explicitly mapped entities', () => {
+        const cfg = { ...DEFAULT_CFG, entity_engines: { '6': 'codex', bad: 'codex', '7': 'openclaw' } };
+        expect(resolveEntityEngine(cfg, 6)).toBe('codex');
+        expect(resolveEntityEngine(cfg, '6')).toBe('codex');
+        expect(resolveEntityEngine(cfg, 2)).toBe('claude');
+        expect(resolveEntityEngine(null, 6)).toBe('claude');
+    });
+});
+
 describe('shouldWarnNow — trigger logic (card acceptance #3/#4)', () => {
     test('5h used 86% (remaining 14%) WARNS at default 15% threshold', () => {
         const out = shouldWarnNow(mkSnap({ five: 86, seven: 30 }), DEFAULT_CFG, NOW);
@@ -82,6 +110,38 @@ describe('shouldWarnNow — trigger logic (card acceptance #3/#4)', () => {
         const out = shouldWarnNow(mkSnap({ five: 85, seven: 50 }), DEFAULT_CFG, NOW);
         // 5h_remaining = 15, threshold 15 → 15 ≤ 15 → warn
         expect(out.warn).toBe(true);
+    });
+
+    test('codex engine ignores breaching Claude live quota and uses Codex rate_limits', () => {
+        const out = shouldWarnNow({
+            captured_at: fresh(60_000),
+            claude_json: { live: { five_hour_pct: 99, seven_day_pct: 100 } },
+            codex_json: { rate_limits: { five_hour_pct: 10, seven_day_pct: 20, updated_at: fresh(30_000) } },
+        }, DEFAULT_CFG, NOW, 'codex');
+        expect(out.warn).toBe(false);
+        expect(out.engine).toBe('codex');
+        expect(out.five_hour_remaining_pct).toBe(90);
+        expect(out.seven_day_remaining_pct).toBe(80);
+    });
+
+    test('codex engine warns when Codex weekly quota breaches threshold', () => {
+        const out = shouldWarnNow({
+            captured_at: fresh(60_000),
+            claude_json: { live: { five_hour_pct: 10, seven_day_pct: 10 } },
+            codex_json: { rate_limits: { five_hour_pct: 20, seven_day_pct: 99, updated_at: fresh(30_000) } },
+        }, DEFAULT_CFG, NOW, 'codex');
+        expect(out.warn).toBe(true);
+        expect(out.seven_day_remaining_pct).toBe(1);
+    });
+
+    test('codex rate_limits updated_at older than 6h is stale even when snapshot row is fresh', () => {
+        const out = shouldWarnNow({
+            captured_at: fresh(60_000),
+            claude_json: { live: { five_hour_pct: 10, seven_day_pct: 10 } },
+            codex_json: { rate_limits: { five_hour_pct: 99, seven_day_pct: 99, updated_at: fresh(STALE_THRESHOLD_MS + 60_000) } },
+        }, DEFAULT_CFG, NOW, 'codex');
+        expect(out.warn).toBe(false);
+        expect(out.stale).toBe(true);
     });
 });
 
@@ -221,6 +281,29 @@ describe('getWarningPrefix — entity-scoped attribution (card_2f6a5659)', () =>
         }]);
         const prefix = await getWarningPrefix(pool, DEV, DEFAULT_CFG, 'en', 6, NOW);
         expect(prefix).toContain('System notice');
+    });
+
+    test('mapped Codex entity reads codex_json and does not inherit Claude 0% remaining from the same row', async () => {
+        const pool = mkSnapshotPool([{
+            device_id: DEV, entity_id: 6, captured_at: fresh(60_000),
+            claude_json: { live: { five_hour_pct: 99, seven_day_pct: 100 } },
+            codex_json: { rate_limits: { five_hour_pct: 10, seven_day_pct: 20, updated_at: fresh(30_000) } },
+        }]);
+        const cfg = { ...DEFAULT_CFG, entity_engines: { '6': 'codex' } };
+        const prefix = await getWarningPrefix(pool, DEV, cfg, 'en', 6, NOW);
+        expect(prefix).toBeNull();
+    });
+
+    test('mapped Codex entity still warns when codex_json breaches', async () => {
+        const pool = mkSnapshotPool([{
+            device_id: DEV, entity_id: 6, captured_at: fresh(60_000),
+            claude_json: { live: { five_hour_pct: 10, seven_day_pct: 10 } },
+            codex_json: { rate_limits: { five_hour_pct: 10, seven_day_pct: 99, updated_at: fresh(30_000) } },
+        }]);
+        const cfg = { ...DEFAULT_CFG, entity_engines: { '6': 'codex' } };
+        const prefix = await getWarningPrefix(pool, DEV, cfg, 'en', 6, NOW);
+        expect(prefix).toContain('System notice');
+        expect(prefix).toContain('1%');
     });
 
     test('entity-scoped row is preferred over a NEWER unscoped row', async () => {


### PR DESCRIPTION
## Summary
- map channel entities to Claude/Codex quota sources through usage_warning_config.entity_engines
- make passive health self-repair Codex/Claude usage source mappings based on channel provider
- classify codex callback URLs as channelProvider=codex so #6 no longer falls back to custom

## Verification
- npx jest --config jest.config.js --testPathIgnorePatterns=/node_modules/ --runTestsByPath tests/jest/usage-warning.test.js tests/jest/device-preferences-usage-warning.test.js tests/jest/passive-health.test.js tests/jest/entities-binding-discovery.test.js tests/jest/transform-usage-warning-entity-scope.test.js
- npm run lint
- git diff --check

## Live evidence before deploy
- production /api/entities currently reports #6 channelProvider=custom
- production /api/usage/snapshot has fresh Codex rate_limits, so the 0% display is a source-attribution/config drift issue rather than missing Codex data