### PR TITLE
fix(usage): repair Codex rate-limit display

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -5905,13 +5905,14 @@
             const fill = document.getElementById(fillId);
             const pctEl = document.getElementById(pctId);
             const resetEl = document.getElementById(resetId);
-            const clamped = Math.max(0, Math.min(100, Number(pct) || 0));
+            const hasPct = Number.isFinite(Number(pct));
+            const clamped = hasPct ? Math.max(0, Math.min(100, Number(pct))) : 0;
             if (fill) fill.style.width = clamped + '%';
             if (pctEl) {
                 while (pctEl.firstChild) pctEl.removeChild(pctEl.firstChild);
                 const usedWord = t(usedKey, 'used');
-                pctEl.appendChild(document.createTextNode(clamped + '% ' + usedWord));
-                if (isEst) {
+                pctEl.appendChild(document.createTextNode((hasPct ? clamped + '%' : '--') + ' ' + usedWord));
+                if (hasPct && isEst) {
                     const mark = document.createElement('span');
                     mark.className = 'uw-est-mark';
                     mark.textContent = ' ' + t('dashboard_usage_widget_estimate_marker', '(est)');
@@ -5971,7 +5972,16 @@
             const normalized = normalizeCodexRateLimits(rl);
             return !!normalized
                 && Number.isFinite(normalized.five_hour_pct)
-                && Number.isFinite(normalized.seven_day_pct);
+                && Number.isFinite(normalized.seven_day_pct)
+                && !isUntrustedZeroCodexRateLimits(normalized);
+        }
+
+        function isUntrustedZeroCodexRateLimits(rl) {
+            const normalized = normalizeCodexRateLimits(rl);
+            return !!normalized
+                && normalized.five_hour_pct === 0
+                && normalized.seven_day_pct === 0
+                && !normalized.plan_type;
         }
 
         function readCachedCodexRateLimits() {
@@ -6091,7 +6101,7 @@
                     'dashboard_usage_widget_session_used');
             } else {
                 paintBar('codexSessFill', 'codexSessPct', 'codexSessReset',
-                    0, false, null, 'h',
+                    null, false, null, 'h',
                     'dashboard_usage_widget_session_used');
             }
             // Weekly (7d)
@@ -6104,7 +6114,7 @@
                     'dashboard_usage_widget_weekly_used');
             } else {
                 paintBar('codexWeekFill', 'codexWeekPct', 'codexWeekReset',
-                    0, false, null, 'd',
+                    null, false, null, 'd',
                     'dashboard_usage_widget_weekly_used');
             }
         }
@@ -6261,7 +6271,7 @@
             }
         }
 
-        window.refreshUsageWidget = function () { loadUsageWidget(); };
+        window.refreshUsageWidget = function () { return loadUsageWidget(); };
 
         // ── Usage timeline modal (card_fb8a5a39ebe67581a66c6061) ──
         // Click the usage widget (not its buttons) → modal with two vanilla-SVG

--- a/backend/tests/jest/dashboard-usage-widget-rate-limits.test.js
+++ b/backend/tests/jest/dashboard-usage-widget-rate-limits.test.js
@@ -28,7 +28,7 @@ function loadUsageHelpers(localStorage = makeLocalStorage()) {
     };
 
     return vm.runInNewContext(
-        helperCode + '\n({ normalizeCodexRateLimits, isValidCodexRateLimits, resolveCodexRateLimits, withResolvedCodexRateLimits });',
+        helperCode + '\n({ normalizeCodexRateLimits, isValidCodexRateLimits, isUntrustedZeroCodexRateLimits, resolveCodexRateLimits, withResolvedCodexRateLimits });',
         context
     );
 }
