### PR TITLE
chore(ios): prepare App Store 1.0.1 build

### DIFF
--- a/ios-app/app.json
+++ b/ios-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "E-Claw",
     "slug": "eclawbot",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "eclawbot",
@@ -28,7 +28,7 @@
         "ITSAppUsesNonExemptEncryption": false,
         "LSApplicationQueriesSchemes": ["itms-apps"]
       },
-      "buildNumber": "3"
+      "buildNumber": "11"
     },
     "android": {
       "adaptiveIcon": {

--- a/ios-app/package-lock.json
+++ b/ios-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ios-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ios-app",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@expo/vector-icons": "^15.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",

--- a/ios-app/package.json
+++ b/ios-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ios-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- bump iOS App Store marketing version to 1.0.1
- bump iOS buildNumber to 11 for the next App Store Connect build upload
- sync ios-app package metadata

## Validation
- cd ios-app && npm test -- --runInBand
- cd ios-app && npx expo config --type public
- git diff --check -- ios-app/app.json ios-app/package.json ios-app/package-lock.json

## App Store Connect note
- iPhone 6.5 and 6.9 screenshot sets were replaced with the six new Image2-enhanced screenshots.
- iPad screenshots are pending re-upload because Chrome file upload is blocked by the local Chrome extension file access permission.