### PR TITLE
fix(ios): declare WidgetKit extension for EAS credentials

### DIFF
--- a/ios-app/app.json
+++ b/ios-app/app.json
@@ -77,7 +77,24 @@
     "extra": {
       "router": {},
       "eas": {
-        "projectId": "9e492c28-9aa9-4bab-997d-780d7eb500ed"
+        "projectId": "9e492c28-9aa9-4bab-997d-780d7eb500ed",
+        "build": {
+          "experimental": {
+            "ios": {
+              "appExtensions": [
+                {
+                  "targetName": "NeedsYouWidgetExtension",
+                  "bundleIdentifier": "com.eclawbot.app.NeedsYouWidgetExtension",
+                  "entitlements": {
+                    "com.apple.security.application-groups": [
+                      "group.com.eclawbot.app.needyou"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
       }
     }
   }

--- a/ios-app/services/__tests__/needyouWidgetKit.test.ts
+++ b/ios-app/services/__tests__/needyouWidgetKit.test.ts
@@ -9,6 +9,23 @@ describe('Needs-you WidgetKit prebuild wiring', () => {
     expect(appJson.expo.plugins).toContain('./plugins/withNeedsYouWidget');
   });
 
+  test('app config declares the WidgetKit extension for EAS credentials', () => {
+    const appJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'app.json'), 'utf8'));
+    const appExtensions =
+      appJson.expo.extra?.eas?.build?.experimental?.ios?.appExtensions || [];
+    expect(appExtensions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          targetName: 'NeedsYouWidgetExtension',
+          bundleIdentifier: 'com.eclawbot.app.NeedsYouWidgetExtension',
+          entitlements: expect.objectContaining({
+            'com.apple.security.application-groups': ['group.com.eclawbot.app.needyou'],
+          }),
+        }),
+      ])
+    );
+  });
+
   test('config plugin creates WidgetKit extension and shared app group', () => {
     const plugin = fs.readFileSync(path.join(repoRoot, 'plugins/withNeedsYouWidget.js'), 'utf8');
     expect(plugin).toContain("withEntitlementsPlist");


### PR DESCRIPTION
## Summary
- declare NeedsYouWidgetExtension under Expo/EAS appExtensions so EAS can provision the extension bundle
- include the WidgetKit App Group entitlement in the extension credential declaration
- add Jest coverage for the EAS app extension config

## Validation
- cd ios-app && npm test -- --runInBand
- cd ios-app && npx expo config --type public --json
- git diff --check -- ios-app/app.json ios-app/services/__tests__/needyouWidgetKit.test.ts

## Build context
- EAS build ddd3a225-47b5-4e15-9431-0914a1c22603 failed because no provisioning profile existed for com.eclawbot.app.NeedsYouWidgetExtension. EAS needs this extension declared before it can manage the extension profile.