@@ -83,6 +83,57 @@ describe('Dashboard usage widget Codex rate limits', () => {
             primary: { used_percent: 0.0, window_minutes: 0, resets_at: 1780000200 },
             secondary: null,
             plan_type: 'pro'
+        })).toEqual(valid);
+    });
+
+    test('does not treat unattributed zero Codex limits as valid quota truth', () => {
+        const helpers = loadUsageHelpers();
+
+        expect(helpers.isUntrustedZeroCodexRateLimits({
+            five_hour_pct: 0,
+            five_hour_resets_at: 1780000000,
+            seven_day_pct: 0,
+            seven_day_resets_at: 1780500000,
+            plan_type: null,
+            updated_at: '2026-07-10T09:47:04.965Z'
+        })).toBe(true);
+        expect(helpers.isValidCodexRateLimits({
+            five_hour_pct: 0,
+            five_hour_resets_at: 1780000000,
+            seven_day_pct: 0,
+            seven_day_resets_at: 1780500000,
+            plan_type: null,
+            updated_at: '2026-07-10T09:47:04.965Z'
+        })).toBe(false);
+        expect(helpers.isValidCodexRateLimits({
+            five_hour_pct: 0,
+            five_hour_resets_at: 1780000000,
+            seven_day_pct: 0,
+            seven_day_resets_at: 1780500000,
+            plan_type: 'prolite',
+            updated_at: '2026-07-10T09:47:04.965Z'
+        })).toBe(true);
+    });
+
+    test('keeps previous nonzero Codex limits when a device-latest row reports unattributed zero', () => {
+        const helpers = loadUsageHelpers();
+        const valid = {
+            five_hour_pct: 94,
+            five_hour_resets_at: 1783677455,
+            seven_day_pct: 17,
+            seven_day_resets_at: 1784244512,
+            plan_type: 'prolite',
+            updated_at: '2026-07-10T09:48:18.522Z'
+        };
+
+        expect(helpers.resolveCodexRateLimits(valid)).toEqual(valid);
+        expect(helpers.resolveCodexRateLimits({
+            five_hour_pct: 0,
+            five_hour_resets_at: 1783694855,
+            seven_day_pct: 0,
+            seven_day_resets_at: 1784281655,
+            plan_type: null,
+            updated_at: '2026-07-10T09:48:01.464Z'
         })).toEqual(valid);
     });
 

--- a/backend/tests/jest/usage-api-codex-rate-limit-repair.test.js
+++ b/backend/tests/jest/usage-api-codex-rate-limit-repair.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const usageApi = require('../../usage-api');
+const {
+    isUsableCodexRateLimits,
+    isUntrustedZeroCodexRateLimits,
+    mergeCodexRateLimits,
+    repairLatestCodexRateLimits,
+} = usageApi({})._internal;
+
+describe('usage-api Codex rate-limit display repair', () => {
+    test('treats zero Codex limits without a plan type as untrusted', () => {
+        const untrusted = {
+            five_hour_pct: 0,
+            five_hour_resets_at: 1783694855,
+            seven_day_pct: 0,
+            seven_day_resets_at: 1784281655,
+            plan_type: null,
+            updated_at: '2026-07-10T09:48:01.464Z'
+        };
+        const realZero = {
+            ...untrusted,
+            plan_type: 'prolite'
+        };
+
+        expect(isUntrustedZeroCodexRateLimits(untrusted)).toBe(true);
+        expect(isUsableCodexRateLimits(untrusted)).toBe(false);
+        expect(isUntrustedZeroCodexRateLimits(realZero)).toBe(false);
+        expect(isUsableCodexRateLimits(realZero)).toBe(true);
+    });
+
+    test('merges the latest usable Codex rate limits into a newer device row', () => {
+        const latest = {
+            id: '51137',
+            entity_id: 2,
+            codex_json: {
+                sessions: [{ project: 'codex-eclaw-bridge' }],
+                rate_limits: {
+                    five_hour_pct: 0,
+                    seven_day_pct: 0,
+                    plan_type: null,
+                    updated_at: '2026-07-10T09:48:01.464Z'
+                }
+            }
+        };
+        const source = {
+            id: '51132',
+            entity_id: 6,
+            captured_at: '2026-07-10T09:48:30.293Z',
+            codex_json: {
+                rate_limits: {
+                    five_hour_pct: 94,
+                    five_hour_resets_at: 1783677455,
+                    seven_day_pct: 17,
+                    seven_day_resets_at: 1784244512,
+                    plan_type: 'prolite',
+                    updated_at: '2026-07-10T09:48:18.522Z'
+                }
+            }
+        };
+
+        const repaired = mergeCodexRateLimits(latest, source);
+
+        expect(repaired).not.toBe(latest);
+        expect(repaired.entity_id).toBe(2);
+        expect(repaired.codex_json.sessions).toEqual(latest.codex_json.sessions);
+        expect(repaired.codex_json.rate_limits).toEqual(source.codex_json.rate_limits);
+        expect(repaired.codex_json.rate_limits_source).toMatchObject({
+            repaired: true,
+            entityId: 6,
+            snapshotId: '51132'
+        });
+    });
+
+    test('repairLatestCodexRateLimits scans recent rows and picks #6-like usable limits', async () => {
+        const latest = {
+            id: '51137',
+            entity_id: 2,
+            codex_json: {
+                rate_limits: { five_hour_pct: 0, seven_day_pct: 0, plan_type: null }
+            }
+        };
+        const pool = {
+            query: jest.fn().mockResolvedValue({
+                rows: [
+                    latest,
+                    {
+                        id: '51132',
+                        entity_id: 6,
+                        captured_at: '2026-07-10T09:48:30.293Z',
+                        codex_json: {
+                            rate_limits: {
+                                five_hour_pct: 94,
+                                five_hour_resets_at: 1783677455,
+                                seven_day_pct: 17,
+                                seven_day_resets_at: 1784244512,
+                                plan_type: 'prolite',
+                                updated_at: '2026-07-10T09:48:18.522Z'
+                            }
+                        }
+                    }
+                ]
+            })
+        };
+
+        const repaired = await repairLatestCodexRateLimits(pool, 'device-1', latest);
+
+        expect(pool.query).toHaveBeenCalledTimes(1);
+        expect(repaired.codex_json.rate_limits.five_hour_pct).toBe(94);
+        expect(repaired.codex_json.rate_limits.seven_day_pct).toBe(17);
+        expect(repaired.codex_json.rate_limits_source.entityId).toBe(6);
+    });
+
+    test('does not scan when the latest row already has usable Codex limits', async () => {
+        const latest = {
+            id: '51140',
+            entity_id: 6,
+            codex_json: {
+                rate_limits: { five_hour_pct: 0, seven_day_pct: 0, plan_type: 'prolite' }
+            }
+        };
+        const pool = { query: jest.fn() };
+
+        await expect(repairLatestCodexRateLimits(pool, 'device-1', latest)).resolves.toBe(latest);
+        expect(pool.query).not.toHaveBeenCalled();
+    });
+
+    test('keeps the original latest row if the repair scan fails', async () => {
+        const latest = {
+            id: '51137',
+            entity_id: 2,
+            codex_json: {
+                rate_limits: { five_hour_pct: 0, seven_day_pct: 0, plan_type: null }
+            }
+        };
+        const pool = {
+            query: jest.fn().mockRejectedValue(new Error('database unavailable'))
+        };
+
+        await expect(repairLatestCodexRateLimits(pool, 'device-1', latest)).resolves.toBe(latest);
+    });
+});

