### PR TITLE
feat(app-bot): POST /api/app-bot/chat gateway + daily quota (I2)

### DIFF
--- a/backend/app-bots-config.js
+++ b/backend/app-bots-config.js
@@ -1,0 +1,54 @@
+// ============================================
+// App-Bot Registry (情緒價值 App pipeline — card I2)
+//
+// Server-side ONLY. The mobile client sends just an { appId, personaId } pair;
+// the persona system prompts (and the ANTHROPIC_API_KEY that consumes them)
+// NEVER leave the server. Keep this file free of secrets — it is the prompt
+// registry, not a credential store.
+// ============================================
+
+const APP_BOTS = {
+    'nighthollow': {
+        name: '深夜樹洞',
+        dailyQuota: 8,
+        adBonus: 5,
+        personas: {
+            'default': {
+                systemPrompt: '你是「深夜樹洞」。只溫柔傾聽與輕回應,絕不給建議、說教或正能量口號。回覆簡短。'
+            }
+        }
+    },
+    'hypebot': {
+        name: '誇誇機',
+        dailyQuota: 10,
+        adBonus: 5,
+        personas: {
+            'default': {
+                systemPrompt: '你是「誇誇機」。無論多小的事都真誠、熱情、有創意地誇獎使用者,具體不空泛,絕不給建議或轉折。'
+            }
+        }
+    }
+};
+
+/**
+ * Resolve an (appId, personaId) pair to its server-side config.
+ * Returns { app, persona } or null when either the app or the persona is
+ * unknown. The caller must NOT disclose which of the two was wrong (avoid
+ * leaking the valid appId/persona namespace to probing clients).
+ *
+ * @param {string} appId
+ * @param {string} personaId
+ * @returns {{ app: object, persona: object } | null}
+ */
+function getPersona(appId, personaId) {
+    const app = APP_BOTS[appId];
+    if (!app) return null;
+    const persona = app.personas && app.personas[personaId];
+    if (!persona) return null;
+    return { app, persona };
+}
+
+module.exports = {
+    APP_BOTS,
+    getPersona
+};

