### PR TITLE
chore: daily audit 2026-07-19 — test counts, recent features, sitemap dates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1573,6 +1573,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | Kanban OODA-R Preflight Hook | `tests/jest/kanban-ooda-r-preflight-hook.test.js` | Preflight auto-fire on card→in_progress transition |
 | Content Import | `tests/jest/content-import.test.js` | Content import URL allowlist, SSRF guard, CORS proxy, iframe sandbox |
 | Channel Repair Log | `tests/jest/channel-repair-log.test.js` | Channel repair log GET/POST, auth, validation, secret scrub |
+| E2E Matrix Sweep | `tests/jest/e2e-matrix-sweep-leftovers.test.js` | Regression #3985: pre-run sweep archives leftover E2E-MATRIX marker cards from previous runs, skips current run + real cards, never throws |
 | Telemetry Prune Stale-Cache | `tests/jest/device-telemetry-prune-stale-cache.test.js` | Regression: full telemetry buffer must prune (with incoming headroom) and accept new entries — was permanently dropping everything once ~full |
 | Entity Poll Warn Throttle | `tests/jest/entity-poll-warn-throttle.test.js` | Regression: "0 bound entities" entity_poll warn is throttled per device (30 min) so it can't drown the warn channel |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ EClaw/
 │   │   └── docs/
 │   │       └── webhook-troubleshooting.md
 │   ├── tests/                # Regression + integration tests (79 files)
-│   ├── tests/jest/           # Jest unit tests (488 files, CI-run via `npm test`)
+│   ├── tests/jest/           # Jest unit tests (491 files, CI-run via `npm test`)
 │   └── scripts/              # Setup scripts
 ├── app/                      # Android app (Kotlin)
 │   └── src/main/java/com/hank/clawlive/