--- a/backend/usage-api.js
+++ b/backend/usage-api.js
@@ -27,6 +27,8 @@ const pool = new Pool({
 const MAX_TIMELINE_HOURS = 720;            // 30 days
 const SNAPSHOT_BODY_LIMIT = '200kb';
 const FUTURE_SKEW_TOLERANCE_MS = 5 * 60 * 1000;  // accept ≤5min clock skew
+const CODEX_RATE_LIMIT_REPAIR_LOOKBACK_MS = 6 * 60 * 60 * 1000;
+const CODEX_RATE_LIMIT_REPAIR_SCAN_ROWS = 40;
 
 // ============================================
 // SCHEMA BOOTSTRAP — idempotent, safe to call on every boot.
@@ -128,6 +130,96 @@ function pickClaudeLivePct(live, key) {
     const nested = live.rate_limits && live.rate_limits[key];
     if (nested && typeof nested.used_percentage === 'number') return nested.used_percentage;
     return null;
+}
+
+function numberOrNull(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+}
+
+function normalizeCodexRateLimits(rateLimits) {
+    if (!rateLimits || typeof rateLimits !== 'object' || Array.isArray(rateLimits)) return null;
+
+    if (rateLimits.primary || rateLimits.secondary) {
+        const primary = rateLimits.primary && typeof rateLimits.primary === 'object' ? rateLimits.primary : {};
+        const secondary = rateLimits.secondary && typeof rateLimits.secondary === 'object' ? rateLimits.secondary : {};
+        return {
+            five_hour_pct: numberOrNull(primary.used_percent),
+            five_hour_resets_at: numberOrNull(primary.resets_at),
+            seven_day_pct: numberOrNull(secondary.used_percent),
+            seven_day_resets_at: numberOrNull(secondary.resets_at),
+            plan_type: typeof rateLimits.plan_type === 'string' && rateLimits.plan_type ? rateLimits.plan_type : null,
+            updated_at: typeof rateLimits.updated_at === 'string' ? rateLimits.updated_at : ''
+        };
+    }
+
+    return {
+        five_hour_pct: numberOrNull(rateLimits.five_hour_pct),
+        five_hour_resets_at: numberOrNull(rateLimits.five_hour_resets_at),
+        seven_day_pct: numberOrNull(rateLimits.seven_day_pct),
+        seven_day_resets_at: numberOrNull(rateLimits.seven_day_resets_at),
+        plan_type: typeof rateLimits.plan_type === 'string' && rateLimits.plan_type ? rateLimits.plan_type : null,
+        updated_at: typeof rateLimits.updated_at === 'string' ? rateLimits.updated_at : ''
+    };
+}
+
+function isUntrustedZeroCodexRateLimits(rateLimits) {
+    const normalized = normalizeCodexRateLimits(rateLimits);
+    return !!normalized
+        && normalized.five_hour_pct === 0
+        && normalized.seven_day_pct === 0
+        && !normalized.plan_type;
+}
+
+function isUsableCodexRateLimits(rateLimits) {
+    const normalized = normalizeCodexRateLimits(rateLimits);
+    return !!normalized
+        && Number.isFinite(normalized.five_hour_pct)
+        && Number.isFinite(normalized.seven_day_pct)
+        && !isUntrustedZeroCodexRateLimits(normalized);
+}
+
+function mergeCodexRateLimits(latest, sourceRow) {
+    if (!latest || !sourceRow) return latest;
+    const sourceLimits = normalizeCodexRateLimits(sourceRow.codex_json && sourceRow.codex_json.rate_limits);
+    if (!isUsableCodexRateLimits(sourceLimits)) return latest;
+    return {
+        ...latest,
+        codex_json: {
+            ...(latest.codex_json || {}),
+            rate_limits: sourceLimits,
+            rate_limits_source: {
+                repaired: true,
+                entityId: sourceRow.entity_id == null ? null : sourceRow.entity_id,
+                snapshotId: sourceRow.id == null ? null : String(sourceRow.id),
+                captured_at: sourceRow.captured_at || null
+            }
+        }
+    };
+}
+
+async function repairLatestCodexRateLimits(poolClient, deviceId, latest) {
+    const currentLimits = latest && latest.codex_json && latest.codex_json.rate_limits;
+    if (!latest || isUsableCodexRateLimits(currentLimits)) return latest;
+
+    const since = new Date(Date.now() - CODEX_RATE_LIMIT_REPAIR_LOOKBACK_MS).toISOString();
+    try {
+        const rowsQ = await poolClient.query(
+            `SELECT id, entity_id, captured_at, codex_json
+             FROM usage_snapshots
+             WHERE device_id = $1 AND captured_at >= $2
+             ORDER BY captured_at DESC
+             LIMIT $3`,
+            [deviceId, since, CODEX_RATE_LIMIT_REPAIR_SCAN_ROWS]
+        );
+        const rows = Array.isArray(rowsQ.rows) ? rowsQ.rows : [];
+        const source = rows.find(row => isUsableCodexRateLimits(row.codex_json && row.codex_json.rate_limits));
+        return source ? mergeCodexRateLimits(latest, source) : latest;
+    } catch (err) {
+        console.warn('[UsageAPI] Codex rate-limit repair skipped:', err && err.message);
+        return latest;
+    }
 }
 
 function sumEngineSessions(engineJson) {
@@ -285,7 +377,8 @@ module.exports = function(devices) {
                 [deviceId]
             );
 
-            const latest = latestQ.rows[0] || null;
+            const latestRaw = latestQ.rows[0] || null;
+            const latest = await repairLatestCodexRateLimits(pool, deviceId, latestRaw);
 
             const now = Date.now();
             const dayMs  = 24 * 60 * 60 * 1000;
@@ -402,6 +495,18 @@ module.exports = function(devices) {
 
     return {
         router,
-        _internal: { authenticate, sumEngineSessions, aggregateOverRange, pickClaudeLivePct, MAX_TIMELINE_HOURS, SNAPSHOT_BODY_LIMIT }
+        _internal: {
+            authenticate,
+            sumEngineSessions,
+            aggregateOverRange,
+            pickClaudeLivePct,
+            normalizeCodexRateLimits,
+            isUntrustedZeroCodexRateLimits,
+            isUsableCodexRateLimits,
+            mergeCodexRateLimits,
+            repairLatestCodexRateLimits,
+            MAX_TIMELINE_HOURS,
+            SNAPSHOT_BODY_LIMIT
+        }
     };
 };


### PR DESCRIPTION
## Summary
- repair /api/usage/snapshot when the latest device row has unattributed Codex 0/0 limits by merging the newest usable Codex rate-limit row
- stop dashboard from treating 0/0 + plan_type=null as valid Codex quota truth or writing it to cache
- render unknown Codex quota as -- used instead of false 0% used

## Tests
- NODE_PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules /Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin/jest --runInBand --testPathIgnorePatterns='/node_modules/' --runTestsByPath tests/jest/dashboard-usage-widget-rate-limits.test.js tests/jest/usage-api-codex-rate-limit-repair.test.js tests/jest/usage-api-aggregate-cumulative-snapshot.test.js tests/jest/usage-api-claude-live-pct.test.js
- NODE_PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules /Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin/eslint . (0 errors, existing warnings)
- git diff --check
- NODE_OPTIONS=--max-old-space-size=8192 NODE_PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules /Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin/jest --runInBand --silent --testPathIgnorePatterns='/node_modules/' (484 suites passed)

## Live finding
Production was deployed, but the dashboard could still show 0 because the latest usage row often came from entityId=2 with Codex sessions but unattributed 0/0 rate limits; a nearby #6 Codex row had the real nonzero rate limits.