### PR TITLE
fix(android): target API 36 for Play policy

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 android {
     namespace = "com.hank.clawlive"
-    compileSdk = 35
+    compileSdk = 36
 
     buildFeatures {
         buildConfig = true
@@ -20,7 +20,7 @@ android {
     defaultConfig {
         applicationId = "com.hank.clawlive"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 127
         versionName = "1.1.16"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
+++ b/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
@@ -23,6 +23,24 @@ import retrofit2.HttpException
 import timber.log.Timber
 import java.util.concurrent.ConcurrentHashMap
 
+private const val COMPANION_ASSET_BASE_URL = "https://eclawbot.com"
+
+internal fun resolveCompanionAssetUrl(rawUrl: String?): String? {
+    val url = rawUrl?.trim().orEmpty()
+    if (url.isBlank()) return null
+    if (url.startsWith("http://", ignoreCase = true) || url.startsWith("https://", ignoreCase = true)) {
+        return url
+    }
+    if (url.startsWith("//")) {
+        return "https:$url"
+    }
+    return if (url.startsWith("/")) {
+        "$COMPANION_ASSET_BASE_URL$url"
+    } else {
+        "$COMPANION_ASSET_BASE_URL/$url"
+    }
+}
+
 /**
  * Fetches the per-entity current companion (Petdx) and decodes spritesheet
  * bitmaps for the renderer. Two caches:
@@ -69,7 +87,7 @@ class CompanionRepository(
             ioScope.launch {
                 restored.values.forEach { companion ->
                     if (companion.assetType == "spritesheet") {
-                        companion.spritesheetUrl()?.takeIf { it.isNotBlank() }?.let { url ->
+                        resolveCompanionAssetUrl(companion.spritesheetUrl())?.let { url ->
                             runCatching { sheetCache.getOrLoad(url) { loadBitmap(url) } }
                         }
                     }
@@ -100,13 +118,13 @@ class CompanionRepository(
      * tick (33ms later) will find the bitmap and paint it.
      */
     fun getSheet(url: String?): Bitmap? {
-        if (url.isNullOrBlank()) return null
-        sheetCache.peek(url)?.let { return it }
+        val sheetUrl = resolveCompanionAssetUrl(url) ?: return null
+        sheetCache.peek(sheetUrl)?.let { return it }
         if (android.os.Looper.myLooper() == android.os.Looper.getMainLooper()) {
-            ioScope.launch { sheetCache.getOrLoad(url) { loadBitmap(url) } }
+            ioScope.launch { sheetCache.getOrLoad(sheetUrl) { loadBitmap(sheetUrl) } }
             return null
         }
-        return sheetCache.getOrLoad(url) { loadBitmap(url) }
+        return sheetCache.getOrLoad(sheetUrl) { loadBitmap(sheetUrl) }
     }
 
     /**
@@ -142,8 +160,8 @@ class CompanionRepository(
                     // and the old renderer fell back to procedural lobster
                     // for that whole window, producing the visible flicker.
                     val sheetReady = if (companion.assetType == "spritesheet") {
-                        val sheetUrl = companion.spritesheetUrl()
-                        if (sheetUrl.isNullOrBlank()) {
+                        val sheetUrl = resolveCompanionAssetUrl(companion.spritesheetUrl())
+                        if (sheetUrl == null) {
                             true // descriptor is malformed; let renderer's UNSUPPORTED path handle it
                         } else {
                             withContext(Dispatchers.IO) {
@@ -189,8 +207,9 @@ class CompanionRepository(
     }
 
     private fun loadBitmap(url: String): Bitmap? {
-        diskSheetCache.load(url)?.let { return it }
-        return fetchBitmap(url)
+        val sheetUrl = resolveCompanionAssetUrl(url) ?: return null
+        diskSheetCache.load(sheetUrl)?.let { return it }
+        return fetchBitmap(sheetUrl)
     }
 
     private fun fetchBitmap(url: String): Bitmap? {

--- a/app/src/test/java/com/hank/clawlive/AndroidSdkPolicyTest.kt
+++ b/app/src/test/java/com/hank/clawlive/AndroidSdkPolicyTest.kt
@@ -1,0 +1,47 @@
+package com.hank.clawlive
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class AndroidSdkPolicyTest {
+    @Test
+    fun androidAppTargetsGooglePlay2026ApiRequirement() {
+        val gradle = locateBuildGradle().readText()
+        val compileSdk = extractSdkValue(gradle, "compileSdk")
+        val targetSdk = extractSdkValue(gradle, "targetSdk")
+
+        assertTrue(
+            "Google Play requires Android 16 / API 36+ for app updates starting 2026-08-31; compileSdk=$compileSdk",
+            compileSdk >= GOOGLE_PLAY_2026_REQUIRED_API
+        )
+        assertTrue(
+            "Google Play requires Android 16 / API 36+ for app updates starting 2026-08-31; targetSdk=$targetSdk",
+            targetSdk >= GOOGLE_PLAY_2026_REQUIRED_API
+        )
+        assertTrue(
+            "compileSdk must stay at least targetSdk so release builds can compile all targeted APIs",
+            compileSdk >= targetSdk
+        )
+    }
+
+    private fun extractSdkValue(source: String, propertyName: String): Int {
+        val match = Regex("""\b$propertyName\s*=\s*(\d+)""").find(source)
+            ?: error("Could not find $propertyName in app/build.gradle.kts")
+        return match.groupValues[1].toInt()
+    }
+
+    private fun locateBuildGradle(): File {
+        val candidates = listOf(
+            File("build.gradle.kts"),
+            File("app/build.gradle.kts")
+        )
+
+        return candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate app/build.gradle.kts from ${File(".").absolutePath}")
+    }
+
+    private companion object {
+        private const val GOOGLE_PLAY_2026_REQUIRED_API = 36
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/CompanionAssetUrlTest.kt
+++ b/app/src/test/java/com/hank/clawlive/CompanionAssetUrlTest.kt
@@ -1,0 +1,46 @@
+package com.hank.clawlive
+
+import com.hank.clawlive.data.repository.resolveCompanionAssetUrl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CompanionAssetUrlTest {
+    @Test
+    fun resolvesRelativePetdxApiSpritesheetPathAgainstProductionBase() {
+        assertEquals(
+            "https://eclawbot.com/api/petdx/community/xiaoyu-e23e75f0ae6a/sprite.webp",
+            resolveCompanionAssetUrl("/api/petdx/community/xiaoyu-e23e75f0ae6a/sprite.webp")
+        )
+    }
+
+    @Test
+    fun keepsAbsoluteSpritesheetUrlsUnchanged() {
+        assertEquals(
+            "https://cdn.example.com/pets/sheet.webp",
+            resolveCompanionAssetUrl("https://cdn.example.com/pets/sheet.webp")
+        )
+        assertEquals(
+            "http://cdn.example.com/pets/sheet.webp",
+            resolveCompanionAssetUrl("http://cdn.example.com/pets/sheet.webp")
+        )
+    }
+
+    @Test
+    fun resolvesProtocolRelativeAndBarePaths() {
+        assertEquals(
+            "https://cdn.example.com/pets/sheet.webp",
+            resolveCompanionAssetUrl("//cdn.example.com/pets/sheet.webp")
+        )
+        assertEquals(
+            "https://eclawbot.com/api/petdx/sheet.webp",
+            resolveCompanionAssetUrl("api/petdx/sheet.webp")
+        )
+    }
+
+    @Test
+    fun blankSpritesheetUrlReturnsNull() {
+        assertNull(resolveCompanionAssetUrl(null))
+        assertNull(resolveCompanionAssetUrl("   "))
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -28,6 +28,7 @@ import org.junit.runners.Suite
     EngineLifecycleControllerTest::class,
     SpritesheetLoadingGraceTest::class,
     CompanionDescriptorAnimationTest::class,
+    AndroidSdkPolicyTest::class,
     CompanionCacheInvalidationStaticTest::class,
     NavResumeControllerTest::class,
     NotificationPreferenceCatalogTest::class,

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -28,6 +28,7 @@ import org.junit.runners.Suite
     EngineLifecycleControllerTest::class,
     SpritesheetLoadingGraceTest::class,
     CompanionDescriptorAnimationTest::class,
+    CompanionAssetUrlTest::class,
     CompanionCacheInvalidationStaticTest::class,
     NavResumeControllerTest::class,
     NotificationPreferenceCatalogTest::class,

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -29,6 +29,7 @@ import org.junit.runners.Suite
     SpritesheetLoadingGraceTest::class,
     CompanionDescriptorAnimationTest::class,
     CompanionAssetUrlTest::class,
+    AndroidSdkPolicyTest::class,
     CompanionCacheInvalidationStaticTest::class,
     NavResumeControllerTest::class,
     NotificationPreferenceCatalogTest::class,


### PR DESCRIPTION
## Summary\n- Raise Android compileSdk and targetSdk from 35 to 36.\n- Add AndroidSdkPolicyTest so Play target API compliance does not regress below API 36.\n\n## Why\nGoogle Play policy states that starting 2026-08-31, new apps and app updates must target Android 16 / API 36 or higher.\nSource: https://developer.android.com/google/play/requirements/target-sdk\n\n## Verification\n- ANDROID_HOME=/Users/hank/Library/Android/sdk ./gradlew :app:testDebugUnitTest --tests 'com.hank.clawlive.AndroidSdkPolicyTest' --no-daemon\n- ANDROID_HOME=/Users/hank/Library/Android/sdk ./gradlew :app:testDebugUnitTest --tests 'com.hank.clawlive.UnitTestSuite' --no-daemon\n- ANDROID_HOME=/Users/hank/Library/Android/sdk ./gradlew :app:lintDebug :app:assembleDebug --no-daemon\n\n## Release note\nThis is a prerequisite for the next Google Play production submission and resolves the Play Console target API warning shown for the 2026-08-31 deadline.