### PR TITLE
fix(vault): channel agents get [[VAULT_KEYREF]] hint, not raw value (card_247a3a68)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -13262,22 +13262,30 @@ app.post('/api/client/speak', idempotencyMiddleware, clientSpeakDedupeMiddleware
         pushText = pushText ? `${pushText}\n${hints}` : hints;
     }
 
-    // ── Vault variable interpolation: {{KEY_NAME}} → actual value ──
-    // Resolve {{KEY_NAME}} tokens in pushText only (bot-facing).
-    // Original text (with {{KEY_NAME}}) is stored in chat_messages for privacy.
-    const vaultTokenRe = /\{\{(\w+)\}\}/g;
-    if (vaultTokenRe.test(pushText)) {
+    // ── Vault variable interpolation: {{KEY_NAME}} → per-target resolution ──
+    // Channel-bound (keyref-first) agents receive `[[VAULT_KEYREF name=KEY]]`
+    // and resolve the value on-demand via GET /api/device-vars/value
+    // (owner-decided spec, card_247a3a68 / card_keyref). Legacy webhook agents
+    // (openclaw, discord) keep receiving the expanded value inline for
+    // backward compat — they predate the keyref endpoint. Chat_messages
+    // always stores the literal `{{KEY_NAME}}` for privacy regardless.
+    // Fetch vault once per request; per-target form is picked inside the
+    // fan-out loop below via resolveVaultTokensForEntity().
+    const pushTextHasVaultTokens = /\{\{(\w+)\}\}/.test(pushText);
+    let vaultVarsForInterp = null;
+    if (pushTextHasVaultTokens) {
         try {
             const varsRow = await db.getDeviceVars(deviceId);
             if (varsRow && !varsRow.is_locked) {
-                const vars = decryptVars(varsRow.encrypted_vars, varsRow.iv, varsRow.auth_tag);
-                pushText = pushText.replace(/\{\{(\w+)\}\}/g, (match, key) => {
-                    return vars[key] !== undefined ? String(vars[key]) : match;
-                });
+                vaultVarsForInterp = decryptVars(varsRow.encrypted_vars, varsRow.iv, varsRow.auth_tag);
             }
         } catch (varsErr) {
             console.warn(`[VaultInterp] Failed to resolve vars for ${deviceId}:`, varsErr.message);
         }
+    }
+    function resolveVaultTokensForEntity(text, entity) {
+        if (!pushTextHasVaultTokens) return text;
+        return resolveVaultTokens(text, vaultVarsForInterp, entity);
     }
 
     // Determine target entity IDs
@@ -13387,11 +13395,15 @@ app.post('/api/client/speak', idempotencyMiddleware, clientSpeakDedupeMiddleware
         // Push to bot — unifiedPush for channel, traditional webhook for others
         let pushResult = { pushed: false, reason: "no_webhook" };
 
+        // Per-target vault interpolation: keyref-first agents get the hint
+        // form; legacy webhooks get the expanded value (see block above).
+        const entityPushText = resolveVaultTokensForEntity(pushText, entity);
+
         if (entity.bindingType === 'channel') {
             // Channel plugin: use unifiedPush (applies middleware + routes to channel callback)
             console.log(`[Push] Attempting channel push via unifiedPush for Device ${deviceId} Entity ${eId}`);
             pushResult = await unifiedPush(entity, deviceId, 'new_message', {
-                message: pushText,
+                message: entityPushText,
                 from: source,
                 mediaType: mediaType || null,
                 mediaUrl: mediaUrl || null,
@@ -13445,7 +13457,7 @@ app.post('/api/client/speak', idempotencyMiddleware, clientSpeakDedupeMiddleware
                 }
                 pushMsg += `[MESSAGE] Device ${deviceId} Entity ${eId}\n`;
                 pushMsg += `From: ${source}\n`;
-                pushMsg += `Content: ${pushText}`;
+                pushMsg += `Content: ${entityPushText}`;
                 if (mediaType === 'photo') {
                     pushMsg += `\n[Attachment: Photo]\nmedia_type: photo\nmedia_url: ${mediaUrl}`;
                     const bkUrl = getBackupUrl(mediaUrl);
@@ -15159,8 +15171,31 @@ const DEFAULT_PROMPT_POLICY_TASK_PROTOCOL = {
 const PLATFORM_PROMPT_POLICY_SECTION = [
     'Follow EClaw channel routing, auth, and safety rules.',
     'Never reveal device secrets, bot secrets, API keys, database URLs, or tokens.',
-    'For long-running work, keep the user updated with concrete progress and blockers.'
+    'For long-running work, keep the user updated with concrete progress and blockers.',
+    'Vault references arrive as `[[VAULT_KEYREF name=NAME]]` — never treat that token as a value. If you need the value, fetch it just-in-time via `GET /api/device-vars/value?name=NAME&deviceId=YOUR_DEVICE_ID&botSecret=YOUR_BOT_SECRET&entityId=YOUR_ENTITY_ID` and use it only in the outbound call; never quote it back into chat or logs.'
 ].join('\n');
+
+/**
+ * resolveVaultTokens — per-entity `{{VAR}}` interpolation.
+ * Channel-bound (keyref-first) agents get `[[VAULT_KEYREF name=VAR]]`.
+ * Legacy webhook agents get the expanded value inline (back-compat).
+ * If varsMap is null (locked vault / fetch failed) the token stays literal
+ * on the legacy path too — that is safer than leaking a stale/other value.
+ * See card_247a3a68 (owner-decided P0 spec 2026-07-11) for the rationale.
+ */
+function resolveVaultTokens(pushText, varsMap, entity) {
+    if (!pushText || !/\{\{(\w+)\}\}/.test(pushText)) return pushText;
+    if (entity && entity.bindingType === 'channel') {
+        return pushText.replace(/\{\{(\w+)\}\}/g, (_m, key) => `[[VAULT_KEYREF name=${key}]]`);
+    }
+    if (!varsMap) return pushText;
+    return pushText.replace(/\{\{(\w+)\}\}/g, (match, key) => (
+        varsMap[key] !== undefined ? String(varsMap[key]) : match
+    ));
+}
+// Note: the actual test export (`module.exports._resolveVaultTokens = ...`)
+// lives BELOW the `module.exports = app` reassignment near the end of this
+// file so it survives the reset. Do not add another export line here.
 
 function asPromptPolicyLines(value, fieldName, maxItems = PROMPT_POLICY_MAX_ITEMS) {
     if (value === undefined) return { lines: undefined };
@@ -16597,28 +16632,32 @@ app.post('/api/client/cross-speak', async (req, res) => {
     resetBotToBotCounter(deviceId);
 
     // ── Vault variable interpolation for cross-speak ──
+    // Same rules as /api/client/speak: channel-bound (keyref-first) receivers
+    // get `[[VAULT_KEYREF name=KEY]]` (fetch value via GET /api/device-vars/value);
+    // legacy webhook receivers get the expanded value inline for back-compat.
+    // Chat_messages always stores the literal `{{KEY_NAME}}` regardless.
     let pushText = text;
-    // Surface structured attachments as filename-only hints (same rationale as
-    // /api/client/speak — keep signed URL out of push text / DB).
     if (validatedAttachments && validatedAttachments.length > 0) {
         const hints = validatedAttachments
             .map(a => `[📎 ${a.filename || a.fileId}]`)
             .join(' ');
         pushText = pushText ? `${pushText}\n${hints}` : hints;
     }
-    const vaultTokenReXD = /\{\{(\w+)\}\}/g;
-    if (vaultTokenReXD.test(text)) {
-        try {
-            const varsRow = await db.getDeviceVars(deviceId);
-            if (varsRow && !varsRow.is_locked) {
-                const vars = decryptVars(varsRow.encrypted_vars, varsRow.iv, varsRow.auth_tag);
-                pushText = text.replace(/\{\{(\w+)\}\}/g, (match, key) => {
-                    return vars[key] !== undefined ? String(vars[key]) : match;
-                });
+    if (/\{\{(\w+)\}\}/.test(pushText)) {
+        let varsMap = null;
+        // Only pay the DB fetch when the receiver actually needs the value
+        // (channel-bound receivers get the hint form and don't need it).
+        if (!(toEntity && toEntity.bindingType === 'channel')) {
+            try {
+                const varsRow = await db.getDeviceVars(deviceId);
+                if (varsRow && !varsRow.is_locked) {
+                    varsMap = decryptVars(varsRow.encrypted_vars, varsRow.iv, varsRow.auth_tag);
+                }
+            } catch (varsErr) {
+                console.warn(`[VaultInterp:CrossSpeak] Failed to resolve vars for ${deviceId}:`, varsErr.message);
             }
-        } catch (varsErr) {
-            console.warn(`[VaultInterp:CrossSpeak] Failed to resolve vars for ${deviceId}:`, varsErr.message);
         }
+        pushText = resolveVaultTokens(pushText, varsMap, toEntity);
     }
 
     const senderName = isOwnerMode ? (req.user && req.user.email ? req.user.email.split('@')[0] : 'User') : (fromEntity.name || fromEntity.publicCode);
@@ -25931,6 +25970,7 @@ module.exports._petdxPhase0 = {
     getPetdxEntityEnrichmentMap,
 };
 module.exports._enqueueMessage = enqueueMessage;
+module.exports._resolveVaultTokens = resolveVaultTokens;
 module.exports._MESSAGE_QUEUE_CAP = MESSAGE_QUEUE_CAP;
 module.exports._DEAD_LETTER_CAP = DEAD_LETTER_CAP;
 module.exports._clampQueuesOnLoad = clampQueuesOnLoad;

--- a/backend/tests/jest/mention-ux-static.test.js
+++ b/backend/tests/jest/mention-ux-static.test.js
@@ -150,21 +150,26 @@ describe('Mention feature — Fix A: displayText propagation (regression)', () =
     test('channel push uses pushText (not raw text)', () => {
         // After unifiedPush refactoring, the client/speak channel path calls
         // unifiedPush with message: pushText, which internally calls pushToChannelCallback.
+        // Post-vault-keyref (card_247a3a68) the local name may be
+        // `entityPushText` — a per-target derivative of `pushText` used to
+        // pick the [[VAULT_KEYREF]] hint form for channel-bound receivers.
+        // Both names are acceptable; raw `text` is not.
         const speakIdx = indexJs.indexOf("app.post('/api/client/speak'");
         expect(speakIdx).toBeGreaterThan(0);
-        // Check that unifiedPush is called with pushText in the channel path
         const channelSection = indexJs.indexOf("entity.bindingType === 'channel'", speakIdx);
         expect(channelSection).toBeGreaterThan(speakIdx);
         const nextElse = indexJs.indexOf('} else if (entity.webhook)', channelSection);
         const channelSnippet = indexJs.slice(channelSection, nextElse);
-        expect(channelSnippet).toContain('message: pushText');
+        expect(channelSnippet).toMatch(/message:\s+(?:entityPushText|pushText)\b/);
     });
 
     test('OpenClaw webhook pushMsg uses pushText in Content: line', () => {
         // The instruction-first push format builds a pushMsg string that
         // includes `Content: ${text}` — this must be updated to pushText
-        // so the LLM sees human-readable @name instead of raw tokens.
-        expect(indexJs).toContain('Content: ${pushText}');
+        // (or its per-target derivative `entityPushText`, post
+        // card_247a3a68) so the LLM sees human-readable @name instead of
+        // raw tokens and never the raw `${text}`.
+        expect(indexJs).toMatch(/Content:\s*\$\{(entityPushText|pushText)\}/);
         // The raw `${text}` form must not appear in the OpenClaw Content line
         expect(indexJs).not.toMatch(/pushMsg\s*\+=\s*`Content: \$\{text\}/);
     });

--- a/backend/tests/jest/vault-keyref-hint-channel.test.js
+++ b/backend/tests/jest/vault-keyref-hint-channel.test.js
@@ -1,0 +1,96 @@
+/**
+ * Vault {{VAR}} interpolation — per-entity resolution (card_247a3a68 P0 fix)
+ *
+ * Owner-decided semantics (card_247a3a68 spec correction 2026-07-11):
+ *   - Channel-bound (keyref-first) agents receive `[[VAULT_KEYREF name=X]]`
+ *     and fetch the value on-demand via GET /api/device-vars/value.
+ *   - Legacy webhook agents keep receiving the expanded value inline
+ *     (back-compat — they predate the keyref endpoint).
+ *   - Chat_messages ALWAYS stores the literal `{{VAR}}` for privacy
+ *     (that's guarded by the callers of resolveVaultTokens, not the helper
+ *     itself — resolveVaultTokens only transforms the push-facing string).
+ *
+ * Live-repro that this test regresses against:
+ *   2026-07-11 23:17 TW: Hank typed `{{TEST_A}}` in web_chat.
+ *   Before the fix: the channel-mode agent's pushText was inlined to the
+ *     TEST_A vault value → agent context leaked the value.
+ *   After the fix: the channel-mode agent's pushText carries the literal
+ *     `[[VAULT_KEYREF name=TEST_A]]` token; value never traverses chat/log.
+ */
+
+require('./helpers/mock-setup');
+const { _resolveVaultTokens: resolveVaultTokens } = require('../../index');
+
+const CHANNEL_ENTITY = { bindingType: 'channel' };
+const WEBHOOK_ENTITY = { bindingType: 'webhook', webhook: { type: 'openclaw' } };
+const DISCORD_ENTITY = { bindingType: 'webhook', webhook: { type: 'discord' } };
+const VARS_MAP = { TEST_A: 'SECRET_VALUE_TEST_A', RAILWAY_TOKEN: 'raw-uuid-of-doom' };
+
+describe('resolveVaultTokens — channel receiver (keyref-first)', () => {
+    it('rewrites {{VAR}} to [[VAULT_KEYREF name=VAR]] and NEVER inlines the value', () => {
+        const out = resolveVaultTokens('use {{TEST_A}} to call the api', VARS_MAP, CHANNEL_ENTITY);
+        expect(out).toBe('use [[VAULT_KEYREF name=TEST_A]] to call the api');
+        expect(out).not.toContain('SECRET_VALUE_TEST_A');
+    });
+
+    it('handles multiple distinct {{VAR}} tokens in the same message', () => {
+        const out = resolveVaultTokens(
+            'A={{TEST_A}} R={{RAILWAY_TOKEN}}',
+            VARS_MAP,
+            CHANNEL_ENTITY
+        );
+        expect(out).toBe('A=[[VAULT_KEYREF name=TEST_A]] R=[[VAULT_KEYREF name=RAILWAY_TOKEN]]');
+        expect(out).not.toContain('SECRET_VALUE_TEST_A');
+        expect(out).not.toContain('raw-uuid-of-doom');
+    });
+
+    it('still emits hint form even when the vault map is null (locked/absent)', () => {
+        const out = resolveVaultTokens('try {{TEST_A}}', null, CHANNEL_ENTITY);
+        expect(out).toBe('try [[VAULT_KEYREF name=TEST_A]]');
+    });
+
+    it('leaves the string alone when there are no {{...}} tokens', () => {
+        const out = resolveVaultTokens('plain hello', VARS_MAP, CHANNEL_ENTITY);
+        expect(out).toBe('plain hello');
+    });
+});
+
+describe('resolveVaultTokens — legacy webhook receiver (back-compat)', () => {
+    it('expands {{VAR}} to the vault value inline for openclaw', () => {
+        const out = resolveVaultTokens('use {{TEST_A}} now', VARS_MAP, WEBHOOK_ENTITY);
+        expect(out).toBe('use SECRET_VALUE_TEST_A now');
+    });
+
+    it('expands {{VAR}} to the vault value inline for discord', () => {
+        const out = resolveVaultTokens('use {{TEST_A}} now', VARS_MAP, DISCORD_ENTITY);
+        expect(out).toBe('use SECRET_VALUE_TEST_A now');
+    });
+
+    it('leaves an unknown key literal (no vault entry) instead of leaking undefined', () => {
+        const out = resolveVaultTokens('use {{NOT_A_KEY}} now', VARS_MAP, WEBHOOK_ENTITY);
+        expect(out).toBe('use {{NOT_A_KEY}} now');
+    });
+
+    it('leaves the token literal when varsMap is null (locked vault) — no crash, no leak', () => {
+        const out = resolveVaultTokens('use {{TEST_A}} now', null, WEBHOOK_ENTITY);
+        expect(out).toBe('use {{TEST_A}} now');
+    });
+});
+
+describe('resolveVaultTokens — defensive edge cases', () => {
+    it('handles a null/undefined entity by falling through to legacy expansion', () => {
+        const out = resolveVaultTokens('use {{TEST_A}}', VARS_MAP, null);
+        expect(out).toBe('use SECRET_VALUE_TEST_A');
+    });
+
+    it('does nothing for empty pushText', () => {
+        expect(resolveVaultTokens('', VARS_MAP, CHANNEL_ENTITY)).toBe('');
+        expect(resolveVaultTokens(null, VARS_MAP, CHANNEL_ENTITY)).toBe(null);
+    });
+
+    it('does NOT re-expand a `[[VAULT_KEYREF name=X]]` token (idempotence)', () => {
+        const already = 'use [[VAULT_KEYREF name=TEST_A]] to call';
+        expect(resolveVaultTokens(already, VARS_MAP, CHANNEL_ENTITY)).toBe(already);
+        expect(resolveVaultTokens(already, VARS_MAP, WEBHOOK_ENTITY)).toBe(already);
+    });
+});


### PR DESCRIPTION
## Summary

- `/api/client/speak` and `/api/transform` cross-speak previously **eagerly expanded `{{VAR}}` in pushText to the raw vault value** BEFORE delivering it to the receiving agent. For channel-bound (keyref-first) receivers this defeated the entire security model of PR #3853 — the value entered agent context whether the agent needed it or not, and any quote-reply re-wrote the value into chat_history.
- **Fix**: split vault interpolation per-entity. Channel receivers get `[[VAULT_KEYREF name=X]]` (agent fetches on demand via GET `/api/device-vars/value`). Legacy webhook (openclaw / discord) receivers keep the inline expansion for back-compat. `chat_messages` still stores the literal `{{X}}` regardless.
- **Managed-prompt line added** so channel agents (claude_code / codex / gemini_cli / anthropic_bot / openai_bot) know to interpret + resolve the `[[VAULT_KEYREF]]` marker via the keyref endpoint instead of quoting it back.

## Live-repro this fixes

- 2026-07-11 18:30 TW: Hank's `{{RAILWAY_EMOTIONAL_GATEWAY_0711}}` was inlined to a raw UUID in the channel-agent payload.
- 2026-07-11 23:17 TW: `{{TEST_A}}` → `TEST_B` (vault value) leaked into my agent context via pushText, then I echoed it into chat as a quote-reply — twice-leaked.

Both are prevented by the hint form.

## Owner spec authority

card_247a3a68 (P0) two SPEC comments define this exact behavior; Hank formulated the security argument (botSecret is device-bound → the keyref endpoint can only be reached by the correctly-bound agent → value stays out of chat/log/audit-message-face).

## Test plan

- [x] `backend/tests/jest/vault-keyref-hint-channel.test.js` — 11 unit tests covering:
  - channel receiver → hint form, no value inlined
  - multiple distinct tokens rewritten correctly
  - null vault map (locked/absent) → channel still gets hint form
  - legacy openclaw/discord webhook → value inlined as before
  - unknown key → left literal (no `undefined` leak)
  - locked vault + webhook → literal stays, no crash, no leak
  - null entity → falls back to legacy expansion
  - empty / null pushText → no-op
  - idempotence on already-resolved `[[VAULT_KEYREF]]` token
- [x] Local jest run: **11/11 pass** (1.25s)
- [ ] Post-merge: verify with `{{TEST_A}}` from web_chat → chat_history literal preserved (already true) + my #2 (claude_code) receives `[[VAULT_KEYREF name=TEST_A]]` not `TEST_B`

## Card refs

- Primary: card_247a3a68 (P0 security)
- Related: PR #3853 (keyref endpoint that this fix restores as the sole vault-value read path for channel agents)
- Twin memory: [[reference_pushtext_expands_vault_vars_agent_context]] documented the trap this closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcjiAE7C3id3bAozXyBMkQ