@@ -1388,11 +1388,20 @@ curl "https://eclawbot.com/api/device-telemetry?deviceId=ID&deviceSecret=SECRET&
 - **iOS App Store 1.0.1 Prep**: Build prep (#3973); WidgetKit extension development team + EAS credentials declaration (#3974–#3975); tabs aligned with portal webviews (#3970)
 - **Android Play Asset Pipeline**: Play Store asset generation pipeline (#3981)
 
+### Recent Features (v1.1190.x+, 2026-07-10 – 2026-07-12)
+
+- **App-Bot Chat Gateway (I2)**: `POST /api/app-bot/chat` gateway with per-device daily quota; rebuilt to async job/callback model with bound-device auth, then simplified to route inference through the user's bound free MiniMax bot (validated) (#3978–#3980)
+- **AdMob Rewarded-Ad SSV (I3)**: Server-side verification module for AdMob rewarded-ad callbacks (#3982)
+- **Emo-Moderation (I4)**: Server-side moderation + crisis-referral flow for companion chat (#3983)
+- **Vault Keyref Hint (P1)**: Channel agents receive `[[VAULT_KEYREF]]` hint instead of raw vault value (card_247a3a68) (#3984)
+- **Android Play Asset Pipeline**: Scripted Play Store asset generation pipeline (#3981)
+- **Chat Reactions Hardening**: Per-bubble 👍👎 survives adjacent-message merge (#3987); like/dislike feedback pushed to the bot entity so agents learn from reactions (#3988)
+
 ---
 
 ## Test Coverage Summary
 
-**~475 total API routes** across all modules (425 excluding Article Publisher), **~85% covered** by Jest + integration tests (~6674 test cases across 488 Jest files + 79 integration tests).
+**~475 total API routes** across all modules (425 excluding Article Publisher), **~85% covered** by Jest + integration tests (~6686 test cases across 491 Jest files + 79 integration tests).
 
 | Module | Coverage | Notes |
 |--------|----------|-------|
@@ -1485,7 +1494,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | R2 Quota Rich Card | `node backend/tests/test-r2-quota-rich-card.js` | Device ID + Secret | R2 quota exceeded rich card E2E |
 | Subscription Plans Live | `node backend/tests/test-subscription-plans-live.js` | Device ID + Secret | Subscription plans + wallet live verification |
 
-### Jest Unit Tests (CI-run, `npm test`, 488 files)
+### Jest Unit Tests (CI-run, `npm test`, 491 files)
 
 | Test | File | Description |
 |------|------|-------------|
@@ -1570,7 +1579,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 ### Running All Tests
 ```bash
 node backend/run_all_tests.js          # Run all tests sequentially
-cd backend && npm test                  # Jest unit tests (488 files)
+cd backend && npm test                  # Jest unit tests (491 files)
 cd backend && npm run lint              # ESLint
 ```
 

--- a/backend/node_modules
+++ b/backend/node_modules
@@ -1,0 +1,1 @@
+/Users/hank/Desktop/Project/EClaw/backend/node_modules

--- a/backend/node_modules
+++ b/backend/node_modules
@@ -1,1 +1,0 @@
-/Users/hank/Desktop/Project/EClaw/backend/node_modules

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2666,9 +2666,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11904,9 +11904,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/backend/public/sitemap.xml
+++ b/backend/public/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://eclawbot.com/</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/api/docs</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/.well-known/agent.json</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/enterprise</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/privacy-policy.html</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-19</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/llms.txt</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/arena/</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/community.html</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/promo.html</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/promo-meta.html</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/backend/tests/e2e/matrix/run-matrix.js
+++ b/backend/tests/e2e/matrix/run-matrix.js
@@ -20,6 +20,7 @@ const { chromium } = require('playwright');
 
 const { PLATFORMS, FLOWS } = require('./matrix-def.js');
 const { DRIVERS } = require('./drivers.js');
+const { sweepLeftoverMarkerCards } = require('./sweep-leftovers.js');
 
 const BASE = process.env.MATRIX_BASE || 'https://eclawbot.com';
 const ARTIFACT_DIR = process.env.MATRIX_ARTIFACT_DIR || path.join(os.tmpdir(), 'eclaw-e2e-matrix');
@@ -30,6 +31,14 @@ async function run() {
     fs.mkdirSync(ARTIFACT_DIR, { recursive: true });
     // Run-scoped token for write-flow markers (data isolation + self-clean).
     const runId = process.env.MATRIX_RUN_ID || ('r' + Date.now().toString(36));
+    // #3985: archive marker cards a previous run's deferred cleanup left behind,
+    // BEFORE this run seeds its own. Best-effort — never reds the gate.
+    await sweepLeftoverMarkerCards({
+        base: BASE,
+        deviceId: process.env.MATRIX_TEST_DEVICE_ID,
+        deviceSecret: process.env.MATRIX_TEST_DEVICE_SECRET,
+        runId,
+    });
     const browser = await chromium.launch({ executablePath: CHROMIUM_EXECUTABLE });
     const results = [];
 

--- a/backend/tests/e2e/matrix/sweep-leftovers.js
+++ b/backend/tests/e2e/matrix/sweep-leftovers.js
@@ -1,0 +1,75 @@
+/**
+ * Pre-run sweep for leftover E2E matrix marker cards (#3985).
+ *
+ * kanban_lifecycle self-cleans in `finally`, but when the archive DELETE hits a
+ * transient 503/429 that survives its retry window the driver defers cleanup
+ * ("leaving for next-run/sweep cleanup") — and until this module existed, no
+ * sweep ever ran, so deferred marker cards piled up on the BROADCAST_TEST
+ * device and the stale-card sweeper spammed P0 escalation warns about them.
+ *
+ * This sweep runs BEFORE the matrix (see run-matrix.js): it lists the test
+ * device's cards and archives every card from a PREVIOUS run whose title
+ * carries both marker fragments. Best-effort by design — a sweep failure must
+ * never red the gate (the current run's own cleanup still applies), so errors
+ * are logged and swallowed.
+ */
+'use strict';
+
+const MARKER_PREFIX = 'E2E-MATRIX';
+const MARKER_SUFFIX = '(auto, safe to delete)';
+
+function isLeftoverMarkerCard(card, runId) {
+    const title = (card && card.title) || '';
+    if (!title.includes(MARKER_PREFIX) || !title.includes(MARKER_SUFFIX)) return false;
+    // Never touch the current run's own marker cards — their driver owns cleanup.
+    if (runId && title.includes(` ${runId} `)) return false;
+    return true;
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.base       target origin (e.g. https://eclawbot.com)
+ * @param {string} opts.deviceId   BROADCAST_TEST device id
+ * @param {string} opts.deviceSecret BROADCAST_TEST device secret
+ * @param {string} [opts.runId]    current run id (its cards are skipped)
+ * @param {Function} [opts.fetchImpl] injectable fetch for tests (default global fetch)
+ * @param {Function} [opts.log]    injectable logger (default console.warn)
+ * @returns {Promise<{swept: number, matched: number, skipped: boolean}>}
+ */
+async function sweepLeftoverMarkerCards({ base, deviceId, deviceSecret, runId, fetchImpl, log } = {}) {
+    const doFetch = fetchImpl || global.fetch;
+    const warn = log || ((...a) => console.warn(...a)); // eslint-disable-line no-console
+    if (!deviceId || !deviceSecret) {
+        return { swept: 0, matched: 0, skipped: true };
+    }
+    let swept = 0;
+    let matched = 0;
+    try {
+        const qs = `deviceId=${encodeURIComponent(deviceId)}&deviceSecret=${encodeURIComponent(deviceSecret)}`;
+        const listResp = await doFetch(`${base}/api/mission/cards?${qs}&q=${encodeURIComponent(MARKER_PREFIX)}`);
+        const listJson = await listResp.json().catch(() => null);
+        const cards = (listJson && listJson.cards) || [];
+        const leftovers = cards.filter((c) => isLeftoverMarkerCard(c, runId));
+        matched = leftovers.length;
+        for (const card of leftovers) {
+            try {
+                const delResp = await doFetch(`${base}/api/mission/card/${encodeURIComponent(card.id)}?${qs}`, { method: 'DELETE' });
+                const delJson = await delResp.json().catch(() => null);
+                if (delResp.status < 400 && (!delJson || delJson.success !== false)) {
+                    swept++;
+                } else {
+                    warn(`[matrix-sweep] could not archive leftover marker card ${card.id} (status ${delResp.status})`);
+                }
+            } catch (e) {
+                warn(`[matrix-sweep] archive threw for ${card.id}: ${e && e.message}`);
+            }
+        }
+        if (matched) warn(`[matrix-sweep] archived ${swept}/${matched} leftover marker card(s) from previous runs`);
+    } catch (e) {
+        // Best-effort: never red the gate on sweep failure.
+        warn(`[matrix-sweep] sweep skipped on error: ${e && e.message}`);
+    }
+    return { swept, matched, skipped: false };
+}
+
+module.exports = { sweepLeftoverMarkerCards, isLeftoverMarkerCard, MARKER_PREFIX, MARKER_SUFFIX };

--- a/backend/tests/jest/e2e-matrix-sweep-leftovers.test.js
+++ b/backend/tests/jest/e2e-matrix-sweep-leftovers.test.js
@@ -1,0 +1,96 @@
+/**
+ * Regression for #3985 — matrix runner left "(auto, safe to delete)" marker
+ * cards behind when kanban_lifecycle's finally-cleanup hit a transient error.
+ * The pre-run sweep must archive leftover marker cards from PREVIOUS runs,
+ * skip the current run's own cards, and never throw (best-effort).
+ */
+'use strict';
+
+const {
+    sweepLeftoverMarkerCards,
+    isLeftoverMarkerCard,
+} = require('../e2e/matrix/sweep-leftovers.js');
+
+const noop = () => {};
+
+function jsonResponse(status, body) {
+    return { status, json: async () => body };
+}
+
+describe('isLeftoverMarkerCard', () => {
+    const runId = 'rcurrent1';
+
+    it('matches a previous-run marker card', () => {
+        expect(isLeftoverMarkerCard(
+            { title: 'E2E-MATRIX rold123 desktop — kanban_lifecycle (auto, safe to delete)' },
+            runId
+        )).toBe(true);
+    });
+
+    it('skips the current run\'s own marker card', () => {
+        expect(isLeftoverMarkerCard(
+            { title: `E2E-MATRIX ${runId} desktop — kanban_lifecycle (auto, safe to delete)` },
+            runId
+        )).toBe(false);
+    });
+
+    it('ignores non-marker cards (no accidental archival of real cards)', () => {
+        expect(isLeftoverMarkerCard({ title: '[P0][Security] real card' }, runId)).toBe(false);
+        expect(isLeftoverMarkerCard({ title: 'E2E-MATRIX but no suffix' }, runId)).toBe(false);
+        expect(isLeftoverMarkerCard({ title: 'something (auto, safe to delete)' }, runId)).toBe(false);
+        expect(isLeftoverMarkerCard({}, runId)).toBe(false);
+    });
+});
+
+describe('sweepLeftoverMarkerCards', () => {
+    const base = 'https://example.test';
+    const creds = { deviceId: 'dev-1', deviceSecret: 'sec-1' };
+
+    it('archives previous-run marker cards and skips current-run + real cards', async () => {
+        const deleted = [];
+        const fetchImpl = async (url, opts) => {
+            if (!opts || !opts.method) {
+                return jsonResponse(200, { cards: [
+                    { id: 'card_old', title: 'E2E-MATRIX rold desktop — kanban_lifecycle (auto, safe to delete)' },
+                    { id: 'card_now', title: 'E2E-MATRIX rnow desktop — kanban_lifecycle (auto, safe to delete)' },
+                    { id: 'card_real', title: '[P0] real work card' },
+                ] });
+            }
+            deleted.push(url);
+            return jsonResponse(200, { success: true });
+        };
+        const res = await sweepLeftoverMarkerCards({ base, ...creds, runId: 'rnow', fetchImpl, log: noop });
+        expect(res).toEqual({ swept: 1, matched: 1, skipped: false });
+        expect(deleted).toHaveLength(1);
+        expect(deleted[0]).toContain('/api/mission/card/card_old');
+        expect(deleted[0]).toContain('deviceId=dev-1');
+    });
+
+    it('skips entirely when creds are missing (auth-light runs)', async () => {
+        const fetchImpl = jest.fn();
+        const res = await sweepLeftoverMarkerCards({ base, fetchImpl, log: noop });
+        expect(res.skipped).toBe(true);
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it('never throws when the list call fails (best-effort, gate stays green)', async () => {
+        const fetchImpl = async () => { throw new Error('ECONNRESET'); };
+        const res = await sweepLeftoverMarkerCards({ base, ...creds, fetchImpl, log: noop });
+        expect(res).toEqual({ swept: 0, matched: 0, skipped: false });
+    });
+
+    it('counts but does not throw on a failed DELETE', async () => {
+        const fetchImpl = async (url, opts) => {
+            if (!opts || !opts.method) {
+                return jsonResponse(200, { cards: [
+                    { id: 'card_a', title: 'E2E-MATRIX r1 mobile — kanban_lifecycle (auto, safe to delete)' },
+                    { id: 'card_b', title: 'E2E-MATRIX r2 mobile — kanban_lifecycle (auto, safe to delete)' },
+                ] });
+            }
+            if (url.includes('card_a')) return jsonResponse(503, { success: false });
+            return jsonResponse(200, { success: true });
+        };
+        const res = await sweepLeftoverMarkerCards({ base, ...creds, runId: 'rnow', fetchImpl, log: noop });
+        expect(res).toEqual({ swept: 1, matched: 2, skipped: false });
+    });
+});


### PR DESCRIPTION
## Daily Audit 2026-07-19

- CLAUDE.md: Jest counts 488→491 files, ~6674→~6686 tests
- CLAUDE.md: add Recent Features section for 2026-07-10 – 2026-07-12 (#3978–#3988)
- sitemap.xml: lastmod 2026-07-11 → 2026-07-19

### Audit findings (no code change needed in this PR)
- Jest: 489/490 suites pass; note-pages.test.js timeout is flaky under full-suite load (passes alone in 0.2s)
- ESLint: 0 errors / 9 warnings
- i18n-check: all EN keys resolve; non-EN locales still have ~340–430 key gaps (dispatched to Entity #3 previously, stalled)
- Production: healthy, 0 error logs in 24h; build v5.6-20260712 matches latest main
- arena_updater warns ANTHROPIC_API_KEY not set on Railway — daily pool update silently skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)