### PR TITLE
fix(web): prevent AiHankApps redirect loop

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -350,7 +350,7 @@ app.use('/js', express.static(path.join(__dirname, 'public/js'), {
 }));
 // Hank's public app portfolio. Keep the trailing slash so relative promo image
 // paths resolve under /AiHankApps/ instead of the site root.
-app.get('/AiHankApps', (_req, res) => {
+app.get(/^\/AiHankApps$/, (_req, res) => {
     res.redirect(308, '/AiHankApps/');
 });
 app.use('/AiHankApps', express.static(path.join(__dirname, 'public/AiHankApps'), {

--- a/backend/tests/jest/ai-hank-apps-route.test.js
+++ b/backend/tests/jest/ai-hank-apps-route.test.js
@@ -1,15 +1,29 @@
 const fs = require('fs');
 const path = require('path');
+const express = require('express');
+const request = require('supertest');
 
 const backendDir = path.resolve(__dirname, '../..');
 const serverSource = fs.readFileSync(path.join(backendDir, 'index.js'), 'utf8');
 const portfolioDir = path.join(backendDir, 'public', 'AiHankApps');
 
 describe('AiHankApps portfolio route', () => {
-    test('redirects the bare path and serves the portfolio directory', () => {
-        expect(serverSource).toContain("app.get('/AiHankApps'");
+    test('redirects only the bare path and serves the trailing-slash URL', async () => {
+        expect(serverSource).toContain("app.get(/^\\/AiHankApps$/");
         expect(serverSource).toContain("res.redirect(308, '/AiHankApps/')");
         expect(serverSource).toContain("app.use('/AiHankApps', express.static");
+
+        const routeApp = express();
+        routeApp.get(/^\/AiHankApps$/, (_req, res) => res.redirect(308, '/AiHankApps/'));
+        routeApp.use('/AiHankApps', express.static(portfolioDir));
+
+        const bareResponse = await request(routeApp).get('/AiHankApps');
+        expect(bareResponse.status).toBe(308);
+        expect(bareResponse.headers.location).toBe('/AiHankApps/');
+
+        const pageResponse = await request(routeApp).get('/AiHankApps/');
+        expect(pageResponse.status).toBe(200);
+        expect(pageResponse.text).toContain('我的APP作品集');
     });
 
     test('includes the portfolio page and promotional images', () => {


### PR DESCRIPTION
Fixes the production redirect loop discovered after PR #4463 deployed. The redirect now uses an exact regular-expression route so only /AiHankApps redirects, while /AiHankApps/ is served normally. Adds a regression test that verifies 308 for the bare path and 200 for the trailing-slash page. Local focused test passes.