### PR TITLE
Bust AiHankApps asset cache

### DIFF
--- a/backend/public/AiHankApps/index.html
+++ b/backend/public/AiHankApps/index.html
@@ -431,8 +431,8 @@
         }
       }
     </style>
-    <link rel="icon" type="image/png" href="favicon.png">
-    <link rel="stylesheet" href="community.css">
+    <link rel="icon" type="image/png" href="favicon.png?v=20260823-2">
+    <link rel="stylesheet" href="community.css?v=20260823-2">
 </head>
   <body>
     <div class="grain" aria-hidden="true"></div>
@@ -709,6 +709,6 @@
       renderChips();
       renderGrid();
     </script>
-    <script src="community.js"></script>
+    <script src="community.js?v=20260823-2"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- version the newly published community CSS, JavaScript, and favicon URLs
- bypass Cloudflare negative cache entries created before the assets reached production

## Validation
- versioned production asset URLs return HTTP 200
- no product logic changes