--- a/backend/db.js
+++ b/backend/db.js
@@ -736,6 +736,25 @@ async function createTables() {
         await client.query(`CREATE INDEX IF NOT EXISTS idx_scheduled_messages_pending ON scheduled_messages (scheduled_at) WHERE sent_at IS NULL AND cancelled_at IS NULL`);
         await client.query(`CREATE INDEX IF NOT EXISTS idx_scheduled_messages_device ON scheduled_messages (device_id, chat_entity_id)`);
 
+        // App-Bot daily quota (情緒價值 App pipeline — card I2). One row per
+        // (app_id, device_id, quota_date); messages_used counts LLM calls that
+        // fired that UTC day, bonus_from_ads is extra quota earned via rewarded
+        // ads. The effective daily limit = app.dailyQuota + bonus_from_ads.
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS app_bot_quota (
+                id SERIAL PRIMARY KEY,
+                app_id TEXT NOT NULL,
+                device_id TEXT NOT NULL,
+                quota_date DATE NOT NULL,
+                messages_used INTEGER NOT NULL DEFAULT 0,
+                bonus_from_ads INTEGER NOT NULL DEFAULT 0,
+                created_at TIMESTAMPTZ DEFAULT NOW(),
+                updated_at TIMESTAMPTZ DEFAULT NOW(),
+                UNIQUE(app_id, device_id, quota_date)
+            )
+        `);
+        await client.query(`CREATE INDEX IF NOT EXISTS idx_app_bot_quota_lookup ON app_bot_quota (app_id, device_id, quota_date)`);
+
         console.log('[DB] Database tables ready');
         client.release();
     } catch (err) {
@@ -2614,6 +2633,82 @@ async function upsertCommunityRating(publicCode, deviceId, stars) {
     }
 }
 
+// ============================================
+// App-Bot daily quota (情緒價值 App pipeline — card I2)
+// ============================================
+
+/**
+ * Read the current quota row for (appId, deviceId, quotaDate).
+ * @returns {Promise<{messages_used:number, bonus_from_ads:number} | null>}
+ *          null when there is no row yet OR when the DB is unavailable.
+ */
+async function getAppBotQuota(appId, deviceId, quotaDate) {
+    if (!pool) return null;
+    try {
+        const result = await pool.query(
+            `SELECT messages_used, bonus_from_ads
+             FROM app_bot_quota
+             WHERE app_id = $1 AND device_id = $2 AND quota_date = $3`,
+            [appId, deviceId, quotaDate]
+        );
+        if (result.rows.length === 0) return null;
+        return {
+            messages_used: result.rows[0].messages_used,
+            bonus_from_ads: result.rows[0].bonus_from_ads
+        };
+    } catch (err) {
+        console.error('[DB] getAppBotQuota error:', err.message);
+        return null;
+    }
+}
+
+/**
+ * Increment messages_used for the day by `count` (upsert). Called AFTER a
+ * successful LLM reply so a failed inference never burns quota.
+ * @returns {Promise<boolean>} true on success.
+ */
+async function incrementAppBotQuotaUsage(appId, deviceId, quotaDate, count = 1) {
+    if (!pool) return false;
+    try {
+        await pool.query(
+            `INSERT INTO app_bot_quota (app_id, device_id, quota_date, messages_used)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (app_id, device_id, quota_date)
+             DO UPDATE SET messages_used = app_bot_quota.messages_used + $4,
+                           updated_at = NOW()`,
+            [appId, deviceId, quotaDate, count]
+        );
+        return true;
+    } catch (err) {
+        console.error('[DB] incrementAppBotQuotaUsage error:', err.message);
+        return false;
+    }
+}
+
+/**
+ * Grant extra quota for the day via a rewarded ad (upsert). Reserved for a
+ * later card (rewarded-ad flow); exported now so the schema + write path ship
+ * together.
+ * @returns {Promise<boolean>} true on success.
+ */
+async function addAppBotAdBonus(appId, deviceId, quotaDate, bonus) {
+    if (!pool) return false;
+    try {
+        await pool.query(
+            `INSERT INTO app_bot_quota (app_id, device_id, quota_date, bonus_from_ads)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (app_id, device_id, quota_date)
+             DO UPDATE SET bonus_from_ads = app_bot_quota.bonus_from_ads + $4,
+                           updated_at = NOW()`,
+            [appId, deviceId, quotaDate, bonus]
+        );
+        return true;
+    } catch (err) {
+        console.error('[DB] addAppBotAdBonus error:', err.message);
+        return false;
+    }
+}
+
 module.exports = {
     initDatabase,
     saveDeviceData,
@@ -2724,4 +2819,8 @@ module.exports = {
     logInviteClick,
     getInviteClickStats,
     getInviteClickStatsForOwner,
+    // App-Bot daily quota (情緒價值 App pipeline — card I2)
+    getAppBotQuota,
+    incrementAppBotQuotaUsage,
+    addAppBotAdBonus,
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -22,6 +22,8 @@ const { isLowSignalFwd, classifyLowSignalFwd } = require('./org-fwd-filter');
 const orgFwdEscalation = require('./org-fwd-escalation');
 const { buildOrgEntitySessionKey, isOrgEntitySessionKey } = require('./session-scope');
 const { assignDefaultCompanionIfMissing } = require('./petdx-phase0-hook');
+const { getPersona } = require('./app-bots-config'); // 情緒價值 App pipeline (card I2)
+const { callAnthropic } = require('./anthropic-client'); // App-Bot LLM kernel (card I2)
 // JWT secret: fail-safe random per process if env var is missing (tokens signed in one process won't verify in another)
 const JWT_SECRET_FALLBACK = process.env.JWT_SECRET || require('crypto').randomBytes(32).toString('hex');
 
@@ -625,6 +627,93 @@ setInterval(() => {
         if (now - entry.ts > DNS_RESOLVE_CACHE_TTL) dnsResolveCache.delete(h);
     }
 }, 1800000).unref();
+
+// ============================================
+// APP-BOT GATEWAY (情緒價值 App pipeline — card I2)
+// POST /api/app-bot/chat — server-side kernel for a family of mobile apps.
+// Client sends { appId, personaId, deviceId, message }; server injects the
+// per-persona system prompt, calls Anthropic, enforces a per-(appId,deviceId)
+// daily message quota, and returns { reply, quotaRemaining }.
+//
+// SECURITY INVARIANTS:
+//  - ANTHROPIC_API_KEY and the persona system prompts stay server-side and are
+//    NEVER echoed to the client.
+//  - The LLM call MUST NOT fire once the daily quota is exhausted (cost guard).
+// ============================================
+
+// ── App-Bot chat rate limiter (in-memory, per IP sliding window) ──
+const appBotChatRateLimits = {};
+const APP_BOT_CHAT_RATE_WINDOW = 60 * 1000; // 60s
+const APP_BOT_CHAT_RATE_MAX = 60; // max requests per window per IP
+function appBotChatRateLimit(req, res, next) {
+    // Skip rate limiting in test environment
+    if (process.env.NODE_ENV === 'test') return next();
+    const ip = req.ip || req.connection.remoteAddress || 'unknown';
+    const now = Date.now();
+    if (!appBotChatRateLimits[ip] || now - appBotChatRateLimits[ip].start > APP_BOT_CHAT_RATE_WINDOW) {
+        appBotChatRateLimits[ip] = { start: now, count: 1 };
+    } else {
+        appBotChatRateLimits[ip].count++;
+    }
+    if (appBotChatRateLimits[ip].count > APP_BOT_CHAT_RATE_MAX) {
+        return res.status(429).json({ success: false, error: 'rate_limited' });
+    }
+    next();
+}
+// Clean up stale IP buckets every 5 minutes
+setInterval(() => {
+    const now = Date.now();
+    for (const ip in appBotChatRateLimits) {
+        if (now - appBotChatRateLimits[ip].start > APP_BOT_CHAT_RATE_WINDOW) delete appBotChatRateLimits[ip];
+    }
+}, 5 * 60 * 1000).unref();
+
+app.post('/api/app-bot/chat', appBotChatRateLimit, async (req, res) => {
+    const { appId, personaId, deviceId, message } = req.body || {};
+
+    // Validate inputs
+    if (typeof appId !== 'string' || typeof personaId !== 'string' ||
+        typeof deviceId !== 'string' || typeof message !== 'string' ||
+        !appId || !personaId || !deviceId || !message.trim()) {
+        return res.status(400).json({ success: false, error: 'appId, personaId, deviceId and message are required' });
+    }
+    if (message.length > 2000) {
+        return res.status(400).json({ success: false, error: 'message too long (max 2000 chars)' });
+    }
+
+    // Resolve persona server-side. Do NOT reveal which of appId/personaId was
+    // wrong (avoid leaking the valid namespace to probing clients).
+    const resolved = getPersona(appId, personaId);
+    if (!resolved) {
+        return res.status(403).json({ success: false, error: 'unknown_app_or_persona' });
+    }
+    const { app: appCfg, persona } = resolved;
+
+    // Quota check (UTC day). CRITICAL: the LLM must NOT fire when exhausted.
+    const today = new Date().toISOString().slice(0, 10);
+    const q = (await db.getAppBotQuota(appId, deviceId, today)) || { messages_used: 0, bonus_from_ads: 0 };
+    const limit = appCfg.dailyQuota + q.bonus_from_ads;
+    const remaining = limit - q.messages_used;
+    if (remaining <= 0) {
+        return res.status(429).json({ success: false, error: 'daily_quota_exceeded', needAd: true, quotaRemaining: 0 });
+    }
+
+    // Generate reply. Persona prompt stays server-side; only the text comes back.
+    let reply;
+    try {
+        const result = await callAnthropic(persona.systemPrompt, [{ role: 'user', content: message }]);
+        reply = (result.content || []).filter(b => b.type === 'text').map(b => b.text).join('');
+    } catch (err) {
+        // Never leak the underlying error (may reference the API key / provider).
+        console.error('[AppBot] inference error:', err.message);
+        return res.status(502).json({ success: false, error: 'inference_failed' });
+    }
+
+    // Only burn quota after a successful inference.
+    await db.incrementAppBotQuotaUsage(appId, deviceId, today, 1);
+
+    return res.status(200).json({ success: true, reply, quotaRemaining: remaining - 1 });
+});
 
 // Shareable chat link: /c/<publicCode>
 // Logged-in users → redirect to chat.html with contact filter

--- a/backend/tests/jest/app-bot-chat.test.js
+++ b/backend/tests/jest/app-bot-chat.test.js
@@ -1,0 +1,136 @@
+/**
+ * Tests for POST /api/app-bot/chat (情緒價值 App pipeline — card I2).
+ *
+ * Verifies the server-side app-bot gateway:
+ *  - input validation (missing appId → 400, over-long message → 400)
+ *  - unknown app/persona → 403
+ *  - happy path → 200 with reply + numeric quotaRemaining, quota incremented once
+ *  - quota exhausted → 429 with needAd, AND the LLM is NOT called (cost guard)
+ *
+ * anthropic-client.callAnthropic and the two db quota helpers are mocked so we
+ * control the response + quota state per-test and assert the side effects.
+ */
+
+// ── Standard pg mock (matches other Jest tests) ──
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../flickr', () => ({
+    router: require('express').Router(),
+    uploadToFlickr: jest.fn(),
+}));
+
+// ── Mock the Anthropic client so no real network / API key is used ──
+jest.mock('../../anthropic-client', () => ({
+    callAnthropic: jest.fn().mockResolvedValue({
+        content: [{ type: 'text', text: '嗨,我在聽。' }],
+    }),
+}));
+
+// ── Mock db: only the app-bot quota helpers matter for these tests ──
+jest.mock('../../db', () => ({
+    initDatabase: jest.fn().mockResolvedValue(true),
+    saveDeviceData: jest.fn().mockResolvedValue(true),
+    saveAllDevices: jest.fn().mockResolvedValue(true),
+    loadAllDevices: jest.fn().mockResolvedValue({}),
+    deleteDevice: jest.fn().mockResolvedValue(true),
+    getStats: jest.fn().mockResolvedValue({}),
+    closeDatabase: jest.fn().mockResolvedValue(undefined),
+    saveOfficialBot: jest.fn().mockResolvedValue(true),
+    loadOfficialBots: jest.fn().mockResolvedValue({}),
+    deleteOfficialBot: jest.fn().mockResolvedValue(true),
+    loadSubscriptions: jest.fn().mockResolvedValue({}),
+    saveSubscription: jest.fn().mockResolvedValue(true),
+    // App-Bot quota helpers (controlled per-test)
+    getAppBotQuota: jest.fn().mockResolvedValue(null),
+    incrementAppBotQuotaUsage: jest.fn().mockResolvedValue(true),
+    addAppBotAdBonus: jest.fn().mockResolvedValue(true),
+    pool: { query: jest.fn().mockResolvedValue({ rows: [] }) },
+}));
+
+const request = require('supertest');
+const app = require('../../index');
+const db = require('../../db');
+const { callAnthropic } = require('../../anthropic-client');
+
+describe('POST /api/app-bot/chat', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // Default: no prior usage today (getAppBotQuota returns null → treated as fresh)
+        db.getAppBotQuota.mockResolvedValue(null);
+        db.incrementAppBotQuotaUsage.mockResolvedValue(true);
+        callAnthropic.mockResolvedValue({ content: [{ type: 'text', text: '嗨,我在聽。' }] });
+    });
+
+    it('missing appId → 400', async () => {
+        const res = await request(app)
+            .post('/api/app-bot/chat')
+            .send({ personaId: 'default', deviceId: 'dev-1', message: 'hi' });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(callAnthropic).not.toHaveBeenCalled();
+    });
+
+    it('message too long (>2000) → 400', async () => {
+        const res = await request(app)
+            .post('/api/app-bot/chat')
+            .send({ appId: 'nighthollow', personaId: 'default', deviceId: 'dev-1', message: 'x'.repeat(2001) });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(callAnthropic).not.toHaveBeenCalled();
+    });
+
+    it('unknown app/persona → 403 (does not disclose which)', async () => {
+        const res = await request(app)
+            .post('/api/app-bot/chat')
+            .send({ appId: 'no-such-app', personaId: 'default', deviceId: 'dev-1', message: 'hi' });
+        expect(res.status).toBe(403);
+        expect(res.body.error).toBe('unknown_app_or_persona');
+        expect(callAnthropic).not.toHaveBeenCalled();
+
+        // Also an unknown persona on a valid app → same 403.
+        const res2 = await request(app)
+            .post('/api/app-bot/chat')
+            .send({ appId: 'nighthollow', personaId: 'no-such-persona', deviceId: 'dev-1', message: 'hi' });
+        expect(res2.status).toBe(403);
+        expect(res2.body.error).toBe('unknown_app_or_persona');
+    });
+
+    it('valid request → 200 with reply, numeric quotaRemaining, quota incremented once', async () => {
+        const res = await request(app)
+            .post('/api/app-bot/chat')
+            .send({ appId: 'nighthollow', personaId: 'default', deviceId: 'dev-1', message: '今天好累' });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.reply).toBe('嗨,我在聽。');
+        expect(typeof res.body.quotaRemaining).toBe('number');
+        expect(callAnthropic).toHaveBeenCalledTimes(1);
+        // System prompt (persona) is passed server-side, never exposed in body.
+        expect(JSON.stringify(res.body)).not.toContain('深夜樹洞');
+        expect(db.incrementAppBotQuotaUsage).toHaveBeenCalledTimes(1);
+    });
+
+    it('quota exhausted → 429 needAd, LLM NOT called, quota NOT incremented', async () => {
+        // nighthollow dailyQuota is 8; simulate all 8 already used, no ad bonus.
+        db.getAppBotQuota.mockResolvedValue({ messages_used: 8, bonus_from_ads: 0 });
+
+        const res = await request(app)
+            .post('/api/app-bot/chat')
+            .send({ appId: 'nighthollow', personaId: 'default', deviceId: 'dev-1', message: '再聊一句' });
+
+        expect(res.status).toBe(429);
+        expect(res.body.needAd).toBe(true);
+        expect(res.body.quotaRemaining).toBe(0);
+        // The most important invariants: no LLM spend, no quota mutation on reject.
+        expect(callAnthropic).not.toHaveBeenCalled();
+        expect(db.incrementAppBotQuotaUsage).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## What
Server-side kernel for the 情緒價值 mobile-app family (card I2, epic card_6d0f2746). Adds `POST /api/app-bot/chat`.

A mobile client sends `{appId, personaId, deviceId, message}`. The server:
1. Resolves a **server-side** per-persona system prompt from `app-bots-config.js` (client only sends a `personaId` string).
2. Enforces a per-`(appId, deviceId)` **daily message quota** (`app_bot_quota` table, UTC day).
3. Calls the EClaw Anthropic client (`callAnthropic`) and returns `{success, reply, quotaRemaining}`.

## Why
Kernel that every emotional-value app (深夜樹洞 / 誇誇機 / …) sits on top of. Persona prompts and the API key are the product's value and MUST stay server-side.

## Security invariants
- **`ANTHROPIC_API_KEY` never leaves the server** — only the extracted assistant text is returned; inference errors return a generic `502 inference_failed` (the underlying error, which can reference the provider/key, is logged server-side only, never returned).
- **Persona system prompts stay server-side** — client sends an opaque `personaId`; prompts live in `app-bots-config.js`.
- **429-before-LLM on quota** — when `remaining <= 0` the handler returns `429 {needAd:true, quotaRemaining:0}` and does **NOT** call the LLM (cost guard). Quota is only incremented **after** a successful inference, so failed calls don't burn quota.
- **No app/persona namespace leak** — unknown app OR unknown persona both return the same `403 unknown_app_or_persona` (doesn't disclose which was wrong).
- Per-IP sliding-window rate limit (60 req / 60s), bypassed under `NODE_ENV=test`.

## Schema
`app_bot_quota (app_id, device_id, quota_date)` unique row + index; helpers `getAppBotQuota` / `incrementAppBotQuotaUsage` / `addAppBotAdBonus` (the ad-bonus helper ships now for a later rewarded-ad card). All helpers `if(!pool)`-guarded.

## Tests (`backend/tests/jest/app-bot-chat.test.js`, all green — 5/5)
- missing appId → 400
- message too long (>2000) → 400
- unknown app/persona → 403 (both branches)
- valid request → 200, correct reply, numeric `quotaRemaining`, `incrementAppBotQuotaUsage` called exactly once, persona prompt not in body
- **quota exhausted → 429 `needAd`, and asserts `callAnthropic` NOT called + quota NOT incremented** (the critical cost-guard test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)