### PR TITLE
fix(ios): set WidgetKit extension development team

### DIFF
--- a/ios-app/plugins/withNeedsYouWidget.js
+++ b/ios-app/plugins/withNeedsYouWidget.js
@@ -13,6 +13,7 @@ const NEEDS_YOU_WIDGET_CONFIG = {
   widgetDirectory: 'NeedsYouWidget',
   nativeModuleFile: 'NeedsYouWidgetStore.swift',
   nativeModuleExternFile: 'NeedsYouWidgetStoreBridge.m',
+  developmentTeam: 'KLBQRT47CT',
   pendingCountKey: 'pendingCount',
   updatedAtKey: 'updatedAt',
 };
@@ -138,6 +139,7 @@ function ensureWidgetBuildSettings(project, targetUuid, bundleIdentifier, option
   updateTargetBuildSettings(project, targetUuid, (settings) => {
     settings.APPLICATION_EXTENSION_API_ONLY = 'YES';
     settings.CODE_SIGN_ENTITLEMENTS = `${options.widgetDirectory}/NeedsYouWidget.entitlements`;
+    settings.DEVELOPMENT_TEAM = options.developmentTeam;
     settings.INFOPLIST_FILE = `${options.widgetDirectory}/NeedsYouWidget-Info.plist`;
     settings.IPHONEOS_DEPLOYMENT_TARGET = settings.IPHONEOS_DEPLOYMENT_TARGET || '15.1';
     settings.LD_RUNPATH_SEARCH_PATHS =

--- a/ios-app/services/__tests__/needyouWidgetKit.test.ts
+++ b/ios-app/services/__tests__/needyouWidgetKit.test.ts
@@ -23,6 +23,8 @@ describe('Needs-you WidgetKit prebuild wiring', () => {
     expect(plugin).toContain("__WIDGET_SHORT_VERSION__");
     expect(plugin).toContain("__WIDGET_BUILD_VERSION__");
     expect(plugin).toContain("projectConfig.exp?.ios?.buildNumber");
+    expect(plugin).toContain("developmentTeam: 'KLBQRT47CT'");
+    expect(plugin).toContain('settings.DEVELOPMENT_TEAM = options.developmentTeam');
   });
 
   test('native store writes pending count to the WidgetKit app group', () => {


### PR DESCRIPTION
## Summary
- set the Apple development team on the NeedsYou WidgetKit extension target generated during iOS prebuild
- add a Jest invariant so the extension signing team stays wired

## Validation
- cd ios-app && npm test -- --runInBand

## Build context
- EAS iOS build 9437ab01-3822-41b2-9694-e4ec7bed56e0 failed because NeedsYouWidgetExtension had no development team and the current provisioning profile lacks the App Groups entitlement. This PR fixes the project-side team setting; EAS/Apple credentials still need the App Groups-capable profile regenerated before retrying the build.