### PR TITLE
fix(android): resolve companion asset URLs for wallpaper

### DIFF
--- a/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
+++ b/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
@@ -23,6 +23,24 @@ import retrofit2.HttpException
 import timber.log.Timber
 import java.util.concurrent.ConcurrentHashMap
 
+private const val COMPANION_ASSET_BASE_URL = "https://eclawbot.com"
+
+internal fun resolveCompanionAssetUrl(rawUrl: String?): String? {
+    val url = rawUrl?.trim().orEmpty()
+    if (url.isBlank()) return null
+    if (url.startsWith("http://", ignoreCase = true) || url.startsWith("https://", ignoreCase = true)) {
+        return url
+    }
+    if (url.startsWith("//")) {
+        return "https:$url"
+    }
+    return if (url.startsWith("/")) {
+        "$COMPANION_ASSET_BASE_URL$url"
+    } else {
+        "$COMPANION_ASSET_BASE_URL/$url"
+    }
+}
+
 /**
  * Fetches the per-entity current companion (Petdx) and decodes spritesheet
  * bitmaps for the renderer. Two caches:
@@ -69,7 +87,7 @@ class CompanionRepository(
             ioScope.launch {
                 restored.values.forEach { companion ->
                     if (companion.assetType == "spritesheet") {
-                        companion.spritesheetUrl()?.takeIf { it.isNotBlank() }?.let { url ->
+                        resolveCompanionAssetUrl(companion.spritesheetUrl())?.let { url ->
                             runCatching { sheetCache.getOrLoad(url) { loadBitmap(url) } }
                         }
                     }
@@ -100,13 +118,13 @@ class CompanionRepository(
      * tick (33ms later) will find the bitmap and paint it.
      */
     fun getSheet(url: String?): Bitmap? {
-        if (url.isNullOrBlank()) return null
-        sheetCache.peek(url)?.let { return it }
+        val sheetUrl = resolveCompanionAssetUrl(url) ?: return null
+        sheetCache.peek(sheetUrl)?.let { return it }
         if (android.os.Looper.myLooper() == android.os.Looper.getMainLooper()) {
-            ioScope.launch { sheetCache.getOrLoad(url) { loadBitmap(url) } }
+            ioScope.launch { sheetCache.getOrLoad(sheetUrl) { loadBitmap(sheetUrl) } }
             return null
         }
-        return sheetCache.getOrLoad(url) { loadBitmap(url) }
+        return sheetCache.getOrLoad(sheetUrl) { loadBitmap(sheetUrl) }
     }
 
     /**
@@ -142,8 +160,8 @@ class CompanionRepository(
                     // and the old renderer fell back to procedural lobster
                     // for that whole window, producing the visible flicker.
                     val sheetReady = if (companion.assetType == "spritesheet") {
-                        val sheetUrl = companion.spritesheetUrl()
-                        if (sheetUrl.isNullOrBlank()) {
+                        val sheetUrl = resolveCompanionAssetUrl(companion.spritesheetUrl())
+                        if (sheetUrl == null) {
                             true // descriptor is malformed; let renderer's UNSUPPORTED path handle it
                         } else {
                             withContext(Dispatchers.IO) {
@@ -189,8 +207,9 @@ class CompanionRepository(
     }
 
     private fun loadBitmap(url: String): Bitmap? {
-        diskSheetCache.load(url)?.let { return it }
-        return fetchBitmap(url)
+        val sheetUrl = resolveCompanionAssetUrl(url) ?: return null
+        diskSheetCache.load(sheetUrl)?.let { return it }
+        return fetchBitmap(sheetUrl)
     }
 
     private fun fetchBitmap(url: String): Bitmap? {

--- a/app/src/test/java/com/hank/clawlive/CompanionAssetUrlTest.kt
+++ b/app/src/test/java/com/hank/clawlive/CompanionAssetUrlTest.kt
@@ -1,0 +1,46 @@
+package com.hank.clawlive
+
+import com.hank.clawlive.data.repository.resolveCompanionAssetUrl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CompanionAssetUrlTest {
+    @Test
+    fun resolvesRelativePetdxApiSpritesheetPathAgainstProductionBase() {
+        assertEquals(
+            "https://eclawbot.com/api/petdx/community/xiaoyu-e23e75f0ae6a/sprite.webp",
+            resolveCompanionAssetUrl("/api/petdx/community/xiaoyu-e23e75f0ae6a/sprite.webp")
+        )
+    }
+
+    @Test
+    fun keepsAbsoluteSpritesheetUrlsUnchanged() {
+        assertEquals(
+            "https://cdn.example.com/pets/sheet.webp",
+            resolveCompanionAssetUrl("https://cdn.example.com/pets/sheet.webp")
+        )
+        assertEquals(
+            "http://cdn.example.com/pets/sheet.webp",
+            resolveCompanionAssetUrl("http://cdn.example.com/pets/sheet.webp")
+        )
+    }
+
+    @Test
+    fun resolvesProtocolRelativeAndBarePaths() {
+        assertEquals(
+            "https://cdn.example.com/pets/sheet.webp",
+            resolveCompanionAssetUrl("//cdn.example.com/pets/sheet.webp")
+        )
+        assertEquals(
+            "https://eclawbot.com/api/petdx/sheet.webp",
+            resolveCompanionAssetUrl("api/petdx/sheet.webp")
+        )
+    }
+
+    @Test
+    fun blankSpritesheetUrlReturnsNull() {
+        assertNull(resolveCompanionAssetUrl(null))
+        assertNull(resolveCompanionAssetUrl("   "))
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -28,6 +28,7 @@ import org.junit.runners.Suite
     EngineLifecycleControllerTest::class,
     SpritesheetLoadingGraceTest::class,
     CompanionDescriptorAnimationTest::class,
+    CompanionAssetUrlTest::class,
     CompanionCacheInvalidationStaticTest::class,
     NavResumeControllerTest::class,
     NotificationPreferenceCatalogTest::class,


### PR DESCRIPTION
## Summary\n- Resolve relative and protocol-relative Petdx companion asset URLs before Android wallpaper fetch/cache.\n- Reuse the resolved URL across memory cache, disk cache, preload, and fetch paths.\n- Add regression coverage for relative, absolute, protocol-relative, bare, null, and blank companion asset URLs.\n\n## Verification\n- ANDROID_HOME=/Users/hank/Library/Android/sdk ./gradlew :app:testDebugUnitTest --tests 'com.hank.clawlive.CompanionAssetUrlTest' --no-daemon\n- ANDROID_HOME=/Users/hank/Library/Android/sdk ./gradlew :app:testDebugUnitTest --tests 'com.hank.clawlive.UnitTestSuite' --no-daemon\n- ANDROID_HOME=/Users/hank/Library/Android/sdk ./gradlew :app:lintDebug --no-daemon\n- ANDROID_HOME=/Users/hank/Library/Android/sdk ANDROID_SERIAL=emulator-5556 ./gradlew :app:installDebug --no-daemon\n- Computer Use emulator e2e: free bot unbind + rebind, select 小雨 companion, open Wallpaper Preview, verified 小雨 renders on wallpaper.\n- logcat post-fix: expected_url_scheme_errors=0; absolute_xiaoyu_fetches=8.\n\n## Notes\n- This follows up PR #4215. The first fix cleared stale server/cache selection; emulator validation then exposed Android relative spritesheet URL loading as the remaining blocker.