### PR TITLE
Use desktop AiHankApps layout on mobile

### DIFF
--- a/backend/public/AiHankApps/index.html
+++ b/backend/public/AiHankApps/index.html
@@ -2,7 +2,7 @@
 <html lang="zh-Hant">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=1100" />
     <title>我的APP作品集</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- render the portfolio with a fixed desktop viewport on mobile browsers
- make phones show the same two-column, full-gallery composition as desktop mode
- avoid the oversized single-column mobile presentation

## Validation
- Sites production build passed