### PR TITLE
fix wallpaper companion stale appearance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,6 +446,7 @@ EClaw/
    | Info Integration slide lists unsupported integrations and fake platform/SLA stats | `GET /api/debug/info-integration-slide?deviceId=X&deviceSecret=Y` | 2026-05-05 | Active |
    | Info Guide mobile renders too many sidebar sections/cards/slides as one long vertical wall | `GET /api/debug/info-guide-mobile-layout?deviceId=X&deviceSecret=Y` | 2026-05-05 | Active |
    | Chat @mention autocomplete dropdown uses legacy avatar instead of Petdx companion appearance | `GET /api/debug/mention-autocomplete-avatar?deviceId=X&deviceSecret=Y` | 2026-05-12 | Active |
+   | Android wallpaper keeps stale companion appearance after unbind/rebind/select | `GET /api/debug/wallpaper-companion-stale?deviceId=X&deviceSecret=Y&entityId=N` | 2026-07-31 | Active |
    | Codex channel A2A loop from operational bridge errors | `GET /api/debug/a2a-loop-guard?deviceId=X&deviceSecret=Y` | 2026-05-02 | Active |
 
 6. **Demand Elegance (Balanced)** — 在保持 minimal change 的前提下，追求可讀、一致的程式風格；不為了「漂亮」而過度重構，但也不容忍明顯的 code smell 在新增的程式碼中出現。

--- a/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
@@ -465,9 +465,11 @@ class WallpaperPreviewActivity : AppCompatActivity() {
             entity.botSecret?.let { secret -> entity.entityId to secret }
         }
         val activeIds = active.map { it.first }.toSet()
+        companionRepository.pruneTo(activeIds)
 
         companionJobs.keys.toList().forEach { entityId ->
             if (entityId !in activeIds) {
+                companionRepository.clearCompanion(entityId)
                 companionJobs.remove(entityId)?.cancel()
             }
         }

--- a/app/src/main/java/com/hank/clawlive/data/local/WallpaperEntitySnapshotCache.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/WallpaperEntitySnapshotCache.kt
@@ -61,6 +61,21 @@ class WallpaperEntitySnapshotCache private constructor(context: Context) {
         prefs.edit().putString(KEY_COMPANIONS_JSON, gson.toJson(companions)).apply()
     }
 
+    fun removeCompanion(entityId: Int) {
+        val companions = loadCompanionMap().toMutableMap()
+        if (companions.remove(entityId) != null) {
+            prefs.edit().putString(KEY_COMPANIONS_JSON, gson.toJson(companions)).apply()
+        }
+    }
+
+    fun pruneCompanionsTo(activeEntityIds: Set<Int>) {
+        val companions = loadCompanionMap().toMutableMap()
+        val changed = companions.keys.retainAll(activeEntityIds)
+        if (changed) {
+            prefs.edit().putString(KEY_COMPANIONS_JSON, gson.toJson(companions)).apply()
+        }
+    }
+
     fun loadCompanionMap(): Map<Int, CompanionDetail> {
         val json = prefs.getString(KEY_COMPANIONS_JSON, null) ?: return emptyMap()
         return try {

--- a/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
+++ b/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
@@ -81,6 +81,18 @@ class CompanionRepository(
     /** Returns the cached companion for an entity, or null until a fetch lands. */
     fun cached(entityId: Int): CompanionDetail? = descriptorCache[entityId]
 
+    /** Clear stale companion state after unbind, tombstone, or a missing current selection. */
+    fun clearCompanion(entityId: Int) {
+        descriptorCache.remove(entityId)
+        snapshotCache.removeCompanion(entityId)
+    }
+
+    /** Keep companion caches aligned with the currently bound wallpaper entities. */
+    fun pruneTo(activeEntityIds: Set<Int>) {
+        descriptorCache.keys.removeIf { it !in activeEntityIds }
+        snapshotCache.pruneCompanionsTo(activeEntityIds)
+    }
+
     /**
      * Returns a decoded spritesheet bitmap. The wallpaper draw loop runs on
      * the Main thread, so we never block here: a cache miss schedules an
@@ -141,13 +153,16 @@ class CompanionRepository(
                     } else {
                         true // non-spritesheet (procedural) — no preload needed
                     }
+                    descriptorCache[entityId] = companion
+                    snapshotCache.saveCompanion(entityId, companion)
                     if (sheetReady) {
-                        descriptorCache[entityId] = companion
-                        snapshotCache.saveCompanion(entityId, companion)
                         Timber.d("Companion fetched for entity $entityId: ${companion.id} (${companion.assetType})")
                     } else {
-                        Timber.w("Spritesheet preload failed for entity $entityId (${companion.spritesheetUrl()}); keeping previous companion to avoid default-lobster flicker")
+                        Timber.w("Spritesheet preload failed for entity $entityId (${companion.spritesheetUrl()}); published descriptor so stale companion is not retained")
                     }
+                } else {
+                    clearCompanion(entityId)
+                    Timber.d("Companion cleared for entity $entityId: no current selection")
                 }
                 emit(companion)
             } catch (e: HttpException) {

--- a/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
+++ b/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
@@ -308,8 +308,10 @@ class ClawWallpaperService : WallpaperService() {
                 e.botSecret?.let { secret -> e.entityId to secret }
             }
             val activeIds = active.map { it.first }.toSet()
+            companionRepository.pruneTo(activeIds)
             companionJobs.keys.toList().forEach { id ->
                 if (id !in activeIds) {
+                    companionRepository.clearCompanion(id)
                     companionJobs.remove(id)?.cancel()
                 }
             }

--- a/app/src/test/java/com/hank/clawlive/CompanionCacheInvalidationStaticTest.kt
+++ b/app/src/test/java/com/hank/clawlive/CompanionCacheInvalidationStaticTest.kt
@@ -1,0 +1,50 @@
+package com.hank.clawlive
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class CompanionCacheInvalidationStaticTest {
+    @Test
+    fun companionRepositoryClearsCachedDescriptorWhenCurrentSelectionIsNull() {
+        val repo = readSource("com/hank/clawlive/data/repository/CompanionRepository.kt")
+
+        assertTrue(repo.contains("fun clearCompanion(entityId: Int)"))
+        assertTrue(repo.contains("descriptorCache.remove(entityId)"))
+        assertTrue(repo.contains("snapshotCache.removeCompanion(entityId)"))
+        assertTrue(repo.contains("resp.selection?.companion"))
+        assertTrue(repo.contains("Companion cleared for entity \$entityId: no current selection"))
+        assertTrue(!repo.contains("keeping previous companion"))
+    }
+
+    @Test
+    fun wallpaperAndPreviewPruneCompanionCacheToActiveBoundEntities() {
+        val wallpaper = readSource("com/hank/clawlive/service/ClawWallpaperService.kt")
+        val preview = readSource("com/hank/clawlive/WallpaperPreviewActivity.kt")
+
+        assertTrue(wallpaper.contains("companionRepository.pruneTo(activeIds)"))
+        assertTrue(wallpaper.contains("companionRepository.clearCompanion(id)"))
+        assertTrue(preview.contains("companionRepository.pruneTo(activeIds)"))
+        assertTrue(preview.contains("companionRepository.clearCompanion(entityId)"))
+    }
+
+    @Test
+    fun durableSnapshotCacheCanRemoveAndPruneCompanionDescriptors() {
+        val cache = readSource("com/hank/clawlive/data/local/WallpaperEntitySnapshotCache.kt")
+
+        assertTrue(cache.contains("fun removeCompanion(entityId: Int)"))
+        assertTrue(cache.contains("companions.remove(entityId)"))
+        assertTrue(cache.contains("fun pruneCompanionsTo(activeEntityIds: Set<Int>)"))
+        assertTrue(cache.contains("companions.keys.retainAll(activeEntityIds)"))
+    }
+
+    private fun readSource(relPath: String): String {
+        val candidates = listOf(
+            File("src/main/java/$relPath"),
+            File("app/src/main/java/$relPath")
+        )
+        val file = candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate $relPath from ${File(".").absolutePath}")
+        return file.readText()
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -28,6 +28,7 @@ import org.junit.runners.Suite
     EngineLifecycleControllerTest::class,
     SpritesheetLoadingGraceTest::class,
     CompanionDescriptorAnimationTest::class,
+    CompanionCacheInvalidationStaticTest::class,
     NavResumeControllerTest::class,
     NotificationPreferenceCatalogTest::class,
     SettingsManifestResolverTest::class,

--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -428,7 +428,7 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
             // for the descriptor payload. LEFT JOIN so a deleted companion
             // returns selection=null instead of erroring.
             const selectSql = `
-                SELECT s.companion_id, s.selected_at, s.source,
+                SELECT s.companion_id, s.selected_at, s.source, s.origin,
                        c.id, c.name, c.version, c.author_entity_id, c.descriptor,
                        c.asset_type, c.asset_url, c.avatar_url, c.thumbnail_url,
                        c.supported_states, c.scope, c.status, c.license,
@@ -439,7 +439,7 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
              LEFT JOIN companions c ON c.id = s.companion_id
                  WHERE s.device_id = $1
                    AND s.entity_id IS NOT DISTINCT FROM $2
-              ORDER BY s.selected_at DESC
+              ORDER BY s.selected_at DESC, s.id DESC
                  LIMIT 1
             `;
             const favSql = `
@@ -456,7 +456,7 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
             ]);
 
             let selection = null;
-            if (selRes.rowCount > 0 && selRes.rows[0].id) {
+            if (selRes.rowCount > 0 && selRes.rows[0].origin !== 'unbind-cleared' && selRes.rows[0].id) {
                 const r = selRes.rows[0];
                 selection = {
                     selectedAt: Number(r.selected_at),

--- a/backend/index.js
+++ b/backend/index.js
@@ -3871,6 +3871,144 @@ app.get('/api/debug/mention-autocomplete-avatar', async (req, res) => {
     }
 });
 
+// Temporary diagnostic endpoint for the 2026-07-31 Android wallpaper companion
+// stale-appearance bug. It compares the latest companion_select_log row, the
+// tombstone interpretation, and /api/entities Petdx enrichment for one entity.
+// Auth is device-owner only; response never includes deviceSecret, botSecret, or
+// raw companion descriptors.
+app.get('/api/debug/wallpaper-companion-stale', async (req, res) => {
+    const { deviceId, deviceSecret } = req.query || {};
+    const entityIdRaw = req.query?.entityId;
+    const timestamp = new Date().toISOString();
+    try {
+        if (!deviceId || !deviceSecret) {
+            return res.status(401).json({
+                success: false,
+                bug: 'wallpaper-companion-stale',
+                error: 'deviceId and deviceSecret required',
+                timestamp,
+            });
+        }
+
+        const eId = entityIdRaw === undefined || entityIdRaw === null || entityIdRaw === ''
+            ? 0
+            : parseInt(entityIdRaw, 10);
+        if (!Number.isFinite(eId) || eId < 0) {
+            return res.status(400).json({
+                success: false,
+                bug: 'wallpaper-companion-stale',
+                error: 'valid entityId required',
+                timestamp,
+            });
+        }
+
+        const memDevice = devices[deviceId];
+        const pool = db._getPool ? db._getPool() : authModule.pool;
+        const dbDevice = pool
+            ? await pool.query('SELECT device_secret FROM devices WHERE device_id = $1', [deviceId])
+            : { rows: [] };
+        const dbDeviceRow = dbDevice.rows[0] || null;
+        const memSecretOk = !!(memDevice && memDevice.deviceSecret && safeEqual(memDevice.deviceSecret, deviceSecret));
+        const dbSecretOk = !!(dbDeviceRow && dbDeviceRow.device_secret && safeEqual(dbDeviceRow.device_secret, deviceSecret));
+        if (!memSecretOk && !dbSecretOk) {
+            return res.status(403).json({
+                success: false,
+                bug: 'wallpaper-companion-stale',
+                error: 'Invalid credentials',
+                timestamp,
+            });
+        }
+
+        const latestSelection = pool ? await pool.query(
+            `SELECT s.companion_id, s.selected_at, s.source, s.origin,
+                    c.id IS NOT NULL AS companion_exists,
+                    c.asset_type, c.asset_url IS NOT NULL AS has_asset_url,
+                    c.avatar_url IS NOT NULL AS has_avatar_url,
+                    c.status, c.scope
+               FROM companion_select_log s
+          LEFT JOIN companions c ON c.id = s.companion_id
+              WHERE s.device_id = $1 AND s.entity_id = $2
+           ORDER BY s.selected_at DESC, s.id DESC
+              LIMIT 5`,
+            [deviceId, eId]
+        ).catch((err) => ({ rows: [], _error: err.message })) : { rows: [] };
+
+        const latestRows = (latestSelection.rows || []).map((row, index) => ({
+            rank: index + 1,
+            companionId: row.companion_id || null,
+            selectedAt: row.selected_at == null ? null : Number(row.selected_at),
+            source: row.source || null,
+            origin: row.origin || null,
+            tombstoned: row.origin === PETDX_TOMBSTONE_ORIGIN,
+            companionExists: !!row.companion_exists,
+            assetType: row.asset_type || null,
+            hasAssetUrl: !!row.has_asset_url,
+            hasAvatarUrl: !!row.has_avatar_url,
+            status: row.status || null,
+            scope: row.scope || null,
+        }));
+        const newest = latestRows[0] || null;
+        const enrichmentMap = await getPetdxEntityEnrichmentMap(deviceId);
+        const enriched = enrichmentMap.get(eId) || null;
+        const memEntity = memDevice?.entities ? memDevice.entities[eId] : null;
+
+        res.json({
+            success: true,
+            bug: 'wallpaper-companion-stale',
+            diagnostics: {
+                server: {
+                    build: SERVER_BUILD_TAG,
+                    startedAt: SERVER_STARTED_AT.toISOString(),
+                    uptimeSec: Math.round(process.uptime()),
+                },
+                auth: {
+                    memSecretOk,
+                    dbSecretOk,
+                    requestUserDeviceId: req.user?.deviceId || null,
+                    requestUserId: req.user?.userId || null,
+                },
+                entity: {
+                    entityId: eId,
+                    inMemoryPresent: !!memEntity,
+                    inMemoryBound: !!memEntity?.isBound,
+                    hasBotSecret: !!memEntity?.botSecret,
+                    character: memEntity?.character || null,
+                    avatarShape: typeof memEntity?.avatar === 'string'
+                        ? (memEntity.avatar.startsWith('http') ? 'url' : 'emoji_or_text')
+                        : (memEntity?.avatar == null ? null : typeof memEntity.avatar),
+                },
+                companionSelection: {
+                    latest: newest,
+                    recent: latestRows,
+                    queryError: latestSelection._error || null,
+                    currentShouldBeNull: !!(newest && newest.tombstoned),
+                    currentCompanionId: newest && !newest.tombstoned && newest.companionExists
+                        ? newest.companionId
+                        : null,
+                },
+                entitiesEnrichment: enriched ? {
+                    petdxCompanionId: enriched.petdxCompanionId,
+                    hasPetdxAvatarUrl: !!enriched.petdxAvatarUrl,
+                } : null,
+                expectedAndroidBehavior: {
+                    clearCachedCompanionWhenCurrentNull: true,
+                    pruneCompanionCacheWhenEntityUnboundOrRemoved: true,
+                    pollerEndpoint: '/api/companion/current',
+                },
+            },
+            timestamp,
+        });
+    } catch (err) {
+        console.error('[Debug wallpaper-companion-stale] failed:', err);
+        res.status(500).json({
+            success: false,
+            bug: 'wallpaper-companion-stale',
+            error: err.message,
+            timestamp,
+        });
+    }
+});
+
 // Temporary diagnostic endpoint for public Info-page regressions:
 // - roadmap.html must not redirect unauthenticated visitors to index.html
 // - release notes must render Markdown links instead of raw `(https://...)`

--- a/backend/tests/jest/companion-api.test.js
+++ b/backend/tests/jest/companion-api.test.js
@@ -1176,6 +1176,104 @@ describe('companion-api: POST /:id/review', () => {
     });
 });
 
+describe('companion-api: GET /current tombstone handling', () => {
+    beforeEach(() => __mockQuery.mockReset());
+
+    test('latest unbind-cleared row returns selection=null so wallpaper drops stale appearance', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({
+                rowCount: 1,
+                rows: [{
+                    companion_id: 'petdx-old',
+                    selected_at: 1785477600000,
+                    source: 'api',
+                    origin: 'unbind-cleared',
+                    id: 'petdx-old',
+                    name: 'Old Companion',
+                    version: '1.0.0',
+                    author_entity_id: null,
+                    descriptor: { asset: { renderer: 'old-procedural' } },
+                    asset_type: 'procedural',
+                    asset_url: null,
+                    avatar_url: '/old.png',
+                    thumbnail_url: null,
+                    supported_states: ['IDLE'],
+                    scope: 'system',
+                    status: 'published',
+                    license: 'EClaw-default',
+                    category: 'animal',
+                    mood: null,
+                    color: null,
+                    tags: [],
+                    i18n_data: null,
+                    download_count: 0,
+                    favorite_count: 0,
+                    rating_avg: null,
+                    rating_count: 0,
+                    comment_count: 0,
+                    published_at: null,
+                }],
+            })
+            .mockResolvedValueOnce({ rows: [] });
+
+        const res = await request(makeApp())
+            .get('/api/companion/current')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.selection).toBeNull();
+        expect(__mockQuery.mock.calls[0][0]).toMatch(/s\.origin/);
+        expect(__mockQuery.mock.calls[0][0]).toMatch(/ORDER BY s\.selected_at DESC, s\.id DESC/);
+    });
+
+    test('newer user-selected row after rebind/select returns the new companion', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({
+                rowCount: 1,
+                rows: [{
+                    companion_id: 'petdx-new',
+                    selected_at: 1785477600001,
+                    source: 'app',
+                    origin: 'user-selected',
+                    id: 'petdx-new',
+                    name: 'New Companion',
+                    version: '1.0.0',
+                    author_entity_id: null,
+                    descriptor: { asset: { renderer: 'new-procedural' } },
+                    asset_type: 'procedural',
+                    asset_url: null,
+                    avatar_url: '/new.png',
+                    thumbnail_url: null,
+                    supported_states: ['IDLE'],
+                    scope: 'system',
+                    status: 'published',
+                    license: 'EClaw-default',
+                    category: 'animal',
+                    mood: null,
+                    color: '#00AAFF',
+                    tags: [],
+                    i18n_data: null,
+                    download_count: 0,
+                    favorite_count: 0,
+                    rating_avg: null,
+                    rating_count: 0,
+                    comment_count: 0,
+                    published_at: null,
+                }],
+            })
+            .mockResolvedValueOnce({ rows: [] });
+
+        const res = await request(makeApp())
+            .get('/api/companion/current')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+
+        expect(res.status).toBe(200);
+        expect(res.body.selection.companion.id).toBe('petdx-new');
+        expect(res.body.selection.source).toBe('app');
+    });
+});
+
 describe('companion-api: DELETE /:id', () => {
     beforeEach(() => __mockQuery.mockReset());
 

--- a/backend/tests/jest/petdx-vault-clear-on-unbind.test.js
+++ b/backend/tests/jest/petdx-vault-clear-on-unbind.test.js
@@ -108,4 +108,19 @@ describe('clearPetdxVaultForEntity — static invariants', () => {
             expect(!!d && (e !== undefined && e !== null)).toBeFalsy();
         }
     });
+
+    it('debug endpoint exists for wallpaper stale companion diagnostics', () => {
+        const fs = require('fs');
+        const src = fs.readFileSync(require.resolve('../../index'), 'utf8');
+        const i = src.indexOf("app.get('/api/debug/wallpaper-companion-stale'");
+        expect(i).toBeGreaterThan(-1);
+        const body = src.slice(i, i + 7200);
+        expect(body).toMatch(/deviceId and deviceSecret required/);
+        expect(body).toMatch(/companion_select_log/);
+        expect(body).toMatch(/PETDX_TOMBSTONE_ORIGIN/);
+        expect(body).toMatch(/getPetdxEntityEnrichmentMap/);
+        expect(body).toMatch(/clearCachedCompanionWhenCurrentNull/);
+        expect(body).not.toMatch(/botSecret\s*:/);
+        expect(body).not.toMatch(/deviceSecret\s*:/);
+    });
 });


### PR DESCRIPTION
## Summary

Fixes the Android live wallpaper stale companion appearance path after a free bot is unbound, rebound, and assigned a new companion appearance.

## Root cause

GET /api/companion/current could treat the newest unbind tombstone row as a valid latest selection because it did not select/check origin, and it ordered only by selected_at. On Android, wallpaper and preview companion caches were not cleared when the current companion became null or when an entity disappeared from active bound wallpaper entities. A spritesheet preload failure could also intentionally keep the previous descriptor, preserving the old appearance.

## Changes

- Treat origin=unbind-cleared as selection=null in /api/companion/current and order ties by s.id DESC.
- Clear and prune Android companion descriptor/snapshot caches when selections become null or entities are unbound/removed.
- Publish the new descriptor even if spritesheet preload fails, so the old companion is not retained.
- Add temporary production-safe debug endpoint GET /api/debug/wallpaper-companion-stale?deviceId=X&deviceSecret=Y&entityId=N and register it in AGENTS.md.
- Add backend and Android regression tests for the stale companion flow.

## Validation

- cd backend && npx jest tests/jest/companion-api.test.js tests/jest/petdx-vault-clear-on-unbind.test.js --runInBand
- node -c backend/index.js
- node -c backend/companion-api.js
- ./gradlew :app:testDebugUnitTest --tests com.hank.clawlive.UnitTestSuite --no-daemon
- ./gradlew :app:lintDebug --no-daemon

Notes: Android validation in the clean worktree used local ignored prerequisites (local.properties, app/google-services.json). Backend Jest used the existing local ignored backend/node_modules dependency tree.
